### PR TITLE
fix(tui): make overlay scroll when content exceeds the box

### DIFF
--- a/.agents/skills/tui-bug-hunt/reference.md
+++ b/.agents/skills/tui-bug-hunt/reference.md
@@ -116,7 +116,9 @@ Chat composer: `Enter` submit, `Shift+Enter` newline.
   `request→Request failed`, `input→Input error`, `run→Run failed`. Equivalent
   reports fold into one banner and bump `count`.
 - **Modal overlay** (`detail`/`help`/`error`): titles Command/Help/Error;
-  footer `Esc to close`. Used for acks, `/help`, perf modal fallback.
+  footer `Esc to close · PgUp/PgDn: scroll` on its own reserved row, over a
+  scroll viewport that PgUp/PgDn page while the overlay is open and that starts
+  at the top on every open. Used for acks, `/help`, perf modal fallback.
 - **argparse diagnostics** print to the terminal for `-h`/`validate` (bypass
   TUI). In server mode a backend argparse failure is surfaced as an error-banner
   diagnostic (stage `argument_parsing`, exit code, hint) rather than exiting.

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1968,6 +1968,112 @@ describe('OpenTUI presentation', () => {
   });
 });
 
+describe('overlay scrolling', () => {
+  /** Content taller than the overlay box at any terminal size it is used at. */
+  function longOverlayContent(): string {
+    return Array.from(
+      {length: 60},
+      (_, index) => `overlay line ${String(index).padStart(2, '0')}`,
+    ).join('\n');
+  }
+
+  function hintRows(frame: string): number {
+    return frameRows(frame).filter(row => row.includes('PgUp/PgDn: scroll')).length;
+  }
+
+  it('reaches the last line of content taller than the box', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      overlay: {kind: 'help', content: longOverlayContent()},
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const first = await testRenderer.waitForFrame(value => value.includes('overlay line 00'));
+    expect(first).not.toContain('overlay line 59');
+
+    // No named page key in the mock input; send the raw terminal sequence.
+    for (let index = 0; index < 12; index += 1) testRenderer.mockInput.pressKey('\x1B[6~');
+    const scrolled = await frameAfter(testRenderer);
+
+    // The last row of content is the one the hint used to overpaint.
+    expect(scrolled).toContain('overlay line 59');
+    expect(scrolled).not.toContain('overlay line 00');
+
+    for (let index = 0; index < 12; index += 1) testRenderer.mockInput.pressKey('\x1B[5~');
+    expect(await frameAfter(testRenderer)).toContain('overlay line 00');
+  });
+
+  it('keeps one hint row however often the content changes', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      overlay: {kind: 'detail', content: 'ack 0'},
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    expect(hintRows(await frameAfter(testRenderer))).toBe(1);
+
+    for (let index = 1; index <= 6; index += 1) {
+      controller.publish({
+        ...controller.state,
+        overlay: {kind: 'detail', content: `ack ${index}`},
+      });
+      const frame = await frameAfter(testRenderer);
+      expect(frame, `after ${index} content changes`).toContain(`ack ${index}`);
+      expect(hintRows(frame), `after ${index} content changes`).toBe(1);
+    }
+  });
+
+  it('reopens the same overlay at the top', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const overlay = {kind: 'help' as const, content: longOverlayContent()};
+    const controller = new FakeController({...initialSessionState(), overlay});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('overlay line 00'));
+
+    for (let index = 0; index < 12; index += 1) testRenderer.mockInput.pressKey('\x1B[6~');
+    expect(await frameAfter(testRenderer)).toContain('overlay line 59');
+
+    controller.publish({...controller.state, overlay: null});
+    await frameAfter(testRenderer);
+    controller.publish({...controller.state, overlay});
+    const reopened = await frameAfter(testRenderer);
+
+    expect(reopened).toContain('overlay line 00');
+    expect(reopened).not.toContain('overlay line 59');
+  });
+
+  it('scrolls the overlay rather than the docked chat behind it', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 24});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.focus).toBe('chat');
+
+    controller.publish({
+      ...controller.state,
+      overlay: {kind: 'help', content: longOverlayContent()},
+    });
+    await testRenderer.waitForFrame(value => value.includes('overlay line 00'));
+
+    const chatScroll = testRenderer.renderer.root.findDescendantById('chat-pane-scroll');
+    if (!(chatScroll instanceof ScrollBoxRenderable)) throw new Error('no docked chat scroll box');
+    for (let index = 0; index < 12; index += 1) testRenderer.mockInput.pressKey('\x1B[6~');
+    const scrolled = await frameAfter(testRenderer);
+
+    expect(scrolled).toContain('overlay line 59');
+    expect(chatScroll.scrollTop).toBe(0);
+    expect(controller.state.layout.focus).toBe('chat');
+  });
+});
+
 describe('theming', () => {
   const assistantEntry = {
     id: 'themed',

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -441,6 +441,7 @@ export function createOpenTuiApp(
     scrollChatPane: delta => chatPane.scrollBy(delta),
     scrollExperimentDetail: delta => experimentLog.scrollBy(delta),
     scrollErrorBanner: delta => errorBanner.scrollBy(delta),
+    scrollOverlay: delta => overlay.scrollBy(delta),
     clearTransientStatus: () => {
       if (transientStatus === null) return;
       transientStatus = null;

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -27,6 +27,7 @@ export interface KeybindingActions {
   scrollChatPane(delta: number): void;
   scrollExperimentDetail(delta: number): void;
   scrollErrorBanner(delta: number): void;
+  scrollOverlay(delta: number): void;
   clearTransientStatus(): void;
   showClipboardStatus(result: Exclude<ClipboardCopyResult, 'no-selection'>): void;
 }
@@ -180,6 +181,55 @@ export function bindKeybindings(
         return;
       }
       return;
+    }
+    if (controller.state.themePicker !== null) {
+      if (key.name === 'up') controller.moveThemeSelection(-1);
+      else if (key.name === 'down') controller.moveThemeSelection(1);
+      else if (key.name === 'pageup') controller.moveThemeSelection(-10);
+      else if (key.name === 'pagedown') controller.moveThemeSelection(10);
+      else if (key.name === 'escape') controller.closeThemePicker();
+      else if (key.name === 'return' || key.name === 'enter') {
+        if (!actions.inputIsEmpty()) return;
+        controller.applySelectedTheme();
+      } else return;
+      key.preventDefault();
+      return;
+    }
+    if (controller.state.chatOpen) {
+      if (key.name === 'escape') {
+        if (controller.state.layout.right !== null) controller.closeOverlays();
+        else actions.closeChat();
+        key.preventDefault();
+        return;
+      }
+      // Same suggestion-menu priority as the docked chat above.
+      if (key.name === 'up' || key.name === 'down') {
+        if (actions.navigateChatSuggestions(key.name === 'up' ? -1 : 1)) key.preventDefault();
+        return;
+      }
+      if (key.name === 'tab' && !key.shift) {
+        if (actions.completeChatInput()) key.preventDefault();
+        return;
+      }
+      return;
+    }
+    if (controller.state.overlay !== null) {
+      if (key.name === 'escape') {
+        controller.live();
+        viewport.scrollTo(viewport.scrollHeight);
+        key.preventDefault();
+        return;
+      }
+      if (key.name === 'pageup') {
+        actions.scrollOverlay(-1);
+        key.preventDefault();
+        return;
+      }
+      if (key.name === 'pagedown') {
+        actions.scrollOverlay(1);
+        key.preventDefault();
+        return;
+      }
     }
     // The experiment surface owns navigation while it is on screen. The index
     // opens a hypothesis summary; that summary selects and opens one round.

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -156,6 +156,10 @@ export function bindKeybindings(
       if (key.name === 'escape') {
         controller.live();
         viewport.scrollTo(viewport.scrollHeight);
+      } else if (key.name === 'pageup' || key.name === 'pagedown') {
+        // Content taller than the box scrolls here rather than falling through
+        // to the transcript behind it.
+        actions.scrollOverlay(key.name === 'pageup' ? -1 : 1);
       }
       // The overlay is modal: everything it does not handle is swallowed so
       // keys cannot reach the panes or the hidden command input behind it.
@@ -181,55 +185,6 @@ export function bindKeybindings(
         return;
       }
       return;
-    }
-    if (controller.state.themePicker !== null) {
-      if (key.name === 'up') controller.moveThemeSelection(-1);
-      else if (key.name === 'down') controller.moveThemeSelection(1);
-      else if (key.name === 'pageup') controller.moveThemeSelection(-10);
-      else if (key.name === 'pagedown') controller.moveThemeSelection(10);
-      else if (key.name === 'escape') controller.closeThemePicker();
-      else if (key.name === 'return' || key.name === 'enter') {
-        if (!actions.inputIsEmpty()) return;
-        controller.applySelectedTheme();
-      } else return;
-      key.preventDefault();
-      return;
-    }
-    if (controller.state.chatOpen) {
-      if (key.name === 'escape') {
-        if (controller.state.layout.right !== null) controller.closeOverlays();
-        else actions.closeChat();
-        key.preventDefault();
-        return;
-      }
-      // Same suggestion-menu priority as the docked chat above.
-      if (key.name === 'up' || key.name === 'down') {
-        if (actions.navigateChatSuggestions(key.name === 'up' ? -1 : 1)) key.preventDefault();
-        return;
-      }
-      if (key.name === 'tab' && !key.shift) {
-        if (actions.completeChatInput()) key.preventDefault();
-        return;
-      }
-      return;
-    }
-    if (controller.state.overlay !== null) {
-      if (key.name === 'escape') {
-        controller.live();
-        viewport.scrollTo(viewport.scrollHeight);
-        key.preventDefault();
-        return;
-      }
-      if (key.name === 'pageup') {
-        actions.scrollOverlay(-1);
-        key.preventDefault();
-        return;
-      }
-      if (key.name === 'pagedown') {
-        actions.scrollOverlay(1);
-        key.preventDefault();
-        return;
-      }
     }
     // The experiment surface owns navigation while it is on screen. The index
     // opens a hypothesis summary; that summary selects and opens one round.

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -1,4 +1,4 @@
-import {BoxRenderable, type CliRenderer, TextRenderable} from '@opentui/core';
+import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
 import type {SessionState} from '../session-model.js';
 import type {Theme} from './theme.js';
 
@@ -21,6 +21,7 @@ export class OverlayView {
   #theme: Theme;
   #renderedKind: OverlayKind | null = null;
   #renderedContent = '';
+  readonly #scroll: ScrollBoxRenderable;
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -45,6 +46,16 @@ export class OverlayView {
       // submitted from the modal chat has to be visible over it.
       zIndex: 25,
     });
+    this.#scroll = new ScrollBoxRenderable(renderer, {
+      id: 'overlay-scroll',
+      width: '100%',
+      flexGrow: 1,
+    });
+    this.output.add(this.#scroll);
+  }
+
+  scrollBy(delta: number): void {
+    this.#scroll.scrollBy(delta, 'viewport');
   }
 
   applyTheme(theme: Theme): void {
@@ -68,7 +79,8 @@ export class OverlayView {
     this.output.borderColor = borderFor(this.#theme, overlay.kind);
     this.output.title = ` ${TITLE[overlay.kind]} `;
     this.#clear();
-    this.output.add(
+    this.#scroll.scrollTo(0);
+    this.#scroll.add(
       new TextRenderable(this.renderer, {
         content: overlay.content,
         fg:
@@ -80,7 +92,7 @@ export class OverlayView {
     );
     this.output.add(
       new TextRenderable(this.renderer, {
-        content: 'Esc to close',
+        content: 'Esc to close · PgUp/PgDn: scroll',
         fg: this.#theme.textSubtle,
         width: '100%',
       }),
@@ -88,8 +100,8 @@ export class OverlayView {
   }
 
   #clear(): void {
-    for (const child of [...this.output.getChildren()]) {
-      this.output.remove(child);
+    for (const child of [...this.#scroll.getChildren()]) {
+      this.#scroll.remove(child);
       child.destroyRecursively();
     }
   }

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -10,6 +10,19 @@ const TITLE: Record<OverlayKind, string> = {
   error: 'Error',
 };
 
+const HINT = 'Esc to close · PgUp/PgDn: scroll';
+
+/**
+ * The share of the screen the box takes. It is applied in whole rows and
+ * columns rather than as a Yoga percentage: a fractional box edge rounds the
+ * hint back onto the scroll viewport's last row, which hides the final line of
+ * content.
+ */
+const WIDTH_SHARE = 0.7;
+const LEFT_SHARE = 0.15;
+const HEIGHT_SHARE = 0.6;
+const TOP_SHARE = 0.18;
+
 function borderFor(theme: Theme, kind: OverlayKind): string {
   if (kind === 'help') return theme.success;
   if (kind === 'error') return theme.error;
@@ -18,10 +31,11 @@ function borderFor(theme: Theme, kind: OverlayKind): string {
 
 export class OverlayView {
   readonly output: BoxRenderable;
+  readonly #scroll: ScrollBoxRenderable;
+  readonly #hint: TextRenderable;
   #theme: Theme;
   #renderedKind: OverlayKind | null = null;
   #renderedContent = '';
-  readonly #scroll: ScrollBoxRenderable;
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -30,11 +44,7 @@ export class OverlayView {
     this.#theme = theme;
     this.output = new BoxRenderable(renderer, {
       id: 'overlay',
-      width: '70%',
-      height: '60%',
       position: 'absolute',
-      left: '15%',
-      top: '18%',
       flexDirection: 'column',
       paddingLeft: 1,
       paddingRight: 1,
@@ -50,10 +60,27 @@ export class OverlayView {
       id: 'overlay-scroll',
       width: '100%',
       flexGrow: 1,
+      stickyScroll: false,
+      viewportCulling: true,
+      verticalScrollbarOptions: {showArrows: false},
+    });
+    // The box owns its scroll viewport and its hint row for the whole life of
+    // the view: only the scrolled content is rebuilt per overlay. The hint has
+    // a reserved row of its own so it cannot overpaint the last content line.
+    this.#hint = new TextRenderable(renderer, {
+      content: HINT,
+      fg: theme.textSubtle,
+      width: '100%',
+      height: 1,
+      flexShrink: 0,
+      wrapMode: 'none',
+      truncate: true,
     });
     this.output.add(this.#scroll);
+    this.output.add(this.#hint);
   }
 
+  /** Scrolled by Page Up/Page Down while the overlay is open. */
   scrollBy(delta: number): void {
     this.#scroll.scrollBy(delta, 'viewport');
   }
@@ -62,6 +89,7 @@ export class OverlayView {
     this.#theme = theme;
     this.output.backgroundColor = theme.elevatedSurface;
     this.output.borderColor = borderFor(theme, this.#renderedKind ?? 'detail');
+    this.#hint.fg = theme.textSubtle;
     this.#renderedKind = null;
     this.#renderedContent = '';
   }
@@ -70,16 +98,21 @@ export class OverlayView {
     const overlay = state.overlay;
     if (overlay === null) {
       this.output.visible = false;
+      // Scroll position belongs to one viewing of one overlay. Forgetting what
+      // is on screen makes the next open rebuild the content, which puts the
+      // viewport back at the top even when the same overlay is reopened.
+      this.#renderedKind = null;
+      this.#renderedContent = '';
       return;
     }
     this.output.visible = true;
+    this.#applyGeometry();
     if (this.#renderedKind === overlay.kind && this.#renderedContent === overlay.content) return;
     this.#renderedKind = overlay.kind;
     this.#renderedContent = overlay.content;
     this.output.borderColor = borderFor(this.#theme, overlay.kind);
     this.output.title = ` ${TITLE[overlay.kind]} `;
     this.#clear();
-    this.#scroll.scrollTo(0);
     this.#scroll.add(
       new TextRenderable(this.renderer, {
         content: overlay.content,
@@ -88,15 +121,21 @@ export class OverlayView {
             ? this.#theme.conversation.failure.content
             : this.#theme.textPrimary,
         width: '100%',
+        flexShrink: 0,
+        wrapMode: 'word',
       }),
     );
-    this.output.add(
-      new TextRenderable(this.renderer, {
-        content: 'Esc to close · PgUp/PgDn: scroll',
-        fg: this.#theme.textSubtle,
-        width: '100%',
-      }),
-    );
+    this.#scroll.scrollTo(0);
+  }
+
+  /** Whole-row, whole-column geometry, recomputed as the terminal resizes. */
+  #applyGeometry(): void {
+    const columns = this.renderer.terminalWidth;
+    const rows = this.renderer.terminalHeight;
+    this.output.width = Math.round(columns * WIDTH_SHARE);
+    this.output.left = Math.round(columns * LEFT_SHARE);
+    this.output.height = Math.round(rows * HEIGHT_SHARE);
+    this.output.top = Math.round(rows * TOP_SHARE);
   }
 
   #clear(): void {


### PR DESCRIPTION
## Problem

The `/help`, `/design`, and split-fallback overlays rendered their whole content as one `TextRenderable` inside a fixed-share box with no scroll region. On a short terminal everything past the box height was clipped and unreachable: the operator saw the top of the content and had no way to page down.

Closes #554

## Solution

Content renders into a `ScrollBoxRenderable` inside `OverlayView`, the pattern `right-pane.ts` and `error-banner.ts` already use, and Page Up/Page Down scroll it while the overlay is open.

Two things the box has to get right for that to be usable:

- **The hint is part of the box, not part of the content.** `Esc to close · PgUp/PgDn: scroll` is created once in the constructor with a reserved row (`height: 1, flexShrink: 0, wrapMode: 'none', truncate: true`) and lives for the life of the view. Rebuilding it per render leaked one hint row per content change; giving it no row of its own let it overpaint the scroll viewport's last row, which hid the final line of content.
- **The box is sized in whole rows and columns.** It kept the same share of the screen it always had (70% wide, 60% tall, at 15%/18%), but as Yoga percentages those are fractional edges, and at 100x24 the rounding put the hint back on the viewport's last row even with the row reserved. `#applyGeometry` recomputes integer width, height, left, and top from the terminal size on every render, so resizes still track.

Scroll-position rule, pinned by a test: **the scroll resets to the top every time an overlay opens.** The view forgets its rendered snapshot when the overlay closes, so reopening the same overlay rebuilds the content and starts at the top instead of restoring the previous position.

On current `main` the overlay block in `keybindings.ts` already sits above `chatPaneFocused` and is fully modal, with Escape handled inside it and a blanket `key.preventDefault(); return;` for everything else. The keybinding change is therefore one `else if` for `pageup`/`pagedown` inside that block; Escape handling is untouched.

### Architecture

Ownership is unchanged: the TUI owns presentation and interaction state, and the overlay is a view over `state.overlay`.

- `ui/overlay.ts` owns the box, its scroll viewport, its hint row, and its geometry, and exposes `scrollBy(delta)`.
- `ui/app.ts` wires the `scrollOverlay` action to `overlay.scrollBy`.
- `ui/keybindings.ts` routes Page Up/Page Down to that action while an overlay is open, ahead of the panes and the hidden command input behind it.

```mermaid
flowchart LR
  key[PgUp/PgDn] --> kb[keybindings: overlay modal block]
  kb --> act[actions.scrollOverlay]
  act --> view[OverlayView.scrollBy]
  view --> scroll[overlay-scroll viewport]
```

Branch note: this branch was rebuilt on current `main` with only this PR's own commit. Its earlier lower commits belonged to #541, #557, #558, and #559, which are now closed or merged.

## Verification

### Correctness properties

- Content taller than the box is reachable to its last line; the hint never overpaints a content row.
- The box shows exactly one hint row, however many times the content changes while the overlay stays open.
- The scroll position resets to the top on every open, including reopening the same overlay.
- While an overlay is open, Page Up/Page Down scroll the overlay and reach neither the transcript, the docked chat, nor the hidden command input; Escape still closes the overlay and returns to live output.
- The overlay keeps its screen share and z-order (above the chat modal, below the theme picker), now in whole rows and columns.

### Testing

Regression tests in `clients/tui/src/ui/app.test.ts` under `describe('overlay scrolling')`, using `createTestRenderer` at 100x24 with 60 numbered lines of content:

- `reaches the last line of content taller than the box`
- `keeps one hint row however often the content changes`
- `reopens the same overlay at the top`
- `scrolls the overlay rather than the docked chat behind it`

All four fail at `origin/main` and at the pre-fix commit of this branch (which reports two hint rows after the first content change and never reaches the last line); all four pass at this branch head.

| Command | Result |
| --- | --- |
| `bun test --max-concurrency 1 src` (in `clients/tui`) | 494 pass, 1 fail: the pre-existing `launcher > returns the backend argument error for an explicitly empty runs directory`, which cannot run in this sandbox ("The current working directory was deleted") |
| `pnpm check:clients` | pass |
| `pnpm check:ts` | pass (70 files, no fixes applied) |
| `pnpm check:ts-architecture` | pass (no dependency violations) |

A second, docs-only commit updates `.agents/skills/tui-bug-hunt/reference.md`, which still described the overlay footer as `Esc to close` with no scroll viewport. No backend, protocol, or prompt surface is touched.
