### PR TITLE
fix(loops): share gate failure-output truncation lengths as named constants

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -45,7 +45,12 @@ from vibesys.loops.agent.model import (
 )
 from vibesys.loops.agent.state import AgentRunStateStore
 from vibesys.loops.evolve.population import Objective  # noqa: TC001  # tracked: #288
-from vibesys.loops.gates import run_accuracy_gate
+from vibesys.loops.gates import (
+    GATE_FEEDBACK_TAIL_CHARS,
+    GATE_LOG_TAIL_CHARS,
+    GATE_RECORD_TAIL_CHARS,
+    run_accuracy_gate,
+)
 from vibesys.loops.profiler import mcp_spec as profiler_mcp_spec
 from vibesys.profilers import (
     ProfilerKind,
@@ -1778,7 +1783,7 @@ def _run_framework_validation_gate(  # noqa: C901, PLR0912, PLR0915  # tracked: 
                 input_digest=input_digest,
                 passed=passed,
                 exit_code=execution.exit_code,
-                output=output[-8000:],
+                output=output[-GATE_RECORD_TAIL_CHARS:],
                 error=None if passed else "command exited nonzero",
             )
         except Exception as exc:  # noqa: BLE001  # tracked: #288
@@ -1909,7 +1914,7 @@ def _run_framework_accuracy_gate(  # noqa: PLR0913  # tracked: #288
         retry,
         command=result.command or "(not configured)",
         passed=result.passed,
-        output=result.output[-8000:],
+        output=result.output[-GATE_RECORD_TAIL_CHARS:],
     )
     ctx.snapshot_workspace(f"round-{round_number}-retry-{retry}-framework-accuracy")
     return result.feedback
@@ -2155,7 +2160,7 @@ def _run_framework_benchmark(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracke
         passed=passed,
         metric_name=metric_name,
         metric_value=metric_value,
-        output=output[-8000:],
+        output=output[-GATE_RECORD_TAIL_CHARS:],
     )
     ctx.snapshot_workspace(f"round-{round_number}-retry-{retry}-framework-benchmark")
     if passed:
@@ -2184,8 +2189,8 @@ def _run_framework_benchmark(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracke
             row=row,
         )
 
-    feedback = f"Framework benchmark failed.\n{output[-4000:]}"
-    ctx.lprint(f"[framework-benchmark] FAIL: {output[-1000:]}")
+    feedback = f"Framework benchmark failed.\n{output[-GATE_FEEDBACK_TAIL_CHARS:]}"
+    ctx.lprint(f"[framework-benchmark] FAIL: {output[-GATE_LOG_TAIL_CHARS:]}")
     return FrameworkBenchmarkOutcome(feedback=feedback)
 
 

--- a/src/vibesys/loops/gates.py
+++ b/src/vibesys/loops/gates.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from vibesys.run import LoopContext  # noqa: TC001  # tracked: #288
+
+# Truncation lengths for gate failure output. All three values are defined
+# here so that the logged window, the agent-feedback window, and the record
+# window stay consistent across every gate and loop call site.
+GATE_LOG_TAIL_CHARS = 1000
+GATE_FEEDBACK_TAIL_CHARS = 4000
+GATE_RECORD_TAIL_CHARS = 8000
 from vibesys.run.events import CoreEventType, SubprocessOutputData
 
 
@@ -74,8 +81,8 @@ def run_accuracy_gate(
         ctx.lprint("[framework-accuracy] PASS")
         feedback = None
     else:
-        ctx.lprint(f"[framework-accuracy] FAIL: {output[-1000:]}")
-        feedback = f"Framework accuracy gate failed.\n{output[-4000:]}"
+        ctx.lprint(f"[framework-accuracy] FAIL: {output[-GATE_LOG_TAIL_CHARS:]}")
+        feedback = f"Framework accuracy gate failed.\n{output[-GATE_FEEDBACK_TAIL_CHARS:]}"
 
     return AccuracyGateResult(
         command=command,

--- a/src/vibesys/loops/gates.py
+++ b/src/vibesys/loops/gates.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from vibesys.run import LoopContext  # noqa: TC001  # tracked: #288
+from vibesys.run.events import CoreEventType, SubprocessOutputData
 
 # Truncation lengths for gate failure output. All three values are defined
 # here so that the logged window, the agent-feedback window, and the record
@@ -12,7 +13,6 @@ from vibesys.run import LoopContext  # noqa: TC001  # tracked: #288
 GATE_LOG_TAIL_CHARS = 1000
 GATE_FEEDBACK_TAIL_CHARS = 4000
 GATE_RECORD_TAIL_CHARS = 8000
-from vibesys.run.events import CoreEventType, SubprocessOutputData
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Problem
The accuracy gate and benchmark gate each independently hardcode failure
output truncation lengths as bare slice literals: last 1000 chars logged,
last 4000 chars fed back to the agent, last 8000 chars recorded. Seven
copies across gates.py and loop.py are unlinked by the type system, so
changing one silently diverges the others and gives agents an incoherent
view of failures.

Closes #549

## Solution
Define GATE_LOG_TAIL_CHARS=1000, GATE_FEEDBACK_TAIL_CHARS=4000, and
GATE_RECORD_TAIL_CHARS=8000 as named constants in gates.py. All 7 bare
[-N:] slice literals in gates.py and loop.py are replaced with the
constants. Pure de-duplication — no behavior change.

## Architecture
No new modules. Constants live in gates.py (the natural owner of gate
policy). loop.py extends its existing gates import to include the three
constants alongside run_accuracy_gate.

## Verification

### Correctness properties
- Values are byte-for-byte identical to the literals they replace
- A single definition site means future changes propagate automatically
  to all gates and record sites

### Testing
uv run pytest tests/vibesys/loops -x -q
548 passed, 0 failed

grep -n "output\[-[0-9]*:\]" src/vibesys/loops/gates.py src/vibesys/loops/agent/loop.py
(no output — zero residual literals remain)