### PR TITLE
fix(tui): line up the bottom input boxes and stop the chat modal overlapping itself

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -2183,6 +2183,45 @@ describe('OpenTUI presentation', () => {
     expect(controller.state.chatOpen).toBe(false);
   });
 
+  it('stacks the modal chat without a seam at any terminal height', async () => {
+    // The modal takes a share of the terminal, and a share of a row is not a
+    // row: the layout rounds a child's offset from its parent separately from
+    // that child's size, so at a fractional offset the two disagree and the
+    // transcript either runs a row into the composer or leaves a row of the
+    // modal's floor blank. Which heights round badly follows from the shares
+    // rather than from any one size, so the whole range is checked.
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController({...initialSessionState(), chatOpen: true});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    for (let height = 18; height <= 48; height += 1) {
+      testRenderer.renderer.resize(100, height);
+      await frameAfter(testRenderer);
+      const modal = testRenderer.renderer.root.findDescendantById('chat-overlay');
+      const transcript = testRenderer.renderer.root.findDescendantById('chat-transcript');
+      const composer = testRenderer.renderer.root.findDescendantById('chat-modal-composer');
+      if (modal === undefined || transcript === undefined || composer === undefined)
+        throw new Error('modal chat geometry was missing');
+      // The height rides along in the comparison so a failure names the
+      // terminal it happened on, not only the rows that disagreed.
+      expect({
+        height,
+        top: transcript.y,
+        end: transcript.y + transcript.height,
+        floor: composer.y + composer.height,
+      }).toEqual({
+        height,
+        // The transcript starts under the top border and ends exactly where
+        // the composer starts, and the composer's last row is the one above
+        // the bottom border.
+        top: modal.y + 1,
+        end: composer.y,
+        floor: modal.y + modal.height - 1,
+      });
+    }
+  });
+
   it('accepts another chat message while an agent turn is pending', async () => {
     const testRenderer = await createTestRenderer({width: 100, height: 24});
     const controller = new FakeController({

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -64,6 +64,7 @@ import {
 } from '../session-model.js';
 import {TRANSCRIPT_MIN} from './agent-map.js';
 import {createOpenTuiApp, type OpenTuiApp} from './app.js';
+import {MIN_DOCK_WIDTH} from './chat-pane.js';
 import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 import {renderDesignSummary} from './design-log.js';
 import {paneTitle} from './focus.js';
@@ -2984,6 +2985,52 @@ describe('theming', () => {
     expect(paneFrameColumn(landing, 'Experiment chat')).not.toBeNull();
     expect(paneFrameColumn(landing, 'Message')).not.toBeNull();
     expect(paneFrameColumn(landing, 'Command')).toBe(paneFrameColumn(landing, 'Experiments'));
+  });
+
+  it('keeps the message and command boxes on the same rows while the chat is docked', async () => {
+    // Both bottom inputs are one row of the same landing view, so a reader
+    // scanning across the screen finds one input line, not two at different
+    // heights. Each state is checked because the hint above the message box
+    // changes wording, and a taller hint would push the box off the row.
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    const bottomRows = (): {message: number; command: number} => {
+      const message = testRenderer.renderer.root.findDescendantById('chat-dock-composer-box');
+      const command = testRenderer.renderer.root.findDescendantById('command-input-box');
+      if (message === undefined || command === undefined)
+        throw new Error('landing composer geometry was missing');
+      return {message: message.y + message.height, command: command.y + command.height};
+    };
+
+    // Unfocused: the chat says how to reach it.
+    let rows = bottomRows();
+    expect(rows.message).toBe(rows.command);
+
+    // Focused: the hint becomes the send keys.
+    controller.focusPane('chat');
+    await frameAfter(testRenderer);
+    rows = bottomRows();
+    expect(rows.message).toBe(rows.command);
+
+    // Pending: the hint says a follow-up is queued, and the title grows too.
+    controller.publish({...controller.state, chatPending: true});
+    expect(await frameAfter(testRenderer)).toContain('Awaiting the agent');
+    rows = bottomRows();
+    expect(rows.message).toBe(rows.command);
+
+    // Narrow enough that the hint no longer fits: it truncates on its one row
+    // rather than wrapping onto a second, so the boxes stay on their row.
+    controller.publish({...controller.state, chatPending: false});
+    testRenderer.renderer.resize(MIN_DOCK_WIDTH, 20);
+    const narrow = await frameAfter(testRenderer);
+    expect(narrow).toContain('╭─ Message ');
+    rows = bottomRows();
+    expect(rows.message).toBe(rows.command);
   });
 
   it('routes typing to whichever input Ctrl+W points at', async () => {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -3067,9 +3067,46 @@ describe('theming', () => {
     controller.publish({...controller.state, chatPending: false});
     testRenderer.renderer.resize(MIN_DOCK_WIDTH, 20);
     const narrow = await frameAfter(testRenderer);
-    expect(narrow).toContain('╭─ Message ');
+    // Either focus form: this test is about the rows the boxes sit on, not
+    // which of them holds focus.
+    expect(narrow).toMatch(/[╭┏][─━]\s*▸?\s*Message/);
     rows = bottomRows();
     expect(rows.message).toBe(rows.command);
+  });
+
+  it('opens both suggestion menus flush on the box they complete', async () => {
+    // A menu that is not touching its input reads as belonging to whatever it
+    // is touching instead. The composer's hint sits above its box, so a menu
+    // anchored on the composer as a whole clears the hint rather than the box.
+    // The command bar is the reference on the other side of the same view.
+    const testRenderer = await createTestRenderer({width: 140, height: 24});
+    const controller = new FakeController(initialSessionState());
+    controller.publish({...controller.state, experimentLog: emptyLog(), layout: chatFocus()});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+
+    const boxTopUnder = (menuId: string, boxId: string): {menu: number; box: number} => {
+      const menu = testRenderer.renderer.root.findDescendantById(menuId);
+      const box = testRenderer.renderer.root.findDescendantById(boxId);
+      if (menu === undefined || box === undefined)
+        throw new Error(`${menuId} geometry was missing`);
+      if (!menu.visible) throw new Error(`${menuId} was not on screen`);
+      return {menu: menu.y + menu.height, box: box.y};
+    };
+
+    await testRenderer.mockInput.typeText('/');
+    await testRenderer.waitForFrame(value => value.includes('/resume'));
+    const chat = boxTopUnder('chat-dock-composer-menu', 'chat-dock-composer-box');
+    expect(chat.menu).toBe(chat.box);
+
+    // The same rule on the command bar, whose list this one is meant to match.
+    controller.focusPane('left');
+    await frameAfter(testRenderer);
+    await testRenderer.mockInput.typeText('/');
+    await testRenderer.waitForFrame(value => value.includes('/pause'));
+    const command = boxTopUnder('command-input-suggestions', 'command-input-box');
+    expect(command.menu).toBe(command.box);
   });
 
   it('routes typing to whichever input Ctrl+W points at', async () => {
@@ -4526,7 +4563,9 @@ describe('theming', () => {
   });
 
   it('uses the empty hypotheses screen as a truthful planning kickoff', async () => {
-    const testRenderer = await createTestRenderer({width: 100, height: 16});
+    // 18 rows, not 16: the header is a three-row pane, so a 16-row terminal
+    // no longer leaves room for the kickoff copy.
+    const testRenderer = await createTestRenderer({width: 100, height: 18});
     const planningStartedAt = new Date(Date.now() - 65_000).toISOString();
     const controller = new FakeController({
       ...initialSessionState(),

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -2222,6 +2222,79 @@ describe('OpenTUI presentation', () => {
     }
   });
 
+  it('pins the modal rectangle across a width sweep', async () => {
+    // Whole-cell edges replaced percentage ones, and the two agree only
+    // because the layout rounds per edge rather than per size: it rounds the
+    // absolute left and the absolute right and subtracts. Rounding the width
+    // itself instead, `round(0.8W)`, looks equivalent and is not, so the
+    // rectangle is pinned column by column rather than at one width.
+    const testRenderer = await createTestRenderer({width: 100, height: 32});
+    const controller = new FakeController({...initialSessionState(), chatOpen: true});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    for (let width = 60; width <= 160; width += 1) {
+      testRenderer.renderer.resize(width, 32);
+      await frameAfter(testRenderer);
+      const modal = testRenderer.renderer.root.findDescendantById('chat-overlay');
+      if (modal === undefined) throw new Error('modal chat geometry was missing');
+      // The width rides along so a failure names the terminal it happened on.
+      expect({width, left: modal.x, right: modal.x + modal.width}).toEqual({
+        width,
+        left: Math.round(width * 0.1),
+        right: Math.round(width * 0.9),
+      });
+    }
+  });
+
+  it('rewraps the modal composer against the width the resize just gave it', async () => {
+    // A renderable answers `width` with the last width the layout computed,
+    // not the one just assigned, so reading the modal back after resizing it
+    // describes the previous rectangle. The composer sizes its editor from
+    // that number, and nothing else asks again: a resize is not a state
+    // change, so a draft would stay wrapped for the old width until the
+    // operator happened to type.
+    const testRenderer = await createTestRenderer({width: 140, height: 30});
+    const controller = new FakeController({...initialSessionState(), chatOpen: true});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+
+    const composerBox = (): {y: number; height: number} => {
+      const box = testRenderer.renderer.root.findDescendantById('chat-modal-composer-box');
+      if (box === undefined) throw new Error('modal composer geometry was missing');
+      return {y: box.y, height: box.height};
+    };
+
+    // A state update after the first layout, so the composer starts out sized
+    // against the modal as drawn rather than against the width it reported
+    // before ever being laid out. The resize below is then the only thing that
+    // can put the two out of step.
+    controller.publish({...controller.state});
+    await frameAfter(testRenderer);
+
+    // Sixty characters: one editor row inside the 140-column modal, whose
+    // editor is 104 columns wide, and two inside the 60-column modal's 40.
+    await testRenderer.mockInput.typeText('x'.repeat(60));
+    await frameAfter(testRenderer);
+    expect(composerBox().height).toBe(3);
+
+    testRenderer.renderer.resize(60, 30);
+    await frameAfter(testRenderer);
+    expect(composerBox().height).toBe(4);
+
+    // And the modal still stacks: the transcript ends where the composer
+    // starts, so the taller box came out of the transcript rather than
+    // overrunning the floor.
+    const modal = testRenderer.renderer.root.findDescendantById('chat-overlay');
+    const transcript = testRenderer.renderer.root.findDescendantById('chat-transcript');
+    const composer = testRenderer.renderer.root.findDescendantById('chat-modal-composer');
+    if (modal === undefined || transcript === undefined || composer === undefined)
+      throw new Error('modal chat geometry was missing');
+    expect(transcript.y + transcript.height).toBe(composer.y);
+    expect(composer.y + composer.height).toBe(modal.y + modal.height - 1);
+  });
+
   it('accepts another chat message while an agent turn is pending', async () => {
     const testRenderer = await createTestRenderer({width: 100, height: 24});
     const controller = new FakeController({
@@ -3072,6 +3145,44 @@ describe('theming', () => {
     expect(narrow).toMatch(/[╭┏][─━]\s*▸?\s*Message/);
     rows = bottomRows();
     expect(rows.message).toBe(rows.command);
+  });
+
+  it('gives the short terminal its landing rows back instead of the box alignment', async () => {
+    // The row that puts the Command box on the Message box's row comes out of
+    // the table above it. On a terminal with no row to spare the table keeps
+    // it and the two boxes sit one row apart: the operator can see that and
+    // undo it by resizing, whereas a clipped last line of the kickoff copy
+    // just looks like the copy ends there.
+    const testRenderer = await createTestRenderer({width: 100, height: 16});
+    const controller = kickoffController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    const bottomRows = (): {message: number; command: number} => {
+      const message = testRenderer.renderer.root.findDescendantById('chat-dock-composer-box');
+      const command = testRenderer.renderer.root.findDescendantById('command-input-box');
+      if (message === undefined || command === undefined)
+        throw new Error('landing composer geometry was missing');
+      return {message: message.y + message.height, command: command.y + command.height};
+    };
+
+    // The kickoff copy is whole, down to its last line, and the command
+    // surface is on screen with it.
+    const short = await frameAfter(testRenderer);
+    expect(short).toContain('Run kickoff');
+    expect(short).toContain('Form Hypothesis 1');
+    expect(short).toContain('This activity becomes');
+    expect(short).toMatch(/[╭┏][─━]\s*▸?\s*Command/);
+    expect(short).toContain('Type /help for commands');
+    // The cost, stated: the boxes are one row apart rather than level.
+    expect(bottomRows().command).toBe(bottomRows().message + 1);
+
+    // One more row and the alignment is affordable again, copy still whole.
+    testRenderer.renderer.resize(100, 17);
+    const taller = await frameAfter(testRenderer);
+    expect(taller).toContain('This activity becomes');
+    expect(bottomRows().command).toBe(bottomRows().message);
   });
 
   it('opens both suggestion menus flush on the box they complete', async () => {
@@ -4563,26 +4674,8 @@ describe('theming', () => {
   });
 
   it('uses the empty hypotheses screen as a truthful planning kickoff', async () => {
-    // 18 rows, not 16: the header is a three-row pane, so a 16-row terminal
-    // no longer leaves room for the kickoff copy.
-    const testRenderer = await createTestRenderer({width: 100, height: 18});
-    const planningStartedAt = new Date(Date.now() - 65_000).toISOString();
-    const controller = new FakeController({
-      ...initialSessionState(),
-      core: {
-        ...initialSessionState().core,
-        status: 'running',
-        phases: [
-          {
-            kind: 'orchestrator',
-            status: 'active',
-            roundNumber: 1,
-            roundLabel: 'round-1-pre',
-            startedAt: planningStartedAt,
-          },
-        ],
-      },
-    });
+    const testRenderer = await createTestRenderer({width: 100, height: 16});
+    const controller = kickoffController();
     const app = createOpenTuiApp(testRenderer.renderer, controller);
     registerCleanup(testRenderer.renderer, app);
     await controller.openExperimentLog();
@@ -4901,6 +4994,31 @@ function logController(): FakeController {
     }),
   ];
   return controller;
+}
+
+/**
+ * A run that has started planning but has no hypotheses yet, which is the
+ * landing view at its tallest: the kickoff panel is the widest and longest
+ * thing the table ever shows.
+ */
+function kickoffController(): FakeController {
+  const planningStartedAt = new Date(Date.now() - 65_000).toISOString();
+  return new FakeController({
+    ...initialSessionState(),
+    core: {
+      ...initialSessionState().core,
+      status: 'running',
+      phases: [
+        {
+          kind: 'orchestrator',
+          status: 'active',
+          roundNumber: 1,
+          roundLabel: 'round-1-pre',
+          startedAt: planningStartedAt,
+        },
+      ],
+    },
+  });
 }
 
 function splitController(): FakeController {

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -401,6 +401,10 @@ export function createOpenTuiApp(
         ? renderer.terminalWidth
         : chatPaneWidth(renderer.terminalWidth, rightWidth)
       : 0;
+    // The docked chat spends its last row on the pane's bottom border, so the
+    // command column beside it gives up the same row. Without that the Command
+    // box would sit one row below the Message box it lines up with.
+    const commandInset = showChatPane ? 1 : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
     paintHeader(renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME));
     errorBanner.render(state);
@@ -478,7 +482,8 @@ export function createOpenTuiApp(
       // The rounds rail lives inside the row, not above it, so the chat pane
       // starts just below the header and error banner.
       const top = headerFrame.height + errorHeight;
-      const below = todoStrip.output.height + help.height + commandInput.box.height;
+      const below =
+        todoStrip.output.height + help.height + commandInput.box.height + commandInset;
       chat.setPaneBounds({
         left: 1,
         width: leftWidth - 2,
@@ -491,6 +496,7 @@ export function createOpenTuiApp(
     chatPane.render(state, showChatPane, chatWidth);
     const chatInputFocused = showChatPane && state.layout.focus === 'chat';
     commandColumn.visible = zoomedPane !== 'chat';
+    bottom.paddingBottom = commandInset;
     // The command list completes the box it belongs to, and on this view that
     // box cannot open a chat that is already beside it.
     commandInput.setCommandContext({chatDocked: showChatPane});

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -18,7 +18,7 @@ import {ActivityBarView} from './activity-bar.js';
 import {AgentMapView} from './agent-map.js';
 import {createChatDraft} from './chat-composer.js';
 import {ChatOverlayView} from './chat-overlay.js';
-import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
+import {ChatPaneView, chatDockFits, chatPaneWidth, commandColumnInset} from './chat-pane.js';
 import {RendererSelectionClipboard, type SelectionClipboard} from './clipboard.js';
 import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
@@ -401,10 +401,6 @@ export function createOpenTuiApp(
         ? renderer.terminalWidth
         : chatPaneWidth(renderer.terminalWidth, rightWidth)
       : 0;
-    // The docked chat spends its last row on the pane's bottom border, so the
-    // command column beside it gives up the same row. Without that the Command
-    // box would sit one row below the Message box it lines up with.
-    const commandInset = showChatPane ? 1 : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
     paintHeader(renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME));
     errorBanner.render(state);
@@ -475,20 +471,29 @@ export function createOpenTuiApp(
     // the focus border whenever the round view's keys are on it.
     const transcriptFocused = !showLog && paneFocus === 'transcript';
     applyPaneFocus(transcriptFrame, theme, TRANSCRIPT_TITLE, transcriptFocused);
+    // Rows the siblings above and below the main area occupy, measured rather
+    // than assumed so a taller todo strip or a wrapped banner still fits. A
+    // hidden renderable still reports a row of its own, so each is asked
+    // whether it is on screen before its rows are counted.
+    const rowsOn = (pane: BoxRenderable): number => (pane.visible ? pane.height : 0);
+    // The rounds rail is a column inside the main row, not a strip above it, so
+    // only the header and the banner take rows off the top.
+    const above = headerFrame.height + rowsOn(errorBanner.output);
+    const belowRows = rowsOn(todoStrip.output) + help.height + commandInput.box.height;
+    // Taken from the same budget the main area draws from, so the decision and
+    // the consequence cannot disagree.
+    const commandInset = commandColumnInset(
+      showChatPane,
+      renderer.terminalHeight - above - belowRows,
+    );
     // Match the chat to the left pane's rectangle so it sits beside the
-    // visualization instead of over it. Bounds come from the siblings that
-    // actually occupy those rows, so a taller todo strip still fits.
+    // visualization instead of over it.
     if (showSplit) {
-      // The rounds rail lives inside the row, not above it, so the chat pane
-      // starts just below the header and error banner.
-      const top = headerFrame.height + errorHeight;
-      const below =
-        todoStrip.output.height + help.height + commandInput.box.height + commandInset;
       chat.setPaneBounds({
         left: 1,
         width: leftWidth - 2,
-        top,
-        height: renderer.terminalHeight - top - below,
+        top: above,
+        height: renderer.terminalHeight - above - belowRows - commandInset,
       });
     } else {
       chat.setPaneBounds(null);

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -177,8 +177,11 @@ export class ChatComposerView {
     });
     this.menu.add(this.#menuList);
     this.#box.add(this.#editor);
-    this.output.add(this.#box);
+    // Hint first, then the box. The command column on the other side of the
+    // landing view is ordered the same way, so both columns end on a bordered
+    // input and the two boxes share a row.
     this.output.add(this.#hint);
+    this.output.add(this.#box);
   }
 
   /**

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -15,7 +15,10 @@ import type {Theme} from './theme.js';
 
 const MIN_EDITOR_ROWS = 1;
 const MAX_EDITOR_ROWS = 6;
-const COMPOSER_CHROME = 3;
+/** Border rows the message box adds around the editor it holds. */
+const BOX_CHROME = 2;
+/** The box's own rows plus the hint row above it. */
+const COMPOSER_CHROME = BOX_CHROME + 1;
 const EDITOR_HORIZONTAL_CHROME = 4;
 /** Rows the menu shows at once before it scrolls its selection into view. */
 const MAX_MENU_ROWS = 10;
@@ -110,7 +113,7 @@ export class ChatComposerView {
     this.#box = new BoxRenderable(renderer, {
       id: `${id}-composer-box`,
       width: '100%',
-      height: MIN_EDITOR_ROWS + 2,
+      height: MIN_EDITOR_ROWS + BOX_CHROME,
       border: true,
       borderStyle: paneBorderStyle(false),
       borderColor: paneBorderColor(theme, false),
@@ -151,9 +154,11 @@ export class ChatComposerView {
     this.menu = new BoxRenderable(renderer, {
       id: `${id}-composer-menu`,
       position: 'absolute',
-      // Anchored directly above the composer, which is the bottom of whichever
-      // chat surface mounts it. Kept in step with the editor's height below.
-      bottom: COMPOSER_CHROME + MIN_EDITOR_ROWS,
+      // Anchored on the message box, not above the whole composer: the hint
+      // row sits over the box, and a menu cleared of it would float with that
+      // row showing through the gap. The command bar's list sits on its own
+      // box the same way. Kept in step with the editor's height below.
+      bottom: MIN_EDITOR_ROWS + BOX_CHROME,
       left: 0,
       width: '100%',
       height: 3,
@@ -354,10 +359,10 @@ export class ChatComposerView {
       Math.max(MIN_EDITOR_ROWS, wrappedRows(this.draft.value, contentWidth)),
     );
     this.#editor.height = rows;
-    this.#box.height = rows + 2;
+    this.#box.height = rows + BOX_CHROME;
     this.output.height = rows + COMPOSER_CHROME;
-    // The menu sits on top of the composer, so it moves with it.
-    this.menu.bottom = this.output.height;
+    // The menu sits on top of the box, so it moves with it.
+    this.menu.bottom = this.#box.height;
   }
 
   #submit(): void {

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -19,6 +19,11 @@ const MODAL_RIGHT = 0.9;
 const MODAL_TOP = 0.1;
 const MODAL_BOTTOM = 0.86;
 
+/** Columns the modal's border and padding take from every child. */
+const MODAL_CHROME = 4;
+/** A border, one row to type on, and a border. */
+const MIN_MODAL_HEIGHT = 3;
+
 /** Screen rectangle the chat occupies when it shares the row with a pane. */
 export interface PaneBounds {
   left: number;
@@ -43,6 +48,14 @@ export class ChatOverlayView {
   readonly #conversation: ConversationView;
   readonly #composer: ChatComposerView;
   #bounds: PaneBounds | null = null;
+  /**
+   * Columns inside the modal's chrome, as the geometry below just set them.
+   * `output.width` answers with the last width the layout computed rather than
+   * the one assigned, so after a resize it still describes the previous
+   * rectangle; the composer would wrap its draft against a stale width for as
+   * long as no state change happened to ask again.
+   */
+  #contentWidth = 1;
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -115,10 +128,12 @@ export class ChatOverlayView {
     }
     if (samePaneBounds(this.#bounds, bounds)) return;
     this.#bounds = bounds;
-    this.output.left = bounds.left;
-    this.output.width = Math.max(1, bounds.width);
-    this.output.top = bounds.top;
-    this.output.height = Math.max(3, bounds.height);
+    this.#applyGeometry(
+      bounds.left,
+      bounds.top,
+      Math.max(1, bounds.width),
+      Math.max(MIN_MODAL_HEIGHT, bounds.height),
+    );
   }
 
   /**
@@ -126,18 +141,40 @@ export class ChatOverlayView {
    * land mid-row at most terminal heights, and the layout rounds a child's
    * offset from its parent separately from that child's size: at a fractional
    * offset the two disagree and the transcript either runs a row into the
-   * composer or leaves a row of the modal's floor blank. Rounding each edge
-   * here is what the layout already did to the modal itself, so the rectangle
-   * is unchanged, but every offset inside it is now whole.
+   * composer or leaves a row of the modal's floor blank.
+   *
+   * Rounding the four edges reproduces the rectangle the percentages already
+   * produced, so the modal is the same size and in the same place as before;
+   * only the offsets inside it become whole. That equivalence is a property of
+   * how the layout rounds, which is per edge and not per size: it rounds a
+   * node's absolute left and its absolute right, then takes the width from the
+   * difference. So the width was already `round(0.9W) - round(0.1W)` and never
+   * `round(0.8W)`, which disagrees with it at 104 of the 261 widths from 40 to
+   * 300. `pins the modal rectangle across a width sweep` holds this.
    */
   #applyModalGeometry(): void {
     const {terminalWidth, terminalHeight} = this.renderer;
     const left = Math.round(terminalWidth * MODAL_LEFT);
     const top = Math.round(terminalHeight * MODAL_TOP);
+    this.#applyGeometry(
+      left,
+      top,
+      Math.max(1, Math.round(terminalWidth * MODAL_RIGHT) - left),
+      Math.max(MIN_MODAL_HEIGHT, Math.round(terminalHeight * MODAL_BOTTOM) - top),
+    );
+  }
+
+  /**
+   * The one place the modal's rectangle is written, so the width its children
+   * are told is the width just assigned rather than a read back out of the
+   * layout.
+   */
+  #applyGeometry(left: number, top: number, width: number, height: number): void {
     this.output.left = left;
-    this.output.width = Math.max(1, Math.round(terminalWidth * MODAL_RIGHT) - left);
     this.output.top = top;
-    this.output.height = Math.max(3, Math.round(terminalHeight * MODAL_BOTTOM) - top);
+    this.output.width = width;
+    this.output.height = height;
+    this.#contentWidth = Math.max(1, width - MODAL_CHROME);
   }
 
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
@@ -154,7 +191,7 @@ export class ChatOverlayView {
     this.#composer.syncPending(state.chatPending, state.chatOpen);
     if (!state.chatOpen) return;
     this.output.title = ` ${chatThreadHeading(state)} `;
-    this.#composer.activate(Math.max(1, this.output.width - 4), true, state.chatPending);
+    this.#composer.activate(this.#contentWidth, true, state.chatPending);
     this.#composer.renderMenu(state);
     this.#conversation.render(state);
     this.#transcript.scrollTo(this.#transcript.scrollHeight);

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -10,6 +10,15 @@ import {ChatComposerView, type ChatDraft} from './chat-composer.js';
 import {ConversationView} from './conversation.js';
 import type {Theme} from './theme.js';
 
+/**
+ * The centred modal's four edges as fractions of the terminal: 80% of the
+ * columns, centred, and 76% of the rows starting a tenth of the way down.
+ */
+const MODAL_LEFT = 0.1;
+const MODAL_RIGHT = 0.9;
+const MODAL_TOP = 0.1;
+const MODAL_BOTTOM = 0.86;
+
 /** Screen rectangle the chat occupies when it shares the row with a pane. */
 export interface PaneBounds {
   left: number;
@@ -36,7 +45,7 @@ export class ChatOverlayView {
   #bounds: PaneBounds | null = null;
 
   constructor(
-    renderer: CliRenderer,
+    private readonly renderer: CliRenderer,
     controller: SessionController,
     markdownStyle: SyntaxStyle,
     theme: Theme,
@@ -44,11 +53,7 @@ export class ChatOverlayView {
   ) {
     this.output = new BoxRenderable(renderer, {
       id: 'chat-overlay',
-      width: '80%',
-      height: '76%',
       position: 'absolute',
-      left: '10%',
-      top: '10%',
       flexDirection: 'column',
       paddingLeft: 1,
       paddingRight: 1,
@@ -86,6 +91,7 @@ export class ChatOverlayView {
       theme,
       'chat-modal',
     );
+    this.#applyModalGeometry();
     this.#transcript.add(this.#conversation.output);
     this.output.add(this.#transcript);
     // Anchored to the composer, matching the docked pane: the same commands
@@ -100,19 +106,38 @@ export class ChatOverlayView {
    * ``null`` restores the centred modal geometry.
    */
   setPaneBounds(bounds: PaneBounds | null): void {
-    if (samePaneBounds(this.#bounds, bounds)) return;
-    this.#bounds = bounds;
+    // The modal measures itself against the terminal, so it is recomputed even
+    // when the bounds did not change: a resize changes the answer.
     if (bounds === null) {
-      this.output.left = '10%';
-      this.output.width = '80%';
-      this.output.top = '10%';
-      this.output.height = '76%';
+      this.#bounds = null;
+      this.#applyModalGeometry();
       return;
     }
+    if (samePaneBounds(this.#bounds, bounds)) return;
+    this.#bounds = bounds;
     this.output.left = bounds.left;
     this.output.width = Math.max(1, bounds.width);
     this.output.top = bounds.top;
     this.output.height = Math.max(3, bounds.height);
+  }
+
+  /**
+   * Places the centred modal on whole cells. Left as percentages, its edges
+   * land mid-row at most terminal heights, and the layout rounds a child's
+   * offset from its parent separately from that child's size: at a fractional
+   * offset the two disagree and the transcript either runs a row into the
+   * composer or leaves a row of the modal's floor blank. Rounding each edge
+   * here is what the layout already did to the modal itself, so the rectangle
+   * is unchanged, but every offset inside it is now whole.
+   */
+  #applyModalGeometry(): void {
+    const {terminalWidth, terminalHeight} = this.renderer;
+    const left = Math.round(terminalWidth * MODAL_LEFT);
+    const top = Math.round(terminalHeight * MODAL_TOP);
+    this.output.left = left;
+    this.output.width = Math.max(1, Math.round(terminalWidth * MODAL_RIGHT) - left);
+    this.output.top = top;
+    this.output.height = Math.max(3, Math.round(terminalHeight * MODAL_BOTTOM) - top);
   }
 
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -41,6 +41,38 @@ export function chatDockFits(terminalWidth: number, rightPaneWidth = 0): boolean
 }
 
 /**
+ * The row the command column gives up so its box shares a bottom edge with the
+ * docked Message box. The pane is bordered and the column is not, so the pane
+ * spends the terminal's last row on its own bottom border and the column has to
+ * skip the same row to end level with it.
+ */
+const DOCK_ALIGNMENT_ROWS = 1;
+
+/**
+ * Rows the landing table keeps for itself before presentation may spend one.
+ * Nine is the kickoff panel: two borders around the round's title, the phase
+ * list, and the lines saying what the round produces.
+ */
+const MIN_LANDING_ROWS = 9;
+
+/**
+ * Rows the command column insets itself by so the Command and Message boxes
+ * line up beneath a docked chat.
+ *
+ * The row is not free: it comes out of the table above it. A terminal short
+ * enough that the table would lose a line keeps the row instead and lets the
+ * two boxes sit one row apart. Alignment is presentation and the table is the
+ * view, so a short terminal degrades in the direction the operator can see and
+ * undo (resize) rather than silently clipping the content.
+ *
+ * `landingRows` is what the table has before this inset is taken.
+ */
+export function commandColumnInset(chatDocked: boolean, landingRows: number): number {
+  if (!chatDocked) return 0;
+  return landingRows - DOCK_ALIGNMENT_ROWS >= MIN_LANDING_ROWS ? DOCK_ALIGNMENT_ROWS : 0;
+}
+
+/**
  * Width in columns for the docked chat. It asks for the columns left over once
  * the table has enough for its claim, so a wide terminal loses no table column
  * to the chat; where there is no such surplus it still takes its readable


### PR DESCRIPTION
Closes #563.

## Problem

Three defects in the bottom of the screen, where you type.

**The Message and Command boxes did not line up.** Two separate one-row asymmetries: the two columns ordered hint and box differently, and the docked chat pane is bordered so its bottom border owns the terminal's last row while the command column has no border. Measured at 150x40: Message bottom on row 38, Command bottom on row 40.

![The bottom five rows: the Message and Command boxes sharing a top and a bottom edge, each hint on the row above](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr556.png)

**The chat modal overlapped its own transcript.** Its edges were fractions of a row (`top: 10%, height: 76%`), and Yoga rounds a child's offset independently of its size:

```
transcript end = round(0.86H - 5)
composer start = round(0.1H) + round(0.76H - 5)
```

These disagree at **25 of the 111 heights** from 10 to 120. The sign varies: some overlap by a row, others leave a gap and push the input onto the border.

**The slash-command menu floated a row above its box** instead of sitting flush on it, unlike the command bar's.

## Solution

Both columns read hint-then-box, and `app.ts` adds a one-row inset when the chat is docked. The modal computes its four edges in whole cells, which reproduces the rectangle the layout already painted at every size, and hands the composer the width it just assigned rather than one read back out of the layout. The menu anchors on the box height rather than the whole composer.

**Cost:** when the chat is docked and the landing table can spare the row, the terminal's last row carries only the chat pane's closing border. A terminal too short to spare it keeps the row and the two boxes sit one row apart. Undocked, the layout is byte-identical to before.

## Verification

The modal test resizes across heights 18 to 48 and pins the invariant **per height** rather than at one size, since the earlier one-size sweep is what hid this. Each test was confirmed to fail without its fix. Rebased onto `adi/focus-contrast` at bfd2607 (itself on `main` at 8e09827), which moved the nested `Message` composer to the resting frame; no conflicts and no test asserted the old chrome.

| Check | Result |
| --- | --- |
| `pnpm --filter @vibesys/tui test` | 679 pass, 0 fail, 28 files |
| `pnpm --filter @vibesys/tui check` | clean |
| `pnpm exec biome check clients/tui/src clients/tui/dev` | clean, 68 files |
| `pnpm check:ts-architecture` | clean |

