### PR TITLE
fix(tui): give the header real content and its own housing

### DIFF
--- a/clients/tui/dev/fixtures/markdown.experiments.json
+++ b/clients/tui/dev/fixtures/markdown.experiments.json
@@ -1,0 +1,21 @@
+[
+  {
+    "hypothesis_id": "h1",
+    "title": "Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path",
+    "claim": "Removing the mutex from the producer/consumer path removes the dominant cost.",
+    "action": "Replace the queue with a bounded SPSC ring and keep the C ABI identical.",
+    "first_round": 1,
+    "last_round": 1,
+    "rounds": [{"round": 1, "passed": true, "reviewed": true, "hypothesis_outcome": "proven"}],
+    "resolved_outcome": "proven",
+    "judge_verdict": "accepted",
+    "perf_metric": 301.4,
+    "perf_unit": "ms",
+    "perf_metric_name": "total_ms",
+    "perf_direction": "min",
+    "perf_baseline_value": 412.7,
+    "perf_delta_pct": -27.0,
+    "kept": true,
+    "active": false
+  }
+]

--- a/clients/tui/dev/mock-server.ts
+++ b/clients/tui/dev/mock-server.ts
@@ -266,6 +266,24 @@ function activeExecutionsFrom(delivered: RunEventRecord[]): ActiveExecutionCheck
   return [...active.values()];
 }
 
+/**
+ * Hypotheses for the experiment log, from `<fixture>.experiments.json` beside
+ * the fixture when one exists.
+ *
+ * Recorded journals hold events, not the projected experiment table, and the
+ * header and log render the hypothesis title rather than anything in the event
+ * stream. A sidecar keeps that title pinnable without inventing event types the
+ * backend never emits.
+ */
+function loadExperiments(fixturePath: string): unknown[] {
+  const sidecar = `${fixturePath.replace(/\.gz$/, '').replace(/\.jsonl$/, '')}.experiments.json`;
+  try {
+    return JSON.parse(readFileSync(sidecar, 'utf8')) as unknown[];
+  } catch {
+    return [];
+  }
+}
+
 /** Milliseconds to wait before `next`, from the recorded timestamps. */
 function gapMs(previous: RunEventRecord, next: RunEventRecord, options: Options): number {
   if (options.speed === 0) return 0;
@@ -470,6 +488,7 @@ function main(): void {
   // out: every read path a client can reach translates legacy lifecycle events,
   // so the replay owes the TUI the translated stream, not the recorded one.
   const events = canonicalJournalEvents(readJournalRecords(options.fixture));
+  const experiments = loadExperiments(options.fixture);
   const replay = new Replay(events, options);
   process.stderr.write(
     `mock: ${String(events.length)} events from ${options.fixture}\n` +
@@ -541,7 +560,10 @@ function main(): void {
           return;
         }
         case 'query.experiments': {
-          writeLine(socket, ok(id, responseBody(type)));
+          writeLine(
+            socket,
+            ok(id, withValues(responseBody(type), {experiments, experiments_ready: true})),
+          );
           return;
         }
         case 'query.events': {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it, test} from 'bun:test';
 import type {RunEvent, RunStatus} from '@vibesys/backend-client';
-import {type CoreRunStatus, hasRunEnded} from '@vibesys/core-state';
+import {hasRunEnded} from '@vibesys/core-state';
 import type {SessionState} from './session-model.js';
 import {
   applyActiveExecutionCheckpoint,
@@ -32,6 +32,7 @@ import {
   openPane,
   openThemePicker,
   reportError,
+  runStatusLabel,
   selectExperimentActivity,
   selectNextAgent,
   selectNextRound,
@@ -41,7 +42,6 @@ import {
   setPaneContent,
   setTheme,
   showDetail,
-  statusText,
   togglePaneZoom,
   toggleTodos,
   unownedExperimentRounds,
@@ -50,6 +50,7 @@ import {
   visiblePhases,
   visibleTodos,
 } from './session-model.js';
+import {runStateText, usageText} from './ui/header.js';
 
 describe('event batch projection', () => {
   it('keeps the existing banner while resumed history ends in a running session', () => {
@@ -1349,16 +1350,10 @@ describe('session event model', () => {
   // state. `/pause` is visible as `pausing…` until the backend says the pause
   // landed, and the run's ended status replaces it rather than joining it.
   it('renders one header status token per backend run status', () => {
-    const withStatus = (status: CoreRunStatus): string =>
-      statusText({
-        ...initialSessionState(),
-        core: {...initialSessionState().core, status},
-      });
-
-    expect(withStatus('running')).toBe('running · starting · no round yet');
-    expect(withStatus('pausing')).toBe('pausing… · starting · no round yet');
-    expect(withStatus('paused')).toBe('paused · starting · no round yet');
-    expect(withStatus('completed')).toBe('completed · starting · no round yet');
+    expect(runStatusLabel('running')).toBe('running');
+    expect(runStatusLabel('pausing')).toBe('pausing…');
+    expect(runStatusLabel('paused')).toBe('paused');
+    expect(runStatusLabel('completed')).toBe('completed');
   });
 
   it('reads a pause from the backend and drops it when the run ends', () => {
@@ -1370,18 +1365,17 @@ describe('session event model', () => {
       });
 
     let state = applyEvent(initialSessionState(), statusChange(1, 'pausing', 'running'));
-    expect(statusText(state)).toContain('pausing…');
+    expect(runStateText(state)).toBe('pausing…');
     state = applyEvent(state, statusChange(2, 'paused', 'pausing'));
-    expect(statusText(state)).toContain('paused');
+    expect(runStateText(state)).toBe('paused');
     state = applyEvent(state, statusChange(3, 'completed', 'paused'));
 
-    expect(statusText(state)).toContain('completed');
-    expect(statusText(state)).not.toContain('paused');
+    expect(runStateText(state)).toBe('completed');
   });
 
-  it('feeds usage updates into the status token meter', () => {
+  it('feeds usage updates into the header token meter', () => {
     let state = initialSessionState();
-    expect(statusText(state)).not.toContain('tokens');
+    expect(usageText(state)).toBeNull();
     state = applyEvent(
       state,
       event(1, 'usage_update', {
@@ -1397,7 +1391,7 @@ describe('session event model', () => {
       contextWindow: 1_000_000,
       model: 'claude-sonnet-4-6',
     });
-    expect(statusText(state)).toContain('20k/1.0M tokens');
+    expect(usageText(state)).toBe('20k/1.0M context');
     expect(state.core.transcript).toHaveLength(0);
   });
 

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -166,6 +166,12 @@ export type ExperimentIndexItem =
 export interface HypothesisScope {
   id: string;
   label: string;
+  /**
+   * The claim on its own, without the `· r1-r2` range `label` carries. The
+   * header shows this: the range duplicates the rounds strip, and spending
+   * header width on it pushed the title itself off the line.
+   */
+  title: string;
   rounds: number[];
   /** A single recorded round not yet associated with a hypothesis. */
   source?: 'hypothesis' | 'round';
@@ -922,6 +928,7 @@ export function enterExperimentRound(
     hypothesisScope: {
       id: entry.hypothesis_id,
       label: hypothesisLabel(entry),
+      title: hypothesisTitle(entry),
       rounds: scopeRounds(entry),
       source: 'hypothesis',
     },
@@ -954,6 +961,7 @@ export function enterUnownedExperimentRound(
     hypothesisScope: {
       id: `round-${roundNumber}`,
       label: `Round ${roundNumber}`,
+      title: `Round ${roundNumber}`,
       rounds: [roundNumber],
       source: 'round',
     },
@@ -985,12 +993,17 @@ export function hypothesisRoundNumbers(entry: HypothesisEntry): number[] {
   return scopeRounds(entry);
 }
 
+/** The claim itself, falling back to its id when the record carries no title. */
+function hypothesisTitle(entry: HypothesisEntry): string {
+  return entry.title ?? entry.hypothesis_id;
+}
+
 function hypothesisLabel(entry: HypothesisEntry): string {
   const range =
     entry.first_round === entry.last_round
       ? `r${entry.first_round}`
       : `r${entry.first_round}-${entry.last_round}`;
-  return `${entry.title ?? entry.hypothesis_id} · ${range}`;
+  return `${hypothesisTitle(entry)} · ${range}`;
 }
 
 export function selectedExperiment(state: SessionState): HypothesisEntry | null {
@@ -1866,23 +1879,6 @@ export function runStatusLabel(status: CoreRunStatus): string {
       return unhandled;
     }
   }
-}
-
-export function statusText(state: SessionState): string {
-  const base = `${runStatusLabel(state.core.status)} · ${state.core.agentKind ?? 'starting'} · ${state.core.roundLabel ?? 'no round yet'}`;
-  if (state.core.usage === null) return base;
-  const used = formatTokenCount(state.core.usage.inputTokens);
-  const meter =
-    state.core.usage.contextWindow === null
-      ? used
-      : `${used}/${formatTokenCount(state.core.usage.contextWindow)}`;
-  return `${base} · ${meter} tokens`;
-}
-
-function formatTokenCount(count: number): string {
-  if (count < 1_000) return String(count);
-  if (count < 1_000_000) return `${Math.floor(count / 1_000)}k`;
-  return `${(count / 1_000_000).toFixed(1)}M`;
 }
 
 export function visibleConversation(state: SessionState): ConversationEntry[] {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -106,7 +106,11 @@ describe('OpenTUI presentation', () => {
     registerCleanup(testRenderer.renderer, app);
 
     const frame = await testRenderer.waitForFrame(value => value.includes('fast_path()'));
-    expect(frame).toContain('running · optimizer · round 2');
+    // The header names the run state and the activity, never the backend's
+    // round label. `round 2` is not a label this loop emits, so the agent kind
+    // supplies the word.
+    expect(frame).toContain('VibeSys · running · optimizer');
+    expect(frame).not.toContain('running · optimizer · round 2');
     // No round is selected, so the agent strip is headed by the run. The run has
     // no rounds yet, so the rounds rail stays off and leaves the width to the
     // agents graph and transcript.
@@ -1195,7 +1199,7 @@ describe('OpenTUI presentation', () => {
     const testRenderer = await createTestRenderer({width: 130, height: 22});
     const controller = new FakeController({
       ...initialSessionState(),
-      hypothesisScope: {id: 'H-01', label: 'H-01 · r1', rounds: [1]},
+      hypothesisScope: {id: 'H-01', label: 'H-01 · r1', title: 'H-01', rounds: [1]},
       selectedRound: 1,
       core: {
         ...initialSessionState().core,
@@ -2739,7 +2743,10 @@ describe('theming', () => {
     expect(trajectory).toContain('r43');
     expect(trajectory).toContain('regression found');
     expect(trajectory).not.toContain('unrelated round 41');
-    expect(trajectory).toContain('H-08 · r42-43');
+    // The header names the hypothesis; the round range beside it duplicated
+    // the rounds strip directly below, so only the title is up there now.
+    expect(trajectory).toContain('H-08');
+    expect(trajectory).not.toContain('H-08 · r42-43');
     expect(trajectory).toContain('r42');
     expect(trajectory).toContain('r43');
     // The strip covers the whole run, so rounds outside this hypothesis are

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -4314,6 +4314,67 @@ describe('theming', () => {
   });
 });
 
+describe('header hierarchy', () => {
+  const runState = (status: string): SessionState => ({
+    ...initialSessionState(),
+    core: {
+      ...initialSessionState().core,
+      status,
+      agentKind: 'implementer',
+      roundLabel: 'round-1-retry-2-implementer',
+      usage: {inputTokens: 223_000, contextWindow: 400_000, model: 'claude-opus-5'},
+    },
+  });
+
+  it('draws each header role in its own tone rather than all in one accent', async () => {
+    const theme = resolveTheme('dark');
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController(runState('completed'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('223k/400k context'));
+
+    // Four tones on one line, which is the point: before this the renderer
+    // reported one accent-coloured span for the whole header.
+    expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(theme.accent);
+    expect(spanColors(testRenderer, 'completed')?.fg).toBe(theme.success);
+    expect(spanColors(testRenderer, 'implementing')?.fg).toBe(theme.textPrimary);
+    expect(spanColors(testRenderer, '223k/400k context')?.fg).toBe(theme.textMuted);
+  });
+
+  it('recolours the run state when the run ends badly', async () => {
+    const theme = resolveTheme('dark');
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController(runState('running'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('223k/400k context'));
+    expect(spanColors(testRenderer, 'running')?.fg).toBe(theme.textPrimary);
+
+    controller.publish({
+      ...controller.state,
+      core: {...controller.state.core, status: 'failed', terminal: true},
+    });
+    await testRenderer.waitForVisualIdle();
+
+    expect(spanColors(testRenderer, 'failed')?.fg).toBe(theme.error);
+  });
+
+  it('keeps the header whole in a terminal too narrow for all of it', async () => {
+    // One renderable per span means the row can shrink, and a shrinking row
+    // puts an ellipsis through every span at once (`V...ys·r...ng`) instead of
+    // the single cut the width budget decided on.
+    const testRenderer = await createTestRenderer({width: 24, height: 20});
+    const controller = new FakeController(runState('running'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('VibeSys'));
+    expect(frame).toContain('VibeSys · running');
+    expect(frame).not.toContain('V...');
+  });
+});
+
 /**
  * The experiment log settles synchronously, so there is no later frame to wait
  * for. Flush pending work, then read the single settled frame.

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -66,7 +66,8 @@ import {TRANSCRIPT_MIN} from './agent-map.js';
 import {createOpenTuiApp, type OpenTuiApp} from './app.js';
 import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 import {renderDesignSummary} from './design-log.js';
-import {resolveTheme, type ThemeName} from './theme.js';
+import {headerBackground} from './header.js';
+import {contrastRatio, listThemes, resolveTheme, type ThemeName} from './theme.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -885,7 +886,7 @@ describe('OpenTUI presentation', () => {
     const controller = new FakeController({
       ...initialSessionState(),
       selectedRound: 2,
-      hypothesisScope: {id: 'H-01', label: 'H-01 · r1-r2', rounds: [1, 2]},
+      hypothesisScope: {id: 'H-01', label: 'H-01 · r1-r2', title: 'H-01', rounds: [1, 2]},
       core: {
         ...initialSessionState().core,
         rounds: [
@@ -1695,9 +1696,9 @@ describe('OpenTUI presentation', () => {
     const frame = await testRenderer.waitForFrame(value => value.includes('2 passed'));
     expect(frame).toContain('→ Bash(command="pytest")');
     expect(frame).toContain('← 2 passed');
-    // Agents pane, transcript frame, and the card's call and result regions: the
-    // rail is absent because this fixture has no rounds.
-    expect(frame.match(/╭/g)).toHaveLength(4);
+    // Header housing, agents pane, transcript frame, and the card's call and
+    // result regions: the rail is absent because this fixture has no rounds.
+    expect(frame.match(/╭/g)).toHaveLength(5);
   });
 
   it('renders a typed command payload with labeled stderr and exit code', async () => {
@@ -2016,9 +2017,12 @@ describe('OpenTUI presentation', () => {
 
     await testRenderer.waitForFrame(value => value.includes('checking behavior'));
     testRenderer.mockInput.pressKey('TAB');
+    // The header names the selection in the same words as the phase segment,
+    // never as the backend phase kind it is stored as.
     const filtered = await testRenderer.waitForFrame(value =>
-      value.includes('selected implementer'),
+      value.includes('filtered to implementing'),
     );
+    expect(filtered).not.toContain('selected implementer');
     expect(filtered).toContain('edited files');
     expect(filtered).not.toContain('checking behavior');
   });
@@ -3815,7 +3819,7 @@ describe('theming', () => {
     expect(untitled).not.toContain('Batch prefill to cut latency');
   });
 
-  it('keeps the newest design round on screen in the pane at 100x30', async () => {
+  it('keeps the newest design round reachable in the pane at 100x30', async () => {
     const testRenderer = await createTestRenderer({width: 100, height: 30});
     const controller = logController();
     controller.paneContent = renderDesignSummary(
@@ -3833,14 +3837,22 @@ describe('theming', () => {
     await controller.openPane('design');
 
     // Ten rounds is 24 lines. The modal this replaced was 60% of 30 rows and
-    // did not scroll, so the newest rounds fell off the bottom; the pane is
-    // the full column and scrolls, so both ends are on screen.
+    // did not scroll, so the newest rounds were unreachable; the pane is the
+    // full column and scrolls, so every round can be read.
+    //
+    // Both ends no longer sit on screen together at 30 rows: the curated
+    // header is housed in a bordered box, which costs two rows the bare status
+    // line did not. The oldest round is there on open and the newest is a page
+    // away, rather than lost as it was in the modal.
     const frame = await testRenderer.waitForFrame(value =>
       value.includes('Design changes by round'),
     );
     expect(frame).toContain('Round 1 · H-07');
-    expect(frame).toContain('Round 10 · H-07');
-    expect(frame).toContain('src/round-10.rs');
+
+    for (let index = 0; index < 3; index += 1) testRenderer.mockInput.pressKey('\x1B[6~');
+    const scrolled = await frameAfter(testRenderer);
+    expect(scrolled).toContain('Round 10 · H-07');
+    expect(scrolled).toContain('src/round-10.rs');
   });
 
   it('annotates the selected round with its design changes once the log loads', async () => {
@@ -4359,6 +4371,42 @@ describe('header hierarchy', () => {
     await testRenderer.waitForVisualIdle();
 
     expect(spanColors(testRenderer, 'failed')?.fg).toBe(theme.error);
+  });
+
+  it('reads the header against the cell it is actually drawn on, in every theme', async () => {
+    // The frame paints a surface of its own, so `theme.canvas` is not what the
+    // header's text sits on and a floor measured against it checks a
+    // background nothing draws. The background here is read back off the
+    // rendered cell rather than named, which is also what pins `app.ts` and
+    // `headerSpanStyle` to one answer about where the header sits.
+    const themes = listThemes();
+    expect(themes).toHaveLength(8);
+    for (const theme of themes) {
+      const testRenderer = await createTestRenderer({width: 90, height: 20});
+      const controller = new FakeController({
+        ...initialSessionState(theme.name),
+        core: {...initialSessionState(theme.name).core, status: 'completed'},
+      });
+      const app = createOpenTuiApp(testRenderer.renderer, controller);
+      registerCleanup(testRenderer.renderer, app);
+      await testRenderer.waitForFrame(value => value.includes('VibeSys'));
+
+      const floor = theme.name.startsWith('high-contrast') ? 7 : 4.5;
+      for (const word of ['VibeSys', 'completed']) {
+        const drawn = spanColors(testRenderer, word);
+        expect({theme: theme.name, word, bg: drawn?.bg}).toEqual({
+          theme: theme.name,
+          word,
+          bg: headerBackground(theme),
+        });
+        const ratio = drawn === undefined ? 0 : contrastRatio(drawn.fg, drawn.bg);
+        expect({theme: theme.name, word, readable: ratio >= floor}).toEqual({
+          theme: theme.name,
+          word,
+          readable: true,
+        });
+      }
+    }
   });
 
   it('keeps the header whole in a terminal too narrow for all of it', async () => {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1700,7 +1700,9 @@ describe('OpenTUI presentation', () => {
   });
 
   it('renders a typed command payload with labeled stderr and exit code', async () => {
-    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    // 18 rows, not 16: the header is a three-row pane, so a 16-row terminal
+    // leaves the transcript too short to hold the whole payload card.
+    const testRenderer = await createTestRenderer({width: 80, height: 18});
     const controller = new FakeController({
       ...initialSessionState(),
       core: {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@opentui/core';
 import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
 import type {ChatOptions, HypothesisEntry} from '@vibesys/backend-client';
+import type {CoreRunStatus} from '@vibesys/core-state';
 import {chatHelpText, parseCommand} from '../commands.js';
 import type {SessionController} from '../session-controller.js';
 import {
@@ -4315,7 +4316,7 @@ describe('theming', () => {
 });
 
 describe('header hierarchy', () => {
-  const runState = (status: string): SessionState => ({
+  const runState = (status: CoreRunStatus): SessionState => ({
     ...initialSessionState(),
     core: {
       ...initialSessionState().core,
@@ -4353,7 +4354,7 @@ describe('header hierarchy', () => {
 
     controller.publish({
       ...controller.state,
-      core: {...controller.state.core, status: 'failed', terminal: true},
+      core: {...controller.state.core, status: 'failed'},
     });
     await testRenderer.waitForVisualIdle();
 

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -24,7 +24,13 @@ import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
 import {ErrorBannerView} from './error-banner.js';
 import {ExperimentLogView} from './experiment-log.js';
-import {type HeaderSpan, headerSpanStyle, MAX_HEADER_SPANS, renderHeader} from './header.js';
+import {
+  type HeaderSpan,
+  headerBackground,
+  headerSpanStyle,
+  MAX_HEADER_SPANS,
+  renderHeader,
+} from './header.js';
 import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RightPaneView, rightPaneWidth, splitFits} from './right-pane.js';
@@ -102,10 +108,12 @@ export function createOpenTuiApp(
     borderStyle: 'rounded',
     borderColor: theme.border,
     // The same surface every other pane sits on. Without this the frame falls
-    // through to the root's `canvas`, which is a lighter shade, so the header
+    // through to the root's `canvas`, which is a different shade, so the header
     // read as a band laid over the UI rather than a pane within it. That is
-    // the exact quality the housing exists to remove.
-    backgroundColor: theme.elevatedSurface,
+    // the exact quality the housing exists to remove. Through
+    // `headerBackground` because `headerSpanStyle` derives the text tones
+    // against the same call: the fill and the contrast basis are one fact.
+    backgroundColor: headerBackground(theme),
   });
   // One renderable per span, because a terminal cell carries one foreground
   // colour and the header's roles do not share one. The row is allocated once
@@ -325,7 +333,7 @@ export function createOpenTuiApp(
     markdownStyle = createMarkdownStyle(theme);
     root.backgroundColor = theme.canvas;
     headerFrame.borderColor = theme.border;
-    headerFrame.backgroundColor = theme.elevatedSurface;
+    headerFrame.backgroundColor = headerBackground(theme);
     transcriptFrame.borderColor = theme.border;
     help.fg = theme.textSubtle;
     roundRail.applyTheme(theme);

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -101,6 +101,11 @@ export function createOpenTuiApp(
     border: true,
     borderStyle: 'rounded',
     borderColor: theme.border,
+    // The same surface every other pane sits on. Without this the frame falls
+    // through to the root's `canvas`, which is a lighter shade, so the header
+    // read as a band laid over the UI rather than a pane within it. That is
+    // the exact quality the housing exists to remove.
+    backgroundColor: theme.elevatedSurface,
   });
   // One renderable per span, because a terminal cell carries one foreground
   // colour and the header's roles do not share one. The row is allocated once
@@ -320,6 +325,7 @@ export function createOpenTuiApp(
     markdownStyle = createMarkdownStyle(theme);
     root.backgroundColor = theme.canvas;
     headerFrame.borderColor = theme.border;
+    headerFrame.backgroundColor = theme.elevatedSurface;
     transcriptFrame.borderColor = theme.border;
     help.fg = theme.textSubtle;
     roundRail.applyTheme(theme);

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -1,4 +1,10 @@
-import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
+import {
+  BoxRenderable,
+  type CliRenderer,
+  ScrollBoxRenderable,
+  TextAttributes,
+  TextRenderable,
+} from '@opentui/core';
 import {COMMAND_NAMES} from '../commands.js';
 import type {SessionController} from '../session-controller.js';
 import {
@@ -18,7 +24,7 @@ import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
 import {ErrorBannerView} from './error-banner.js';
 import {ExperimentLogView} from './experiment-log.js';
-import {renderHeader} from './header.js';
+import {type HeaderSpan, headerSpanStyle, MAX_HEADER_SPANS, renderHeader} from './header.js';
 import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RightPaneView, rightPaneWidth, splitFits} from './right-pane.js';
@@ -96,13 +102,55 @@ export function createOpenTuiApp(
     borderStyle: 'rounded',
     borderColor: theme.border,
   });
-  const header = new TextRenderable(renderer, {
+  // One renderable per span, because a terminal cell carries one foreground
+  // colour and the header's roles do not share one. The row is allocated once
+  // at its maximum and repainted in place: the spans change on every frame, and
+  // rebuilding thirteen renderables that often is churn the header does not
+  // need.
+  //
+  // `flexShrink: 0` because `renderHeader` has already budgeted the line to this
+  // width, so a row that still overruns is a bug rather than something to
+  // absorb. Shrinking spans put an ellipsis through every one of them at once
+  // (`V...ys·r...ng`) instead of leaving the single cut the budget decided on.
+  const headerLine = new BoxRenderable(renderer, {
     id: 'header',
+    width: '100%',
     height: 1,
-    fg: theme.accent,
-    content: 'VibeSys · connecting',
+    flexDirection: 'row',
   });
-  headerFrame.add(header);
+  const headerSpans = Array.from(
+    {length: MAX_HEADER_SPANS},
+    (_unused, index) =>
+      new TextRenderable(renderer, {
+        id: `header-span-${index}`,
+        content: '',
+        fg: theme.textPrimary,
+        wrapMode: 'none',
+        flexShrink: 0,
+      }),
+  );
+  for (const span of headerSpans) headerLine.add(span);
+  headerFrame.add(headerLine);
+  /**
+   * Paints the budgeted spans onto the row. The tones come from the theme in
+   * scope, so a theme change is picked up by the next paint and needs no
+   * separate application.
+   *
+   * A span the current header does not use is hidden rather than emptied: an
+   * empty text renderable still measures one cell, and thirteen of those are
+   * most of a narrow terminal's header.
+   */
+  const paintHeader = (spans: HeaderSpan[]): void => {
+    for (const [index, cell] of headerSpans.entries()) {
+      const span = spans[index];
+      cell.visible = span !== undefined;
+      if (span === undefined) continue;
+      const style = headerSpanStyle(theme, span);
+      cell.content = span.text;
+      cell.fg = style.fg;
+      cell.attributes = style.bold ? TextAttributes.BOLD : TextAttributes.NONE;
+    }
+  };
   const focusTranscript = (): void => {
     controller.focusPane('left');
     controller.focusRound('transcript');
@@ -271,7 +319,6 @@ export function createOpenTuiApp(
     const previousMarkdownStyle = markdownStyle;
     markdownStyle = createMarkdownStyle(theme);
     root.backgroundColor = theme.canvas;
-    header.fg = theme.accent;
     headerFrame.borderColor = theme.border;
     transcriptFrame.borderColor = theme.border;
     help.fg = theme.textSubtle;
@@ -337,7 +384,7 @@ export function createOpenTuiApp(
         : chatPaneWidth(renderer.terminalWidth, rightWidth)
       : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
-    header.content = renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME);
+    paintHeader(renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME));
     errorBanner.render(state);
     // The log carries its own key hints in its footer, so when it shares the
     // row with a pane the global line is the place for the pane's keys.

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -5,7 +5,6 @@ import {
   experimentLogVisible,
   focusedPane,
   type SessionState,
-  statusText,
   stripRounds,
   visibleRoundNumber,
 } from '../session-model.js';
@@ -19,6 +18,7 @@ import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
 import {ErrorBannerView} from './error-banner.js';
 import {ExperimentLogView} from './experiment-log.js';
+import {renderHeader} from './header.js';
 import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RightPaneView, rightPaneWidth, splitFits} from './right-pane.js';
@@ -309,13 +309,7 @@ export function createOpenTuiApp(
         : chatPaneWidth(renderer.terminalWidth, rightWidth)
       : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
-    const dialogOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
-    const returnHint = dialogOpen ? ' · Esc: close dialog' : '';
-    const selection = state.selectedAgentKind ? ` · selected ${state.selectedAgentKind}` : '';
-    const scope = state.hypothesisScope === null ? '' : ` · ${state.hypothesisScope.label}`;
-    header.content = showLog
-      ? `VibeSys · ${statusText(state)} · experiments`
-      : `VibeSys · ${statusText(state)}${scope}${selection}${returnHint}`;
+    header.content = renderHeader(state, showLog, renderer.terminalWidth);
     errorBanner.render(state);
     // The log carries its own key hints in its footer, so when it shares the
     // row with a pane the global line is the place for the pane's keys.

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -41,6 +41,12 @@ const LOG_KEY_HELP = `↑↓ or scroll: select · Enter/click: open hypothesis �
 const LOG_CHAT_KEY_HELP = `↑↓: select · Enter/click: hypothesis · Ctrl+W: chat · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
 const HYPOTHESIS_KEY_HELP =
   '↑↓: select round · Enter/click: trajectory · PgUp/PgDn: scroll · Esc: hypotheses';
+/** Bezel, one content row, bezel. See the header frame below. */
+const HEADER_FRAME_HEIGHT = 3;
+
+/** Two border cells plus a cell of padding on each side. */
+const HEADER_CHROME = 4;
+
 const SPLIT_KEY_HELP =
   'Ctrl+W: switch pane · F4: zoom focused pane · PgUp/PgDn: scroll · Esc: close pane';
 
@@ -70,12 +76,33 @@ export function createOpenTuiApp(
     flexDirection: 'column',
     backgroundColor: theme.canvas,
   });
+  // The header is a pane, not a caption. Every other region on screen sits in
+  // a bordered box, so a bare line above them reads as floating rather than as
+  // part of the same housing. Three rows: bezel, one content row, bezel. The
+  // border rows are the breathing room, so there is no internal padding and no
+  // blank row beneath: the header's bottom bezel meets the next pane's top one,
+  // and two adjacent rules read as a seam between two objects.
+  //
+  // No background fill. A partial-width fill is what reads as a floating band
+  // in a terminal, and a full-width one has nothing to sit against.
+  const headerFrame = new BoxRenderable(renderer, {
+    id: 'header-frame',
+    width: '100%',
+    height: HEADER_FRAME_HEIGHT,
+    flexDirection: 'column',
+    paddingLeft: 1,
+    paddingRight: 1,
+    border: true,
+    borderStyle: 'rounded',
+    borderColor: theme.border,
+  });
   const header = new TextRenderable(renderer, {
     id: 'header',
     height: 1,
     fg: theme.accent,
     content: 'VibeSys · connecting',
   });
+  headerFrame.add(header);
   const focusTranscript = (): void => {
     controller.focusPane('left');
     controller.focusRound('transcript');
@@ -224,7 +251,7 @@ export function createOpenTuiApp(
   commandColumn.add(commandInput.suggestions);
   commandColumn.add(commandInput.box);
   bottom.add(commandColumn);
-  root.add(header);
+  root.add(headerFrame);
   root.add(errorBanner.output);
   body.add(chatPane.output);
   workspace.add(main);
@@ -245,6 +272,7 @@ export function createOpenTuiApp(
     markdownStyle = createMarkdownStyle(theme);
     root.backgroundColor = theme.canvas;
     header.fg = theme.accent;
+    headerFrame.borderColor = theme.border;
     transcriptFrame.borderColor = theme.border;
     help.fg = theme.textSubtle;
     roundRail.applyTheme(theme);
@@ -309,7 +337,7 @@ export function createOpenTuiApp(
         : chatPaneWidth(renderer.terminalWidth, rightWidth)
       : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
-    header.content = renderHeader(state, showLog, renderer.terminalWidth);
+    header.content = renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME);
     errorBanner.render(state);
     // The log carries its own key hints in its footer, so when it shares the
     // row with a pane the global line is the place for the pane's keys.
@@ -363,7 +391,7 @@ export function createOpenTuiApp(
       // indicator) until the next paint.
       const railRows =
         renderer.terminalHeight -
-        header.height -
+        headerFrame.height -
         errorHeight -
         todoStripHeight(state) -
         help.height -
@@ -385,7 +413,7 @@ export function createOpenTuiApp(
     if (showSplit) {
       // The rounds rail lives inside the row, not above it, so the chat pane
       // starts just below the header and error banner.
-      const top = header.height + errorHeight;
+      const top = headerFrame.height + errorHeight;
       const below = todoStrip.output.height + help.height + commandInput.box.height;
       chat.setPaneBounds({
         left: 1,

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -80,6 +80,10 @@ export class ChatPaneView {
       border: true,
       borderStyle: 'rounded',
       borderColor: theme.border,
+      // The surface every other pane sits on. Without it this box falls
+      // through to the root's canvas, a lighter shade, so the chat read as a
+      // pale band beside panes that did not match it.
+      backgroundColor: theme.elevatedSurface,
       title: ' Experiment chat ',
       visible: false,
       // Clicking into the chat gives it the keys, the same thing Ctrl+W does.
@@ -130,6 +134,7 @@ export class ChatPaneView {
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
     this.#theme = theme;
     this.output.borderColor = theme.border;
+    this.output.backgroundColor = theme.elevatedSurface;
     this.#conversation.applyTheme(theme, markdownStyle);
     this.#composer.applyTheme(theme);
     this.#renderedConversation = null;

--- a/clients/tui/src/ui/header.test.ts
+++ b/clients/tui/src/ui/header.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from 'bun:test';
+import type {CoreRunStatus} from '@vibesys/core-state';
 import {initialSessionState, runStatusLabel, type SessionState} from '../session-model.js';
 import {
   type HeaderSpan,
@@ -162,7 +163,14 @@ describe('header', () => {
 
   it('holds the minimum width for every run state it can name', () => {
     // MIN_WIDTH is sized for the widest of these, so none of them is cut.
-    const states = ['running', 'pausing', 'paused', 'completed', 'failed', 'connecting'];
+    const states: CoreRunStatus[] = [
+      'running',
+      'pausing',
+      'paused',
+      'completed',
+      'failed',
+      'connecting',
+    ];
     for (const status of states) {
       const header = line(stateWith({}, {status}), false, MIN_WIDTH);
       expect(header).toBe(`VibeSys · ${runStatusLabel(status)}`);
@@ -283,10 +291,7 @@ describe('run state', () => {
     const dropped = stateWith({eventStreamAvailable: false}, {status: 'running'});
     expect(runStateText(dropped)).toBe('disconnected');
     // A finished run whose socket closed is not a disconnected run.
-    const finished = stateWith(
-      {eventStreamAvailable: false},
-      {status: 'completed', terminal: true},
-    );
+    const finished = stateWith({eventStreamAvailable: false}, {status: 'completed'});
     expect(runStateText(finished)).toBe('completed');
   });
 });
@@ -424,12 +429,12 @@ describe('header hierarchy', () => {
       theme.warning,
     );
     // An ended run, whose status is not restated as a lost stream.
-    expect(
-      stateTone(stateWith({eventStreamAvailable: false}, {status: 'failed', terminal: true})),
-    ).toBe(theme.error);
-    expect(
-      stateTone(stateWith({eventStreamAvailable: false}, {status: 'completed', terminal: true})),
-    ).toBe(theme.success);
+    expect(stateTone(stateWith({eventStreamAvailable: false}, {status: 'failed'}))).toBe(
+      theme.error,
+    );
+    expect(stateTone(stateWith({eventStreamAvailable: false}, {status: 'completed'}))).toBe(
+      theme.success,
+    );
   });
 
   it('keeps each role on its own span through a shortened title and a cut', () => {

--- a/clients/tui/src/ui/header.test.ts
+++ b/clients/tui/src/ui/header.test.ts
@@ -1,0 +1,265 @@
+import {describe, expect, it} from 'bun:test';
+import {initialSessionState, runStatusLabel, type SessionState} from '../session-model.js';
+import {MIN_WIDTH, renderHeader, runStateText, usageText} from './header.js';
+import {displayWidth} from './text-width.js';
+
+const WIDE = 200;
+const NARROW = 100;
+
+function stateWith(
+  overrides: Partial<SessionState> = {},
+  core: Partial<SessionState['core']> = {},
+) {
+  const base = initialSessionState();
+  return {...base, ...overrides, core: {...base.core, ...core}};
+}
+
+/** The live example from #517, as the backend actually reports it. */
+function runningImplementer(): SessionState {
+  return stateWith(
+    {
+      hypothesisScope: {
+        id: 'H-01',
+        label: 'Preallocated lock-free SPSC ring · r1',
+        title: 'Preallocated lock-free SPSC ring',
+        rounds: [1],
+      },
+    },
+    {
+      status: 'running',
+      agentKind: 'implementer',
+      roundLabel: 'round-1-retry-2-implementer',
+      usage: {inputTokens: 223_000, contextWindow: 400_000, model: 'claude-opus-5'},
+    },
+  );
+}
+
+/** The same run, with a claim of a chosen length. */
+function withTitle(title: string): SessionState {
+  const base = runningImplementer();
+  return {
+    ...base,
+    hypothesisScope: {id: 'H-01', label: `${title} · r1`, title, rounds: [1]},
+  };
+}
+
+/** How many times `needle` appears in `text`, for grapheme-integrity checks. */
+function occurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1;
+}
+
+describe('header', () => {
+  it('replaces the raw label line from the issue', () => {
+    const header = renderHeader(runningImplementer(), false, WIDE);
+    expect(header).toBe(
+      'VibeSys · running · implementing · attempt 2 · Preallocated lock-free SPSC ring · 223k/400k context',
+    );
+  });
+
+  it('never renders a backend round label, in any loop mode', () => {
+    const labels = [
+      'round-1-plan',
+      'round-1-pre',
+      'round-1-retry-1-implementer',
+      'round-2-retry-3-judge',
+      'gen-2-cand-1-mutator',
+      'impl issue #7 att2',
+      'perf_eval iter 4',
+    ];
+    for (const roundLabel of labels) {
+      const header = renderHeader(stateWith({}, {roundLabel, status: 'running'}), false, WIDE);
+      expect(header).not.toContain(roundLabel);
+      expect(header).not.toMatch(/round-\d|gen-\d|cand-\d|retry-\d|att\d/);
+    }
+  });
+
+  it('fits 100 columns whole, where the old header clipped the title', () => {
+    const header = renderHeader(runningImplementer(), false, NARROW);
+    expect(header.length).toBeLessThanOrEqual(NARROW);
+    expect(header).toContain('Preallocated lock-free SPSC ring');
+    expect(header).not.toEndWith('…');
+  });
+
+  it('gives up the token meter before the hypothesis title', () => {
+    // 80 columns cannot hold both; the claim is the one worth keeping.
+    const header = renderHeader(runningImplementer(), false, 80);
+    expect(header.length).toBeLessThanOrEqual(80);
+    expect(header).toContain('Preallocated lock-free SPSC ring');
+    expect(header).not.toContain('context');
+    expect(header).not.toEndWith('…');
+  });
+
+  it('drops the dialog hint before the selected agent, and both before the title', () => {
+    const state = {
+      ...runningImplementer(),
+      selectedAgentKind: 'implementer',
+      overlay: {kind: 'detail' as const, content: 'x'},
+    };
+    expect(renderHeader(state, false, WIDE)).toContain('Esc: close dialog');
+    const squeezed = renderHeader(state, false, NARROW);
+    expect(squeezed).not.toContain('Esc: close dialog');
+    expect(squeezed).not.toContain('selected implementer');
+    expect(squeezed).toContain('Preallocated lock-free SPSC ring');
+  });
+
+  it('shortens a long title only once nothing cheaper is left to drop', () => {
+    // The real title from the recorded run: too long for 60 columns even with
+    // every weaker segment already gone, so it shortens rather than vanishing.
+    const state = withTitle(
+      'Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path',
+    );
+    const header = renderHeader(state, false, 60);
+    expect(header.length).toBeLessThanOrEqual(60);
+    expect(header).not.toContain('context');
+    expect(header).toContain('Preallocated');
+    expect(header).toEndWith('…');
+  });
+
+  it('stops shortening the title at the point it stops identifying anything', () => {
+    const state = withTitle(
+      'Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path',
+    );
+    // 34 columns leaves the title exactly its floor of twelve cells.
+    expect(renderHeader(state, false, 34)).toBe('VibeSys · running · Preallocated…');
+    // 22 leaves it less than that, so it goes entirely rather than becoming
+    // `Prealloc…`, and the run stays legible without it.
+    expect(renderHeader(state, false, 22)).toBe('VibeSys · running');
+  });
+
+  it('keeps the brand and the run state whole down to the minimum width', () => {
+    for (const width of [200, 100, 60, 34, MIN_WIDTH]) {
+      const header = renderHeader(runningImplementer(), false, width);
+      expect(header.startsWith('VibeSys · running')).toBe(true);
+      expect(displayWidth(header)).toBeLessThanOrEqual(width);
+    }
+  });
+
+  it('holds the minimum width for every run state it can name', () => {
+    // MIN_WIDTH is sized for the widest of these, so none of them is cut.
+    const states = ['running', 'pausing', 'paused', 'completed', 'failed', 'connecting'];
+    for (const status of states) {
+      const header = renderHeader(stateWith({}, {status}), false, MIN_WIDTH);
+      expect(header).toBe(`VibeSys · ${runStatusLabel(status)}`);
+    }
+    const dropped = stateWith({eventStreamAvailable: false}, {status: 'running'});
+    expect(renderHeader(dropped, false, MIN_WIDTH)).toBe('VibeSys · disconnected');
+  });
+
+  it('cuts the line below the minimum width instead of dropping the state', () => {
+    // Narrower than MIN_WIDTH the brand and the state do not fit together, so
+    // the guarantee stops there and the line is cut and marked. Dropping the
+    // state instead would leave a header that says only `VibeSys`.
+    const header = renderHeader(runningImplementer(), false, MIN_WIDTH - 6);
+    expect(displayWidth(header)).toBeLessThanOrEqual(MIN_WIDTH - 6);
+    expect(header).toBe('VibeSys · runni…');
+    expect(renderHeader(runningImplementer(), false, 0)).toBe('');
+  });
+});
+
+describe('width in terminal cells', () => {
+  it('budgets a CJK title in cells rather than code units', () => {
+    // 30 ideographs are 30 code units and 60 terminal cells. Budgeted by
+    // `String.length` the whole title reads as fitting 60 columns with room to
+    // spare, and lays out over 80.
+    const title = '\u74b0'.repeat(30);
+    const header = renderHeader(withTitle(title), false, 60);
+    expect(displayWidth(header)).toBeLessThanOrEqual(60);
+    expect(header.length).toBeLessThan(60);
+    expect(header).toEndWith('\u2026');
+  });
+
+  it('never cuts an emoji in half', () => {
+    const state = withTitle(`${'\u{1f680}'.repeat(20)} to orbit`);
+    for (const width of [30, 44, 45, 60]) {
+      const header = renderHeader(state, false, width);
+      expect(displayWidth(header)).toBeLessThanOrEqual(width);
+      // With the `u` flag this matches only an unpaired surrogate, which is
+      // what a code-unit slice through a rocket leaves behind.
+      expect(header).not.toMatch(/[\ud800-\udfff]/u);
+    }
+  });
+
+  it('keeps a joined emoji sequence whole', () => {
+    // One grapheme, eight code units. A cut inside it leaves separate people
+    // or a dangling joiner.
+    const family = '\u{1f468}\u200d\u{1f469}\u200d\u{1f467}';
+    const state = withTitle(`${family.repeat(12)} crew`);
+    for (const width of [30, 40, 55]) {
+      const header = renderHeader(state, false, width);
+      expect(displayWidth(header)).toBeLessThanOrEqual(width);
+      expect(header).not.toMatch(/[\ud800-\udfff]/u);
+      expect(header).not.toContain('\u200d\u2026');
+      // Every family carries one of each figure, so unequal counts mean a cut
+      // landed inside a cluster.
+      expect(occurrences(header, '\u{1f468}')).toBe(occurrences(header, '\u{1f467}'));
+    }
+  });
+
+  it('drops a wide grapheme that would straddle the budget', () => {
+    // 44 columns leaves the title 23 cells, which is 11 rockets and a half.
+    // The half goes, so the line comes out a cell under rather than a cell
+    // over.
+    const header = renderHeader(withTitle('\u{1f680}'.repeat(20)), false, 44);
+    expect(displayWidth(header)).toBe(43);
+  });
+});
+
+describe('token meter', () => {
+  it('shows a ratio only when the count is inside the window', () => {
+    const state = stateWith(
+      {},
+      {usage: {inputTokens: 118_000, contextWindow: 400_000, model: null}},
+    );
+    expect(usageText(state)).toBe('118k/400k context');
+  });
+
+  it('drops the denominator rather than reporting over 100 percent', () => {
+    // The issue's observation: 472k/400k rendered as 118 percent and read as
+    // an overflow error.
+    const state = stateWith(
+      {},
+      {usage: {inputTokens: 472_000, contextWindow: 400_000, model: null}},
+    );
+    expect(usageText(state)).toBe('472k tokens');
+    expect(usageText(state)).not.toContain('/');
+  });
+
+  it('shows a bare count when no window is known', () => {
+    const state = stateWith({}, {usage: {inputTokens: 5_400, contextWindow: null, model: null}});
+    expect(usageText(state)).toBe('5k tokens');
+  });
+
+  it('says nothing before any usage is reported', () => {
+    expect(usageText(initialSessionState())).toBeNull();
+    const zero = stateWith({}, {usage: {inputTokens: 0, contextWindow: 400_000, model: null}});
+    expect(usageText(zero)).toBeNull();
+  });
+});
+
+describe('run state', () => {
+  it('reports the backend status by default', () => {
+    expect(runStateText(stateWith({}, {status: 'running'}))).toBe('running');
+    expect(runStateText(stateWith({}, {status: 'completed'}))).toBe('completed');
+  });
+
+  it('spells out a pause the backend has requested but not yet applied', () => {
+    // `/pause` lands at the next invocation boundary, so the call already in
+    // flight keeps running. The backend publishes that wait as `pausing`, and
+    // the header says so rather than claiming the run has stopped.
+    const pausing = stateWith({}, {status: 'pausing'});
+    expect(runStateText(pausing)).toBe('pausing…');
+    const paused = stateWith({}, {status: 'paused'});
+    expect(runStateText(paused)).toBe('paused');
+  });
+
+  it('shows a lost event stream while the run is still going', () => {
+    const dropped = stateWith({eventStreamAvailable: false}, {status: 'running'});
+    expect(runStateText(dropped)).toBe('disconnected');
+    // A finished run whose socket closed is not a disconnected run.
+    const finished = stateWith(
+      {eventStreamAvailable: false},
+      {status: 'completed', terminal: true},
+    );
+    expect(runStateText(finished)).toBe('completed');
+  });
+});

--- a/clients/tui/src/ui/header.test.ts
+++ b/clients/tui/src/ui/header.test.ts
@@ -1,9 +1,16 @@
 import {describe, expect, it} from 'bun:test';
-import type {CoreRunStatus} from '@vibesys/core-state';
-import {initialSessionState, runStatusLabel, type SessionState} from '../session-model.js';
+import type {RunEvent} from '@vibesys/backend-client';
+import {applyRunMapEvent, type CoreRunStatus} from '@vibesys/core-state';
+import {
+  initialSessionState,
+  runStatusLabel,
+  type SessionState,
+  selectAgent,
+} from '../session-model.js';
 import {
   type HeaderSpan,
   type HeaderSpanRole,
+  headerBackground,
   headerSpanStyle,
   MAX_HEADER_SPANS,
   MIN_WIDTH,
@@ -70,6 +77,24 @@ function withTitle(title: string): SessionState {
   };
 }
 
+/**
+ * The plain loop starting its measurement phase, as `loop.py` labels it.
+ *
+ * Fed to the run map rather than asserted on: what matters is the phase set the
+ * projection seeds from it, which is where `perf_eval` becomes selectable.
+ */
+function perfEvalStart(): RunEvent {
+  return {
+    sequence: 1,
+    timestamp: '2026-01-01T00:00:01Z',
+    type: 'agent_execution_started',
+    execution_id: 'exec-1',
+    invocation_id: 'exec-1',
+    agent_kind: 'perf_eval',
+    round_label: 'perf_eval iter 4',
+  };
+}
+
 /** How many times `needle` appears in `text`, for grapheme-integrity checks. */
 function occurrences(text: string, needle: string): number {
   return text.split(needle).length - 1;
@@ -125,7 +150,7 @@ describe('header', () => {
     expect(line(state, false, WIDE)).toContain('Esc: close dialog');
     const squeezed = line(state, false, NARROW);
     expect(squeezed).not.toContain('Esc: close dialog');
-    expect(squeezed).not.toContain('selected implementer');
+    expect(squeezed).not.toContain('filtered to');
     expect(squeezed).toContain('Preallocated lock-free SPSC ring');
   });
 
@@ -177,6 +202,37 @@ describe('header', () => {
     }
     const dropped = stateWith({eventStreamAvailable: false}, {status: 'running'});
     expect(line(dropped, false, MIN_WIDTH)).toBe('VibeSys · disconnected');
+  });
+
+  it('names a selected phase in words, for every kind the plain loop seeds', () => {
+    // The kinds come from the projection rather than from a literal here. The
+    // plain loop seeds `perf_eval` alongside `implementer` and `judge`, and
+    // `selectAgent` stores the phase kind verbatim, so an operator selecting
+    // the measurement phase put `selected perf_eval` on the curated header:
+    // the backend identifier this header exists to remove.
+    const seeded = applyRunMapEvent({outerLoop: 'plain', rounds: [], phases: []}, perfEvalStart());
+    const kinds = seeded.phases.map(phase => phase.kind);
+    expect(kinds).toContain('perf_eval');
+
+    for (const kind of kinds) {
+      const header = line(selectAgent(runningImplementer(), kind), false, WIDE);
+      expect({kind, leaks: header.includes(kind)}).toEqual({kind, leaks: false});
+      expect({kind, named: header.includes('filtered to ')}).toEqual({kind, named: true});
+    }
+    // The same table the phase segment reads, so the two cannot drift apart.
+    expect(line(selectAgent(runningImplementer(), 'perf_eval'), false, WIDE)).toContain(
+      'filtered to measuring',
+    );
+  });
+
+  it('says nothing about a selected kind it has no word for', () => {
+    // A kind added to the backend after this was written. There is no phrase
+    // to fall back to that is not the identifier itself, and this note is the
+    // second cheapest segment on the line, so it goes.
+    const header = line(selectAgent(runningImplementer(), 'verifier'), false, WIDE);
+    expect(header).not.toContain('verifier');
+    expect(header).not.toContain('filtered to');
+    expect(header).toContain('Preallocated lock-free SPSC ring');
   });
 
   it('cuts the line below the minimum width instead of dropping the state', () => {
@@ -297,10 +353,12 @@ describe('run state', () => {
 });
 
 /**
- * The floor `theme.ts` holds every token but `textSubtle` to against the
- * canvas, restated here so this is an independent check rather than a
- * restatement of the same expression. The header pane draws no fill, so the
- * canvas is what its text sits on.
+ * The floor every token but `textSubtle` is held to, restated here rather than
+ * read off `theme.minContrast` so this is an independent check.
+ *
+ * It is measured against `headerBackground`, not the canvas: the header frame
+ * paints a surface of its own, and a tone that clears the floor against a
+ * background nothing draws is not a readable header.
  */
 function minContrast(theme: Theme): number {
   return theme.name.startsWith('high-contrast') ? 7 : 4.5;
@@ -473,19 +531,42 @@ describe('header contrast', () => {
             theme: theme.name,
             role,
             text,
-            ratio: contrastRatio(fg, theme.canvas) >= floor,
+            ratio: contrastRatio(fg, headerBackground(theme)) >= floor,
           }).toEqual({theme: theme.name, role, text, ratio: true});
         }
       }
     }
   });
 
+  it('derives its tones against the surface it paints, not against the canvas', () => {
+    // No built-in theme separates the two: every one of the eight puts its
+    // elevated surface further from mid grey than its canvas, so a tone that
+    // clears the floor on the canvas clears it by more on the header. The
+    // header cannot assume that. #574 is open on the surface ladder being
+    // inverted, and a header background on the other side of the canvas is
+    // exactly what a canvas-derived tone gets wrong: it returns the raw token
+    // for a cell it is unreadable on.
+    const dark = resolveTheme('dark');
+    const moved: Theme = {...dark, elevatedSurface: resolveTheme('light').canvas};
+    expect(contrastRatio(dark.accent, moved.canvas)).toBeGreaterThanOrEqual(dark.minContrast);
+    expect(contrastRatio(dark.accent, headerBackground(moved))).toBeLessThan(dark.minContrast);
+
+    for (const role of SPAN_ROLES) {
+      const {fg} = headerSpanStyle(moved, {text: 'completed', role});
+      const floor = role === 'separator' ? SUBTLE_FLOOR : minContrast(moved);
+      expect({
+        role,
+        ratio: contrastRatio(fg, headerBackground(moved)) >= floor,
+      }).toEqual({role, ratio: true});
+    }
+  });
+
   it('draws metadata below content and separators below both, in every theme', () => {
     // What "greyed out" has to mean to hold in eight palettes: an ordering
-    // against the canvas, not a particular grey.
+    // against the surface the header paints, not a particular grey.
     for (const theme of listThemes()) {
       const against = (role: HeaderSpanRole): number =>
-        contrastRatio(headerSpanStyle(theme, {text: 'x', role}).fg, theme.canvas);
+        contrastRatio(headerSpanStyle(theme, {text: 'x', role}).fg, headerBackground(theme));
       expect({theme: theme.name, dimmer: against('usage') < against('title')}).toEqual({
         theme: theme.name,
         dimmer: true,

--- a/clients/tui/src/ui/header.test.ts
+++ b/clients/tui/src/ui/header.test.ts
@@ -1,10 +1,36 @@
 import {describe, expect, it} from 'bun:test';
 import {initialSessionState, runStatusLabel, type SessionState} from '../session-model.js';
-import {MIN_WIDTH, renderHeader, runStateText, usageText} from './header.js';
+import {
+  type HeaderSpan,
+  type HeaderSpanRole,
+  headerSpanStyle,
+  MAX_HEADER_SPANS,
+  MIN_WIDTH,
+  renderHeader,
+  runStateText,
+  usageText,
+} from './header.js';
 import {displayWidth} from './text-width.js';
+import {contrastRatio, listThemes, resolveTheme, type Theme} from './theme.js';
 
 const WIDE = 200;
 const NARROW = 100;
+
+/**
+ * The spans read back as the line they draw. `renderHeader` returns spans so
+ * each role can carry a colour of its own; what the operator sees is their
+ * concatenation, and every width and dropping assertion below is about that.
+ */
+function line(state: SessionState, showLog: boolean, width: number): string {
+  return renderHeader(state, showLog, width)
+    .map(span => span.text)
+    .join('');
+}
+
+/** The text drawn for one role, or null when the header dropped it. */
+function spanText(spans: HeaderSpan[], role: HeaderSpanRole): string | null {
+  return spans.find(span => span.role === role)?.text ?? null;
+}
 
 function stateWith(
   overrides: Partial<SessionState> = {},
@@ -50,7 +76,7 @@ function occurrences(text: string, needle: string): number {
 
 describe('header', () => {
   it('replaces the raw label line from the issue', () => {
-    const header = renderHeader(runningImplementer(), false, WIDE);
+    const header = line(runningImplementer(), false, WIDE);
     expect(header).toBe(
       'VibeSys · running · implementing · attempt 2 · Preallocated lock-free SPSC ring · 223k/400k context',
     );
@@ -67,14 +93,14 @@ describe('header', () => {
       'perf_eval iter 4',
     ];
     for (const roundLabel of labels) {
-      const header = renderHeader(stateWith({}, {roundLabel, status: 'running'}), false, WIDE);
+      const header = line(stateWith({}, {roundLabel, status: 'running'}), false, WIDE);
       expect(header).not.toContain(roundLabel);
       expect(header).not.toMatch(/round-\d|gen-\d|cand-\d|retry-\d|att\d/);
     }
   });
 
   it('fits 100 columns whole, where the old header clipped the title', () => {
-    const header = renderHeader(runningImplementer(), false, NARROW);
+    const header = line(runningImplementer(), false, NARROW);
     expect(header.length).toBeLessThanOrEqual(NARROW);
     expect(header).toContain('Preallocated lock-free SPSC ring');
     expect(header).not.toEndWith('…');
@@ -82,7 +108,7 @@ describe('header', () => {
 
   it('gives up the token meter before the hypothesis title', () => {
     // 80 columns cannot hold both; the claim is the one worth keeping.
-    const header = renderHeader(runningImplementer(), false, 80);
+    const header = line(runningImplementer(), false, 80);
     expect(header.length).toBeLessThanOrEqual(80);
     expect(header).toContain('Preallocated lock-free SPSC ring');
     expect(header).not.toContain('context');
@@ -95,8 +121,8 @@ describe('header', () => {
       selectedAgentKind: 'implementer',
       overlay: {kind: 'detail' as const, content: 'x'},
     };
-    expect(renderHeader(state, false, WIDE)).toContain('Esc: close dialog');
-    const squeezed = renderHeader(state, false, NARROW);
+    expect(line(state, false, WIDE)).toContain('Esc: close dialog');
+    const squeezed = line(state, false, NARROW);
     expect(squeezed).not.toContain('Esc: close dialog');
     expect(squeezed).not.toContain('selected implementer');
     expect(squeezed).toContain('Preallocated lock-free SPSC ring');
@@ -108,7 +134,7 @@ describe('header', () => {
     const state = withTitle(
       'Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path',
     );
-    const header = renderHeader(state, false, 60);
+    const header = line(state, false, 60);
     expect(header.length).toBeLessThanOrEqual(60);
     expect(header).not.toContain('context');
     expect(header).toContain('Preallocated');
@@ -120,15 +146,15 @@ describe('header', () => {
       'Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path',
     );
     // 34 columns leaves the title exactly its floor of twelve cells.
-    expect(renderHeader(state, false, 34)).toBe('VibeSys · running · Preallocated…');
+    expect(line(state, false, 34)).toBe('VibeSys · running · Preallocated…');
     // 22 leaves it less than that, so it goes entirely rather than becoming
     // `Prealloc…`, and the run stays legible without it.
-    expect(renderHeader(state, false, 22)).toBe('VibeSys · running');
+    expect(line(state, false, 22)).toBe('VibeSys · running');
   });
 
   it('keeps the brand and the run state whole down to the minimum width', () => {
     for (const width of [200, 100, 60, 34, MIN_WIDTH]) {
-      const header = renderHeader(runningImplementer(), false, width);
+      const header = line(runningImplementer(), false, width);
       expect(header.startsWith('VibeSys · running')).toBe(true);
       expect(displayWidth(header)).toBeLessThanOrEqual(width);
     }
@@ -138,21 +164,21 @@ describe('header', () => {
     // MIN_WIDTH is sized for the widest of these, so none of them is cut.
     const states = ['running', 'pausing', 'paused', 'completed', 'failed', 'connecting'];
     for (const status of states) {
-      const header = renderHeader(stateWith({}, {status}), false, MIN_WIDTH);
+      const header = line(stateWith({}, {status}), false, MIN_WIDTH);
       expect(header).toBe(`VibeSys · ${runStatusLabel(status)}`);
     }
     const dropped = stateWith({eventStreamAvailable: false}, {status: 'running'});
-    expect(renderHeader(dropped, false, MIN_WIDTH)).toBe('VibeSys · disconnected');
+    expect(line(dropped, false, MIN_WIDTH)).toBe('VibeSys · disconnected');
   });
 
   it('cuts the line below the minimum width instead of dropping the state', () => {
     // Narrower than MIN_WIDTH the brand and the state do not fit together, so
     // the guarantee stops there and the line is cut and marked. Dropping the
     // state instead would leave a header that says only `VibeSys`.
-    const header = renderHeader(runningImplementer(), false, MIN_WIDTH - 6);
+    const header = line(runningImplementer(), false, MIN_WIDTH - 6);
     expect(displayWidth(header)).toBeLessThanOrEqual(MIN_WIDTH - 6);
     expect(header).toBe('VibeSys · runni…');
-    expect(renderHeader(runningImplementer(), false, 0)).toBe('');
+    expect(line(runningImplementer(), false, 0)).toBe('');
   });
 });
 
@@ -162,7 +188,7 @@ describe('width in terminal cells', () => {
     // `String.length` the whole title reads as fitting 60 columns with room to
     // spare, and lays out over 80.
     const title = '\u74b0'.repeat(30);
-    const header = renderHeader(withTitle(title), false, 60);
+    const header = line(withTitle(title), false, 60);
     expect(displayWidth(header)).toBeLessThanOrEqual(60);
     expect(header.length).toBeLessThan(60);
     expect(header).toEndWith('\u2026');
@@ -171,7 +197,7 @@ describe('width in terminal cells', () => {
   it('never cuts an emoji in half', () => {
     const state = withTitle(`${'\u{1f680}'.repeat(20)} to orbit`);
     for (const width of [30, 44, 45, 60]) {
-      const header = renderHeader(state, false, width);
+      const header = line(state, false, width);
       expect(displayWidth(header)).toBeLessThanOrEqual(width);
       // With the `u` flag this matches only an unpaired surrogate, which is
       // what a code-unit slice through a rocket leaves behind.
@@ -185,7 +211,7 @@ describe('width in terminal cells', () => {
     const family = '\u{1f468}\u200d\u{1f469}\u200d\u{1f467}';
     const state = withTitle(`${family.repeat(12)} crew`);
     for (const width of [30, 40, 55]) {
-      const header = renderHeader(state, false, width);
+      const header = line(state, false, width);
       expect(displayWidth(header)).toBeLessThanOrEqual(width);
       expect(header).not.toMatch(/[\ud800-\udfff]/u);
       expect(header).not.toContain('\u200d\u2026');
@@ -199,7 +225,7 @@ describe('width in terminal cells', () => {
     // 44 columns leaves the title 23 cells, which is 11 rockets and a half.
     // The half goes, so the line comes out a cell under rather than a cell
     // over.
-    const header = renderHeader(withTitle('\u{1f680}'.repeat(20)), false, 44);
+    const header = line(withTitle('\u{1f680}'.repeat(20)), false, 44);
     expect(displayWidth(header)).toBe(43);
   });
 });
@@ -250,6 +276,7 @@ describe('run state', () => {
     expect(runStateText(pausing)).toBe('pausing…');
     const paused = stateWith({}, {status: 'paused'});
     expect(runStateText(paused)).toBe('paused');
+    expect(line(pausing, false, WIDE)).toContain('pausing…');
   });
 
   it('shows a lost event stream while the run is still going', () => {
@@ -261,5 +288,207 @@ describe('run state', () => {
       {status: 'completed', terminal: true},
     );
     expect(runStateText(finished)).toBe('completed');
+  });
+});
+
+/**
+ * The floor `theme.ts` holds every token but `textSubtle` to against the
+ * canvas, restated here so this is an independent check rather than a
+ * restatement of the same expression. The header pane draws no fill, so the
+ * canvas is what its text sits on.
+ */
+function minContrast(theme: Theme): number {
+  return theme.name.startsWith('high-contrast') ? 7 : 4.5;
+}
+
+/** The lower floor `theme.ts` holds `textSubtle` to. Only separators use it. */
+const SUBTLE_FLOOR = 3;
+
+/** Every role a span can carry, which is every role that needs a tone. */
+const SPAN_ROLES: readonly HeaderSpanRole[] = [
+  'brand',
+  'state',
+  'phase',
+  'title',
+  'usage',
+  'selection',
+  'hint',
+  'separator',
+];
+
+/**
+ * Every run state `runStateText` can produce, plus one it cannot.
+ *
+ * The statuses go through `runStatusLabel`, which is what puts them on the
+ * line, so this covers the labels rather than the raw status words. There is no
+ * `interrupted`: `RunStatus` has no such member, and `run_interrupted` ends the
+ * run as `failed`.
+ */
+const RUN_STATES = [
+  ...(
+    ['starting', 'running', 'pausing', 'paused', 'completed', 'failed', 'connecting'] as const
+  ).map(runStatusLabel),
+  'disconnected',
+  // A status the backend adds after this was written, which has no verdict here.
+  'reticulating',
+];
+
+describe('header hierarchy', () => {
+  it('draws every segment and separator as a span of its own', () => {
+    const spans = renderHeader(runningImplementer(), false, WIDE);
+    expect(spans.map(span => span.role)).toEqual([
+      'brand',
+      'separator',
+      'state',
+      'separator',
+      'phase',
+      'separator',
+      'title',
+      'separator',
+      'usage',
+    ]);
+    expect(spanText(spans, 'title')).toBe('Preallocated lock-free SPSC ring');
+    expect(spanText(spans, 'usage')).toBe('223k/400k context');
+    expect(spanText(spans, 'hint')).toBeNull();
+  });
+
+  it('never returns more spans than a caller sized its row for', () => {
+    // Every role at once: phase, title, token meter, selected agent and hint.
+    const state = {
+      ...runningImplementer(),
+      selectedAgentKind: 'implementer',
+      overlay: {kind: 'detail' as const, content: 'x'},
+    };
+    const spans = renderHeader(state, false, WIDE);
+    // Tight, not just an upper bound: a row allocated at this size is fully
+    // used by the widest header, so the constant is neither short nor padding.
+    expect(spans).toHaveLength(MAX_HEADER_SPANS);
+    for (const width of [WIDE, NARROW, 80, 60, 34, MIN_WIDTH, 16, 1, 0]) {
+      expect(renderHeader(state, false, width).length).toBeLessThanOrEqual(MAX_HEADER_SPANS);
+    }
+  });
+
+  it('gives the brand the accent, the content body text, and metadata a grey', () => {
+    const theme = resolveTheme('dark');
+    const tone = (role: HeaderSpanRole): {fg: string; bold: boolean} =>
+      headerSpanStyle(theme, {text: 'x', role});
+    expect(tone('brand')).toEqual({fg: theme.accent, bold: true});
+    expect(tone('phase')).toEqual({fg: theme.textPrimary, bold: false});
+    expect(tone('title')).toEqual({fg: theme.textPrimary, bold: false});
+    expect(tone('usage')).toEqual({fg: theme.textMuted, bold: false});
+    expect(tone('selection')).toEqual({fg: theme.textMuted, bold: false});
+    expect(tone('hint')).toEqual({fg: theme.textMuted, bold: false});
+    expect(tone('separator')).toEqual({fg: theme.textSubtle, bold: false});
+  });
+
+  it('bolds only the two segments no width can drop', () => {
+    const theme = resolveTheme('dark');
+    const bold = SPAN_ROLES.filter(role => headerSpanStyle(theme, {text: 'x', role}).bold);
+    expect(bold).toEqual(['brand', 'state']);
+  });
+
+  it('colours the run state by the verdict the word carries', () => {
+    const theme = resolveTheme('dark');
+    const tone = (text: string): string => headerSpanStyle(theme, {text, role: 'state'}).fg;
+    expect(tone('completed')).toBe(theme.success);
+    expect(tone('failed')).toBe(theme.error);
+    expect(tone('paused')).toBe(theme.warning);
+    // The label, not the status: `pausing` is on the line as `pausing…`.
+    expect(tone(runStatusLabel('pausing'))).toBe(theme.warning);
+    expect(tone('pausing')).toBe(theme.textPrimary);
+    expect(tone('disconnected')).toBe(theme.warning);
+    // Not verdicts. Bold is what sets these apart, and the word is spelled out.
+    expect(tone('running')).toBe(theme.textPrimary);
+    expect(tone('starting')).toBe(theme.textPrimary);
+    expect(tone('connecting')).toBe(theme.textPrimary);
+    // A status the backend adds later reads as body text rather than as a
+    // verdict this file guessed at.
+    expect(tone('reticulating')).toBe(theme.textPrimary);
+  });
+
+  it('tracks the state the header actually rendered, not the backend status', () => {
+    const theme = resolveTheme('dark');
+    const stateTone = (state: SessionState): string => {
+      const spans = renderHeader(state, false, WIDE);
+      const span = spans.find(candidate => candidate.role === 'state');
+      if (span === undefined) throw new Error('the run state is never dropped');
+      return headerSpanStyle(theme, span).fg;
+    };
+    // A pause the backend has not applied yet, which renders as `pausing…`
+    // rather than as the status word the tone table would otherwise be read
+    // against.
+    expect(stateTone(stateWith({}, {status: 'pausing'}))).toBe(theme.warning);
+    expect(stateTone(stateWith({}, {status: 'paused'}))).toBe(theme.warning);
+    // A lost stream, over a status that still says the run is going.
+    expect(stateTone(stateWith({eventStreamAvailable: false}, {status: 'running'}))).toBe(
+      theme.warning,
+    );
+    // An ended run, whose status is not restated as a lost stream.
+    expect(
+      stateTone(stateWith({eventStreamAvailable: false}, {status: 'failed', terminal: true})),
+    ).toBe(theme.error);
+    expect(
+      stateTone(stateWith({eventStreamAvailable: false}, {status: 'completed', terminal: true})),
+    ).toBe(theme.success);
+  });
+
+  it('keeps each role on its own span through a shortened title and a cut', () => {
+    const state = withTitle(
+      'Preallocated lock-free SPSC ring replaces the Mutex<VecDeque> hot path',
+    );
+    // The title shortens rather than losing its role to the ellipsis.
+    const shortened = renderHeader(state, false, 60);
+    expect(spanText(shortened, 'title')).toEndWith('…');
+    // Below MIN_WIDTH the line is cut, and the cut span keeps its role, so the
+    // half-drawn run state is still coloured as the run state.
+    const cut = renderHeader(runningImplementer(), false, MIN_WIDTH - 6);
+    expect(cut).toEqual([
+      {text: 'VibeSys', role: 'brand'},
+      {text: ' · ', role: 'separator'},
+      {text: 'runni…', role: 'state'},
+    ]);
+    // One cell holds nothing but the mark that the rest was cut.
+    expect(renderHeader(runningImplementer(), false, 1)).toEqual([{text: '…', role: 'brand'}]);
+    expect(renderHeader(runningImplementer(), false, 0)).toEqual([]);
+  });
+});
+
+describe('header contrast', () => {
+  it('clears the floor of every theme for every role, in all eight', () => {
+    const themes = listThemes();
+    expect(themes).toHaveLength(8);
+    for (const theme of themes) {
+      for (const role of SPAN_ROLES) {
+        // Only the state's tone depends on its text; the rest ignore it.
+        const texts = role === 'state' ? RUN_STATES : ['x'];
+        for (const text of texts) {
+          const {fg} = headerSpanStyle(theme, {text, role});
+          const floor = role === 'separator' ? SUBTLE_FLOOR : minContrast(theme);
+          expect({
+            theme: theme.name,
+            role,
+            text,
+            ratio: contrastRatio(fg, theme.canvas) >= floor,
+          }).toEqual({theme: theme.name, role, text, ratio: true});
+        }
+      }
+    }
+  });
+
+  it('draws metadata below content and separators below both, in every theme', () => {
+    // What "greyed out" has to mean to hold in eight palettes: an ordering
+    // against the canvas, not a particular grey.
+    for (const theme of listThemes()) {
+      const against = (role: HeaderSpanRole): number =>
+        contrastRatio(headerSpanStyle(theme, {text: 'x', role}).fg, theme.canvas);
+      expect({theme: theme.name, dimmer: against('usage') < against('title')}).toEqual({
+        theme: theme.name,
+        dimmer: true,
+      });
+      expect({theme: theme.name, dimmer: against('separator') < against('usage')}).toEqual({
+        theme: theme.name,
+        dimmer: true,
+      });
+    }
   });
 });

--- a/clients/tui/src/ui/header.ts
+++ b/clients/tui/src/ui/header.ts
@@ -24,9 +24,9 @@
  */
 import {hasRunEnded} from '@vibesys/core-state';
 import {runStatusLabel, type SessionState} from '../session-model.js';
-import {describePhase, phaseText} from './phase-label.js';
+import {agentKindText, describePhase, phaseText} from './phase-label.js';
 import {displayWidth, truncateToWidth} from './text-width.js';
-import type {Theme} from './theme.js';
+import {ensureContrast, SUBTLE_TEXT_MIN_CONTRAST, type Theme} from './theme.js';
 
 /** Separator between header segments, matching the rest of the interface. */
 const SEPARATOR = ' · ';
@@ -205,9 +205,16 @@ export function headerSegments(state: SessionState, showLog: boolean): Segment[]
   const usage = usageText(state);
   if (usage !== null) segments.push({text: usage, role: 'usage', priority: PRIORITY.usage});
 
-  if (!showLog && state.selectedAgentKind !== null) {
+  // Through the same table the phase segment reads, because the selection is a
+  // phase kind and the header prints no phase kind raw. `perf_eval` is the one
+  // the plain loop seeds and the operator can select, and `selected perf_eval`
+  // is exactly the backend identifier #517 removed. A kind with no word is
+  // dropped rather than spelled out: this note is the second cheapest segment
+  // on the line, so saying nothing costs less than saying an identifier.
+  const selected = showLog ? null : agentKindText(state.selectedAgentKind);
+  if (selected !== null) {
     segments.push({
-      text: `selected ${state.selectedAgentKind}`,
+      text: `filtered to ${selected}`,
       role: 'selection',
       priority: PRIORITY.selection,
     });
@@ -261,8 +268,24 @@ export function renderHeader(state: SessionState, showLog: boolean, width: numbe
 }
 
 /**
- * Colour and weight for one span, against `theme.canvas`, which is what the
- * header pane sits on: it draws no fill of its own.
+ * The surface the header paints, and therefore the surface its text is read
+ * against.
+ *
+ * One definition for both: `app.ts` fills the frame with it and
+ * `headerSpanStyle` derives every tone against it. Two independent statements
+ * of where the header sits is how the contrast guarantee below comes to be
+ * measured against a background nothing draws.
+ *
+ * `elevatedSurface` because the header is a pane, and that is the surface every
+ * other pane sits on. Which shade that is belongs to the theme: #574 is open on
+ * the ladder being inverted, and moving it there moves the header with it.
+ */
+export function headerBackground(theme: Theme): string {
+  return theme.elevatedSurface;
+}
+
+/**
+ * Colour and weight for one span, against `headerBackground`.
  *
  * Four levels. The run state is the one fact the header exists to report, so it
  * is bold and carries a verdict colour. The brand is a masthead in the accent:
@@ -272,27 +295,40 @@ export function renderHeader(state: SessionState, showLog: boolean, width: numbe
  * metadata and recede to muted. The separators recede further still: dots
  * divide the words without competing with them.
  *
- * Every colour here comes from the theme, which has already held each of these
- * tokens to its own contrast floor against the canvas, so no theme can be given
- * an unreadable header by this function. `textSubtle` is the exception the
- * theme itself makes, at a floor of 3 rather than 4.5 or 7, which is why only
- * the punctuation is drawn in it and every word clears the full floor.
+ * Every colour comes from the theme, which holds each of these tokens to
+ * `minContrast` against the canvas. The header does not sit on the canvas, so
+ * that guarantee is not the one it needs, and each tone is put back through
+ * `ensureContrast` against the surface the header actually paints. In all eight
+ * built-in themes that is a no-op, because their elevated surface is further
+ * from mid grey than their canvas in every case. It is a no-op the header
+ * cannot assume: a theme, or #574 moving the ladder, can make the two
+ * disagree, and a tone that clears 4.5:1 on a background nothing draws is not
+ * a readable header.
+ *
+ * `textSubtle` is the exception the theme itself makes, at a floor of 3 rather
+ * than 4.5 or 7, which is why only the punctuation is drawn in it and every
+ * word clears the full floor.
  */
 export function headerSpanStyle(theme: Theme, span: HeaderSpan): HeaderSpanStyle {
+  const surface = headerBackground(theme);
+  const readable = (color: string): string => ensureContrast(color, surface, theme.minContrast);
   switch (span.role) {
     case 'brand':
-      return {fg: theme.accent, bold: true};
+      return {fg: readable(theme.accent), bold: true};
     case 'state':
-      return {fg: stateColor(theme, span.text), bold: true};
+      return {fg: readable(stateColor(theme, span.text)), bold: true};
     case 'phase':
     case 'title':
-      return {fg: theme.textPrimary, bold: false};
+      return {fg: readable(theme.textPrimary), bold: false};
     case 'usage':
     case 'selection':
     case 'hint':
-      return {fg: theme.textMuted, bold: false};
+      return {fg: readable(theme.textMuted), bold: false};
     case 'separator':
-      return {fg: theme.textSubtle, bold: false};
+      return {
+        fg: ensureContrast(theme.textSubtle, surface, SUBTLE_TEXT_MIN_CONTRAST),
+        bold: false,
+      };
   }
 }
 

--- a/clients/tui/src/ui/header.ts
+++ b/clients/tui/src/ui/header.ts
@@ -22,6 +22,7 @@
  *   gives each role a tone: the run state carries a verdict, the phase and the
  *   title are content, the metadata recedes.
  */
+import {hasRunEnded} from '@vibesys/core-state';
 import {runStatusLabel, type SessionState} from '../session-model.js';
 import {describePhase, phaseText} from './phase-label.js';
 import {displayWidth, truncateToWidth} from './text-width.js';
@@ -144,9 +145,12 @@ export const MIN_WIDTH = displayWidth(`${BRAND}${SEPARATOR}${WIDEST_STATE}`);
  * reported as `disconnected` rather than as a value that has stopped moving. A
  * run that has ended is exempt: a status it never leaves cannot go stale, and a
  * finished run whose socket closed is finished rather than disconnected.
+ * `hasRunEnded` is the authority on which statuses those are, and it switches
+ * exhaustively, so a status added to the protocol is a compile error there
+ * rather than a run this header quietly reports as live.
  */
 export function runStateText(state: SessionState): string {
-  if (!state.core.terminal && !state.eventStreamAvailable) return DISCONNECTED;
+  if (!hasRunEnded(state.core) && !state.eventStreamAvailable) return DISCONNECTED;
   return runStatusLabel(state.core.status);
 }
 

--- a/clients/tui/src/ui/header.ts
+++ b/clients/tui/src/ui/header.ts
@@ -16,10 +16,16 @@
  *   clipped while `round-1-retry-1-implementer` survived. `renderHeader` drops
  *   whole segments in a defined order instead, and budgets in terminal cells
  *   rather than UTF-16 code units, which are not the same count.
+ * - Every segment was drawn in one colour, so a line that already knew which
+ *   part mattered read as an undifferentiated string. `renderHeader` returns
+ *   the budgeted segments rather than a joined line, and `headerSpanStyle`
+ *   gives each role a tone: the run state carries a verdict, the phase and the
+ *   title are content, the metadata recedes.
  */
 import {runStatusLabel, type SessionState} from '../session-model.js';
 import {describePhase, phaseText} from './phase-label.js';
 import {displayWidth, truncateToWidth} from './text-width.js';
+import type {Theme} from './theme.js';
 
 /** Separator between header segments, matching the rest of the interface. */
 const SEPARATOR = ' · ';
@@ -36,6 +42,8 @@ const BRAND = 'VibeSys';
  */
 interface Segment {
   text: string;
+  /** What the segment is, which is what decides its tone. */
+  role: HeaderRole;
   priority: number;
   /**
    * Never dropped. The brand and the run state are the header's floor, which
@@ -65,6 +73,38 @@ const PRIORITY = {
   selection: 30,
   hint: 10,
 } as const;
+
+/** What a segment is. `headerSegments` emits at most one segment per role. */
+export type HeaderRole = keyof typeof PRIORITY;
+
+/** A drawn run of the header: one segment, or one separator between two. */
+export type HeaderSpanRole = HeaderRole | 'separator';
+
+/**
+ * One run of the header line, in the order it is drawn.
+ *
+ * A terminal cell carries one foreground colour, so a header with internal
+ * hierarchy is several renderables laid out in a row rather than one string.
+ * The separators are spans of their own so the dots can recede behind the words
+ * they divide.
+ */
+export interface HeaderSpan {
+  text: string;
+  role: HeaderSpanRole;
+}
+
+/** How one span is drawn. */
+export interface HeaderSpanStyle {
+  fg: string;
+  bold: boolean;
+}
+
+/**
+ * The most spans `renderHeader` can return: every role at once, with a
+ * separator between each pair. A caller that keeps one renderable per span can
+ * size its row from this rather than rebuilding the row on every frame.
+ */
+export const MAX_HEADER_SPANS = Object.keys(PRIORITY).length * 2 - 1;
 
 /** Cells below which a shortened title is noise rather than an identifier. */
 const MIN_TITLE = 12;
@@ -139,18 +179,19 @@ function formatTokenCount(count: number): string {
 /** Segments for the current state, before any width budgeting. */
 export function headerSegments(state: SessionState, showLog: boolean): Segment[] {
   const segments: Segment[] = [
-    {text: BRAND, priority: PRIORITY.brand, required: true},
-    {text: runStateText(state), priority: PRIORITY.state, required: true},
+    {text: BRAND, role: 'brand', priority: PRIORITY.brand, required: true},
+    {text: runStateText(state), role: 'state', priority: PRIORITY.state, required: true},
   ];
 
   if (showLog) {
-    segments.push({text: 'experiments', priority: PRIORITY.phase});
+    segments.push({text: 'experiments', role: 'phase', priority: PRIORITY.phase});
   } else {
     const phase = phaseText(describePhase(state.core.roundLabel, state.core.agentKind));
-    if (phase !== null) segments.push({text: phase, priority: PRIORITY.phase});
+    if (phase !== null) segments.push({text: phase, role: 'phase', priority: PRIORITY.phase});
     if (state.hypothesisScope !== null) {
       segments.push({
         text: state.hypothesisScope.title,
+        role: 'title',
         priority: PRIORITY.title,
         truncatable: true,
       });
@@ -158,14 +199,20 @@ export function headerSegments(state: SessionState, showLog: boolean): Segment[]
   }
 
   const usage = usageText(state);
-  if (usage !== null) segments.push({text: usage, priority: PRIORITY.usage});
+  if (usage !== null) segments.push({text: usage, role: 'usage', priority: PRIORITY.usage});
 
   if (!showLog && state.selectedAgentKind !== null) {
-    segments.push({text: `selected ${state.selectedAgentKind}`, priority: PRIORITY.selection});
+    segments.push({
+      text: `selected ${state.selectedAgentKind}`,
+      role: 'selection',
+      priority: PRIORITY.selection,
+    });
   }
 
   const dialogOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
-  if (dialogOpen) segments.push({text: 'Esc: close dialog', priority: PRIORITY.hint});
+  if (dialogOpen) {
+    segments.push({text: 'Esc: close dialog', role: 'hint', priority: PRIORITY.hint});
+  }
 
   return segments;
 }
@@ -185,8 +232,12 @@ export function headerSegments(state: SessionState, showLog: boolean): Segment[]
  *
  * At `MIN_WIDTH` and wider the brand and the run state both survive whole.
  * Narrower than that they do not fit together, and the line is cut and marked.
+ *
+ * The result is the budgeted spans in draw order, not a joined line, because a
+ * terminal cell carries one foreground colour and the roles do not share one.
+ * Concatenating the span texts reproduces the line exactly.
  */
-export function renderHeader(state: SessionState, showLog: boolean, width: number): string {
+export function renderHeader(state: SessionState, showLog: boolean, width: number): HeaderSpan[] {
   const kept = headerSegments(state, showLog);
   while (displayWidth(joined(kept)) > width) {
     const weakest = weakestIndex(kept);
@@ -199,11 +250,115 @@ export function renderHeader(state: SessionState, showLog: boolean, width: numbe
     if (kept[weakest]?.truncatable === true && shrinkTitle(kept, width)) break;
     kept.splice(weakest, 1);
   }
-  const line = joined(kept);
-  if (displayWidth(line) <= width) return line;
-  if (width <= 0) return '';
+  const spans = toSpans(kept);
+  if (displayWidth(joined(kept)) <= width) return spans;
+  if (width <= 0) return [];
+  return cutSpans(spans, width);
+}
+
+/**
+ * Colour and weight for one span, against `theme.canvas`, which is what the
+ * header pane sits on: it draws no fill of its own.
+ *
+ * Four levels. The run state is the one fact the header exists to report, so it
+ * is bold and carries a verdict colour. The brand is a masthead in the accent:
+ * fixed text that anchors the left edge and never reports anything. The phase
+ * and the title are what the run is doing and trying, so they stay in body
+ * text. The token meter, the selected-agent note and the dialog hint are
+ * metadata and recede to muted. The separators recede further still: dots
+ * divide the words without competing with them.
+ *
+ * Every colour here comes from the theme, which has already held each of these
+ * tokens to its own contrast floor against the canvas, so no theme can be given
+ * an unreadable header by this function. `textSubtle` is the exception the
+ * theme itself makes, at a floor of 3 rather than 4.5 or 7, which is why only
+ * the punctuation is drawn in it and every word clears the full floor.
+ */
+export function headerSpanStyle(theme: Theme, span: HeaderSpan): HeaderSpanStyle {
+  switch (span.role) {
+    case 'brand':
+      return {fg: theme.accent, bold: true};
+    case 'state':
+      return {fg: stateColor(theme, span.text), bold: true};
+    case 'phase':
+    case 'title':
+      return {fg: theme.textPrimary, bold: false};
+    case 'usage':
+    case 'selection':
+    case 'hint':
+      return {fg: theme.textMuted, bold: false};
+    case 'separator':
+      return {fg: theme.textSubtle, bold: false};
+  }
+}
+
+/**
+ * The verdict the run state carries.
+ *
+ * Compared against `runStatusLabel`'s own output rather than against the raw
+ * status words, because the label is what `runStateText` put on the line and
+ * the two are not always the same string: `pausing` renders as `pausing…`, and
+ * a literal here would silently stop matching it.
+ *
+ * `running`, `starting` and `connecting` are not verdicts, and neither is a
+ * status the backend adds after this was written, so they stay in body text
+ * rather than being forced into one. What sets the state apart in those cases
+ * is the bold `headerSpanStyle` gives it, which is the reason the state is bold
+ * at all: colour alone would say nothing on the statuses that have no colour,
+ * and nothing at all on a terminal that drops it. The word is always spelled
+ * out.
+ *
+ * `pausing` shares the warning of `paused` rather than getting a tone of its
+ * own: it is the same verdict, and the word is what says the pause has not
+ * landed yet. A colour the operator has to learn would say it less clearly.
+ */
+function stateColor(theme: Theme, state: string): string {
+  if (state === runStatusLabel('completed')) return theme.success;
+  if (state === runStatusLabel('failed')) return theme.error;
+  if (state === runStatusLabel('pausing') || state === runStatusLabel('paused')) {
+    return theme.warning;
+  }
+  if (state === DISCONNECTED) return theme.warning;
+  return theme.textPrimary;
+}
+
+/** Segments in draw order with the separators between them made explicit. */
+function toSpans(segments: Segment[]): HeaderSpan[] {
+  const spans: HeaderSpan[] = [];
+  for (const segment of segments) {
+    if (spans.length > 0) spans.push({text: SEPARATOR, role: 'separator'});
+    spans.push({text: segment.text, role: segment.role});
+  }
+  return spans;
+}
+
+/**
+ * Cuts the spans to `width` and marks the cut, for the widths below `MIN_WIDTH`
+ * where not even the brand and the run state fit together. Equivalent to
+ * cutting the joined line, but it keeps the surviving text in its own spans so
+ * the tones hold to the last cell.
+ */
+function cutSpans(spans: HeaderSpan[], width: number): HeaderSpan[] {
   // One cell for the ellipsis that says the rest was cut.
-  return `${truncateToWidth(line, width - 1)}…`;
+  const budget = width - 1;
+  const cut: HeaderSpan[] = [];
+  let used = 0;
+  for (const span of spans) {
+    if (used >= budget) break;
+    const text = truncateToWidth(span.text, budget - used);
+    const fitted = displayWidth(text);
+    if (fitted > 0) {
+      cut.push({...span, text});
+      used += fitted;
+    }
+    // A span that did not survive whole ends the line, whether it was cut mid
+    // text or dropped entirely by a wide grapheme straddling the budget.
+    if (fitted < displayWidth(span.text)) break;
+  }
+  const last = cut.at(-1);
+  if (last === undefined) return [{text: '…', role: spans[0]?.role ?? 'brand'}];
+  cut[cut.length - 1] = {...last, text: `${last.text}…`};
+  return cut;
 }
 
 /** The segment given up first, or null once only required ones are left. */

--- a/clients/tui/src/ui/header.ts
+++ b/clients/tui/src/ui/header.ts
@@ -1,0 +1,245 @@
+/**
+ * The header line: what the run is doing, in operator terms.
+ *
+ * It replaces a line that interpolated backend identifiers verbatim
+ * (`VibeSys · running · implementer · round-1-retry-1-implementer · 118k/400k
+ * tokens · Preallocated lock-free SPSC ring · r1`). Three things were wrong
+ * with that and are fixed here:
+ *
+ * - Raw `round_label` strings meant nothing to an operator and duplicated the
+ *   rounds strip and Agents pane. `describePhase` turns them into words.
+ * - The token meter divided one number by another that does not bound it, so
+ *   it could read 118 percent and look like an overflow error. `usageText`
+ *   only prints a denominator when the numerator is actually inside it.
+ * - Everything was concatenated with no width budget, so at 100 columns the
+ *   hypothesis title, the one segment carrying what the run is trying, was
+ *   clipped while `round-1-retry-1-implementer` survived. `renderHeader` drops
+ *   whole segments in a defined order instead, and budgets in terminal cells
+ *   rather than UTF-16 code units, which are not the same count.
+ */
+import {runStatusLabel, type SessionState} from '../session-model.js';
+import {describePhase, phaseText} from './phase-label.js';
+import {displayWidth, truncateToWidth} from './text-width.js';
+
+/** Separator between header segments, matching the rest of the interface. */
+const SEPARATOR = ' · ';
+
+const BRAND = 'VibeSys';
+
+/**
+ * One header segment and how readily it is given up when the line does not
+ * fit. Lower priority goes first.
+ *
+ * The order encodes the judgement in #517: the hypothesis title outranks the
+ * token meter, the selected-agent note, and the dialog hint, because it is the
+ * only segment that says what the run is trying to achieve.
+ */
+interface Segment {
+  text: string;
+  priority: number;
+  /**
+   * Never dropped. The brand and the run state are the header's floor, which
+   * is what `MIN_WIDTH` is the width of.
+   */
+  required?: boolean;
+  /**
+   * Shortened to fit rather than dropped. Only the hypothesis title is: half a
+   * claim still says which claim, where a dropped one says nothing. Every other
+   * segment is a fixed phrase that means nothing in part.
+   */
+  truncatable?: boolean;
+}
+
+/**
+ * The title outranks the phase deliberately. The phase is also on the Agents
+ * pane and implied by the transcript; the title is the only place the run says
+ * what it is trying, and #517 requires it to survive a narrow terminal ahead of
+ * less useful segments.
+ */
+const PRIORITY = {
+  brand: 100,
+  state: 90,
+  title: 70,
+  phase: 60,
+  usage: 40,
+  selection: 30,
+  hint: 10,
+} as const;
+
+/** Cells below which a shortened title is noise rather than an identifier. */
+const MIN_TITLE = 12;
+
+/**
+ * The one run state that is not a backend status: the event stream is gone, so
+ * whatever the status last said can no longer be trusted to be current.
+ */
+const DISCONNECTED = 'disconnected';
+
+/** The widest word `runStateText` produces; every status label is shorter. */
+const WIDEST_STATE = DISCONNECTED;
+
+/**
+ * The narrowest terminal this header supports, in cells.
+ *
+ * At this width or wider the brand and the run state both render whole: they
+ * are the two segments `renderHeader` will not drop, and no run state is wider
+ * than `WIDEST_STATE`. Below it neither is guaranteed, because there is no
+ * room for both: the line is cut and marked with an ellipsis, which is what a
+ * terminal that narrow can be told. That bound is the property the header
+ * holds; "the brand and the run state always survive" is not true at every
+ * width and was never true of the dropping loop.
+ */
+export const MIN_WIDTH = displayWidth(`${BRAND}${SEPARATOR}${WIDEST_STATE}`);
+
+/**
+ * Run state in words.
+ *
+ * The backend owns the run's lifecycle and publishes every move through it, so
+ * the run state is the run status and `runStatusLabel` is how it reads. There
+ * is no client-local pause flag to prefix it or to outrank it, which is what
+ * keeps the header from claiming a state the backend disagrees with.
+ *
+ * The header adds one word of its own. Without a trustworthy event stream the
+ * status is only as current as the last event that arrived, so a live run is
+ * reported as `disconnected` rather than as a value that has stopped moving. A
+ * run that has ended is exempt: a status it never leaves cannot go stale, and a
+ * finished run whose socket closed is finished rather than disconnected.
+ */
+export function runStateText(state: SessionState): string {
+  if (!state.core.terminal && !state.eventStreamAvailable) return DISCONNECTED;
+  return runStatusLabel(state.core.status);
+}
+
+/**
+ * The token meter, with an honest denominator or none at all.
+ *
+ * `inputTokens` is the context the last agent call carried, and `contextWindow`
+ * is a static per-model lookup that can be absent or stale. When the two
+ * disagree, the count alone is the true statement; a ratio over 100 percent is
+ * not.
+ */
+export function usageText(state: SessionState): string | null {
+  const usage = state.core.usage;
+  if (usage === null || usage.inputTokens <= 0) return null;
+  const used = formatTokenCount(usage.inputTokens);
+  if (usage.contextWindow === null || usage.inputTokens > usage.contextWindow) {
+    return `${used} tokens`;
+  }
+  // Labeled `context` rather than `tokens`: the denominator bounds one call's
+  // context, and calling it "tokens" invited reading it as run spend.
+  return `${used}/${formatTokenCount(usage.contextWindow)} context`;
+}
+
+function formatTokenCount(count: number): string {
+  if (count < 1_000) return String(count);
+  if (count < 1_000_000) return `${Math.floor(count / 1_000)}k`;
+  return `${(count / 1_000_000).toFixed(1)}M`;
+}
+
+/** Segments for the current state, before any width budgeting. */
+export function headerSegments(state: SessionState, showLog: boolean): Segment[] {
+  const segments: Segment[] = [
+    {text: BRAND, priority: PRIORITY.brand, required: true},
+    {text: runStateText(state), priority: PRIORITY.state, required: true},
+  ];
+
+  if (showLog) {
+    segments.push({text: 'experiments', priority: PRIORITY.phase});
+  } else {
+    const phase = phaseText(describePhase(state.core.roundLabel, state.core.agentKind));
+    if (phase !== null) segments.push({text: phase, priority: PRIORITY.phase});
+    if (state.hypothesisScope !== null) {
+      segments.push({
+        text: state.hypothesisScope.title,
+        priority: PRIORITY.title,
+        truncatable: true,
+      });
+    }
+  }
+
+  const usage = usageText(state);
+  if (usage !== null) segments.push({text: usage, priority: PRIORITY.usage});
+
+  if (!showLog && state.selectedAgentKind !== null) {
+    segments.push({text: `selected ${state.selectedAgentKind}`, priority: PRIORITY.selection});
+  }
+
+  const dialogOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
+  if (dialogOpen) segments.push({text: 'Esc: close dialog', priority: PRIORITY.hint});
+
+  return segments;
+}
+
+/**
+ * Assembles the header to fit `width` terminal cells.
+ *
+ * Whole segments are dropped, lowest priority first, rather than clipping the
+ * line: a truncated fixed phrase reads as a rendering bug, while a missing
+ * token meter reads as a header that had better things to say. Only once
+ * everything droppable is gone does the title shorten, and only then, which is
+ * what keeps it from being clipped ahead of less useful segments.
+ *
+ * The budget is in cells, not code units, so a header the caller sized for 40
+ * columns of CJK does not lay out over 50 of them, and the fallback cut lands
+ * on a grapheme boundary rather than inside an emoji.
+ *
+ * At `MIN_WIDTH` and wider the brand and the run state both survive whole.
+ * Narrower than that they do not fit together, and the line is cut and marked.
+ */
+export function renderHeader(state: SessionState, showLog: boolean, width: number): string {
+  const kept = headerSegments(state, showLog);
+  while (displayWidth(joined(kept)) > width) {
+    const weakest = weakestIndex(kept);
+    // Only the brand and the run state are left, and they do not fit: below
+    // MIN_WIDTH the line is cut rather than emptied.
+    if (weakest === null) break;
+    // Nothing left that is cheaper than the title: shortening it now is the
+    // only move that does not cost a whole segment, and by this point it is no
+    // longer being clipped ahead of anything less useful.
+    if (kept[weakest]?.truncatable === true && shrinkTitle(kept, width)) break;
+    kept.splice(weakest, 1);
+  }
+  const line = joined(kept);
+  if (displayWidth(line) <= width) return line;
+  if (width <= 0) return '';
+  // One cell for the ellipsis that says the rest was cut.
+  return `${truncateToWidth(line, width - 1)}…`;
+}
+
+/** The segment given up first, or null once only required ones are left. */
+function weakestIndex(segments: Segment[]): number | null {
+  let weakest: number | null = null;
+  for (const [index, candidate] of segments.entries()) {
+    if (candidate.required === true) continue;
+    const current = weakest === null ? undefined : segments[weakest];
+    // `<=` makes the later of two equal-priority segments the weaker one, so
+    // trailing notes go before leading ones.
+    if (current === undefined || candidate.priority <= current.priority) weakest = index;
+  }
+  return weakest;
+}
+
+/**
+ * Shortens the truncatable segment to close the overrun, if what remains is
+ * still long enough to identify. Returns whether the line now fits.
+ */
+function shrinkTitle(segments: Segment[], width: number): boolean {
+  const index = segments.findIndex(segment => segment.truncatable === true);
+  const segment = segments[index];
+  if (segment === undefined) return false;
+  // What the rest of the line, its separators included, already spends.
+  const rest = displayWidth(joined(segments)) - displayWidth(segment.text);
+  // One cell of the budget goes to the ellipsis.
+  const budget = width - rest - 1;
+  if (budget < MIN_TITLE) return false;
+  const shortened = truncateToWidth(segment.text, budget).trimEnd();
+  // A wide grapheme dropped at the cut, or trailing space, can leave less than
+  // the budget allowed, and below MIN_TITLE the caller is better off dropping.
+  if (displayWidth(shortened) < MIN_TITLE) return false;
+  segments[index] = {...segment, text: `${shortened}…`};
+  return displayWidth(joined(segments)) <= width;
+}
+
+function joined(segments: Segment[]): string {
+  return segments.map(segment => segment.text).join(SEPARATOR);
+}

--- a/clients/tui/src/ui/phase-label.test.ts
+++ b/clients/tui/src/ui/phase-label.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'bun:test';
-import {describePhase, phaseText} from './phase-label.js';
+import {agentKindText, describePhase, phaseText} from './phase-label.js';
 
 /** Every label shape the three loops emit, from their `round_label=` sites. */
 const AGENT_LABELS: ReadonlyArray<[string, string | null, string]> = [
@@ -89,5 +89,36 @@ describe('phase description', () => {
   it('degrades to the kind verbatim for an agent kind it does not know', () => {
     // Better a real kind name than a parse failure; still not a round label.
     expect(phaseText(describePhase(null, 'verifier'))).toBe('verifier');
+  });
+
+  it('has a word for the plain loop measurement phase', () => {
+    // `perf_eval` is a kind, not only a label shape: `expectedRoles` in
+    // `run-map.ts` seeds it as a selectable phase for the plain loop, so it
+    // reaches the header with no label to parse.
+    expect(phaseText(describePhase(null, 'perf_eval'))).toBe('measuring');
+    expect(phaseText(describePhase('perf_eval iter 3', 'perf_eval'))).toBe('measuring');
+  });
+});
+
+describe('agent kind on its own', () => {
+  it('has a word for every kind the run map seeds as a selectable phase', () => {
+    // The union of `expectedRoles` over the three outer loops, plus the chat.
+    // A kind missing here is a backend identifier on an operator's screen.
+    const seeded = ['orchestrator', 'implementer', 'judge', 'profiler', 'perf_eval', 'chat'];
+    for (const kind of seeded) {
+      const word = agentKindText(kind);
+      expect({kind, word}).toEqual({kind, word: expect.any(String)});
+      expect({kind, leaks: word?.includes(kind) ?? true}).toEqual({kind, leaks: false});
+    }
+    expect(agentKindText('perf_eval')).toBe('measuring');
+    expect(agentKindText('mutator')).toBe('mutating');
+  });
+
+  it('says nothing rather than an identifier for a kind it does not know', () => {
+    // Deliberately unlike `describePhase`, which degrades to the kind: a
+    // caller that can drop the text drops it instead of printing `verifier`.
+    expect(agentKindText('verifier')).toBeNull();
+    expect(agentKindText(null)).toBeNull();
+    expect(agentKindText('')).toBeNull();
   });
 });

--- a/clients/tui/src/ui/phase-label.test.ts
+++ b/clients/tui/src/ui/phase-label.test.ts
@@ -1,0 +1,93 @@
+import {describe, expect, it} from 'bun:test';
+import {describePhase, phaseText} from './phase-label.js';
+
+/** Every label shape the three loops emit, from their `round_label=` sites. */
+const AGENT_LABELS: ReadonlyArray<[string, string | null, string]> = [
+  ['round-1-pre', 'orchestrator', 'preparing'],
+  ['round-1-plan', 'orchestrator', 'planning'],
+  ['round-2-profiler', 'profiler', 'profiling'],
+  ['round-1-retry-1-implementer', 'implementer', 'implementing'],
+  ['round-1-retry-1-judge', 'judge', 'judging'],
+  ['round-3-retry-1-single-agent', 'implementer', 'working'],
+  ['round-1-retry-1', 'judge', 'judging'],
+  ['round-1', null, 'working'],
+];
+
+describe('phase description', () => {
+  it.each(AGENT_LABELS)('reads %s as an activity', (label, kind, activity) => {
+    expect(describePhase(label, kind)?.activity).toBe(activity);
+  });
+
+  it('surfaces a retry as an attempt, and stays quiet on the first', () => {
+    expect(describePhase('round-1-retry-1-implementer', 'implementer')?.attempt).toBeNull();
+    expect(describePhase('round-1-retry-2-implementer', 'implementer')?.attempt).toBe(2);
+    expect(phaseText(describePhase('round-1-retry-3-implementer', 'implementer'))).toBe(
+      'implementing · attempt 3',
+    );
+  });
+
+  it('names the candidate in the evolve loop', () => {
+    expect(phaseText(describePhase('gen-2-cand-1-mutator', 'mutator'))).toBe(
+      'mutating candidate 1',
+    );
+    expect(phaseText(describePhase('gen-2-cand-3-judge', 'judge'))).toBe('judging candidate 3');
+    expect(phaseText(describePhase('gen-1-cand-0-profiler', 'profiler'))).toBe(
+      'profiling candidate 0',
+    );
+  });
+
+  it('names the issue in the plain loop', () => {
+    expect(phaseText(describePhase('impl issue #7 att2', 'implementer'))).toBe(
+      'implementing issue #7 · attempt 2',
+    );
+    expect(phaseText(describePhase('judge issue #7 att1', 'judge'))).toBe('judging issue #7');
+    expect(phaseText(describePhase('perf_eval iter 3', null))).toBe('measuring');
+  });
+
+  it('treats the experiment chat as its own activity, both spellings', () => {
+    expect(phaseText(describePhase('experiment chat', 'chat'))).toBe('answering');
+    expect(phaseText(describePhase('experiment-chat', 'chat'))).toBe('answering');
+  });
+
+  it('never returns a raw backend identifier', () => {
+    // The acceptance criterion for #517: no round_label reaches the header in
+    // any loop mode, including labels this parser does not recognize.
+    const labels = [
+      ...AGENT_LABELS.map(([label]) => label),
+      'gen-2-cand-1-mutator',
+      'impl issue #7 att2',
+      'judge issue #12 att4',
+      'perf_eval iter 9',
+      'experiment chat',
+      'round-4-retry-2-implementer',
+      'some-future-loop-label-7',
+    ];
+    for (const label of labels) {
+      const text = phaseText(describePhase(label, 'implementer'));
+      expect(text).not.toBeNull();
+      expect(text).not.toContain(label);
+      // The internal syntaxes, not the information. `issue #7` is what the
+      // operator is working on and belongs on screen; `att2` and `round-1` are
+      // identifiers and do not.
+      expect(text).not.toMatch(/round-\d|gen-\d|cand-\d|retry-\d|att\d/);
+    }
+  });
+
+  it('falls back to the agent kind when the label is unknown or absent', () => {
+    expect(phaseText(describePhase('some-future-loop-label-7', 'implementer'))).toBe(
+      'implementing',
+    );
+    expect(phaseText(describePhase(null, 'judge'))).toBe('judging');
+    expect(phaseText(describePhase('', 'orchestrator'))).toBe('planning');
+  });
+
+  it('has nothing to say before a run reports anything', () => {
+    expect(describePhase(null, null)).toBeNull();
+    expect(phaseText(null)).toBeNull();
+  });
+
+  it('degrades to the kind verbatim for an agent kind it does not know', () => {
+    // Better a real kind name than a parse failure; still not a round label.
+    expect(phaseText(describePhase(null, 'verifier'))).toBe('verifier');
+  });
+});

--- a/clients/tui/src/ui/phase-label.ts
+++ b/clients/tui/src/ui/phase-label.ts
@@ -1,0 +1,151 @@
+/**
+ * Turns a backend `round_label` into something an operator can read.
+ *
+ * The labels are loop-internal identifiers that exist for round attribution,
+ * not for display: `round-1-retry-2-implementer`, `gen-2-cand-1-mutator`,
+ * `impl issue #7 att2`. `roundNumberFromLabel` in core-state parses them and
+ * the run map keys off them, so they are load-bearing and stay exactly as they
+ * are. This is presentation only.
+ *
+ * Every producer, so the parser covers all three loop modes:
+ *
+ *   agent   src/vibesys/loops/agent/loop.py
+ *           round-N-pre, round-N-plan, round-N-profiler, round-N,
+ *           round-N-retry-R-implementer, round-N-retry-R-judge,
+ *           round-N-retry-R-single-agent, round-N-retry-R
+ *   evolve  src/vibesys/loops/evolve/loop.py
+ *           gen-G-cand-C-mutator, gen-G-cand-C-judge, gen-G-cand-C-profiler
+ *   plain   src/vibesys/loops/plain/loop.py
+ *           impl issue #ID attN, judge issue #ID attN, perf_eval iter N
+ */
+
+/** What an agent is doing, in the operator's words rather than the loop's. */
+export interface PhaseDescription {
+  /** The activity: `implementing`, `judging`, `planning`. Never an identifier. */
+  activity: string;
+  /** Retry or attempt number, when the label carries one and it is past the first. */
+  attempt: number | null;
+  /** What is being worked on: `candidate 1`, `issue #7`. Null for plain rounds. */
+  subject: string | null;
+}
+
+/**
+ * Stage word per label suffix. The suffix is the only part of a label that says
+ * what is happening; the numbers around it say which round it belongs to, which
+ * the rounds strip already shows.
+ */
+const STAGE_WORDS: Readonly<Record<string, string>> = {
+  pre: 'preparing',
+  plan: 'planning',
+  profiler: 'profiling',
+  implementer: 'implementing',
+  judge: 'judging',
+  mutator: 'mutating',
+  'single-agent': 'working',
+};
+
+/** Agent kinds, for when the label carries no stage of its own. */
+const KIND_WORDS: Readonly<Record<string, string>> = {
+  orchestrator: 'planning',
+  implementer: 'implementing',
+  judge: 'judging',
+  profiler: 'profiling',
+  mutator: 'mutating',
+  chat: 'answering',
+};
+
+const AGENT_ROUND = /^round-(\d+)(?:-retry-(\d+))?(?:-(.+))?$/;
+const EVOLVE_CANDIDATE = /^gen-(\d+)-cand-(\d+)-(.+)$/;
+const PLAIN_ISSUE = /^(impl|judge)\s+issue\s+#(\S+)\s+att(\d+)$/;
+const PLAIN_PERF = /^perf_eval\s+iter\s+(.+)$/;
+
+/**
+ * Describes what is running, from the round label and the agent kind.
+ *
+ * The label wins where the two disagree: it distinguishes the stages one kind
+ * covers (an orchestrator plans in `round-N-plan` and prepares in
+ * `round-N-pre`), which the kind alone cannot.
+ */
+export function describePhase(
+  roundLabel: string | null,
+  agentKind: string | null,
+): PhaseDescription | null {
+  const label = roundLabel?.trim() ?? '';
+  const kind = agentKind?.trim() ?? '';
+  if (label === '' && kind === '') return null;
+
+  // The chat runs beside the loop rather than inside it, and labels itself in
+  // words already. Both spellings appear in recorded runs.
+  if (label === 'experiment chat' || label === 'experiment-chat' || kind === 'chat') {
+    return {activity: 'answering', attempt: null, subject: null};
+  }
+
+  const evolve = EVOLVE_CANDIDATE.exec(label);
+  if (evolve) {
+    const [, , candidate, stage] = evolve;
+    return {
+      activity: STAGE_WORDS[stage ?? ''] ?? fallbackActivity(stage, kind),
+      attempt: null,
+      subject: candidate === undefined ? null : `candidate ${candidate}`,
+    };
+  }
+
+  const issue = PLAIN_ISSUE.exec(label);
+  if (issue) {
+    const [, stage, id, attempt] = issue;
+    return {
+      activity: stage === 'judge' ? 'judging' : 'implementing',
+      attempt: attemptOrNull(attempt),
+      subject: id === undefined ? null : `issue #${id}`,
+    };
+  }
+
+  if (PLAIN_PERF.test(label)) {
+    return {activity: 'measuring', attempt: null, subject: null};
+  }
+
+  const round = AGENT_ROUND.exec(label);
+  if (round) {
+    const [, , retry, stage] = round;
+    return {
+      // `round-N` and `round-N-retry-R` carry no stage; the kind names the
+      // agent that is between stages.
+      activity:
+        stage === undefined
+          ? fallbackActivity(null, kind)
+          : (STAGE_WORDS[stage] ?? fallbackActivity(stage, kind)),
+      attempt: attemptOrNull(retry),
+      subject: null,
+    };
+  }
+
+  // An unrecognized label is a loop we do not know about. Falling back to the
+  // kind keeps an identifier off the screen; the label stays reachable in the
+  // Agents pane and the round strip.
+  return {activity: fallbackActivity(null, kind), attempt: null, subject: null};
+}
+
+/** One line for the header: `implementing · attempt 2`, `mutating candidate 1`. */
+export function phaseText(phase: PhaseDescription | null): string | null {
+  if (phase === null) return null;
+  const subject = phase.subject === null ? phase.activity : `${phase.activity} ${phase.subject}`;
+  return phase.attempt === null ? subject : `${subject} · attempt ${phase.attempt}`;
+}
+
+/**
+ * First attempts are the normal case and saying so adds nothing; a retry is
+ * the thing worth surfacing.
+ */
+function attemptOrNull(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const attempt = Number(value);
+  return Number.isFinite(attempt) && attempt > 1 ? attempt : null;
+}
+
+function fallbackActivity(stage: string | undefined | null, kind: string): string {
+  if (stage !== undefined && stage !== null) {
+    const known = STAGE_WORDS[stage];
+    if (known !== undefined) return known;
+  }
+  return KIND_WORDS[kind] ?? (kind === '' ? 'working' : kind);
+}

--- a/clients/tui/src/ui/phase-label.ts
+++ b/clients/tui/src/ui/phase-label.ts
@@ -44,12 +44,19 @@ const STAGE_WORDS: Readonly<Record<string, string>> = {
   'single-agent': 'working',
 };
 
-/** Agent kinds, for when the label carries no stage of its own. */
+/**
+ * Agent kinds, for when the label carries no stage of its own.
+ *
+ * Every kind the backend runs an agent as, which is also every kind
+ * `expectedRoles` in `run-map.ts` seeds as a selectable phase: an entry missing
+ * here is a backend identifier on screen.
+ */
 const KIND_WORDS: Readonly<Record<string, string>> = {
   orchestrator: 'planning',
   implementer: 'implementing',
   judge: 'judging',
   profiler: 'profiling',
+  perf_eval: 'measuring',
   mutator: 'mutating',
   chat: 'answering',
 };
@@ -123,6 +130,20 @@ export function describePhase(
   // kind keeps an identifier off the screen; the label stays reachable in the
   // Agents pane and the round strip.
   return {activity: fallbackActivity(null, kind), attempt: null, subject: null};
+}
+
+/**
+ * The word for an agent kind on its own, or null when this file has none.
+ *
+ * Same table as `describePhase`'s fallback, and deliberately not the same
+ * contract. A phase description has to say something about what is running, so
+ * an unrecognized kind degrades to the kind itself; a note about which agent a
+ * view is filtered to has no such obligation, and printing the raw kind there
+ * is the backend identifier #517 exists to keep out of the header. Callers that
+ * can drop the text get null and drop it.
+ */
+export function agentKindText(agentKind: string | null): string | null {
+  return KIND_WORDS[agentKind?.trim() ?? ''] ?? null;
 }
 
 /** One line for the header: `implementing · attempt 2`, `mutating candidate 1`. */

--- a/clients/tui/src/ui/text-width.ts
+++ b/clients/tui/src/ui/text-width.ts
@@ -1,0 +1,99 @@
+/**
+ * Terminal cell measurement, for code that has a column budget to spend.
+ *
+ * A terminal lays text out in cells, not UTF-16 code units, and the two differ
+ * in both directions: a CJK ideograph is one code unit and two cells, a
+ * combining mark is one code unit and no cell, and an emoji is several code
+ * units that occupy two cells together. Budgeting with `String.length` makes a
+ * line the caller believes is 40 columns take 50, and slicing by code units
+ * can cut a surrogate pair or a joined emoji sequence in half.
+ *
+ * The rules here are the ones terminals actually apply: East Asian Wide and
+ * Fullwidth are two cells, so is anything with an emoji presentation, marks
+ * and format characters are none, everything else is one.
+ */
+
+/** Grapheme clusters, so a slice never lands inside one. */
+const GRAPHEMES = new Intl.Segmenter('en', {granularity: 'grapheme'});
+
+/**
+ * Code point ranges that occupy two cells: East Asian Wide and Fullwidth,
+ * which JS exposes no property escape for. Emoji are covered separately by
+ * `Emoji_Presentation`, which is a property escape.
+ */
+const WIDE_RANGES: readonly (readonly [number, number])[] = [
+  [0x1100, 0x115f], // Hangul Jamo initial consonants
+  [0x2e80, 0x303e], // CJK radicals, Kangxi, CJK symbols and punctuation
+  [0x3041, 0x33ff], // Kana, Hangul Compatibility Jamo, CJK compatibility
+  [0x3400, 0x4dbf], // CJK Unified Ideographs Extension A
+  [0x4e00, 0x9fff], // CJK Unified Ideographs
+  [0xa000, 0xa4cf], // Yi syllables and radicals
+  [0xa960, 0xa97f], // Hangul Jamo Extended-A
+  [0xac00, 0xd7a3], // Hangul syllables
+  [0xf900, 0xfaff], // CJK compatibility ideographs
+  [0xfe10, 0xfe19], // Vertical forms
+  [0xfe30, 0xfe6f], // CJK compatibility forms, small form variants
+  [0xff00, 0xff60], // Fullwidth forms
+  [0xffe0, 0xffe6], // Fullwidth signs
+  [0x17000, 0x18aff], // Tangut
+  [0x20000, 0x3fffd], // CJK Unified Ideographs, Extension B onward
+];
+
+/** Two cells without asking: the code point's default form is the emoji one. */
+const EMOJI_PRESENTATION = /\p{Emoji_Presentation}/u;
+
+/** U+FE0F asks for the emoji form of a code point that defaults to text. */
+const EMOJI_VARIATION_SELECTOR = '\uFE0F';
+
+/**
+ * No cell of its own: combining marks stack onto the previous character and
+ * format characters (joiners, variation selectors) are instructions, not glyphs.
+ */
+const ZERO_WIDTH = /^[\p{Mn}\p{Me}\p{Cf}]$/u;
+
+/** Cells `text` occupies in a terminal. */
+export function displayWidth(text: string): number {
+  let width = 0;
+  for (const {segment} of GRAPHEMES.segment(text)) width += graphemeWidth(segment);
+  return width;
+}
+
+/**
+ * The longest prefix of `text` that fits `maxWidth` cells, cut on a grapheme
+ * boundary.
+ *
+ * A wide grapheme that would straddle the limit is dropped whole, so the
+ * result is sometimes one cell narrower than the budget. That is the point:
+ * half of a grapheme is not half a character, it is a broken one.
+ */
+export function truncateToWidth(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return '';
+  let width = 0;
+  let end = 0;
+  for (const {segment, index} of GRAPHEMES.segment(text)) {
+    const next = width + graphemeWidth(segment);
+    if (next > maxWidth) break;
+    width = next;
+    end = index + segment.length;
+  }
+  return text.slice(0, end);
+}
+
+/**
+ * A cluster is as wide as the character it is built around: the code points
+ * after the first are marks, joiners and selectors that render into the same
+ * cells.
+ */
+function graphemeWidth(cluster: string): number {
+  const first = cluster.codePointAt(0);
+  if (first === undefined) return 0;
+  const base = String.fromCodePoint(first);
+  if (ZERO_WIDTH.test(base)) return 0;
+  if (EMOJI_PRESENTATION.test(base)) return 2;
+  if (cluster.includes(EMOJI_VARIATION_SELECTOR)) return 2;
+  return isWide(first) ? 2 : 1;
+}
+
+function isWide(codePoint: number): boolean {
+  return WIDE_RANGES.some(([start, end]) => codePoint >= start && codePoint <= end);
+}

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -64,6 +64,17 @@ export interface Theme {
   label: string;
   appearance: Appearance;
 
+  /**
+   * The contrast floor every token here clears, `textSubtle` excepted: it is
+   * held to `SUBTLE_TEXT_MIN_CONTRAST` instead.
+   *
+   * Carried on the theme rather than kept in the spec because `buildTheme`
+   * makes that guarantee against the canvas alone. A region that paints another
+   * surface has to remake it there, and the alternative to reading the number
+   * is restating it.
+   */
+  minContrast: number;
+
   canvas: string;
   surface: string;
   elevatedSurface: string;
@@ -197,7 +208,8 @@ interface ThemeSpec {
   };
 }
 
-const SUBTLE_TEXT_MIN_CONTRAST = 3;
+/** The lower floor `textSubtle` is held to: punctuation and rules, not words. */
+export const SUBTLE_TEXT_MIN_CONTRAST = 3;
 
 /**
  * How far a card's label is pulled toward the theme's strongest text before the
@@ -265,6 +277,7 @@ function buildTheme(spec: ThemeSpec): Theme {
     name: spec.name,
     label: spec.label,
     appearance: spec.appearance,
+    minContrast: spec.minContrast,
     canvas: spec.canvas,
     surface: spec.surface,
     elevatedSurface: spec.elevatedSurface,


### PR DESCRIPTION
Closes #517.

## Problem

The header interpolated backend identifiers verbatim, so a live run read:

```
VibeSys · running · implementer · round-1-retry-1-implementer · 2/200k tokens · Preallocated lock-free SPSC ring · r1
```

`round-1-retry-1-implementer` is a loop-internal key, duplicating both the agent kind beside it and the rounds strip below. The token meter rendered 118 percent during a real run, because `input_tokens` is the last call's context pressure while `context_window` is a static lookup. At 100 columns the line clipped mid-title, losing the segment saying what the run was trying.

It also rendered as a bare one-row line while every other region sits in a bordered box, in a single flat accent, on a lighter surface than the panes beneath it.

![Five header captures stacked vertically, at 200, 60, 34, 22 and 16 columns, segments dropping whole in priority order](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr571.png)

## Solution

**Content.** `phase-label.ts` parses every loop's labels into operator-facing words; an unrecognized label degrades to the agent kind rather than printing an identifier. Segments drop whole in priority order rather than clipping, and width is measured in terminal cells via `text-width.ts`, so CJK and emoji budget correctly. A terminal status always outranks a local override.

**Run state.** `runStateText` defers to main's `runStatusLabel`, so the backend's status is the only source of truth. An earlier revision of this branch carried a client-local `pauseOverride` set from the `/pause` ack, which review correctly flagged for reading `paused` while the run was still going. #578 landed that transition as a real `pausing` status, so the override and its ack handling are gone rather than fixed: two sources of truth for run state is the worse bug. `session-controller.ts` is no longer touched by this branch at all.

**Housing.** The header is a pane: three rows, bezel to bezel, no fill, no blank separator, so its bottom bezel meets the next pane's top one. An earlier attempt used a surface band and a rule, which read as a floating strip and was replaced. The header frame, and then `chat-pane.ts`, set no background at all, so both fell through to the root's `canvas` while every pane beside them sits on `elevatedSurface`; both now name the surface they sit on.

**Hierarchy.** One `TextRenderable` per span, so roles carry tones: brand in accent, run state in a verdict colour and bold, phase and title as content, metadata greyed. Every tone clears its theme's contrast floor in all eight themes.

**Cost:** two extra rows. The housing is bezel, one content row, bezel, so it costs two rows the bare status line did not; on a short terminal that is two rows of transcript. At 100x30 the design pane can no longer show all ten rounds at once: the oldest is on screen at open and the newest is a page away. The pane scrolls, so nothing is unreachable, but that is narrower than what #497's `keeps the newest design round on screen in the pane at 100x30` guaranteed; it passes on the base and fails only after this branch's commits. Rather than raising the terminal size to hide the cost, the test is re-premised at the same 100x30 as `keeps the newest design round reachable in the pane at 100x30`: `Round 1` on screen at open, then three PgDn presses, then `Round 10` and `src/round-10.rs`.

**Known limit:** the state word keeps its text and its bold weight when it truncates, but loses its role colour. `stateColor` matches on the span's rendered text, so `completed` is `success` `#22c55e` at 60 columns while `complet…` falls through to `textPrimary` `#e2e8f0` at 22. Both rows are in the image. Brand and run state do survive to 22 columns as claimed; the state arrives uncoloured. The honest fix is carrying the role's semantic state on the span rather than re-deriving it from rendered text, which is a header refactor and not this PR.

## Verification

Tests cover the backend's `pausing` and `paused` statuses reading correctly through `runStateText`, CJK and emoji budgeting, grapheme-safe truncation, the width ladder at 200/100/60/34/22/16 columns, the tone per role, and contrast for every tone in every theme. Backend labels are unchanged on the wire, so round attribution in `run-map.ts` is unaffected.

One bug found and fixed during the hierarchy work: one renderable per span let OpenTUI shrink every span at once, rendering `V...ys·r...ng` at 24 columns. Fixed with `flexShrink: 0` and hidden unused spans, pinned by a test at that width.

| Check | Result |
| --- | --- |
| `pnpm --filter @vibesys/tui test` | 629 pass, 0 fail, 27 files |
| `check:ts` / `check:clients` / `check:ts-architecture` | clean |

Rebased onto `main` at 8e09827. An earlier rebase, onto 84dfe92, took two upstream changes into this branch. #576 removed `CoreState.terminal` for a typed status behind `hasRunEnded`, so a follow-up commit migrates `runStateText` and drops the tests' `terminal: true` literals. #578 made the run lifecycle a state machine that publishes every transition, which is what removed the pause override above.

One bug came out of that reconciliation: `runStatusLabel` renders `pausing` as `pausing…`, while `stateColor` matched the bare literal `'pausing'` against rendered span text. Deferring to the label without touching `stateColor` would have dropped a pause out of `theme.warning` into body text with no compile error and no failing test. `stateColor` now compares against `runStatusLabel('pausing')`, so the two cannot drift.

Note on structure: commits 1 to 5 do not compile against the new base, since commit 6 is the `hasRunEnded` migration. The repo squash-merges, so this does not reach `main`; say the word if you want it folded for bisectability.

