### PR TITLE
fix(tui): give the header real content and its own housing

### DIFF
--- a/clients/tui/dev/fixtures/markdown.experiments.json
+++ b/clients/tui/dev/fixtures/markdown.experiments.json
@@ -1,0 +1,21 @@
+[
+  {
+    "hypothesis_id": "h1",
+    "title": "Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path",
+    "claim": "Removing the mutex from the producer/consumer path removes the dominant cost.",
+    "action": "Replace the queue with a bounded SPSC ring and keep the C ABI identical.",
+    "first_round": 1,
+    "last_round": 1,
+    "rounds": [{"round": 1, "passed": true, "reviewed": true, "hypothesis_outcome": "proven"}],
+    "resolved_outcome": "proven",
+    "judge_verdict": "accepted",
+    "perf_metric": 301.4,
+    "perf_unit": "ms",
+    "perf_metric_name": "total_ms",
+    "perf_direction": "min",
+    "perf_baseline_value": 412.7,
+    "perf_delta_pct": -27.0,
+    "kept": true,
+    "active": false
+  }
+]

--- a/clients/tui/dev/mock-server.ts
+++ b/clients/tui/dev/mock-server.ts
@@ -152,6 +152,24 @@ function resolveFixture(name: string): string {
   throw new Error(`no fixture found for ${name}`);
 }
 
+/**
+ * Hypotheses for the experiment log, from `<fixture>.experiments.json` beside
+ * the fixture when one exists.
+ *
+ * Recorded journals hold events, not the projected experiment table, and the
+ * header and log render the hypothesis title rather than anything in the event
+ * stream. A sidecar keeps that title pinnable without inventing event types the
+ * backend never emits.
+ */
+function loadExperiments(fixturePath: string): unknown[] {
+  const sidecar = `${fixturePath.replace(/\.gz$/, '').replace(/\.jsonl$/, '')}.experiments.json`;
+  try {
+    return JSON.parse(readFileSync(sidecar, 'utf8')) as unknown[];
+  } catch {
+    return [];
+  }
+}
+
 function loadFixture(path: string): RunEventRecord[] {
   const raw = readFileSync(path);
   const text = path.endsWith('.gz') ? gunzipSync(raw).toString('utf8') : raw.toString('utf8');
@@ -342,6 +360,7 @@ function main(): void {
   const options = parseOptions(process.argv.slice(2));
   options.fixture = resolveFixture(options.fixture);
   const events = loadFixture(options.fixture);
+  const experiments = loadExperiments(options.fixture);
   const replay = new Replay(events, options);
   process.stderr.write(
     `mock: ${String(events.length)} events from ${options.fixture}\n` +
@@ -408,7 +427,10 @@ function main(): void {
           return;
         }
         case 'query.experiments': {
-          writeLine(socket, ok(id, responseBody(type)));
+          writeLine(
+            socket,
+            ok(id, withValues(responseBody(type), {experiments, experiments_ready: true})),
+          );
           return;
         }
         case 'query.events': {

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -78,6 +78,7 @@ import {
   setChatThreadPending,
   setExperiments,
   setPaneContent,
+  setPauseOverride,
   setTheme,
   showDetail,
   showLive,
@@ -903,6 +904,17 @@ export class SocketSessionController implements SessionController {
     }
     try {
       const response = await this.client.request(parsed.request);
+      // The ack is the only pause signal the client gets: the backend tracks
+      // its own paused status but never pushes a status change, and the
+      // snapshot is read once at boot. A resume is recorded as its own state
+      // rather than as the absence of a pause, so it can also override a boot
+      // snapshot that arrived reading `paused`.
+      if (response.ack?.action === 'pause') {
+        this.#setState(setPauseOverride(this.#state, 'paused'));
+      }
+      if (response.ack?.action === 'resume') {
+        this.#setState(setPauseOverride(this.#state, 'resumed'));
+      }
       const rendered = renderResponse(parsed.request, response, parsed.responseView);
       if (rendered !== null) this.#setState(showDetail(this.#state, rendered));
     } catch (error) {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -40,7 +40,6 @@ import {
   setPaneContent,
   setTheme,
   showDetail,
-  statusText,
   togglePaneZoom,
   toggleTodos,
   unownedExperimentRounds,
@@ -49,6 +48,7 @@ import {
   visiblePhases,
   visibleTodos,
 } from './session-model.js';
+import {usageText} from './ui/header.js';
 
 describe('event batch projection', () => {
   it('keeps the existing banner while resumed history ends in a running session', () => {
@@ -1327,9 +1327,9 @@ describe('session event model', () => {
     expect(toggleTodos(toggleTodos(state)).todosExpanded).toBe(false);
   });
 
-  it('feeds usage updates into the status token meter', () => {
+  it('feeds usage updates into the header token meter', () => {
     let state = initialSessionState();
-    expect(statusText(state)).not.toContain('tokens');
+    expect(usageText(state)).toBeNull();
     state = applyEvent(
       state,
       event(1, 'usage_update', {
@@ -1345,7 +1345,7 @@ describe('session event model', () => {
       contextWindow: 1_000_000,
       model: 'claude-sonnet-4-6',
     });
-    expect(statusText(state)).toContain('20k/1.0M tokens');
+    expect(usageText(state)).toBe('20k/1.0M context');
     expect(state.core.transcript).toHaveLength(0);
   });
 

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -30,11 +30,32 @@ import {
 import {agentRuntimeLabel} from './ui/agent-runtime-label.js';
 import {DEFAULT_THEME_NAME, THEME_NAMES, type ThemeName} from './ui/theme.js';
 
+/**
+ * A pause command the operator issued, standing against the backend status
+ * until they issue the other one. `null` is "issued neither", which is not the
+ * same as `resumed`: only `resumed` contradicts a status that reads `paused`.
+ */
+export type PauseOverride = 'paused' | 'resumed' | null;
+
 export interface SessionState {
   /** Pure projection of backend snapshots, events, and execution checkpoints. */
   readonly core: CoreState;
   /** False after the frontend loses a trustworthy backend event stream. */
   eventStreamAvailable: boolean;
+  /**
+   * The operator's last pause or resume command, from its ack, or null while
+   * they have issued neither and the backend status stands unopposed.
+   *
+   * The backend flips its own run status to `paused`, but it never pushes a
+   * status change and the client reads the snapshot only at boot, so the ack is
+   * the only signal available here. Three states rather than a boolean because
+   * `resumed` has to contradict a boot snapshot that already said `paused`,
+   * which "not paused" cannot: a `false` is indistinguishable from having
+   * issued nothing. Still optimistic: it does not survive a reconnect and does
+   * not see a pause this client did not issue. A terminal run status outranks
+   * it either way, in `runStateText`. Authoritative pause state is #515.
+   */
+  pauseOverride: PauseOverride;
   selectedRound: number | null;
   selectedAgentKind: string | null;
   /** Transcript entry the arrow keys are on, so a trace is readable without a mouse. */
@@ -155,6 +176,12 @@ export type ExperimentIndexItem =
 export interface HypothesisScope {
   id: string;
   label: string;
+  /**
+   * The claim on its own, without the `· r1-r2` range `label` carries. The
+   * header shows this: the range duplicates the rounds strip, and spending
+   * header width on it pushed the title itself off the line.
+   */
+  title: string;
   rounds: number[];
   /** A single recorded round not yet associated with a hypothesis. */
   source?: 'hypothesis' | 'round';
@@ -293,6 +320,7 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     experimentLog: {entries: [], selectedId: null, pending: true, error: null},
     hypothesisDetail: null,
     hypothesisScope: null,
+    pauseOverride: null,
     layout: {right: null, focus: 'left', zoomedPane: null},
     // Docked until the renderer measures otherwise, so the landing view carries
     // the chat from the first frame rather than after a resize.
@@ -844,6 +872,7 @@ export function enterExperimentRound(
     hypothesisScope: {
       id: entry.hypothesis_id,
       label: hypothesisLabel(entry),
+      title: hypothesisTitle(entry),
       rounds: scopeRounds(entry),
       source: 'hypothesis',
     },
@@ -876,6 +905,7 @@ export function enterUnownedExperimentRound(
     hypothesisScope: {
       id: `round-${roundNumber}`,
       label: `Round ${roundNumber}`,
+      title: `Round ${roundNumber}`,
       rounds: [roundNumber],
       source: 'round',
     },
@@ -907,12 +937,17 @@ export function hypothesisRoundNumbers(entry: HypothesisEntry): number[] {
   return scopeRounds(entry);
 }
 
+/** The claim itself, falling back to its id when the record carries no title. */
+function hypothesisTitle(entry: HypothesisEntry): string {
+  return entry.title ?? entry.hypothesis_id;
+}
+
 function hypothesisLabel(entry: HypothesisEntry): string {
   const range =
     entry.first_round === entry.last_round
       ? `r${entry.first_round}`
       : `r${entry.first_round}-${entry.last_round}`;
-  return `${entry.title ?? entry.hypothesis_id} · ${range}`;
+  return `${hypothesisTitle(entry)} · ${range}`;
 }
 
 export function selectedExperiment(state: SessionState): HypothesisEntry | null {
@@ -1752,21 +1787,17 @@ export function showDetail(
   return {...state, overlay: {kind, content}};
 }
 
-export function statusText(state: SessionState): string {
-  const base = `${state.core.status} · ${state.core.agentKind ?? 'starting'} · ${state.core.roundLabel ?? 'no round yet'}`;
-  if (state.core.usage === null) return base;
-  const used = formatTokenCount(state.core.usage.inputTokens);
-  const meter =
-    state.core.usage.contextWindow === null
-      ? used
-      : `${used}/${formatTokenCount(state.core.usage.contextWindow)}`;
-  return `${base} · ${meter} tokens`;
-}
-
-function formatTokenCount(count: number): string {
-  if (count < 1_000) return String(count);
-  if (count < 1_000_000) return `${Math.floor(count / 1_000)}k`;
-  return `${(count / 1_000_000).toFixed(1)}M`;
+/**
+ * Records a pause or resume command's ack, so the header can say which of the
+ * two the operator asked for.
+ *
+ * A pause is `pending` until the current agent call returns, and both that and
+ * `consumed` mean the request is in force. A resume does not clear the override
+ * back to null: null means "never asked", and only an explicit `resumed` can
+ * override a backend status that already reads `paused`.
+ */
+export function setPauseOverride(state: SessionState, override: PauseOverride): SessionState {
+  return state.pauseOverride === override ? state : {...state, pauseOverride: override};
 }
 
 export function visibleConversation(state: SessionState): ConversationEntry[] {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -104,7 +104,11 @@ describe('OpenTUI presentation', () => {
     registerCleanup(testRenderer.renderer, app);
 
     const frame = await testRenderer.waitForFrame(value => value.includes('fast_path()'));
-    expect(frame).toContain('running · optimizer · round 2');
+    // The header names the run state and the activity, never the backend's
+    // round label. `round 2` is not a label this loop emits, so the agent kind
+    // supplies the word.
+    expect(frame).toContain('VibeSys · running · optimizer');
+    expect(frame).not.toContain('running · optimizer · round 2');
     // No round is selected, so the agent strip is headed by the run.
     expect(frame).toContain('Run flow');
     expect(frame).toContain('Rounds');
@@ -966,7 +970,7 @@ describe('OpenTUI presentation', () => {
     const testRenderer = await createTestRenderer({width: 130, height: 22});
     const controller = new FakeController({
       ...initialSessionState(),
-      hypothesisScope: {id: 'H-01', label: 'H-01 · r1', rounds: [1]},
+      hypothesisScope: {id: 'H-01', label: 'H-01 · r1', title: 'H-01', rounds: [1]},
       selectedRound: 1,
       core: {
         ...initialSessionState().core,
@@ -2398,7 +2402,10 @@ describe('theming', () => {
     expect(trajectory).toContain('r43');
     expect(trajectory).toContain('regression found');
     expect(trajectory).not.toContain('unrelated round 41');
-    expect(trajectory).toContain('H-08 · r42-43');
+    // The header names the hypothesis; the round range beside it duplicated
+    // the rounds strip directly below, so only the title is up there now.
+    expect(trajectory).toContain('H-08');
+    expect(trajectory).not.toContain('H-08 · r42-43');
     expect(trajectory).toContain('r42');
     expect(trajectory).toContain('r43');
     // The strip covers the whole run, so rounds outside this hypothesis are

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1463,7 +1463,9 @@ describe('OpenTUI presentation', () => {
   });
 
   it('renders a typed command payload with labeled stderr and exit code', async () => {
-    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    // 18 rows, not 16: the header is a three-row pane, so a 16-row terminal
+    // leaves the transcript too short to hold the whole payload card.
+    const testRenderer = await createTestRenderer({width: 80, height: 18});
     const controller = new FakeController({
       ...initialSessionState(),
       core: {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -3906,6 +3906,67 @@ describe('theming', () => {
   });
 });
 
+describe('header hierarchy', () => {
+  const runState = (status: string): SessionState => ({
+    ...initialSessionState(),
+    core: {
+      ...initialSessionState().core,
+      status,
+      agentKind: 'implementer',
+      roundLabel: 'round-1-retry-2-implementer',
+      usage: {inputTokens: 223_000, contextWindow: 400_000, model: 'claude-opus-5'},
+    },
+  });
+
+  it('draws each header role in its own tone rather than all in one accent', async () => {
+    const theme = resolveTheme('dark');
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController(runState('completed'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('223k/400k context'));
+
+    // Four tones on one line, which is the point: before this the renderer
+    // reported one accent-coloured span for the whole header.
+    expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(theme.accent);
+    expect(spanColors(testRenderer, 'completed')?.fg).toBe(theme.success);
+    expect(spanColors(testRenderer, 'implementing')?.fg).toBe(theme.textPrimary);
+    expect(spanColors(testRenderer, '223k/400k context')?.fg).toBe(theme.textMuted);
+  });
+
+  it('recolours the run state when the run ends badly', async () => {
+    const theme = resolveTheme('dark');
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController(runState('running'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('223k/400k context'));
+    expect(spanColors(testRenderer, 'running')?.fg).toBe(theme.textPrimary);
+
+    controller.publish({
+      ...controller.state,
+      core: {...controller.state.core, status: 'failed', terminal: true},
+    });
+    await testRenderer.waitForVisualIdle();
+
+    expect(spanColors(testRenderer, 'failed')?.fg).toBe(theme.error);
+  });
+
+  it('keeps the header whole in a terminal too narrow for all of it', async () => {
+    // One renderable per span means the row can shrink, and a shrinking row
+    // puts an ellipsis through every span at once (`V...ys·r...ng`) instead of
+    // the single cut the width budget decided on.
+    const testRenderer = await createTestRenderer({width: 24, height: 20});
+    const controller = new FakeController(runState('running'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('VibeSys'));
+    expect(frame).toContain('VibeSys · running');
+    expect(frame).not.toContain('V...');
+  });
+});
+
 /**
  * The experiment log settles synchronously, so there is no later frame to wait
  * for. Flush pending work, then read the single settled frame.

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -104,6 +104,11 @@ export function createOpenTuiApp(
     border: true,
     borderStyle: 'rounded',
     borderColor: theme.border,
+    // The same surface every other pane sits on. Without this the frame falls
+    // through to the root's `canvas`, which is a lighter shade, so the header
+    // read as a band laid over the UI rather than a pane within it. That is
+    // the exact quality the housing exists to remove.
+    backgroundColor: theme.elevatedSurface,
   });
   // One renderable per span, because a terminal cell carries one foreground
   // colour and the header's roles do not share one. The row is allocated once
@@ -321,6 +326,7 @@ export function createOpenTuiApp(
     markdownStyle = createMarkdownStyle(theme);
     root.backgroundColor = theme.canvas;
     headerFrame.borderColor = theme.border;
+    headerFrame.backgroundColor = theme.elevatedSurface;
     transcriptFrame.borderColor = theme.border;
     help.fg = theme.textSubtle;
     roundStrip.applyTheme(theme);

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -44,6 +44,12 @@ const LOG_CHAT_KEY_HELP =
   '↑↓: select · Enter/click: hypothesis · Ctrl+W: chat · F4: zoom · /open-round --N';
 const HYPOTHESIS_KEY_HELP =
   '↑↓: select round · Enter/click: trajectory · PgUp/PgDn: scroll · Esc: hypotheses';
+/** Bezel, one content row, bezel. See the header frame below. */
+const HEADER_FRAME_HEIGHT = 3;
+
+/** Two border cells plus a cell of padding on each side. */
+const HEADER_CHROME = 4;
+
 const SPLIT_KEY_HELP =
   'Ctrl+W: switch pane · F4: zoom focused pane · PgUp/PgDn: scroll · Esc: close pane';
 
@@ -73,12 +79,33 @@ export function createOpenTuiApp(
     flexDirection: 'column',
     backgroundColor: theme.canvas,
   });
+  // The header is a pane, not a caption. Every other region on screen sits in
+  // a bordered box, so a bare line above them reads as floating rather than as
+  // part of the same housing. Three rows: bezel, one content row, bezel. The
+  // border rows are the breathing room, so there is no internal padding and no
+  // blank row beneath: the header's bottom bezel meets the next pane's top one,
+  // and two adjacent rules read as a seam between two objects.
+  //
+  // No background fill. A partial-width fill is what reads as a floating band
+  // in a terminal, and a full-width one has nothing to sit against.
+  const headerFrame = new BoxRenderable(renderer, {
+    id: 'header-frame',
+    width: '100%',
+    height: HEADER_FRAME_HEIGHT,
+    flexDirection: 'column',
+    paddingLeft: 1,
+    paddingRight: 1,
+    border: true,
+    borderStyle: 'rounded',
+    borderColor: theme.border,
+  });
   const header = new TextRenderable(renderer, {
     id: 'header',
     height: 1,
     fg: theme.accent,
     content: 'VibeSys · connecting',
   });
+  headerFrame.add(header);
   const focusTranscript = (): void => {
     controller.focusPane('left');
     controller.focusRound('transcript');
@@ -224,7 +251,7 @@ export function createOpenTuiApp(
   commandColumn.add(commandInput.suggestions);
   commandColumn.add(commandInput.box);
   bottom.add(commandColumn);
-  root.add(header);
+  root.add(headerFrame);
   root.add(errorBanner.output);
   root.add(roundStrip.output);
   body.add(chatPane.output);
@@ -246,6 +273,7 @@ export function createOpenTuiApp(
     markdownStyle = createMarkdownStyle(theme);
     root.backgroundColor = theme.canvas;
     header.fg = theme.accent;
+    headerFrame.borderColor = theme.border;
     transcriptFrame.borderColor = theme.border;
     help.fg = theme.textSubtle;
     roundStrip.applyTheme(theme);
@@ -310,7 +338,7 @@ export function createOpenTuiApp(
         : chatPaneWidth(renderer.terminalWidth, rightWidth)
       : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
-    header.content = renderHeader(state, showLog, renderer.terminalWidth);
+    header.content = renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME);
     errorBanner.render(state);
     // The log carries its own key hints in its footer, so when it shares the
     // row with a pane the global line is the place for the pane's keys.
@@ -361,7 +389,7 @@ export function createOpenTuiApp(
     // actually occupy those rows, so a taller todo strip still fits.
     if (showSplit) {
       const errorHeight = state.errorBanner === null ? 0 : errorBanner.output.height;
-      const top = header.height + errorHeight + (showLog ? 0 : roundStrip.output.height);
+      const top = headerFrame.height + errorHeight + (showLog ? 0 : roundStrip.output.height);
       const below = todoStrip.output.height + help.height + commandInput.box.height;
       chat.setPaneBounds({
         left: 1,

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -4,7 +4,6 @@ import {
   experimentLogVisible,
   focusedPane,
   type SessionState,
-  statusText,
   stripRounds,
   visibleRoundNumber,
 } from '../session-model.js';
@@ -18,6 +17,7 @@ import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
 import {ErrorBannerView} from './error-banner.js';
 import {ExperimentLogView} from './experiment-log.js';
+import {renderHeader} from './header.js';
 import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RightPaneView, rightPaneWidth, splitFits} from './right-pane.js';
@@ -310,13 +310,7 @@ export function createOpenTuiApp(
         : chatPaneWidth(renderer.terminalWidth, rightWidth)
       : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
-    const dialogOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
-    const returnHint = dialogOpen ? ' · Esc: close dialog' : '';
-    const selection = state.selectedAgentKind ? ` · selected ${state.selectedAgentKind}` : '';
-    const scope = state.hypothesisScope === null ? '' : ` · ${state.hypothesisScope.label}`;
-    header.content = showLog
-      ? `VibeSys · ${statusText(state)} · experiments`
-      : `VibeSys · ${statusText(state)}${scope}${selection}${returnHint}`;
+    header.content = renderHeader(state, showLog, renderer.terminalWidth);
     errorBanner.render(state);
     // The log carries its own key hints in its footer, so when it shares the
     // row with a pane the global line is the place for the pane's keys.

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -1,4 +1,10 @@
-import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
+import {
+  BoxRenderable,
+  type CliRenderer,
+  ScrollBoxRenderable,
+  TextAttributes,
+  TextRenderable,
+} from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
 import {
   experimentLogVisible,
@@ -17,7 +23,7 @@ import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
 import {ErrorBannerView} from './error-banner.js';
 import {ExperimentLogView} from './experiment-log.js';
-import {renderHeader} from './header.js';
+import {type HeaderSpan, headerSpanStyle, MAX_HEADER_SPANS, renderHeader} from './header.js';
 import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RightPaneView, rightPaneWidth, splitFits} from './right-pane.js';
@@ -99,13 +105,55 @@ export function createOpenTuiApp(
     borderStyle: 'rounded',
     borderColor: theme.border,
   });
-  const header = new TextRenderable(renderer, {
+  // One renderable per span, because a terminal cell carries one foreground
+  // colour and the header's roles do not share one. The row is allocated once
+  // at its maximum and repainted in place: the spans change on every frame, and
+  // rebuilding thirteen renderables that often is churn the header does not
+  // need.
+  //
+  // `flexShrink: 0` because `renderHeader` has already budgeted the line to this
+  // width, so a row that still overruns is a bug rather than something to
+  // absorb. Shrinking spans put an ellipsis through every one of them at once
+  // (`V...ys·r...ng`) instead of leaving the single cut the budget decided on.
+  const headerLine = new BoxRenderable(renderer, {
     id: 'header',
+    width: '100%',
     height: 1,
-    fg: theme.accent,
-    content: 'VibeSys · connecting',
+    flexDirection: 'row',
   });
-  headerFrame.add(header);
+  const headerSpans = Array.from(
+    {length: MAX_HEADER_SPANS},
+    (_unused, index) =>
+      new TextRenderable(renderer, {
+        id: `header-span-${index}`,
+        content: '',
+        fg: theme.textPrimary,
+        wrapMode: 'none',
+        flexShrink: 0,
+      }),
+  );
+  for (const span of headerSpans) headerLine.add(span);
+  headerFrame.add(headerLine);
+  /**
+   * Paints the budgeted spans onto the row. The tones come from the theme in
+   * scope, so a theme change is picked up by the next paint and needs no
+   * separate application.
+   *
+   * A span the current header does not use is hidden rather than emptied: an
+   * empty text renderable still measures one cell, and thirteen of those are
+   * most of a narrow terminal's header.
+   */
+  const paintHeader = (spans: HeaderSpan[]): void => {
+    for (const [index, cell] of headerSpans.entries()) {
+      const span = spans[index];
+      cell.visible = span !== undefined;
+      if (span === undefined) continue;
+      const style = headerSpanStyle(theme, span);
+      cell.content = span.text;
+      cell.fg = style.fg;
+      cell.attributes = style.bold ? TextAttributes.BOLD : TextAttributes.NONE;
+    }
+  };
   const focusTranscript = (): void => {
     controller.focusPane('left');
     controller.focusRound('transcript');
@@ -272,7 +320,6 @@ export function createOpenTuiApp(
     const previousMarkdownStyle = markdownStyle;
     markdownStyle = createMarkdownStyle(theme);
     root.backgroundColor = theme.canvas;
-    header.fg = theme.accent;
     headerFrame.borderColor = theme.border;
     transcriptFrame.borderColor = theme.border;
     help.fg = theme.textSubtle;
@@ -338,7 +385,7 @@ export function createOpenTuiApp(
         : chatPaneWidth(renderer.terminalWidth, rightWidth)
       : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
-    header.content = renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME);
+    paintHeader(renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME));
     errorBanner.render(state);
     // The log carries its own key hints in its footer, so when it shares the
     // row with a pane the global line is the place for the pane's keys.

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -7,13 +7,14 @@ import {
 import type {SessionController} from '../session-controller.js';
 import {
   type ConversationEntry,
-  chatPaneFocused,
   chatThreadHeading,
+  focusedPane,
   type SessionState,
 } from '../session-model.js';
 import {ChatComposerView, type ChatDraft} from './chat-composer.js';
 import {ConversationView} from './conversation.js';
 import {LOG_CLAIM_PANEL_WIDTH, LOG_COMPACT_PANEL_WIDTH} from './experiment-log.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import type {Theme} from './theme.js';
 
 /**
@@ -78,9 +79,13 @@ export class ChatPaneView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
-      borderColor: theme.border,
-      title: ' Experiment chat ',
+      borderStyle: paneBorderStyle(false),
+      borderColor: paneBorderColor(theme, false),
+      // The surface every other pane sits on. Without it this box falls
+      // through to the root's canvas, a lighter shade, so the chat read as a
+      // pale band beside panes that did not match it.
+      backgroundColor: theme.elevatedSurface,
+      title: paneTitle('Experiment chat', false),
       visible: false,
       // Clicking into the chat gives it the keys, the same thing Ctrl+W does.
       // Without this the pane took the click but the focus border stayed on the
@@ -130,6 +135,7 @@ export class ChatPaneView {
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
     this.#theme = theme;
     this.output.borderColor = theme.border;
+    this.output.backgroundColor = theme.elevatedSurface;
     this.#conversation.applyTheme(theme, markdownStyle);
     this.#composer.applyTheme(theme);
     this.#renderedConversation = null;
@@ -162,15 +168,12 @@ export class ChatPaneView {
       return;
     }
     this.output.width = width;
-    const focused = chatPaneFocused(state);
-    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
-    // The column can be as narrow as its minimum, where a spelled-out "focused"
-    // costs the title itself: a box with no title reads as nothing at all. The
-    // marker is the one the table already uses for the row that has the keys.
+    const focused = focusedPane(state) === 'chat';
     // The title names the active thread so switching is visible at a glance,
-    // and its runtime so the operator can tell which agent is answering.
-    const label = chatThreadHeading(state);
-    this.output.title = focused ? ` ▸ ${label} ` : ` ${label} `;
+    // and its runtime so the operator can tell which agent is answering. The
+    // column can be as narrow as its minimum, where a spelled-out "focused"
+    // would cost the title itself.
+    applyPaneFocus(this.output, this.#theme, chatThreadHeading(state), focused);
     this.#composer.activate(Math.max(1, width - 4), focused, state.chatPending);
     this.#composer.renderMenu(state);
     if (state.chatConversation === this.#renderedConversation) return;

--- a/clients/tui/src/ui/header.test.ts
+++ b/clients/tui/src/ui/header.test.ts
@@ -1,10 +1,36 @@
 import {describe, expect, it} from 'bun:test';
 import {initialSessionState, type SessionState} from '../session-model.js';
-import {MIN_WIDTH, renderHeader, runStateText, usageText} from './header.js';
+import {
+  type HeaderSpan,
+  type HeaderSpanRole,
+  headerSpanStyle,
+  MAX_HEADER_SPANS,
+  MIN_WIDTH,
+  renderHeader,
+  runStateText,
+  usageText,
+} from './header.js';
 import {displayWidth} from './text-width.js';
+import {contrastRatio, listThemes, resolveTheme, type Theme} from './theme.js';
 
 const WIDE = 200;
 const NARROW = 100;
+
+/**
+ * The spans read back as the line they draw. `renderHeader` returns spans so
+ * each role can carry a colour of its own; what the operator sees is their
+ * concatenation, and every width and dropping assertion below is about that.
+ */
+function line(state: SessionState, showLog: boolean, width: number): string {
+  return renderHeader(state, showLog, width)
+    .map(span => span.text)
+    .join('');
+}
+
+/** The text drawn for one role, or null when the header dropped it. */
+function spanText(spans: HeaderSpan[], role: HeaderSpanRole): string | null {
+  return spans.find(span => span.role === role)?.text ?? null;
+}
 
 function stateWith(
   overrides: Partial<SessionState> = {},
@@ -50,7 +76,7 @@ function occurrences(text: string, needle: string): number {
 
 describe('header', () => {
   it('replaces the raw label line from the issue', () => {
-    const header = renderHeader(runningImplementer(), false, WIDE);
+    const header = line(runningImplementer(), false, WIDE);
     expect(header).toBe(
       'VibeSys · running · implementing · attempt 2 · Preallocated lock-free SPSC ring · 223k/400k context',
     );
@@ -67,14 +93,14 @@ describe('header', () => {
       'perf_eval iter 4',
     ];
     for (const roundLabel of labels) {
-      const header = renderHeader(stateWith({}, {roundLabel, status: 'running'}), false, WIDE);
+      const header = line(stateWith({}, {roundLabel, status: 'running'}), false, WIDE);
       expect(header).not.toContain(roundLabel);
       expect(header).not.toMatch(/round-\d|gen-\d|cand-\d|retry-\d|att\d/);
     }
   });
 
   it('fits 100 columns whole, where the old header clipped the title', () => {
-    const header = renderHeader(runningImplementer(), false, NARROW);
+    const header = line(runningImplementer(), false, NARROW);
     expect(header.length).toBeLessThanOrEqual(NARROW);
     expect(header).toContain('Preallocated lock-free SPSC ring');
     expect(header).not.toEndWith('…');
@@ -82,7 +108,7 @@ describe('header', () => {
 
   it('gives up the token meter before the hypothesis title', () => {
     // 80 columns cannot hold both; the claim is the one worth keeping.
-    const header = renderHeader(runningImplementer(), false, 80);
+    const header = line(runningImplementer(), false, 80);
     expect(header.length).toBeLessThanOrEqual(80);
     expect(header).toContain('Preallocated lock-free SPSC ring');
     expect(header).not.toContain('context');
@@ -95,8 +121,8 @@ describe('header', () => {
       selectedAgentKind: 'implementer',
       overlay: {kind: 'detail' as const, content: 'x'},
     };
-    expect(renderHeader(state, false, WIDE)).toContain('Esc: close dialog');
-    const squeezed = renderHeader(state, false, NARROW);
+    expect(line(state, false, WIDE)).toContain('Esc: close dialog');
+    const squeezed = line(state, false, NARROW);
     expect(squeezed).not.toContain('Esc: close dialog');
     expect(squeezed).not.toContain('selected implementer');
     expect(squeezed).toContain('Preallocated lock-free SPSC ring');
@@ -108,7 +134,7 @@ describe('header', () => {
     const state = withTitle(
       'Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path',
     );
-    const header = renderHeader(state, false, 60);
+    const header = line(state, false, 60);
     expect(header.length).toBeLessThanOrEqual(60);
     expect(header).not.toContain('context');
     expect(header).toContain('Preallocated');
@@ -120,15 +146,15 @@ describe('header', () => {
       'Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path',
     );
     // 34 columns leaves the title exactly its floor of twelve cells.
-    expect(renderHeader(state, false, 34)).toBe('VibeSys · running · Preallocated…');
+    expect(line(state, false, 34)).toBe('VibeSys · running · Preallocated…');
     // 22 leaves it less than that, so it goes entirely rather than becoming
     // `Prealloc…`, and the run stays legible without it.
-    expect(renderHeader(state, false, 22)).toBe('VibeSys · running');
+    expect(line(state, false, 22)).toBe('VibeSys · running');
   });
 
   it('keeps the brand and the run state whole down to the minimum width', () => {
     for (const width of [200, 100, 60, 34, MIN_WIDTH]) {
-      const header = renderHeader(runningImplementer(), false, width);
+      const header = line(runningImplementer(), false, width);
       expect(header.startsWith('VibeSys · running')).toBe(true);
       expect(displayWidth(header)).toBeLessThanOrEqual(width);
     }
@@ -138,21 +164,21 @@ describe('header', () => {
     // MIN_WIDTH is sized for the widest of these, so none of them is cut.
     const states = ['running', 'paused', 'completed', 'failed', 'connecting'];
     for (const status of states) {
-      const header = renderHeader(stateWith({}, {status}), false, MIN_WIDTH);
+      const header = line(stateWith({}, {status}), false, MIN_WIDTH);
       expect(header).toBe(`VibeSys · ${status}`);
     }
     const dropped = stateWith({eventStreamAvailable: false}, {status: 'running'});
-    expect(renderHeader(dropped, false, MIN_WIDTH)).toBe('VibeSys · disconnected');
+    expect(line(dropped, false, MIN_WIDTH)).toBe('VibeSys · disconnected');
   });
 
   it('cuts the line below the minimum width instead of dropping the state', () => {
     // Narrower than MIN_WIDTH the brand and the state do not fit together, so
     // the guarantee stops there and the line is cut and marked. Dropping the
     // state instead would leave a header that says only `VibeSys`.
-    const header = renderHeader(runningImplementer(), false, MIN_WIDTH - 6);
+    const header = line(runningImplementer(), false, MIN_WIDTH - 6);
     expect(displayWidth(header)).toBeLessThanOrEqual(MIN_WIDTH - 6);
     expect(header).toBe('VibeSys · runni…');
-    expect(renderHeader(runningImplementer(), false, 0)).toBe('');
+    expect(line(runningImplementer(), false, 0)).toBe('');
   });
 });
 
@@ -162,7 +188,7 @@ describe('width in terminal cells', () => {
     // `String.length` the whole title reads as fitting 60 columns with room to
     // spare, and lays out over 80.
     const title = '\u74b0'.repeat(30);
-    const header = renderHeader(withTitle(title), false, 60);
+    const header = line(withTitle(title), false, 60);
     expect(displayWidth(header)).toBeLessThanOrEqual(60);
     expect(header.length).toBeLessThan(60);
     expect(header).toEndWith('\u2026');
@@ -171,7 +197,7 @@ describe('width in terminal cells', () => {
   it('never cuts an emoji in half', () => {
     const state = withTitle(`${'\u{1f680}'.repeat(20)} to orbit`);
     for (const width of [30, 44, 45, 60]) {
-      const header = renderHeader(state, false, width);
+      const header = line(state, false, width);
       expect(displayWidth(header)).toBeLessThanOrEqual(width);
       // With the `u` flag this matches only an unpaired surrogate, which is
       // what a code-unit slice through a rocket leaves behind.
@@ -185,7 +211,7 @@ describe('width in terminal cells', () => {
     const family = '\u{1f468}\u200d\u{1f469}\u200d\u{1f467}';
     const state = withTitle(`${family.repeat(12)} crew`);
     for (const width of [30, 40, 55]) {
-      const header = renderHeader(state, false, width);
+      const header = line(state, false, width);
       expect(displayWidth(header)).toBeLessThanOrEqual(width);
       expect(header).not.toMatch(/[\ud800-\udfff]/u);
       expect(header).not.toContain('\u200d\u2026');
@@ -199,7 +225,7 @@ describe('width in terminal cells', () => {
     // 44 columns leaves the title 23 cells, which is 11 rockets and a half.
     // The half goes, so the line comes out a cell under rather than a cell
     // over.
-    const header = renderHeader(withTitle('\u{1f680}'.repeat(20)), false, 44);
+    const header = line(withTitle('\u{1f680}'.repeat(20)), false, 44);
     expect(displayWidth(header)).toBe(43);
   });
 });
@@ -245,7 +271,7 @@ describe('run state', () => {
   it('shows a pause the operator asked for, over the backend status', () => {
     const paused = stateWith({pauseOverride: 'paused'}, {status: 'running'});
     expect(runStateText(paused)).toBe('paused');
-    expect(renderHeader(paused, false, WIDE)).toContain('paused');
+    expect(line(paused, false, WIDE)).toContain('paused');
   });
 
   it('clears a paused boot snapshot once the operator resumes', () => {
@@ -256,7 +282,7 @@ describe('run state', () => {
     expect(runStateText(booted)).toBe('paused');
     const resumed = stateWith({pauseOverride: 'resumed'}, {status: 'paused'});
     expect(runStateText(resumed)).toBe('running');
-    expect(renderHeader(resumed, false, WIDE)).not.toContain('paused');
+    expect(line(resumed, false, WIDE)).not.toContain('paused');
   });
 
   it('leaves a status that is not paused alone when the operator resumes', () => {
@@ -270,7 +296,7 @@ describe('run state', () => {
     for (const status of ['completed', 'failed', 'interrupted']) {
       const ended = stateWith({pauseOverride: 'paused'}, {status, terminal: true});
       expect(runStateText(ended)).toBe(status);
-      expect(renderHeader(ended, false, WIDE)).not.toContain('paused');
+      expect(line(ended, false, WIDE)).not.toContain('paused');
     }
   });
 
@@ -283,5 +309,198 @@ describe('run state', () => {
       {status: 'completed', terminal: true},
     );
     expect(runStateText(finished)).toBe('completed');
+  });
+});
+
+/**
+ * The floor `theme.ts` holds every token but `textSubtle` to against the
+ * canvas, restated here so this is an independent check rather than a
+ * restatement of the same expression. The header pane draws no fill, so the
+ * canvas is what its text sits on.
+ */
+function minContrast(theme: Theme): number {
+  return theme.name.startsWith('high-contrast') ? 7 : 4.5;
+}
+
+/** The lower floor `theme.ts` holds `textSubtle` to. Only separators use it. */
+const SUBTLE_FLOOR = 3;
+
+/** Every role a span can carry, which is every role that needs a tone. */
+const SPAN_ROLES: readonly HeaderSpanRole[] = [
+  'brand',
+  'state',
+  'phase',
+  'title',
+  'usage',
+  'selection',
+  'hint',
+  'separator',
+];
+
+/** Every run state `runStateText` can produce, plus one it cannot. */
+const RUN_STATES = [
+  'running',
+  'connecting',
+  'completed',
+  'failed',
+  'interrupted',
+  'paused',
+  'disconnected',
+  'reticulating',
+];
+
+describe('header hierarchy', () => {
+  it('draws every segment and separator as a span of its own', () => {
+    const spans = renderHeader(runningImplementer(), false, WIDE);
+    expect(spans.map(span => span.role)).toEqual([
+      'brand',
+      'separator',
+      'state',
+      'separator',
+      'phase',
+      'separator',
+      'title',
+      'separator',
+      'usage',
+    ]);
+    expect(spanText(spans, 'title')).toBe('Preallocated lock-free SPSC ring');
+    expect(spanText(spans, 'usage')).toBe('223k/400k context');
+    expect(spanText(spans, 'hint')).toBeNull();
+  });
+
+  it('never returns more spans than a caller sized its row for', () => {
+    // Every role at once: phase, title, token meter, selected agent and hint.
+    const state = {
+      ...runningImplementer(),
+      selectedAgentKind: 'implementer',
+      overlay: {kind: 'detail' as const, content: 'x'},
+    };
+    const spans = renderHeader(state, false, WIDE);
+    // Tight, not just an upper bound: a row allocated at this size is fully
+    // used by the widest header, so the constant is neither short nor padding.
+    expect(spans).toHaveLength(MAX_HEADER_SPANS);
+    for (const width of [WIDE, NARROW, 80, 60, 34, MIN_WIDTH, 16, 1, 0]) {
+      expect(renderHeader(state, false, width).length).toBeLessThanOrEqual(MAX_HEADER_SPANS);
+    }
+  });
+
+  it('gives the brand the accent, the content body text, and metadata a grey', () => {
+    const theme = resolveTheme('dark');
+    const tone = (role: HeaderSpanRole): {fg: string; bold: boolean} =>
+      headerSpanStyle(theme, {text: 'x', role});
+    expect(tone('brand')).toEqual({fg: theme.accent, bold: true});
+    expect(tone('phase')).toEqual({fg: theme.textPrimary, bold: false});
+    expect(tone('title')).toEqual({fg: theme.textPrimary, bold: false});
+    expect(tone('usage')).toEqual({fg: theme.textMuted, bold: false});
+    expect(tone('selection')).toEqual({fg: theme.textMuted, bold: false});
+    expect(tone('hint')).toEqual({fg: theme.textMuted, bold: false});
+    expect(tone('separator')).toEqual({fg: theme.textSubtle, bold: false});
+  });
+
+  it('bolds only the two segments no width can drop', () => {
+    const theme = resolveTheme('dark');
+    const bold = SPAN_ROLES.filter(role => headerSpanStyle(theme, {text: 'x', role}).bold);
+    expect(bold).toEqual(['brand', 'state']);
+  });
+
+  it('colours the run state by the verdict the word carries', () => {
+    const theme = resolveTheme('dark');
+    const tone = (text: string): string => headerSpanStyle(theme, {text, role: 'state'}).fg;
+    expect(tone('completed')).toBe(theme.success);
+    expect(tone('failed')).toBe(theme.error);
+    expect(tone('interrupted')).toBe(theme.error);
+    expect(tone('paused')).toBe(theme.warning);
+    expect(tone('disconnected')).toBe(theme.warning);
+    // Not verdicts. Bold is what sets these apart, and the word is spelled out.
+    expect(tone('running')).toBe(theme.textPrimary);
+    expect(tone('connecting')).toBe(theme.textPrimary);
+    // A status the backend adds later reads as body text rather than as a
+    // verdict this file guessed at.
+    expect(tone('reticulating')).toBe(theme.textPrimary);
+  });
+
+  it('tracks the state the header actually rendered, not the backend status', () => {
+    const theme = resolveTheme('dark');
+    const stateTone = (state: SessionState): string => {
+      const spans = renderHeader(state, false, WIDE);
+      const span = spans.find(candidate => candidate.role === 'state');
+      if (span === undefined) throw new Error('the run state is never dropped');
+      return headerSpanStyle(theme, span).fg;
+    };
+    // The operator's own pause, which the backend never reports as a status.
+    expect(stateTone(stateWith({pauseOverride: 'paused'}, {status: 'running'}))).toBe(
+      theme.warning,
+    );
+    // A lost stream, over a status that still says the run is going.
+    expect(stateTone(stateWith({eventStreamAvailable: false}, {status: 'running'}))).toBe(
+      theme.warning,
+    );
+    // A terminal status outranks a pause that was never resumed.
+    expect(
+      stateTone(stateWith({pauseOverride: 'paused'}, {status: 'failed', terminal: true})),
+    ).toBe(theme.error);
+    expect(
+      stateTone(stateWith({pauseOverride: 'paused'}, {status: 'completed', terminal: true})),
+    ).toBe(theme.success);
+  });
+
+  it('keeps each role on its own span through a shortened title and a cut', () => {
+    const state = withTitle(
+      'Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path',
+    );
+    // The title shortens rather than losing its role to the ellipsis.
+    const shortened = renderHeader(state, false, 60);
+    expect(spanText(shortened, 'title')).toEndWith('…');
+    // Below MIN_WIDTH the line is cut, and the cut span keeps its role, so the
+    // half-drawn run state is still coloured as the run state.
+    const cut = renderHeader(runningImplementer(), false, MIN_WIDTH - 6);
+    expect(cut).toEqual([
+      {text: 'VibeSys', role: 'brand'},
+      {text: ' · ', role: 'separator'},
+      {text: 'runni…', role: 'state'},
+    ]);
+    // One cell holds nothing but the mark that the rest was cut.
+    expect(renderHeader(runningImplementer(), false, 1)).toEqual([{text: '…', role: 'brand'}]);
+    expect(renderHeader(runningImplementer(), false, 0)).toEqual([]);
+  });
+});
+
+describe('header contrast', () => {
+  it('clears the floor of every theme for every role, in all eight', () => {
+    const themes = listThemes();
+    expect(themes).toHaveLength(8);
+    for (const theme of themes) {
+      for (const role of SPAN_ROLES) {
+        // Only the state's tone depends on its text; the rest ignore it.
+        const texts = role === 'state' ? RUN_STATES : ['x'];
+        for (const text of texts) {
+          const {fg} = headerSpanStyle(theme, {text, role});
+          const floor = role === 'separator' ? SUBTLE_FLOOR : minContrast(theme);
+          expect({
+            theme: theme.name,
+            role,
+            text,
+            ratio: contrastRatio(fg, theme.canvas) >= floor,
+          }).toEqual({theme: theme.name, role, text, ratio: true});
+        }
+      }
+    }
+  });
+
+  it('draws metadata below content and separators below both, in every theme', () => {
+    // What "greyed out" has to mean to hold in eight palettes: an ordering
+    // against the canvas, not a particular grey.
+    for (const theme of listThemes()) {
+      const against = (role: HeaderSpanRole): number =>
+        contrastRatio(headerSpanStyle(theme, {text: 'x', role}).fg, theme.canvas);
+      expect({theme: theme.name, dimmer: against('usage') < against('title')}).toEqual({
+        theme: theme.name,
+        dimmer: true,
+      });
+      expect({theme: theme.name, dimmer: against('separator') < against('usage')}).toEqual({
+        theme: theme.name,
+        dimmer: true,
+      });
+    }
   });
 });

--- a/clients/tui/src/ui/header.test.ts
+++ b/clients/tui/src/ui/header.test.ts
@@ -1,0 +1,287 @@
+import {describe, expect, it} from 'bun:test';
+import {initialSessionState, type SessionState} from '../session-model.js';
+import {MIN_WIDTH, renderHeader, runStateText, usageText} from './header.js';
+import {displayWidth} from './text-width.js';
+
+const WIDE = 200;
+const NARROW = 100;
+
+function stateWith(
+  overrides: Partial<SessionState> = {},
+  core: Partial<SessionState['core']> = {},
+) {
+  const base = initialSessionState();
+  return {...base, ...overrides, core: {...base.core, ...core}};
+}
+
+/** The live example from #517, as the backend actually reports it. */
+function runningImplementer(): SessionState {
+  return stateWith(
+    {
+      hypothesisScope: {
+        id: 'H-01',
+        label: 'Preallocated lock-free SPSC ring · r1',
+        title: 'Preallocated lock-free SPSC ring',
+        rounds: [1],
+      },
+    },
+    {
+      status: 'running',
+      agentKind: 'implementer',
+      roundLabel: 'round-1-retry-2-implementer',
+      usage: {inputTokens: 223_000, contextWindow: 400_000, model: 'claude-opus-5'},
+    },
+  );
+}
+
+/** The same run, with a claim of a chosen length. */
+function withTitle(title: string): SessionState {
+  const base = runningImplementer();
+  return {
+    ...base,
+    hypothesisScope: {id: 'H-01', label: `${title} · r1`, title, rounds: [1]},
+  };
+}
+
+/** How many times `needle` appears in `text`, for grapheme-integrity checks. */
+function occurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1;
+}
+
+describe('header', () => {
+  it('replaces the raw label line from the issue', () => {
+    const header = renderHeader(runningImplementer(), false, WIDE);
+    expect(header).toBe(
+      'VibeSys · running · implementing · attempt 2 · Preallocated lock-free SPSC ring · 223k/400k context',
+    );
+  });
+
+  it('never renders a backend round label, in any loop mode', () => {
+    const labels = [
+      'round-1-plan',
+      'round-1-pre',
+      'round-1-retry-1-implementer',
+      'round-2-retry-3-judge',
+      'gen-2-cand-1-mutator',
+      'impl issue #7 att2',
+      'perf_eval iter 4',
+    ];
+    for (const roundLabel of labels) {
+      const header = renderHeader(stateWith({}, {roundLabel, status: 'running'}), false, WIDE);
+      expect(header).not.toContain(roundLabel);
+      expect(header).not.toMatch(/round-\d|gen-\d|cand-\d|retry-\d|att\d/);
+    }
+  });
+
+  it('fits 100 columns whole, where the old header clipped the title', () => {
+    const header = renderHeader(runningImplementer(), false, NARROW);
+    expect(header.length).toBeLessThanOrEqual(NARROW);
+    expect(header).toContain('Preallocated lock-free SPSC ring');
+    expect(header).not.toEndWith('…');
+  });
+
+  it('gives up the token meter before the hypothesis title', () => {
+    // 80 columns cannot hold both; the claim is the one worth keeping.
+    const header = renderHeader(runningImplementer(), false, 80);
+    expect(header.length).toBeLessThanOrEqual(80);
+    expect(header).toContain('Preallocated lock-free SPSC ring');
+    expect(header).not.toContain('context');
+    expect(header).not.toEndWith('…');
+  });
+
+  it('drops the dialog hint before the selected agent, and both before the title', () => {
+    const state = {
+      ...runningImplementer(),
+      selectedAgentKind: 'implementer',
+      overlay: {kind: 'detail' as const, content: 'x'},
+    };
+    expect(renderHeader(state, false, WIDE)).toContain('Esc: close dialog');
+    const squeezed = renderHeader(state, false, NARROW);
+    expect(squeezed).not.toContain('Esc: close dialog');
+    expect(squeezed).not.toContain('selected implementer');
+    expect(squeezed).toContain('Preallocated lock-free SPSC ring');
+  });
+
+  it('shortens a long title only once nothing cheaper is left to drop', () => {
+    // The real title from the recorded run: too long for 60 columns even with
+    // every weaker segment already gone, so it shortens rather than vanishing.
+    const state = withTitle(
+      'Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path',
+    );
+    const header = renderHeader(state, false, 60);
+    expect(header.length).toBeLessThanOrEqual(60);
+    expect(header).not.toContain('context');
+    expect(header).toContain('Preallocated');
+    expect(header).toEndWith('…');
+  });
+
+  it('stops shortening the title at the point it stops identifying anything', () => {
+    const state = withTitle(
+      'Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path',
+    );
+    // 34 columns leaves the title exactly its floor of twelve cells.
+    expect(renderHeader(state, false, 34)).toBe('VibeSys · running · Preallocated…');
+    // 22 leaves it less than that, so it goes entirely rather than becoming
+    // `Prealloc…`, and the run stays legible without it.
+    expect(renderHeader(state, false, 22)).toBe('VibeSys · running');
+  });
+
+  it('keeps the brand and the run state whole down to the minimum width', () => {
+    for (const width of [200, 100, 60, 34, MIN_WIDTH]) {
+      const header = renderHeader(runningImplementer(), false, width);
+      expect(header.startsWith('VibeSys · running')).toBe(true);
+      expect(displayWidth(header)).toBeLessThanOrEqual(width);
+    }
+  });
+
+  it('holds the minimum width for every run state it can name', () => {
+    // MIN_WIDTH is sized for the widest of these, so none of them is cut.
+    const states = ['running', 'paused', 'completed', 'failed', 'connecting'];
+    for (const status of states) {
+      const header = renderHeader(stateWith({}, {status}), false, MIN_WIDTH);
+      expect(header).toBe(`VibeSys · ${status}`);
+    }
+    const dropped = stateWith({eventStreamAvailable: false}, {status: 'running'});
+    expect(renderHeader(dropped, false, MIN_WIDTH)).toBe('VibeSys · disconnected');
+  });
+
+  it('cuts the line below the minimum width instead of dropping the state', () => {
+    // Narrower than MIN_WIDTH the brand and the state do not fit together, so
+    // the guarantee stops there and the line is cut and marked. Dropping the
+    // state instead would leave a header that says only `VibeSys`.
+    const header = renderHeader(runningImplementer(), false, MIN_WIDTH - 6);
+    expect(displayWidth(header)).toBeLessThanOrEqual(MIN_WIDTH - 6);
+    expect(header).toBe('VibeSys · runni…');
+    expect(renderHeader(runningImplementer(), false, 0)).toBe('');
+  });
+});
+
+describe('width in terminal cells', () => {
+  it('budgets a CJK title in cells rather than code units', () => {
+    // 30 ideographs are 30 code units and 60 terminal cells. Budgeted by
+    // `String.length` the whole title reads as fitting 60 columns with room to
+    // spare, and lays out over 80.
+    const title = '\u74b0'.repeat(30);
+    const header = renderHeader(withTitle(title), false, 60);
+    expect(displayWidth(header)).toBeLessThanOrEqual(60);
+    expect(header.length).toBeLessThan(60);
+    expect(header).toEndWith('\u2026');
+  });
+
+  it('never cuts an emoji in half', () => {
+    const state = withTitle(`${'\u{1f680}'.repeat(20)} to orbit`);
+    for (const width of [30, 44, 45, 60]) {
+      const header = renderHeader(state, false, width);
+      expect(displayWidth(header)).toBeLessThanOrEqual(width);
+      // With the `u` flag this matches only an unpaired surrogate, which is
+      // what a code-unit slice through a rocket leaves behind.
+      expect(header).not.toMatch(/[\ud800-\udfff]/u);
+    }
+  });
+
+  it('keeps a joined emoji sequence whole', () => {
+    // One grapheme, eight code units. A cut inside it leaves separate people
+    // or a dangling joiner.
+    const family = '\u{1f468}\u200d\u{1f469}\u200d\u{1f467}';
+    const state = withTitle(`${family.repeat(12)} crew`);
+    for (const width of [30, 40, 55]) {
+      const header = renderHeader(state, false, width);
+      expect(displayWidth(header)).toBeLessThanOrEqual(width);
+      expect(header).not.toMatch(/[\ud800-\udfff]/u);
+      expect(header).not.toContain('\u200d\u2026');
+      // Every family carries one of each figure, so unequal counts mean a cut
+      // landed inside a cluster.
+      expect(occurrences(header, '\u{1f468}')).toBe(occurrences(header, '\u{1f467}'));
+    }
+  });
+
+  it('drops a wide grapheme that would straddle the budget', () => {
+    // 44 columns leaves the title 23 cells, which is 11 rockets and a half.
+    // The half goes, so the line comes out a cell under rather than a cell
+    // over.
+    const header = renderHeader(withTitle('\u{1f680}'.repeat(20)), false, 44);
+    expect(displayWidth(header)).toBe(43);
+  });
+});
+
+describe('token meter', () => {
+  it('shows a ratio only when the count is inside the window', () => {
+    const state = stateWith(
+      {},
+      {usage: {inputTokens: 118_000, contextWindow: 400_000, model: null}},
+    );
+    expect(usageText(state)).toBe('118k/400k context');
+  });
+
+  it('drops the denominator rather than reporting over 100 percent', () => {
+    // The issue's observation: 472k/400k rendered as 118 percent and read as
+    // an overflow error.
+    const state = stateWith(
+      {},
+      {usage: {inputTokens: 472_000, contextWindow: 400_000, model: null}},
+    );
+    expect(usageText(state)).toBe('472k tokens');
+    expect(usageText(state)).not.toContain('/');
+  });
+
+  it('shows a bare count when no window is known', () => {
+    const state = stateWith({}, {usage: {inputTokens: 5_400, contextWindow: null, model: null}});
+    expect(usageText(state)).toBe('5k tokens');
+  });
+
+  it('says nothing before any usage is reported', () => {
+    expect(usageText(initialSessionState())).toBeNull();
+    const zero = stateWith({}, {usage: {inputTokens: 0, contextWindow: 400_000, model: null}});
+    expect(usageText(zero)).toBeNull();
+  });
+});
+
+describe('run state', () => {
+  it('reports the backend status by default', () => {
+    expect(runStateText(stateWith({}, {status: 'running'}))).toBe('running');
+    expect(runStateText(stateWith({}, {status: 'completed'}))).toBe('completed');
+  });
+
+  it('shows a pause the operator asked for, over the backend status', () => {
+    const paused = stateWith({pauseOverride: 'paused'}, {status: 'running'});
+    expect(runStateText(paused)).toBe('paused');
+    expect(renderHeader(paused, false, WIDE)).toContain('paused');
+  });
+
+  it('clears a paused boot snapshot once the operator resumes', () => {
+    // The snapshot is read once at boot and the backend never pushes a status
+    // change, so `core.status` stays `paused` for the rest of the session. A
+    // boolean override cannot say "resumed" here: false is what it starts as.
+    const booted = stateWith({}, {status: 'paused'});
+    expect(runStateText(booted)).toBe('paused');
+    const resumed = stateWith({pauseOverride: 'resumed'}, {status: 'paused'});
+    expect(runStateText(resumed)).toBe('running');
+    expect(renderHeader(resumed, false, WIDE)).not.toContain('paused');
+  });
+
+  it('leaves a status that is not paused alone when the operator resumes', () => {
+    const resumed = stateWith({pauseOverride: 'resumed'}, {status: 'running'});
+    expect(runStateText(resumed)).toBe('running');
+  });
+
+  it('lets a terminal status outrank a pause that was never resumed', () => {
+    // `run_finished`, `run_failed` and `run_interrupted` all set `terminal`.
+    // The run is over, so the operator's standing pause is no longer true.
+    for (const status of ['completed', 'failed', 'interrupted']) {
+      const ended = stateWith({pauseOverride: 'paused'}, {status, terminal: true});
+      expect(runStateText(ended)).toBe(status);
+      expect(renderHeader(ended, false, WIDE)).not.toContain('paused');
+    }
+  });
+
+  it('shows a lost event stream while the run is still going', () => {
+    const dropped = stateWith({eventStreamAvailable: false}, {status: 'running'});
+    expect(runStateText(dropped)).toBe('disconnected');
+    // A finished run whose socket closed is not a disconnected run.
+    const finished = stateWith(
+      {eventStreamAvailable: false},
+      {status: 'completed', terminal: true},
+    );
+    expect(runStateText(finished)).toBe('completed');
+  });
+});

--- a/clients/tui/src/ui/header.ts
+++ b/clients/tui/src/ui/header.ts
@@ -16,10 +16,16 @@
  *   clipped while `round-1-retry-1-implementer` survived. `renderHeader` drops
  *   whole segments in a defined order instead, and budgets in terminal cells
  *   rather than UTF-16 code units, which are not the same count.
+ * - Every segment was drawn in one colour, so a line that already knew which
+ *   part mattered read as an undifferentiated string. `renderHeader` returns
+ *   the budgeted segments rather than a joined line, and `headerSpanStyle`
+ *   gives each role a tone: the run state carries a verdict, the phase and the
+ *   title are content, the metadata recedes.
  */
 import type {SessionState} from '../session-model.js';
 import {describePhase, phaseText} from './phase-label.js';
 import {displayWidth, truncateToWidth} from './text-width.js';
+import type {Theme} from './theme.js';
 
 /** Separator between header segments, matching the rest of the interface. */
 const SEPARATOR = ' · ';
@@ -36,6 +42,8 @@ const BRAND = 'VibeSys';
  */
 interface Segment {
   text: string;
+  /** What the segment is, which is what decides its tone. */
+  role: HeaderRole;
   priority: number;
   /**
    * Never dropped. The brand and the run state are the header's floor, which
@@ -65,6 +73,38 @@ const PRIORITY = {
   selection: 30,
   hint: 10,
 } as const;
+
+/** What a segment is. `headerSegments` emits at most one segment per role. */
+export type HeaderRole = keyof typeof PRIORITY;
+
+/** A drawn run of the header: one segment, or one separator between two. */
+export type HeaderSpanRole = HeaderRole | 'separator';
+
+/**
+ * One run of the header line, in the order it is drawn.
+ *
+ * A terminal cell carries one foreground colour, so a header with internal
+ * hierarchy is several renderables laid out in a row rather than one string.
+ * The separators are spans of their own so the dots can recede behind the words
+ * they divide.
+ */
+export interface HeaderSpan {
+  text: string;
+  role: HeaderSpanRole;
+}
+
+/** How one span is drawn. */
+export interface HeaderSpanStyle {
+  fg: string;
+  bold: boolean;
+}
+
+/**
+ * The most spans `renderHeader` can return: every role at once, with a
+ * separator between each pair. A caller that keeps one renderable per span can
+ * size its row from this rather than rebuilding the row on every frame.
+ */
+export const MAX_HEADER_SPANS = Object.keys(PRIORITY).length * 2 - 1;
 
 /** Cells below which a shortened title is noise rather than an identifier. */
 const MIN_TITLE = 12;
@@ -139,18 +179,19 @@ function formatTokenCount(count: number): string {
 /** Segments for the current state, before any width budgeting. */
 export function headerSegments(state: SessionState, showLog: boolean): Segment[] {
   const segments: Segment[] = [
-    {text: BRAND, priority: PRIORITY.brand, required: true},
-    {text: runStateText(state), priority: PRIORITY.state, required: true},
+    {text: BRAND, role: 'brand', priority: PRIORITY.brand, required: true},
+    {text: runStateText(state), role: 'state', priority: PRIORITY.state, required: true},
   ];
 
   if (showLog) {
-    segments.push({text: 'experiments', priority: PRIORITY.phase});
+    segments.push({text: 'experiments', role: 'phase', priority: PRIORITY.phase});
   } else {
     const phase = phaseText(describePhase(state.core.roundLabel, state.core.agentKind));
-    if (phase !== null) segments.push({text: phase, priority: PRIORITY.phase});
+    if (phase !== null) segments.push({text: phase, role: 'phase', priority: PRIORITY.phase});
     if (state.hypothesisScope !== null) {
       segments.push({
         text: state.hypothesisScope.title,
+        role: 'title',
         priority: PRIORITY.title,
         truncatable: true,
       });
@@ -158,14 +199,20 @@ export function headerSegments(state: SessionState, showLog: boolean): Segment[]
   }
 
   const usage = usageText(state);
-  if (usage !== null) segments.push({text: usage, priority: PRIORITY.usage});
+  if (usage !== null) segments.push({text: usage, role: 'usage', priority: PRIORITY.usage});
 
   if (!showLog && state.selectedAgentKind !== null) {
-    segments.push({text: `selected ${state.selectedAgentKind}`, priority: PRIORITY.selection});
+    segments.push({
+      text: `selected ${state.selectedAgentKind}`,
+      role: 'selection',
+      priority: PRIORITY.selection,
+    });
   }
 
   const dialogOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
-  if (dialogOpen) segments.push({text: 'Esc: close dialog', priority: PRIORITY.hint});
+  if (dialogOpen) {
+    segments.push({text: 'Esc: close dialog', role: 'hint', priority: PRIORITY.hint});
+  }
 
   return segments;
 }
@@ -185,8 +232,12 @@ export function headerSegments(state: SessionState, showLog: boolean): Segment[]
  *
  * At `MIN_WIDTH` and wider the brand and the run state both survive whole.
  * Narrower than that they do not fit together, and the line is cut and marked.
+ *
+ * The result is the budgeted spans in draw order, not a joined line, because a
+ * terminal cell carries one foreground colour and the roles do not share one.
+ * Concatenating the span texts reproduces the line exactly.
  */
-export function renderHeader(state: SessionState, showLog: boolean, width: number): string {
+export function renderHeader(state: SessionState, showLog: boolean, width: number): HeaderSpan[] {
   const kept = headerSegments(state, showLog);
   while (displayWidth(joined(kept)) > width) {
     const weakest = weakestIndex(kept);
@@ -199,11 +250,102 @@ export function renderHeader(state: SessionState, showLog: boolean, width: numbe
     if (kept[weakest]?.truncatable === true && shrinkTitle(kept, width)) break;
     kept.splice(weakest, 1);
   }
-  const line = joined(kept);
-  if (displayWidth(line) <= width) return line;
-  if (width <= 0) return '';
+  const spans = toSpans(kept);
+  if (displayWidth(joined(kept)) <= width) return spans;
+  if (width <= 0) return [];
+  return cutSpans(spans, width);
+}
+
+/**
+ * Colour and weight for one span, against `theme.canvas`, which is what the
+ * header pane sits on: it draws no fill of its own.
+ *
+ * Four levels. The run state is the one fact the header exists to report, so it
+ * is bold and carries a verdict colour. The brand is a masthead in the accent:
+ * fixed text that anchors the left edge and never reports anything. The phase
+ * and the title are what the run is doing and trying, so they stay in body
+ * text. The token meter, the selected-agent note and the dialog hint are
+ * metadata and recede to muted. The separators recede further still: dots
+ * divide the words without competing with them.
+ *
+ * Every colour here comes from the theme, which has already held each of these
+ * tokens to its own contrast floor against the canvas, so no theme can be given
+ * an unreadable header by this function. `textSubtle` is the exception the
+ * theme itself makes, at a floor of 3 rather than 4.5 or 7, which is why only
+ * the punctuation is drawn in it and every word clears the full floor.
+ */
+export function headerSpanStyle(theme: Theme, span: HeaderSpan): HeaderSpanStyle {
+  switch (span.role) {
+    case 'brand':
+      return {fg: theme.accent, bold: true};
+    case 'state':
+      return {fg: stateColor(theme, span.text), bold: true};
+    case 'phase':
+    case 'title':
+      return {fg: theme.textPrimary, bold: false};
+    case 'usage':
+    case 'selection':
+    case 'hint':
+      return {fg: theme.textMuted, bold: false};
+    case 'separator':
+      return {fg: theme.textSubtle, bold: false};
+  }
+}
+
+/**
+ * The verdict the run state carries.
+ *
+ * `running` and `connecting` are not verdicts, and neither is a status the
+ * backend added after this was written, so they stay in body text rather than
+ * being forced into one. What sets the state apart in those cases is the bold
+ * `headerSpanStyle` gives it, which is the reason the state is bold at all:
+ * colour alone would say nothing on the statuses that have no colour, and
+ * nothing at all on a terminal that drops it. The word is always spelled out.
+ */
+function stateColor(theme: Theme, state: string): string {
+  if (state === 'completed') return theme.success;
+  if (state === 'failed' || state === 'interrupted') return theme.error;
+  if (state === 'paused' || state === 'disconnected') return theme.warning;
+  return theme.textPrimary;
+}
+
+/** Segments in draw order with the separators between them made explicit. */
+function toSpans(segments: Segment[]): HeaderSpan[] {
+  const spans: HeaderSpan[] = [];
+  for (const segment of segments) {
+    if (spans.length > 0) spans.push({text: SEPARATOR, role: 'separator'});
+    spans.push({text: segment.text, role: segment.role});
+  }
+  return spans;
+}
+
+/**
+ * Cuts the spans to `width` and marks the cut, for the widths below `MIN_WIDTH`
+ * where not even the brand and the run state fit together. Equivalent to
+ * cutting the joined line, but it keeps the surviving text in its own spans so
+ * the tones hold to the last cell.
+ */
+function cutSpans(spans: HeaderSpan[], width: number): HeaderSpan[] {
   // One cell for the ellipsis that says the rest was cut.
-  return `${truncateToWidth(line, width - 1)}…`;
+  const budget = width - 1;
+  const cut: HeaderSpan[] = [];
+  let used = 0;
+  for (const span of spans) {
+    if (used >= budget) break;
+    const text = truncateToWidth(span.text, budget - used);
+    const fitted = displayWidth(text);
+    if (fitted > 0) {
+      cut.push({...span, text});
+      used += fitted;
+    }
+    // A span that did not survive whole ends the line, whether it was cut mid
+    // text or dropped entirely by a wide grapheme straddling the budget.
+    if (fitted < displayWidth(span.text)) break;
+  }
+  const last = cut.at(-1);
+  if (last === undefined) return [{text: '…', role: spans[0]?.role ?? 'brand'}];
+  cut[cut.length - 1] = {...last, text: `${last.text}…`};
+  return cut;
 }
 
 /** The segment given up first, or null once only required ones are left. */

--- a/clients/tui/src/ui/header.ts
+++ b/clients/tui/src/ui/header.ts
@@ -1,0 +1,245 @@
+/**
+ * The header line: what the run is doing, in operator terms.
+ *
+ * It replaces a line that interpolated backend identifiers verbatim
+ * (`VibeSys · running · implementer · round-1-retry-1-implementer · 118k/400k
+ * tokens · Preallocated lock-free SPSC ring · r1`). Three things were wrong
+ * with that and are fixed here:
+ *
+ * - Raw `round_label` strings meant nothing to an operator and duplicated the
+ *   rounds strip and Agents pane. `describePhase` turns them into words.
+ * - The token meter divided one number by another that does not bound it, so
+ *   it could read 118 percent and look like an overflow error. `usageText`
+ *   only prints a denominator when the numerator is actually inside it.
+ * - Everything was concatenated with no width budget, so at 100 columns the
+ *   hypothesis title, the one segment carrying what the run is trying, was
+ *   clipped while `round-1-retry-1-implementer` survived. `renderHeader` drops
+ *   whole segments in a defined order instead, and budgets in terminal cells
+ *   rather than UTF-16 code units, which are not the same count.
+ */
+import type {SessionState} from '../session-model.js';
+import {describePhase, phaseText} from './phase-label.js';
+import {displayWidth, truncateToWidth} from './text-width.js';
+
+/** Separator between header segments, matching the rest of the interface. */
+const SEPARATOR = ' · ';
+
+const BRAND = 'VibeSys';
+
+/**
+ * One header segment and how readily it is given up when the line does not
+ * fit. Lower priority goes first.
+ *
+ * The order encodes the judgement in #517: the hypothesis title outranks the
+ * token meter, the selected-agent note, and the dialog hint, because it is the
+ * only segment that says what the run is trying to achieve.
+ */
+interface Segment {
+  text: string;
+  priority: number;
+  /**
+   * Never dropped. The brand and the run state are the header's floor, which
+   * is what `MIN_WIDTH` is the width of.
+   */
+  required?: boolean;
+  /**
+   * Shortened to fit rather than dropped. Only the hypothesis title is: half a
+   * claim still says which claim, where a dropped one says nothing. Every other
+   * segment is a fixed phrase that means nothing in part.
+   */
+  truncatable?: boolean;
+}
+
+/**
+ * The title outranks the phase deliberately. The phase is also on the Agents
+ * pane and implied by the transcript; the title is the only place the run says
+ * what it is trying, and #517 requires it to survive a narrow terminal ahead of
+ * less useful segments.
+ */
+const PRIORITY = {
+  brand: 100,
+  state: 90,
+  title: 70,
+  phase: 60,
+  usage: 40,
+  selection: 30,
+  hint: 10,
+} as const;
+
+/** Cells below which a shortened title is noise rather than an identifier. */
+const MIN_TITLE = 12;
+
+/** The widest word `runStateText` produces; every backend status is shorter. */
+const WIDEST_STATE = 'disconnected';
+
+/**
+ * The narrowest terminal this header supports, in cells.
+ *
+ * At this width or wider the brand and the run state both render whole: they
+ * are the two segments `renderHeader` will not drop, and no run state is wider
+ * than `WIDEST_STATE`. Below it neither is guaranteed, because there is no
+ * room for both: the line is cut and marked with an ellipsis, which is what a
+ * terminal that narrow can be told. That bound is the property the header
+ * holds; "the brand and the run state always survive" is not true at every
+ * width and was never true of the dropping loop.
+ */
+export const MIN_WIDTH = displayWidth(`${BRAND}${SEPARATOR}${WIDEST_STATE}`);
+
+/**
+ * Run state in words, strongest claim first.
+ *
+ * 1. A terminal status. The run is over, so no client-local override can still
+ *    be true: a pause that was never resumed still ends `completed` or
+ *    `failed`, and `core.terminal` is set by every path that ends a run
+ *    (`run_finished`, `run_failed`, `run_interrupted`, `configuration_failed`,
+ *    and a boot snapshot taken after any of them).
+ * 2. The operator's own `/pause`, which the backend acks but never reports as
+ *    a status change.
+ * 3. A lost event stream, which makes everything below it stale.
+ * 4. An explicit `/resume` over a `paused` status, which is how a boot
+ *    snapshot that read `paused` stops being the last word. Without this the
+ *    header would stay `paused` for the rest of the session, since the
+ *    snapshot is read once and the status never moves off it.
+ */
+export function runStateText(state: SessionState): string {
+  const {status, terminal} = state.core;
+  if (terminal) return status;
+  if (state.pauseOverride === 'paused') return 'paused';
+  if (!state.eventStreamAvailable) return 'disconnected';
+  if (state.pauseOverride === 'resumed' && status === 'paused') return 'running';
+  return status;
+}
+
+/**
+ * The token meter, with an honest denominator or none at all.
+ *
+ * `inputTokens` is the context the last agent call carried, and `contextWindow`
+ * is a static per-model lookup that can be absent or stale. When the two
+ * disagree, the count alone is the true statement; a ratio over 100 percent is
+ * not.
+ */
+export function usageText(state: SessionState): string | null {
+  const usage = state.core.usage;
+  if (usage === null || usage.inputTokens <= 0) return null;
+  const used = formatTokenCount(usage.inputTokens);
+  if (usage.contextWindow === null || usage.inputTokens > usage.contextWindow) {
+    return `${used} tokens`;
+  }
+  // Labeled `context` rather than `tokens`: the denominator bounds one call's
+  // context, and calling it "tokens" invited reading it as run spend.
+  return `${used}/${formatTokenCount(usage.contextWindow)} context`;
+}
+
+function formatTokenCount(count: number): string {
+  if (count < 1_000) return String(count);
+  if (count < 1_000_000) return `${Math.floor(count / 1_000)}k`;
+  return `${(count / 1_000_000).toFixed(1)}M`;
+}
+
+/** Segments for the current state, before any width budgeting. */
+export function headerSegments(state: SessionState, showLog: boolean): Segment[] {
+  const segments: Segment[] = [
+    {text: BRAND, priority: PRIORITY.brand, required: true},
+    {text: runStateText(state), priority: PRIORITY.state, required: true},
+  ];
+
+  if (showLog) {
+    segments.push({text: 'experiments', priority: PRIORITY.phase});
+  } else {
+    const phase = phaseText(describePhase(state.core.roundLabel, state.core.agentKind));
+    if (phase !== null) segments.push({text: phase, priority: PRIORITY.phase});
+    if (state.hypothesisScope !== null) {
+      segments.push({
+        text: state.hypothesisScope.title,
+        priority: PRIORITY.title,
+        truncatable: true,
+      });
+    }
+  }
+
+  const usage = usageText(state);
+  if (usage !== null) segments.push({text: usage, priority: PRIORITY.usage});
+
+  if (!showLog && state.selectedAgentKind !== null) {
+    segments.push({text: `selected ${state.selectedAgentKind}`, priority: PRIORITY.selection});
+  }
+
+  const dialogOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
+  if (dialogOpen) segments.push({text: 'Esc: close dialog', priority: PRIORITY.hint});
+
+  return segments;
+}
+
+/**
+ * Assembles the header to fit `width` terminal cells.
+ *
+ * Whole segments are dropped, lowest priority first, rather than clipping the
+ * line: a truncated fixed phrase reads as a rendering bug, while a missing
+ * token meter reads as a header that had better things to say. Only once
+ * everything droppable is gone does the title shorten, and only then, which is
+ * what keeps it from being clipped ahead of less useful segments.
+ *
+ * The budget is in cells, not code units, so a header the caller sized for 40
+ * columns of CJK does not lay out over 50 of them, and the fallback cut lands
+ * on a grapheme boundary rather than inside an emoji.
+ *
+ * At `MIN_WIDTH` and wider the brand and the run state both survive whole.
+ * Narrower than that they do not fit together, and the line is cut and marked.
+ */
+export function renderHeader(state: SessionState, showLog: boolean, width: number): string {
+  const kept = headerSegments(state, showLog);
+  while (displayWidth(joined(kept)) > width) {
+    const weakest = weakestIndex(kept);
+    // Only the brand and the run state are left, and they do not fit: below
+    // MIN_WIDTH the line is cut rather than emptied.
+    if (weakest === null) break;
+    // Nothing left that is cheaper than the title: shortening it now is the
+    // only move that does not cost a whole segment, and by this point it is no
+    // longer being clipped ahead of anything less useful.
+    if (kept[weakest]?.truncatable === true && shrinkTitle(kept, width)) break;
+    kept.splice(weakest, 1);
+  }
+  const line = joined(kept);
+  if (displayWidth(line) <= width) return line;
+  if (width <= 0) return '';
+  // One cell for the ellipsis that says the rest was cut.
+  return `${truncateToWidth(line, width - 1)}…`;
+}
+
+/** The segment given up first, or null once only required ones are left. */
+function weakestIndex(segments: Segment[]): number | null {
+  let weakest: number | null = null;
+  for (const [index, candidate] of segments.entries()) {
+    if (candidate.required === true) continue;
+    const current = weakest === null ? undefined : segments[weakest];
+    // `<=` makes the later of two equal-priority segments the weaker one, so
+    // trailing notes go before leading ones.
+    if (current === undefined || candidate.priority <= current.priority) weakest = index;
+  }
+  return weakest;
+}
+
+/**
+ * Shortens the truncatable segment to close the overrun, if what remains is
+ * still long enough to identify. Returns whether the line now fits.
+ */
+function shrinkTitle(segments: Segment[], width: number): boolean {
+  const index = segments.findIndex(segment => segment.truncatable === true);
+  const segment = segments[index];
+  if (segment === undefined) return false;
+  // What the rest of the line, its separators included, already spends.
+  const rest = displayWidth(joined(segments)) - displayWidth(segment.text);
+  // One cell of the budget goes to the ellipsis.
+  const budget = width - rest - 1;
+  if (budget < MIN_TITLE) return false;
+  const shortened = truncateToWidth(segment.text, budget).trimEnd();
+  // A wide grapheme dropped at the cut, or trailing space, can leave less than
+  // the budget allowed, and below MIN_TITLE the caller is better off dropping.
+  if (displayWidth(shortened) < MIN_TITLE) return false;
+  segments[index] = {...segment, text: `${shortened}…`};
+  return displayWidth(joined(segments)) <= width;
+}
+
+function joined(segments: Segment[]): string {
+  return segments.map(segment => segment.text).join(SEPARATOR);
+}

--- a/clients/tui/src/ui/phase-label.test.ts
+++ b/clients/tui/src/ui/phase-label.test.ts
@@ -1,0 +1,93 @@
+import {describe, expect, it} from 'bun:test';
+import {describePhase, phaseText} from './phase-label.js';
+
+/** Every label shape the three loops emit, from their `round_label=` sites. */
+const AGENT_LABELS: ReadonlyArray<[string, string | null, string]> = [
+  ['round-1-pre', 'orchestrator', 'preparing'],
+  ['round-1-plan', 'orchestrator', 'planning'],
+  ['round-2-profiler', 'profiler', 'profiling'],
+  ['round-1-retry-1-implementer', 'implementer', 'implementing'],
+  ['round-1-retry-1-judge', 'judge', 'judging'],
+  ['round-3-retry-1-single-agent', 'implementer', 'working'],
+  ['round-1-retry-1', 'judge', 'judging'],
+  ['round-1', null, 'working'],
+];
+
+describe('phase description', () => {
+  it.each(AGENT_LABELS)('reads %s as an activity', (label, kind, activity) => {
+    expect(describePhase(label, kind)?.activity).toBe(activity);
+  });
+
+  it('surfaces a retry as an attempt, and stays quiet on the first', () => {
+    expect(describePhase('round-1-retry-1-implementer', 'implementer')?.attempt).toBeNull();
+    expect(describePhase('round-1-retry-2-implementer', 'implementer')?.attempt).toBe(2);
+    expect(phaseText(describePhase('round-1-retry-3-implementer', 'implementer'))).toBe(
+      'implementing · attempt 3',
+    );
+  });
+
+  it('names the candidate in the evolve loop', () => {
+    expect(phaseText(describePhase('gen-2-cand-1-mutator', 'mutator'))).toBe(
+      'mutating candidate 1',
+    );
+    expect(phaseText(describePhase('gen-2-cand-3-judge', 'judge'))).toBe('judging candidate 3');
+    expect(phaseText(describePhase('gen-1-cand-0-profiler', 'profiler'))).toBe(
+      'profiling candidate 0',
+    );
+  });
+
+  it('names the issue in the plain loop', () => {
+    expect(phaseText(describePhase('impl issue #7 att2', 'implementer'))).toBe(
+      'implementing issue #7 · attempt 2',
+    );
+    expect(phaseText(describePhase('judge issue #7 att1', 'judge'))).toBe('judging issue #7');
+    expect(phaseText(describePhase('perf_eval iter 3', null))).toBe('measuring');
+  });
+
+  it('treats the experiment chat as its own activity, both spellings', () => {
+    expect(phaseText(describePhase('experiment chat', 'chat'))).toBe('answering');
+    expect(phaseText(describePhase('experiment-chat', 'chat'))).toBe('answering');
+  });
+
+  it('never returns a raw backend identifier', () => {
+    // The acceptance criterion for #517: no round_label reaches the header in
+    // any loop mode, including labels this parser does not recognize.
+    const labels = [
+      ...AGENT_LABELS.map(([label]) => label),
+      'gen-2-cand-1-mutator',
+      'impl issue #7 att2',
+      'judge issue #12 att4',
+      'perf_eval iter 9',
+      'experiment chat',
+      'round-4-retry-2-implementer',
+      'some-future-loop-label-7',
+    ];
+    for (const label of labels) {
+      const text = phaseText(describePhase(label, 'implementer'));
+      expect(text).not.toBeNull();
+      expect(text).not.toContain(label);
+      // The internal syntaxes, not the information. `issue #7` is what the
+      // operator is working on and belongs on screen; `att2` and `round-1` are
+      // identifiers and do not.
+      expect(text).not.toMatch(/round-\d|gen-\d|cand-\d|retry-\d|att\d/);
+    }
+  });
+
+  it('falls back to the agent kind when the label is unknown or absent', () => {
+    expect(phaseText(describePhase('some-future-loop-label-7', 'implementer'))).toBe(
+      'implementing',
+    );
+    expect(phaseText(describePhase(null, 'judge'))).toBe('judging');
+    expect(phaseText(describePhase('', 'orchestrator'))).toBe('planning');
+  });
+
+  it('has nothing to say before a run reports anything', () => {
+    expect(describePhase(null, null)).toBeNull();
+    expect(phaseText(null)).toBeNull();
+  });
+
+  it('degrades to the kind verbatim for an agent kind it does not know', () => {
+    // Better a real kind name than a parse failure; still not a round label.
+    expect(phaseText(describePhase(null, 'verifier'))).toBe('verifier');
+  });
+});

--- a/clients/tui/src/ui/phase-label.ts
+++ b/clients/tui/src/ui/phase-label.ts
@@ -1,0 +1,151 @@
+/**
+ * Turns a backend `round_label` into something an operator can read.
+ *
+ * The labels are loop-internal identifiers that exist for round attribution,
+ * not for display: `round-1-retry-2-implementer`, `gen-2-cand-1-mutator`,
+ * `impl issue #7 att2`. `roundNumberFromLabel` in core-state parses them and
+ * the run map keys off them, so they are load-bearing and stay exactly as they
+ * are. This is presentation only.
+ *
+ * Every producer, so the parser covers all three loop modes:
+ *
+ *   agent   src/vibesys/loops/agent/loop.py
+ *           round-N-pre, round-N-plan, round-N-profiler, round-N,
+ *           round-N-retry-R-implementer, round-N-retry-R-judge,
+ *           round-N-retry-R-single-agent, round-N-retry-R
+ *   evolve  src/vibesys/loops/evolve/loop.py
+ *           gen-G-cand-C-mutator, gen-G-cand-C-judge, gen-G-cand-C-profiler
+ *   plain   src/vibesys/loops/plain/loop.py
+ *           impl issue #ID attN, judge issue #ID attN, perf_eval iter N
+ */
+
+/** What an agent is doing, in the operator's words rather than the loop's. */
+export interface PhaseDescription {
+  /** The activity: `implementing`, `judging`, `planning`. Never an identifier. */
+  activity: string;
+  /** Retry or attempt number, when the label carries one and it is past the first. */
+  attempt: number | null;
+  /** What is being worked on: `candidate 1`, `issue #7`. Null for plain rounds. */
+  subject: string | null;
+}
+
+/**
+ * Stage word per label suffix. The suffix is the only part of a label that says
+ * what is happening; the numbers around it say which round it belongs to, which
+ * the rounds strip already shows.
+ */
+const STAGE_WORDS: Readonly<Record<string, string>> = {
+  pre: 'preparing',
+  plan: 'planning',
+  profiler: 'profiling',
+  implementer: 'implementing',
+  judge: 'judging',
+  mutator: 'mutating',
+  'single-agent': 'working',
+};
+
+/** Agent kinds, for when the label carries no stage of its own. */
+const KIND_WORDS: Readonly<Record<string, string>> = {
+  orchestrator: 'planning',
+  implementer: 'implementing',
+  judge: 'judging',
+  profiler: 'profiling',
+  mutator: 'mutating',
+  chat: 'answering',
+};
+
+const AGENT_ROUND = /^round-(\d+)(?:-retry-(\d+))?(?:-(.+))?$/;
+const EVOLVE_CANDIDATE = /^gen-(\d+)-cand-(\d+)-(.+)$/;
+const PLAIN_ISSUE = /^(impl|judge)\s+issue\s+#(\S+)\s+att(\d+)$/;
+const PLAIN_PERF = /^perf_eval\s+iter\s+(.+)$/;
+
+/**
+ * Describes what is running, from the round label and the agent kind.
+ *
+ * The label wins where the two disagree: it distinguishes the stages one kind
+ * covers (an orchestrator plans in `round-N-plan` and prepares in
+ * `round-N-pre`), which the kind alone cannot.
+ */
+export function describePhase(
+  roundLabel: string | null,
+  agentKind: string | null,
+): PhaseDescription | null {
+  const label = roundLabel?.trim() ?? '';
+  const kind = agentKind?.trim() ?? '';
+  if (label === '' && kind === '') return null;
+
+  // The chat runs beside the loop rather than inside it, and labels itself in
+  // words already. Both spellings appear in recorded runs.
+  if (label === 'experiment chat' || label === 'experiment-chat' || kind === 'chat') {
+    return {activity: 'answering', attempt: null, subject: null};
+  }
+
+  const evolve = EVOLVE_CANDIDATE.exec(label);
+  if (evolve) {
+    const [, , candidate, stage] = evolve;
+    return {
+      activity: STAGE_WORDS[stage ?? ''] ?? fallbackActivity(stage, kind),
+      attempt: null,
+      subject: candidate === undefined ? null : `candidate ${candidate}`,
+    };
+  }
+
+  const issue = PLAIN_ISSUE.exec(label);
+  if (issue) {
+    const [, stage, id, attempt] = issue;
+    return {
+      activity: stage === 'judge' ? 'judging' : 'implementing',
+      attempt: attemptOrNull(attempt),
+      subject: id === undefined ? null : `issue #${id}`,
+    };
+  }
+
+  if (PLAIN_PERF.test(label)) {
+    return {activity: 'measuring', attempt: null, subject: null};
+  }
+
+  const round = AGENT_ROUND.exec(label);
+  if (round) {
+    const [, , retry, stage] = round;
+    return {
+      // `round-N` and `round-N-retry-R` carry no stage; the kind names the
+      // agent that is between stages.
+      activity:
+        stage === undefined
+          ? fallbackActivity(null, kind)
+          : (STAGE_WORDS[stage] ?? fallbackActivity(stage, kind)),
+      attempt: attemptOrNull(retry),
+      subject: null,
+    };
+  }
+
+  // An unrecognized label is a loop we do not know about. Falling back to the
+  // kind keeps an identifier off the screen; the label stays reachable in the
+  // Agents pane and the round strip.
+  return {activity: fallbackActivity(null, kind), attempt: null, subject: null};
+}
+
+/** One line for the header: `implementing · attempt 2`, `mutating candidate 1`. */
+export function phaseText(phase: PhaseDescription | null): string | null {
+  if (phase === null) return null;
+  const subject = phase.subject === null ? phase.activity : `${phase.activity} ${phase.subject}`;
+  return phase.attempt === null ? subject : `${subject} · attempt ${phase.attempt}`;
+}
+
+/**
+ * First attempts are the normal case and saying so adds nothing; a retry is
+ * the thing worth surfacing.
+ */
+function attemptOrNull(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const attempt = Number(value);
+  return Number.isFinite(attempt) && attempt > 1 ? attempt : null;
+}
+
+function fallbackActivity(stage: string | undefined | null, kind: string): string {
+  if (stage !== undefined && stage !== null) {
+    const known = STAGE_WORDS[stage];
+    if (known !== undefined) return known;
+  }
+  return KIND_WORDS[kind] ?? (kind === '' ? 'working' : kind);
+}

--- a/clients/tui/src/ui/text-width.ts
+++ b/clients/tui/src/ui/text-width.ts
@@ -1,0 +1,99 @@
+/**
+ * Terminal cell measurement, for code that has a column budget to spend.
+ *
+ * A terminal lays text out in cells, not UTF-16 code units, and the two differ
+ * in both directions: a CJK ideograph is one code unit and two cells, a
+ * combining mark is one code unit and no cell, and an emoji is several code
+ * units that occupy two cells together. Budgeting with `String.length` makes a
+ * line the caller believes is 40 columns take 50, and slicing by code units
+ * can cut a surrogate pair or a joined emoji sequence in half.
+ *
+ * The rules here are the ones terminals actually apply: East Asian Wide and
+ * Fullwidth are two cells, so is anything with an emoji presentation, marks
+ * and format characters are none, everything else is one.
+ */
+
+/** Grapheme clusters, so a slice never lands inside one. */
+const GRAPHEMES = new Intl.Segmenter('en', {granularity: 'grapheme'});
+
+/**
+ * Code point ranges that occupy two cells: East Asian Wide and Fullwidth,
+ * which JS exposes no property escape for. Emoji are covered separately by
+ * `Emoji_Presentation`, which is a property escape.
+ */
+const WIDE_RANGES: readonly (readonly [number, number])[] = [
+  [0x1100, 0x115f], // Hangul Jamo initial consonants
+  [0x2e80, 0x303e], // CJK radicals, Kangxi, CJK symbols and punctuation
+  [0x3041, 0x33ff], // Kana, Hangul Compatibility Jamo, CJK compatibility
+  [0x3400, 0x4dbf], // CJK Unified Ideographs Extension A
+  [0x4e00, 0x9fff], // CJK Unified Ideographs
+  [0xa000, 0xa4cf], // Yi syllables and radicals
+  [0xa960, 0xa97f], // Hangul Jamo Extended-A
+  [0xac00, 0xd7a3], // Hangul syllables
+  [0xf900, 0xfaff], // CJK compatibility ideographs
+  [0xfe10, 0xfe19], // Vertical forms
+  [0xfe30, 0xfe6f], // CJK compatibility forms, small form variants
+  [0xff00, 0xff60], // Fullwidth forms
+  [0xffe0, 0xffe6], // Fullwidth signs
+  [0x17000, 0x18aff], // Tangut
+  [0x20000, 0x3fffd], // CJK Unified Ideographs, Extension B onward
+];
+
+/** Two cells without asking: the code point's default form is the emoji one. */
+const EMOJI_PRESENTATION = /\p{Emoji_Presentation}/u;
+
+/** U+FE0F asks for the emoji form of a code point that defaults to text. */
+const EMOJI_VARIATION_SELECTOR = '\uFE0F';
+
+/**
+ * No cell of its own: combining marks stack onto the previous character and
+ * format characters (joiners, variation selectors) are instructions, not glyphs.
+ */
+const ZERO_WIDTH = /^[\p{Mn}\p{Me}\p{Cf}]$/u;
+
+/** Cells `text` occupies in a terminal. */
+export function displayWidth(text: string): number {
+  let width = 0;
+  for (const {segment} of GRAPHEMES.segment(text)) width += graphemeWidth(segment);
+  return width;
+}
+
+/**
+ * The longest prefix of `text` that fits `maxWidth` cells, cut on a grapheme
+ * boundary.
+ *
+ * A wide grapheme that would straddle the limit is dropped whole, so the
+ * result is sometimes one cell narrower than the budget. That is the point:
+ * half of a grapheme is not half a character, it is a broken one.
+ */
+export function truncateToWidth(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return '';
+  let width = 0;
+  let end = 0;
+  for (const {segment, index} of GRAPHEMES.segment(text)) {
+    const next = width + graphemeWidth(segment);
+    if (next > maxWidth) break;
+    width = next;
+    end = index + segment.length;
+  }
+  return text.slice(0, end);
+}
+
+/**
+ * A cluster is as wide as the character it is built around: the code points
+ * after the first are marks, joiners and selectors that render into the same
+ * cells.
+ */
+function graphemeWidth(cluster: string): number {
+  const first = cluster.codePointAt(0);
+  if (first === undefined) return 0;
+  const base = String.fromCodePoint(first);
+  if (ZERO_WIDTH.test(base)) return 0;
+  if (EMOJI_PRESENTATION.test(base)) return 2;
+  if (cluster.includes(EMOJI_VARIATION_SELECTOR)) return 2;
+  return isWide(first) ? 2 : 1;
+}
+
+function isWide(codePoint: number): boolean {
+  return WIDE_RANGES.some(([start, end]) => codePoint >= start && codePoint <= end);
+}


### PR DESCRIPTION
Closes #517.

> Stacked on #545. Base is `adi/tui-markdown-render`, so the diff is this change alone. GitHub retargets to `main` when #545 merges.

## Problem

The header interpolated backend identifiers verbatim, so a live run read:

```
VibeSys · running · implementer · round-1-retry-1-implementer · 2/200k tokens · Preallocated lock-free SPSC ring · r1
```

`round-1-retry-1-implementer` is a loop-internal key that duplicated both the agent kind beside it and the rounds strip below. The token meter rendered 118 percent during a real run, because `input_tokens` is the last call's context pressure while `context_window` is a static lookup. At 100 columns the line clipped mid-title, losing the one segment saying what the run was trying.

It also rendered into a bare one-row line while every other region sits in a bordered box, so it read as a caption above the UI rather than part of it.

![before and after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/m546.png)

## Solution

**Content.** `phase-label.ts` parses every loop's labels into operator-facing words (`implementing · attempt 2`); an unrecognized label degrades to the agent kind rather than printing an identifier. Segments drop whole in priority order rather than clipping, and the hypothesis title outranks the meter, the selection note and the hint. Width is measured in terminal cells via `text-width.ts`, not UTF-16 code units, so CJK and emoji budget correctly.

Pause is a tri-state (`paused | resumed | null`) rather than a boolean, because a boolean cannot distinguish "explicitly resumed" from "issued neither" — that is why a paused boot snapshot stayed paused after `/resume`. A terminal status always outranks a local override.

**Housing.** The header is now a pane: three rows, bezel to bezel, no fill, no blank separator, so its bottom bezel meets the next pane's top one. An earlier attempt used a surface band and a rule, which was worse: a partial-width fill is exactly what reads as floating in a terminal.

**Cost:** two extra rows. On a short terminal that is two rows of transcript.

## Verification

| Check | Result |
| --- | --- |
| `bun test clients/tui/src/` | 541 pass, 0 fail |
| `check:ts` / `check:clients` / `check:ts-architecture` | clean |

Tests cover the pause tri-state, CJK and emoji budgeting, grapheme-safe truncation, and the width ladder at 200/100/60/34/22/16 columns. Backend labels are unchanged on the wire, so round attribution in `run-map.ts` is unaffected.
