### PR TITLE
fix(tui): make pane focus unambiguous and legible in every theme

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -149,7 +149,8 @@ stacking another surface on top.
 `Ctrl+W` moves focus one column to the right and wraps, through whichever
 columns are actually on screen. Every pane reads the same authoritative focus
 state: the focused pane carries the theme's focus border and a `▸` in its title,
-while every other pane uses the neutral border. Page Up and Page Down scroll
+while every other pane uses the neutral border. The treatment belongs to a pane
+frame, so a box inside one, the chat's composer for instance, never repeats it. Page Up and Page Down scroll
 whichever pane has focus, and Escape on the right pane closes it and restores
 the full-width view. Chat and transcript state survive the pane closing.
 
@@ -158,13 +159,16 @@ content row; pressing `F4` again restores the previous split and focus. It does
 not create a second pane or move its data, so hypothesis and agent selection,
 chat drafts, and pane scroll positions remain in place. The shortcut works for
 the hypothesis list, agent graph, transcript, experiment chat, and performance
-pane. Modal dialogs keep `F4` to themselves until they close.
+pane. It does nothing over an expanded todo list, which is as tall as its own
+contents and has no use for the row. Modal dialogs keep `F4` to themselves until
+they close.
 
 Pane widths are computed from the terminal, so a wide terminal gives the
 visualization real room while the left pane keeps a readable floor. Below 100
 columns there is not enough width for both, and visualizations fall back to the
-modal they used before panes existed. The layout re-flows on resize in either
-direction.
+modal they used before panes existed. That modal is the same surface as the
+pane, so it keeps the pane's title and its focus marker rather than reading as a
+generic dialog. The layout re-flows on resize in either direction.
 
 `/help`, `/theme`, and errors stay modal.
 
@@ -193,8 +197,8 @@ Inside a hypothesis the footer shows keyboard navigation. `←` and `→` step
 focus across the rounds rail, the agents graph, and the transcript, `↑` and `↓`
 move within whichever holds it, `[` and `]` select rounds from anywhere, Tab and
 Shift+Tab select agents, Page Up/Page Down scroll the transcript, and F2 (or
-Ctrl+T) expands the todo box, which then takes the arrow keys until Escape closes
-it.
+Ctrl+T) expands the todo box, which then takes the arrow keys, and the focus
+marker with them, until Escape closes it.
 F3 (or Ctrl+P) expands the latest prompt in the current selection. Function keys
 are offered alongside the Control chords because a terminal is free to keep a
 Control chord for itself, and on macOS several do.

--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -108,12 +108,15 @@ list rises out of the command input rather than across the chat.
 
 The cursor starts in the command input, and `Ctrl+W` moves both it and the pane
 keys to the chat and back; the chat's instruction line says so (`Ctrl+W to type
-here`) until it holds them, and the focused input carries the focus border, so
-where a keystroke lands is never a guess. Only the chat composer accepts
-ordinary questions; the command input accepts slash commands. Page Up and Page Down scroll the focused pane, and
-Escape hands the keys back to the table. Arrows, Enter, and the rest of the
-table's keys are unaffected by the dock. A slash command typed into the chat
-input runs through the same command path as the command box.
+here`) until it holds them, and the chat pane carries the focus border while it
+does, so where a keystroke lands is never a guess. The command box is shared by
+every pane in its column rather than being one of them, so it keeps the neutral
+border in every theme and never competes with the pane that holds the keys.
+Only the chat composer accepts ordinary questions; the command input accepts
+slash commands. Page Up and Page Down scroll the focused pane, and Escape hands
+the keys back to the table. Arrows, Enter, and the rest of the table's keys are
+unaffected by the dock. A slash command typed into the chat input runs through
+the same command path as the command box.
 
 `/chat` leaves the command surface on this view, since the chat is already
 beside the table: it is absent from `/help` and from the completions, though it

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -1286,7 +1286,12 @@ export function focusPane(state: SessionState, focus: PaneFocus): SessionState {
   return {...state, layout: {...state.layout, focus}};
 }
 
-/** The semantic pane currently receiving pane navigation keys. */
+/**
+ * The semantic pane currently receiving pane navigation keys, and the single
+ * authority for the focus treatment: every pane view compares its own `PaneId`
+ * against this, so at most one of them can be lit at a time. Surfaces that are
+ * not panes, the command box above all, never wear that treatment.
+ */
 export function focusedPane(state: SessionState): PaneId {
   if (experimentLogVisible(state)) {
     if (state.layout.focus === 'chat' && chatPaneVisible(state)) return 'chat';

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -207,8 +207,14 @@ export interface LayoutState {
   zoomedPane: PaneId | null;
 }
 
-/** Semantic pane identities, independent of their current screen position. */
-export type PaneId = 'agents' | 'chat' | 'experiments' | 'performance' | 'transcript';
+/**
+ * Semantic pane identities, independent of their current screen position.
+ *
+ * `todos` is the expanded todo list. It is a strip rather than a column, but it
+ * takes the arrow keys from the pane it opens over, so it is a pane for the
+ * purpose the identities exist for: naming the one surface the keys are on.
+ */
+export type PaneId = 'agents' | 'chat' | 'experiments' | 'performance' | 'todos' | 'transcript';
 
 export interface ThemePicker {
   selected: ThemeName;
@@ -1287,10 +1293,28 @@ export function focusPane(state: SessionState, focus: PaneFocus): SessionState {
 }
 
 /**
+ * True while the expanded todo list is on screen and taking the arrow keys.
+ *
+ * `keybindings` routes Up and Down to the list for as long as it is open, so
+ * the list rather than the pane it opened over is the surface those keys are
+ * on. Derived from the toggle rather than stored beside it: collapsing the list
+ * hands the keys back to whichever pane held them, with nothing to restore.
+ *
+ * The strip is drawn whenever the visible agent has todos, including under a
+ * zoomed pane, so this is the whole condition: an empty list is not on screen
+ * and cannot hold the keys.
+ */
+export function todoListFocused(state: SessionState): boolean {
+  if (experimentLogVisible(state) || !state.todosExpanded) return false;
+  return visibleTodos(state).length > 0;
+}
+
+/**
  * The semantic pane currently receiving pane navigation keys, and the single
  * authority for the focus treatment: every pane view compares its own `PaneId`
  * against this, so at most one of them can be lit at a time. Surfaces that are
- * not panes, the command box above all, never wear that treatment.
+ * not panes, the command box above all, never wear that treatment, and neither
+ * does a box nested inside a pane that already wears it.
  */
 export function focusedPane(state: SessionState): PaneId {
   if (experimentLogVisible(state)) {
@@ -1298,6 +1322,10 @@ export function focusedPane(state: SessionState): PaneId {
     if (state.layout.focus === 'right' && state.layout.right !== null) return 'performance';
     return 'experiments';
   }
+  // The expanded todo list takes the arrow keys from whichever pane held them,
+  // so it holds the focus until it closes. Ahead of the panes below because the
+  // keys reach it first.
+  if (todoListFocused(state)) return 'todos';
   // Opening a visualization replaces the agent summary in the left column
   // with the transcript. Keep roundFocus intact so closing the visualization
   // can restore it, but never report the hidden Agents pane as focused.
@@ -1318,16 +1346,21 @@ export function focusedPane(state: SessionState): PaneId {
  * presentation, so toggling cannot replace or reconstruct pane state.
  */
 export function togglePaneZoom(state: SessionState): SessionState {
-  return {
-    ...state,
-    layout: {
-      ...state.layout,
-      zoomedPane: state.layout.zoomedPane === null ? focusedPane(state) : null,
-    },
-  };
+  if (state.layout.zoomedPane !== null) {
+    return {...state, layout: {...state.layout, zoomedPane: null}};
+  }
+  const pane = focusedPane(state);
+  // Zoom hands the content row to a column. The todo list is a strip as tall as
+  // its own contents, so the row has nothing to give it: leave the layout as it
+  // is rather than clearing the screen around a five-row box.
+  if (pane === 'todos') return state;
+  return {...state, layout: {...state.layout, zoomedPane: pane}};
 }
 
-/** Every pane currently available to focus or zoom in the active view. */
+/**
+ * Every pane the content row can be given to in the active view. The expanded
+ * todo list is deliberately absent: it can hold the keys, but not the row.
+ */
 export function visiblePaneIds(state: SessionState): PaneId[] {
   if (experimentLogVisible(state)) {
     return [

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -7,7 +7,13 @@ import {
 } from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
-import {scopedRounds, stripRounds, visiblePhases, visibleRoundNumber} from '../session-model.js';
+import {
+  focusedPane,
+  scopedRounds,
+  stripRounds,
+  visiblePhases,
+  visibleRoundNumber,
+} from '../session-model.js';
 import {
   type AgentGraph,
   type EdgeTone,
@@ -17,6 +23,7 @@ import {
   stageKinds,
 } from './agent-graph.js';
 import {agentRuntimeLabel} from './agent-runtime-label.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {elapsedLabel} from './previews.js';
 import type {Theme} from './theme.js';
 
@@ -68,6 +75,8 @@ export function agentPaneWidth(terminalWidth: number, stageCount: number): numbe
   return Math.min(ceiling, room, Math.max(floor, share));
 }
 
+const AGENTS_TITLE = 'Agents';
+
 export class AgentMapView {
   readonly output: BoxRenderable;
   #theme: Theme;
@@ -92,9 +101,9 @@ export class AgentMapView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
-      borderColor: theme.border,
-      title: ' Agents ',
+      borderStyle: paneBorderStyle(false),
+      borderColor: paneBorderColor(theme, false),
+      title: paneTitle(AGENTS_TITLE, false),
       onMouseUp: () => this.controller.focusRound('agents'),
     });
   }
@@ -139,9 +148,10 @@ export class AgentMapView {
     this.#renderedFocus = focused;
     this.output.width = paneWidth;
     // The pane that owns the arrow keys says so, the way every other focusable
-    // surface in the client does.
-    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
-    this.output.title = focused ? ' ▸ Agents ' : ' Agents ';
+    // surface in the client does. `focusedPane` is that single authority:
+    // reading `roundFocus` directly lit this pane while a visualization too
+    // narrow to split held the keys.
+    applyPaneFocus(this.output, this.#theme, AGENTS_TITLE, focusedPane(state) === 'agents');
     this.#clear();
     if (phases.length === 0) {
       // A round the run has not reached has no agents, and never will until it

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -66,8 +66,9 @@ import {TRANSCRIPT_MIN} from './agent-map.js';
 import {createOpenTuiApp, type OpenTuiApp} from './app.js';
 import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 import {renderDesignSummary} from './design-log.js';
+import {paneTitle} from './focus.js';
 import {headerBackground} from './header.js';
-import {contrastRatio, listThemes, resolveTheme, type ThemeName} from './theme.js';
+import {contrastRatio, listThemes, resolveTheme, THEME_NAMES, type ThemeName} from './theme.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -489,17 +490,17 @@ describe('OpenTUI presentation', () => {
     const helpLine = lines.findIndex(line => line.includes('[/]: round'));
     const viewportBottomBorder = lines.findIndex(
       (line, index) =>
-        index > activityLineIndex && index < helpLine && line.trimEnd().endsWith('╯'),
+        index > activityLineIndex && index < helpLine && FRAME_BOTTOM_RIGHT.test(line.trimEnd()),
     );
     expect(activityLineIndex).toBeGreaterThan(promptLine);
-    expect(activityLine?.trimEnd().endsWith('│')).toBe(true);
+    expect(FRAME_VERTICAL.test(activityLine?.trimEnd() ?? '')).toBe(true);
     expect(viewportBottomBorder).toBeGreaterThan(activityLineIndex);
     expect(viewportBottomBorder).toBeLessThan(helpLine);
     const transcriptColumn = Math.max(0, (activityLine?.indexOf('Implementer') ?? 2) - 2);
     expect(
       lines
         .slice(activityLineIndex + 1, viewportBottomBorder)
-        .every(line => line.slice(transcriptColumn).replaceAll('│', '').trim() === ''),
+        .every(line => line.slice(transcriptColumn).replaceAll(FRAME_VERTICALS, '').trim() === ''),
     ).toBe(true);
 
     controller.selectAgent('implementer');
@@ -1698,7 +1699,8 @@ describe('OpenTUI presentation', () => {
     expect(frame).toContain('← 2 passed');
     // Header housing, agents pane, transcript frame, and the card's call and
     // result regions: the rail is absent because this fixture has no rounds.
-    expect(frame.match(/╭/g)).toHaveLength(5);
+    // A focused pane draws a heavy corner, so the count is over both styles.
+    expect(frame.match(/[╭┏]/g)).toHaveLength(5);
   });
 
   it('renders a typed command payload with labeled stderr and exit code', async () => {
@@ -2614,6 +2616,7 @@ describe('theming', () => {
     expect(landing).not.toContain('round 41 detail');
     // The rounds strip and agent map are per-round chrome; neither is drawn.
     expect(landing).not.toContain('─ Rounds ─');
+    expect(paneFrameColumn(landing, 'Agents')).toBeNull();
     expect(landing).not.toContain('Agents');
   });
 
@@ -2973,12 +2976,9 @@ describe('theming', () => {
     // it.
     // The cursor starts in the command box, and the chat says how to reach it.
     expect(landing).toContain('Ctrl+W to type here');
-    const lines = landing.split('\n');
-    const paneTop = lines.find(line => line.includes('╭─ Experiment chat')) ?? '';
-    const messageTop = lines.find(line => line.includes('╭─ Message ')) ?? '';
-    const commandTop = lines.find(line => line.includes('╭─ Command')) ?? '';
-    expect(messageTop).not.toBe('');
-    expect(commandTop.indexOf('╭─ Command')).toBe(paneTop.indexOf('╭─ ▸ Experiments'));
+    expect(paneFrameColumn(landing, 'Experiment chat')).not.toBeNull();
+    expect(paneFrameColumn(landing, 'Message')).not.toBeNull();
+    expect(paneFrameColumn(landing, 'Command')).toBe(paneFrameColumn(landing, 'Experiments'));
   });
 
   it('routes typing to whichever input Ctrl+W points at', async () => {
@@ -3205,12 +3205,12 @@ describe('theming', () => {
     await testRenderer.mockInput.typeText('/pe');
     const frame = await testRenderer.waitForFrame(value => value.includes('[Tab]'));
 
-    const lines = frame.split('\n');
-    const suggestion = lines.find(line => line.includes('/perf')) ?? '';
-    const commandInput = lines.find(line => line.includes('╭─ Command')) ?? '';
+    const suggestion = frame.split('\n').find(line => line.includes('/perf')) ?? '';
+    const commandColumn = paneFrameColumn(frame, 'Command');
     // The list belongs to the box it completes, so it starts where that box
     // starts rather than running back across the chat column.
-    expect(suggestion.indexOf('/perf')).toBeGreaterThan(commandInput.indexOf('╭─ Command'));
+    expect(commandColumn).not.toBeNull();
+    expect(suggestion.indexOf('/perf')).toBeGreaterThan(commandColumn ?? 0);
   });
 
   it('drops /chat from the command surface while the chat is already docked', async () => {
@@ -3697,7 +3697,7 @@ describe('theming', () => {
     expect(frame).toContain('H-07');
     // The per-round chrome belongs to a hypothesis the operator never opened.
     expect(frame).not.toContain('─ Rounds ─');
-    expect(frame).not.toContain('─ Agents ─');
+    expect(paneFrameColumn(frame, 'Agents')).toBeNull();
   });
 
   it('moves the pane keys onto the docked chat and back with Ctrl+W', async () => {
@@ -3787,6 +3787,126 @@ describe('theming', () => {
     testRenderer.mockInput.pressKey('w', {ctrl: true});
     expect(await frameAfter(testRenderer)).toContain('▸ Experiments');
     expect(controller.state.layout.focus).toBe('left');
+  });
+
+  it('lights one pane and never the command box, in every built-in theme', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 24});
+    const controller = splitController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+
+    for (const name of THEME_NAMES) {
+      controller.setTheme(name);
+      const theme = resolveTheme(name);
+      await frameAfter(testRenderer);
+
+      // The transcript holds the round view's keys by default. Every other
+      // titled surface, the shared command box included, stays neutral.
+      expect(paneBorders(testRenderer)).toEqual({
+        Rounds: theme.borderStrong,
+        Agents: theme.border,
+        '▸ Transcript': theme.borderFocus,
+        Command: theme.border,
+      });
+
+      testRenderer.mockInput.pressKey('ARROW_LEFT');
+      await frameAfter(testRenderer);
+      // The treatment moves whole: the pane that gains it and the pane that
+      // loses it are repainted in the same frame.
+      expect(paneBorders(testRenderer)).toEqual({
+        Rounds: theme.borderStrong,
+        '▸ Agents': theme.borderFocus,
+        Transcript: theme.border,
+        Command: theme.border,
+      });
+
+      testRenderer.mockInput.pressKey('ARROW_RIGHT');
+      await frameAfter(testRenderer);
+    }
+  });
+
+  it('keeps the command box neutral while a proven hypothesis is on screen', async () => {
+    // Issue #433: the command box was painted in the success colour, so it read
+    // as the focused surface while the keys were on the table beside it. A
+    // success outcome on screen must not put any focus treatment on that box.
+    const testRenderer = await createTestRenderer({width: 160, height: 22});
+    const controller = logController();
+    controller.experiments = [
+      logEntry('H-07', 41, 41, {claim: 'batch the prefill step', resolved_outcome: 'disproven'}),
+      logEntry('H-08', 42, 42, {claim: 'bigger KV cache block', resolved_outcome: 'proven'}),
+    ];
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    for (const name of THEME_NAMES) {
+      controller.setTheme(name);
+      const theme = resolveTheme(name);
+      const frame = await frameAfter(testRenderer);
+
+      // The success colour really is on screen, which is the state #433 was
+      // reported in rather than a hypothetical one.
+      expect(frame).toContain('Accepted');
+      expect(spanColors(testRenderer, 'Accepted')?.fg).toBe(theme.success);
+
+      const borders = paneBorders(testRenderer);
+      expect(borders['▸ Experiments']).toBe(theme.borderFocus);
+      expect(borders['Command']).toBe(theme.border);
+      expect(borders['Command']).not.toBe(theme.success);
+      expect(borders['Command']).not.toBe(theme.borderFocus);
+    }
+  });
+
+  it('leaves every round pane neutral when a fallback modal takes the keys', async () => {
+    // Under the split width the visualization has no pane to be focused in, so
+    // it falls back to a modal and takes the keys with it. Reading `roundFocus`
+    // instead of `focusedPane` left the Agents pane lit behind that modal. The
+    // terminal is tall enough that the modal starts below the pane headings it
+    // would otherwise cover.
+    const testRenderer = await createTestRenderer({width: 90, height: 40});
+    const controller = splitController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('agents');
+
+    await controller.openPane('perf');
+    const frame = await frameAfter(testRenderer);
+
+    expect(controller.state.layout.focus).toBe('right');
+    expect(frame).not.toContain('▸ Agents');
+    expect(frame).not.toContain('▸ Transcript');
+    const theme = resolveTheme('dark');
+    const borders = paneBorders(testRenderer);
+    expect(borders['Agents']).toBe(theme.border);
+    expect(borders['Transcript']).toBe(theme.border);
+  });
+
+  it('moves the focus treatment on a click, not only on a keystroke', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 24});
+    const controller = splitController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    let frame = await frameAfter(testRenderer);
+    const theme = resolveTheme('dark');
+    expect(paneBorders(testRenderer)['▸ Agents']).toBe(theme.borderFocus);
+
+    const lines = frame.split('\n');
+    const row = lines.findIndex(line => line.includes('batched the prefill step'));
+    const column = (lines[row]?.indexOf('batched the prefill step') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    frame = await frameAfter(testRenderer);
+
+    expect(controller.state.roundFocus).toBe('transcript');
+    expect(paneBorders(testRenderer)).toEqual({
+      Rounds: theme.borderStrong,
+      Agents: theme.border,
+      '▸ Transcript': theme.borderFocus,
+      Command: theme.border,
+    });
   });
 
   it('shows the hypothesis title as a heading in the detail view', async () => {
@@ -4098,6 +4218,40 @@ describe('theming', () => {
     // Focus moved to the transcript, so the pane border drops back to the
     // ordinary border colour and the transcript takes the focus colour.
     expect(spanColors(testRenderer, 'Performance')?.fg).toBe(theme.border);
+  });
+
+  /**
+   * Focus has to survive a palette that cannot express it. `borderFocus` and
+   * `border` are within 1.5x of each other in five of the eight themes, so the
+   * marker in the title's reserved gutter and the frame style are what actually
+   * carry the change, and neither may move the label they sit beside.
+   */
+  it.each(
+    THEME_NAMES.map(name => [name] as const),
+  )('marks focus in %s without moving the title', async (name: ThemeName) => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = splitController();
+    controller.publish({...controller.state, themeName: name});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openPane('perf');
+
+    const onRight = await frameAfter(testRenderer);
+    controller.cyclePaneFocus();
+    const onLeft = await frameAfter(testRenderer);
+
+    const focused = paneFrameCorner(onRight, 'Performance');
+    const resting = paneFrameCorner(onLeft, 'Performance');
+    expect(focused).toBeDefined();
+    expect(resting).toBeDefined();
+    // The marker is the non-colour channel, and it is independent of the theme.
+    expect(onRight).toContain(paneTitle('Performance', true));
+    expect(onLeft).toContain(paneTitle('Performance', false));
+    // The frame does not change: focus never alters a pane's shape.
+    expect(focused?.glyph).toBe(resting?.glyph);
+    // And the label itself does not move when either changes.
+    expect(focused?.column).toBe(resting?.column);
+    expect(onRight.split('\n')[0]?.length).toBe(onLeft.split('\n')[0]?.length);
   });
 
   it('keeps the pane current while the run advances', async () => {
@@ -4523,6 +4677,54 @@ function logEntry(
     active: false,
     ...overrides,
   };
+}
+
+/**
+ * Every titled box on screen, as its rendered title and border colour. The
+ * focus treatment is a frame style, a border colour, and a `▸` in the title's
+ * reserved gutter, so keying on the title as drawn asserts the marker and the
+ * colour together, and asserting the whole record catches a second surface
+ * lighting up as well as the right one going dark.
+ */
+function paneBorders(testRenderer: TestRendererSetup): Record<string, string> {
+  const borders: Record<string, string> = {};
+  for (const line of testRenderer.captureSpans().lines) {
+    for (const span of line.spans) {
+      // Either frame style, since a focused pane draws the heavy one.
+      for (const match of span.text.matchAll(/[╭┏][─━]([^─━╮┓]+)[─━]/g)) {
+        borders[(match[1] ?? '').trim()] = rgbToHex(span.fg).toLowerCase();
+      }
+    }
+  }
+  return borders;
+}
+
+/** The frame glyphs a pane draws, in either border style. */
+const FRAME_VERTICAL = /[│┃]$/;
+const FRAME_VERTICALS = /[│┃]/g;
+const FRAME_BOTTOM_RIGHT = /[╯┛]$/;
+
+/**
+ * The column a pane's frame starts at, or null when the pane is not on screen.
+ *
+ * Focus swaps the frame's glyphs and the marker in the title's reserved
+ * gutter, so a test about layout has to match on neither.
+ */
+function paneFrameColumn(frame: string, label: string): number | null {
+  return paneFrameCorner(frame, label)?.column ?? null;
+}
+
+/** The frame's top-left glyph and column, which together say how it is drawn. */
+function paneFrameCorner(
+  frame: string,
+  label: string,
+): {glyph: string; column: number} | undefined {
+  const top = new RegExp(`[╭┏][─━] [▸ ] ${label} `);
+  for (const line of frame.split('\n')) {
+    const match = top.exec(line);
+    if (match !== null) return {glyph: match[0][0] ?? '', column: match.index};
+  }
+  return undefined;
 }
 
 function spanColors(

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1139,9 +1139,14 @@ describe('OpenTUI presentation', () => {
     const focused = await frameAfter(testRenderer);
 
     expect(controller.state.layout.focus).toBe('chat');
-    // And the box says so: clicking must move the border, not only the cursor.
+    // And the surface says so: clicking must move the treatment, not only the
+    // cursor. It moves onto the pane frame, since the composer is a box inside
+    // that pane rather than a pane of its own.
     expect(focused).not.toContain('Ctrl+W to type here');
-    expect(spanColors(testRenderer, 'Message')?.fg).toBe(resolveTheme('dark').borderFocus);
+    const theme = resolveTheme('dark');
+    const borders = paneBorders(testRenderer);
+    expect(borders['▸ Experiment chat']).toBe(theme.borderFocus);
+    expect(borders['Message']).toBe(theme.border);
   });
 
   it('gives the chat the keys when it is clicked, not only on Ctrl+W', async () => {
@@ -3909,6 +3914,117 @@ describe('theming', () => {
     });
   });
 
+  it('moves the focus treatment onto the expanded todo list, under every parent focus', async () => {
+    // Ctrl+T routes Up/Down to the list, so the list is the surface taking the
+    // keys and has to be the one wearing the marker. Whichever pane held them
+    // before goes back to rest, whether that is the transcript, the agent
+    // graph, or a visualization beside them.
+    const testRenderer = await createTestRenderer({width: 140, height: 32});
+    const controller = todoController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    const theme = resolveTheme('dark');
+    await testRenderer.waitForFrame(value => value.includes('Todo 1/3'));
+
+    for (const parent of ['▸ Transcript', '▸ Agents', '▸ Performance'] as const) {
+      if (parent === '▸ Agents') controller.focusRound('agents');
+      if (parent === '▸ Performance') await controller.openPane('perf');
+      await frameAfter(testRenderer);
+      expect(markedPanes(paneBorders(testRenderer))).toEqual([parent]);
+
+      testRenderer.mockInput.pressKey('t', {ctrl: true});
+      const expanded = await testRenderer.waitForFrame(value =>
+        value.includes('Re-run the benchmark'),
+      );
+      expect(expanded).toContain('▸ Todo 1/3');
+      const borders = paneBorders(testRenderer);
+      expect(markedPanes(borders)).toEqual(['▸ Todo 1/3']);
+      expect(borders['▸ Todo 1/3']).toBe(theme.borderFocus);
+      // The pane it opened over is back at rest: one surface takes the keys,
+      // so one surface says so.
+      expect(borders[parent.slice(2)]).toBe(theme.border);
+
+      testRenderer.mockInput.pressKey('t', {ctrl: true});
+      await frameAfter(testRenderer);
+    }
+  });
+
+  it('keeps zoom and the expanded todo list from claiming the row together', async () => {
+    // The list holds the keys but is as tall as its own contents, so F4 has
+    // nothing to give it and leaves the row alone. A zoomed pane still has the
+    // strip under it, so opening the list there moves the marker onto it the
+    // same way, rather than lighting both.
+    const testRenderer = await createTestRenderer({width: 140, height: 32});
+    const controller = todoController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('Todo 1/3'));
+    testRenderer.mockInput.pressKey('t', {ctrl: true});
+    await testRenderer.waitForFrame(value => value.includes('Re-run the benchmark'));
+
+    testRenderer.mockInput.pressKey('F4');
+    const open = await frameAfter(testRenderer);
+
+    expect(controller.state.layout.zoomedPane).toBeNull();
+    expect(open).toContain('batched the prefill step');
+    expect(markedPanes(paneBorders(testRenderer))).toEqual(['▸ Todo 1/3']);
+
+    testRenderer.mockInput.pressKey('t', {ctrl: true});
+    await frameAfter(testRenderer);
+    testRenderer.mockInput.pressKey('F4');
+    await frameAfter(testRenderer);
+
+    expect(controller.state.layout.zoomedPane).toBe('transcript');
+    expect(markedPanes(paneBorders(testRenderer))).toEqual(['▸ Transcript']);
+
+    testRenderer.mockInput.pressKey('t', {ctrl: true});
+    await frameAfter(testRenderer);
+
+    expect(markedPanes(paneBorders(testRenderer))).toEqual(['▸ Todo 1/3']);
+  });
+
+  it('shows the narrow fallback as the focused visualization, not a Command box', async () => {
+    // Under the split width the visualization is drawn through the modal, so
+    // that modal is the keyboard target and has to carry the pane's own title
+    // and its focus marker. It used to render as a generic Command box in the
+    // info border, leaving the treatment on a RightPaneView nobody could see.
+    const testRenderer = await createTestRenderer({width: 90, height: 40});
+    const controller = splitController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await controller.openPane('perf');
+    const frame = await frameAfter(testRenderer);
+
+    expect(controller.state.layout.focus).toBe('right');
+    expect(frame).toContain('best r7 1135 tok_s');
+    const theme = resolveTheme('dark');
+    const borders = paneBorders(testRenderer);
+    expect(markedPanes(borders)).toEqual(['▸ Performance']);
+    expect(borders['▸ Performance']).toBe(theme.borderFocus);
+    // The shared command box is still on screen under the modal and stays
+    // neutral, so the only lit frame is the one taking the keys.
+    expect(borders['Command']).toBe(theme.border);
+  });
+
+  it('keeps the composer inside a focused chat pane at rest', async () => {
+    // The treatment belongs to the pane frame. The composer is a box inside
+    // that frame rather than a pane of its own, so a focused chat used to draw
+    // the marker and the focused border twice, one nested in the other.
+    const testRenderer = await createTestRenderer({width: 160, height: 24});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    controller.focusPane('chat');
+    await frameAfter(testRenderer);
+
+    const theme = resolveTheme('dark');
+    const borders = paneBorders(testRenderer);
+    expect(markedPanes(borders)).toEqual(['▸ Experiment chat']);
+    expect(borders['Message']).toBe(theme.border);
+  });
+
   it('shows the hypothesis title as a heading in the detail view', async () => {
     const testRenderer = await createTestRenderer({width: 200, height: 22});
     const controller = logController();
@@ -4011,6 +4127,29 @@ describe('theming', () => {
     expect(annotated).toContain('- src/ffi.rs');
     // Stage facts stay on the round's own row, stated once.
     expect(annotated).not.toContain('Outcome proven');
+  });
+  it('keeps the hypothesis title through a no-op state notification', async () => {
+    // Clicking an already-focused log area calls focusPane('left'), which
+    // returns the same state; the controller notifies every listener anyway.
+    // The pane then has to redraw the title it is actually showing, not the
+    // index title, which the detail body underneath would contradict.
+    const testRenderer = await createTestRenderer({width: 200, height: 22});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    controller.publish({
+      ...controller.state,
+      hypothesisDetail: {entryKey: 'H-07', selectedRound: 41},
+    });
+    await testRenderer.waitForFrame(value => value.includes('Hypothesis H-07'));
+
+    controller.focusPane('left');
+    const frame = await frameAfter(testRenderer);
+
+    expect(frame).toContain('▸ Hypothesis H-07');
+    expect(frame).not.toContain('Experiments');
+    expect(frame).toContain('batch the prefill step');
   });
 
   it('opens hypothesis detail from a row click and keeps pane clicks routed', async () => {
@@ -4661,6 +4800,41 @@ function splitController(): FakeController {
   return controller;
 }
 
+/** A live round with a todo list, and a visualization to open beside it. */
+function todoController(): FakeController {
+  const controller = new FakeController({
+    ...initialSessionState(),
+    core: {
+      ...initialSessionState().core,
+      status: 'running',
+      agentKind: 'implementer',
+      rounds: [{number: 7, status: 'active'}],
+      todos: [
+        {
+          agentKind: 'implementer',
+          roundNumber: null,
+          items: [
+            {content: 'Profile the hot loop', status: 'completed'},
+            {content: 'Vectorize the kernel', status: 'in_progress'},
+            {content: 'Re-run the benchmark', status: 'pending'},
+          ],
+        },
+      ],
+      transcript: [
+        {
+          id: 'a',
+          kind: 'assistant',
+          label: 'implementer · round 7',
+          content: 'batched the prefill step',
+          roundNumber: 7,
+        },
+      ],
+    },
+  });
+  controller.paneContent = 'Performance · tok_s\nbest r7 1135 tok_s';
+  return controller;
+}
+
 function logEntry(
   id: string,
   firstRound: number,
@@ -4697,6 +4871,14 @@ function paneBorders(testRenderer: TestRendererSetup): Record<string, string> {
     }
   }
   return borders;
+}
+
+/**
+ * The titles wearing the focus marker, which is never more than one: the marker
+ * says where the keys go, and the keys go to one surface.
+ */
+function markedPanes(borders: Record<string, string>): string[] {
+  return Object.keys(borders).filter(title => title.startsWith('▸'));
 }
 
 /** The frame glyphs a pane draws, in either border style. */
@@ -5023,8 +5205,7 @@ class FakeController implements SessionController {
     this.#promptToggle?.();
   }
   toggleTodos(): void {
-    this.state = {...this.state, todosExpanded: !this.state.todosExpanded};
-    for (const listener of this.#listeners) listener(this.state);
+    this.publish({...this.state, todosExpanded: !this.state.todosExpanded});
   }
 
   /** Rows the fake server returns for query.experiments. */

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -24,6 +24,7 @@ import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
 import {ErrorBannerView} from './error-banner.js';
 import {ExperimentLogView} from './experiment-log.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {
   type HeaderSpan,
   headerBackground,
@@ -61,6 +62,8 @@ const HEADER_CHROME = 4;
 
 const SPLIT_KEY_HELP =
   'Ctrl+W: switch pane · F4: zoom focused pane · PgUp/PgDn: scroll · Esc: close pane';
+
+const TRANSCRIPT_TITLE = 'Transcript';
 
 /**
  * A round the run has not reached has no turns and never will until it runs.
@@ -176,8 +179,9 @@ export function createOpenTuiApp(
     paddingLeft: 1,
     paddingRight: 1,
     border: true,
-    borderStyle: 'rounded',
-    borderColor: theme.border,
+    borderStyle: paneBorderStyle(false),
+    borderColor: paneBorderColor(theme, false),
+    title: paneTitle(TRANSCRIPT_TITLE, false),
     onMouseUp: focusTranscript,
   });
   const viewport = new ScrollBoxRenderable(renderer, {
@@ -466,8 +470,7 @@ export function createOpenTuiApp(
     // Inside a round the transcript is one of two navigable panes, so it carries
     // the focus border whenever the round view's keys are on it.
     const transcriptFocused = !showLog && paneFocus === 'transcript';
-    transcriptFrame.borderColor = transcriptFocused ? theme.borderFocus : theme.border;
-    transcriptFrame.title = transcriptFocused ? ' ▸ Transcript ' : ' Transcript ';
+    applyPaneFocus(transcriptFrame, theme, TRANSCRIPT_TITLE, transcriptFocused);
     // Match the chat to the left pane's rectangle so it sits beside the
     // visualization instead of over it. Bounds come from the siblings that
     // actually occupy those rows, so a taller todo strip still fits.
@@ -488,7 +491,6 @@ export function createOpenTuiApp(
     chatPane.render(state, showChatPane, chatWidth);
     const chatInputFocused = showChatPane && state.layout.focus === 'chat';
     commandColumn.visible = zoomedPane !== 'chat';
-    commandInput.setFocused(paneFocus === 'experiments' || paneFocus === 'transcript');
     // The command list completes the box it belongs to, and on this view that
     // box cannot open a chat that is already beside it.
     commandInput.setCommandContext({chatDocked: showChatPane});

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -498,11 +498,7 @@ export function createOpenTuiApp(
     experimentLog.render(state);
     experimentLog.output.visible = showExperimentLog;
     rightPane.render(state, showRightPane, rightWidth);
-    overlay.render(
-      paneFallback === null
-        ? state
-        : {...state, overlay: {kind: 'detail' as const, content: paneFallback.content}},
-    );
+    overlay.render(state, paneFallback);
     themePicker.render(state);
     chat.render(state);
     conversationActivityBar.render(state, !showLog);

--- a/clients/tui/src/ui/chat-composer.test.ts
+++ b/clients/tui/src/ui/chat-composer.test.ts
@@ -3,20 +3,21 @@ import {BoxRenderable, type Renderable} from '@opentui/core';
 import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
 import type {SessionController} from '../session-controller.js';
 import {initialSessionState, type SessionState} from '../session-model.js';
-import {createChatDraft, pendingComposerTitle} from './chat-composer.js';
+import {createChatDraft, pendingComposerLabel} from './chat-composer.js';
 import {ChatPaneView} from './chat-pane.js';
+import {paneTitle} from './focus.js';
 import {createMarkdownStyle} from './styles.js';
 import {resolveTheme} from './theme.js';
 
 describe('pending composer title', () => {
   it('shows a spinner frame and the elapsed wait', () => {
-    expect(pendingComposerTitle(0, 0)).toBe(' Message · ⠋ 0s ');
-    expect(pendingComposerTitle(1, 5_000)).toBe(' Message · ⠙ 5s ');
+    expect(pendingComposerLabel(0, 0)).toBe('Message · ⠋ 0s');
+    expect(pendingComposerLabel(1, 5_000)).toBe('Message · ⠙ 5s');
   });
 
   it('wraps the frame index so a long wait keeps animating', () => {
-    expect(pendingComposerTitle(10, 1_000)).toBe(pendingComposerTitle(0, 1_000));
-    expect(pendingComposerTitle(23, 1_000)).toBe(pendingComposerTitle(3, 1_000));
+    expect(pendingComposerLabel(10, 1_000)).toBe(pendingComposerLabel(0, 1_000));
+    expect(pendingComposerLabel(23, 1_000)).toBe(pendingComposerLabel(3, 1_000));
   });
 });
 
@@ -92,12 +93,12 @@ describe('composer spinner across a hidden surface', () => {
     const dock = await dockedChat();
     setSystemTime(new Date(EPOCH));
     dock.render(true, true);
-    expect(dock.title()).toBe(' Message · ⠋ 0s ');
+    expect(dock.title()).toBe(paneTitle(pendingComposerLabel(0, 0), false));
 
     dock.render(true, false);
     dock.render(false, false);
 
-    expect(dock.title()).toBe(' Message ');
+    expect(dock.title()).toBe(paneTitle('Message', false));
   });
 
   it('restarts the elapsed wait for the question asked after a hidden one', async () => {
@@ -112,7 +113,7 @@ describe('composer spinner across a hidden surface', () => {
     dock.render(true, true);
 
     // The new question's wait, not the one that ran out of sight.
-    expect(dock.title()).toBe(' Message · ⠋ 0s ');
+    expect(dock.title()).toBe(paneTitle(pendingComposerLabel(0, 0), false));
   });
 
   it('animates again after a destroy rather than staying frozen', async () => {
@@ -124,6 +125,6 @@ describe('composer spinner across a hidden surface', () => {
     setSystemTime(new Date(EPOCH + 7_000));
     dock.render(true, true);
 
-    expect(dock.title()).toBe(' Message · ⠋ 0s ');
+    expect(dock.title()).toBe(paneTitle(pendingComposerLabel(0, 0), false));
   });
 });

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -8,6 +8,7 @@ import {
 import {suggestSlashCommands} from '../commands.js';
 import type {ChatMenuRow, SessionState} from '../session-model.js';
 import {SPINNER_FRAMES, SPINNER_INTERVAL_MS} from './activity-bar.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {elapsedLabel} from './previews.js';
 import {SuggestionMenu} from './suggestion-menu.js';
 import type {Theme} from './theme.js';
@@ -19,13 +20,20 @@ const EDITOR_HORIZONTAL_CHROME = 4;
 /** Rows the menu shows at once before it scrolls its selection into view. */
 const MAX_MENU_ROWS = 10;
 const MENU_CHROME = 2;
-
-const IDLE_TITLE = ' Message ';
-
-/** Composer title while a question is in flight: spinner plus wait time. */
-export function pendingComposerTitle(frame: number, elapsedMs: number): string {
+const COMPOSER_TITLE = 'Message';
+/**
+ * Composer label while a question is in flight: spinner plus wait time. It is
+ * unpadded because the pane frame owns the padding and the focus gutter, so
+ * the wait and the focus marker compose instead of overwriting each other.
+ */
+function pendingComposerLabel(frame: number, elapsedMs: number): string {
   const spinner = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? SPINNER_FRAMES[0];
-  return ` Message · ${spinner} ${elapsedLabel(elapsedMs)} `;
+  return `${COMPOSER_TITLE} · ${spinner} ${elapsedLabel(elapsedMs)}`;
+}
+
+/** The same label as its own title, for callers that set one directly. */
+export function pendingComposerTitle(frame: number, elapsedMs: number): string {
+  return ` ${pendingComposerLabel(frame, elapsedMs)} `;
 }
 
 class ChatTextareaRenderable extends TextareaRenderable {
@@ -82,6 +90,7 @@ export class ChatComposerView {
   #theme: Theme;
   #renderedMenu: string | null = null;
   #lastState: SessionState | null = null;
+  /** Whether the agent still owes an answer, which the title says. */
   #pending = false;
   #onScreen = false;
   #pendingSince = 0;
@@ -109,9 +118,9 @@ export class ChatComposerView {
       width: '100%',
       height: MIN_EDITOR_ROWS + 2,
       border: true,
-      borderStyle: 'rounded',
-      borderColor: theme.border,
-      title: IDLE_TITLE,
+      borderStyle: paneBorderStyle(false),
+      borderColor: paneBorderColor(theme, false),
+      title: paneTitle(COMPOSER_TITLE, false),
       paddingLeft: 1,
       paddingRight: 1,
       onMouseUp: this.onFocusRequest,
@@ -244,6 +253,7 @@ export class ChatComposerView {
       this.#editor.setText(this.draft.value);
       this.#syncSuggestions();
     }
+    this.#pending = pending;
     this.setFocused(focused);
     this.#hint.content = pending
       ? 'Awaiting the agent · Enter: queue follow-up'
@@ -302,9 +312,7 @@ export class ChatComposerView {
   }
 
   #refreshTitle(): void {
-    this.#box.title = this.#pending
-      ? pendingComposerTitle(this.#frame, Date.now() - this.#pendingSince)
-      : IDLE_TITLE;
+    this.#applyFocus();
   }
 
   isEmpty(): boolean {
@@ -317,12 +325,19 @@ export class ChatComposerView {
 
   setFocused(focused: boolean): void {
     this.#focused = focused;
-    this.#box.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
+    this.#applyFocus();
+  }
+
+  #applyFocus(): void {
+    const label = this.#pending
+      ? pendingComposerLabel(this.#frame, Date.now() - this.#pendingSince)
+      : COMPOSER_TITLE;
+    applyPaneFocus(this.#box, this.#theme, label, this.#focused);
   }
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.#box.borderColor = this.#focused ? theme.borderFocus : theme.border;
+    this.#applyFocus();
     this.#editor.textColor = theme.textStrong;
     this.#editor.focusedTextColor = theme.textStrong;
     this.#hint.fg = theme.textSubtle;

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -26,14 +26,9 @@ const COMPOSER_TITLE = 'Message';
  * unpadded because the pane frame owns the padding and the focus gutter, so
  * the wait and the focus marker compose instead of overwriting each other.
  */
-function pendingComposerLabel(frame: number, elapsedMs: number): string {
+export function pendingComposerLabel(frame: number, elapsedMs: number): string {
   const spinner = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? SPINNER_FRAMES[0];
   return `${COMPOSER_TITLE} · ${spinner} ${elapsedLabel(elapsedMs)}`;
-}
-
-/** The same label as its own title, for callers that set one directly. */
-export function pendingComposerTitle(frame: number, elapsedMs: number): string {
-  return ` ${pendingComposerLabel(frame, elapsedMs)} `;
 }
 
 class ChatTextareaRenderable extends TextareaRenderable {
@@ -86,7 +81,6 @@ export class ChatComposerView {
   readonly #hint: TextRenderable;
   readonly #menuList: TextRenderable;
   #availableWidth = 1;
-  #focused = false;
   #theme: Theme;
   #renderedMenu: string | null = null;
   #lastState: SessionState | null = null;
@@ -254,7 +248,7 @@ export class ChatComposerView {
       this.#syncSuggestions();
     }
     this.#pending = pending;
-    this.setFocused(focused);
+    this.#applyChrome();
     this.#hint.content = pending
       ? 'Awaiting the agent · Enter: queue follow-up'
       : focused
@@ -312,7 +306,7 @@ export class ChatComposerView {
   }
 
   #refreshTitle(): void {
-    this.#applyFocus();
+    this.#applyChrome();
   }
 
   isEmpty(): boolean {
@@ -323,21 +317,25 @@ export class ChatComposerView {
     this.#editor.focus();
   }
 
-  setFocused(focused: boolean): void {
-    this.#focused = focused;
-    this.#applyFocus();
-  }
-
-  #applyFocus(): void {
+  /**
+   * The composer's frame, always the resting one.
+   *
+   * The focus treatment names the pane the keys are on, and this box is inside
+   * that pane rather than being one. Wearing it here drew the marker and the
+   * focused border twice, one nested in the other, which is the ambiguity the
+   * treatment exists to remove. Which composer has the cursor is carried by the
+   * cursor itself and by the hint line under the box, both non-colour channels.
+   */
+  #applyChrome(): void {
     const label = this.#pending
       ? pendingComposerLabel(this.#frame, Date.now() - this.#pendingSince)
       : COMPOSER_TITLE;
-    applyPaneFocus(this.#box, this.#theme, label, this.#focused);
+    applyPaneFocus(this.#box, this.#theme, label, false);
   }
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.#applyFocus();
+    this.#applyChrome();
     this.#editor.textColor = theme.textStrong;
     this.#editor.focusedTextColor = theme.textStrong;
     this.#hint.fg = theme.textSubtle;

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -14,6 +14,7 @@ import {
 import {ChatComposerView, type ChatDraft} from './chat-composer.js';
 import {ConversationView} from './conversation.js';
 import {LOG_CLAIM_PANEL_WIDTH, LOG_COMPACT_PANEL_WIDTH} from './experiment-log.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import type {Theme} from './theme.js';
 
 /**
@@ -22,6 +23,9 @@ import type {Theme} from './theme.js';
  */
 const CHAT_PANE_MIN = 25;
 const CHAT_PANE_MAX = 52;
+
+/** Stands in until the first render names the active thread. */
+const CHAT_PANE_TITLE = 'Experiment chat';
 
 /**
  * The chat is part of the landing view, so it docks wherever the table is still
@@ -78,13 +82,13 @@ export class ChatPaneView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
-      borderColor: theme.border,
+      borderStyle: paneBorderStyle(false),
+      borderColor: paneBorderColor(theme, false),
       // The surface every other pane sits on. Without it this box falls
       // through to the root's canvas, a lighter shade, so the chat read as a
       // pale band beside panes that did not match it.
       backgroundColor: theme.elevatedSurface,
-      title: ' Experiment chat ',
+      title: paneTitle(CHAT_PANE_TITLE, false),
       visible: false,
       // Clicking into the chat gives it the keys, the same thing Ctrl+W does.
       // Without this the pane took the click but the focus border stayed on the
@@ -133,7 +137,8 @@ export class ChatPaneView {
 
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
     this.#theme = theme;
-    this.output.borderColor = theme.border;
+    // Resting colour: `render` repaints from the live focus on the next frame.
+    this.output.borderColor = paneBorderColor(theme, false);
     this.output.backgroundColor = theme.elevatedSurface;
     this.#conversation.applyTheme(theme, markdownStyle);
     this.#composer.applyTheme(theme);
@@ -176,14 +181,13 @@ export class ChatPaneView {
     }
     this.output.width = width;
     const focused = chatPaneFocused(state);
-    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
-    // The column can be as narrow as its minimum, where a spelled-out "focused"
-    // costs the title itself: a box with no title reads as nothing at all. The
-    // marker is the one the table already uses for the row that has the keys.
-    // The title names the active thread so switching is visible at a glance,
-    // and its runtime so the operator can tell which agent is answering.
-    const label = chatThreadHeading(state);
-    this.output.title = focused ? ` ▸ ${label} ` : ` ${label} `;
+    // The chat is a pane, so it wears the same focus channels as the panes
+    // beside it rather than a treatment of its own. `focus.ts` reserves the
+    // marker's cell in the title, which keeps the label at a fixed column
+    // whether or not the chat holds the keys. The label names the active thread
+    // so switching is visible at a glance, and its runtime so the operator can
+    // tell which agent is answering.
+    applyPaneFocus(this.output, this.#theme, chatThreadHeading(state), focused);
     this.#composer.activate(Math.max(1, width - 4), focused, state.chatPending);
     this.#composer.renderMenu(state);
     if (state.chatConversation === this.#renderedConversation) return;

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -7,6 +7,7 @@ import {
   TextRenderable,
 } from '@opentui/core';
 import {type CommandContext, slashCommandRange, suggestSlashCommands} from '../commands.js';
+import {paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {SuggestionMenu} from './suggestion-menu.js';
 import type {Theme} from './theme.js';
 
@@ -20,10 +21,11 @@ export interface CommandInputPanel {
   /** True when nothing is typed, so Enter belongs to whatever pane is behind. */
   isEmpty(): boolean;
   focus(): void;
-  setFocused(focused: boolean): void;
   applyTheme(theme: Theme): void;
   destroy(): void;
 }
+
+const COMMAND_TITLE = 'Command';
 
 function commandSyntaxStyle(theme: Theme): SyntaxStyle {
   return SyntaxStyle.fromStyles({'slash-command': {fg: theme.accent, bold: true}});
@@ -41,9 +43,16 @@ export function createCommandInputPanel(
     height: 3,
     width: '100%',
     border: true,
-    borderStyle: 'rounded',
-    borderColor: theme.borderFocus,
-    title: ' Command ',
+    // The focus treatment names the one pane the navigation keys are on. The
+    // command box is shared by every pane in the column rather than being one of
+    // them, so it never wears that treatment: resting frame, resting colour, and
+    // the gutter cell where a pane would put its marker. A second lit border
+    // made the marked pane ambiguous, which is the whole complaint behind #433.
+    // It still takes the title from `focus.ts` so its label sits at the same
+    // column as the panes it shares the column with.
+    borderStyle: paneBorderStyle(false),
+    borderColor: paneBorderColor(theme, false),
+    title: paneTitle(COMMAND_TITLE, false),
     paddingLeft: 1,
     paddingRight: 1,
     onMouseUp: onFocusRequest,
@@ -108,8 +117,6 @@ export function createCommandInputPanel(
   input.on(InputRenderableEvents.INPUT, updateDecorations);
   input.on(InputRenderableEvents.ENTER, submit);
   box.add(input);
-  let focused = true;
-  let current = theme;
   return {
     box,
     suggestions,
@@ -131,13 +138,8 @@ export function createCommandInputPanel(
     },
     isEmpty: () => input.value.trim() === '',
     focus: () => input.focus(),
-    setFocused(next: boolean): void {
-      focused = next;
-      box.borderColor = next ? current.borderFocus : current.border;
-    },
     applyTheme(next: Theme): void {
-      current = next;
-      box.borderColor = focused ? next.borderFocus : next.border;
+      box.borderColor = paneBorderColor(next, false);
       input.textColor = next.textStrong;
       input.focusedTextColor = next.textStrong;
       suggestions.borderColor = next.border;

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -156,10 +156,16 @@ export class ExperimentLogView {
       return;
     }
     this.output.visible = true;
+    // Both the label and the focus channels are derived from the state being
+    // rendered, so this runs on every notification, including the ones the
+    // cache below returns from. Naming the panel `Experiments` here and
+    // correcting it during detail rendering left a same-state notification
+    // titling a hypothesis body with the index's title.
+    const detail = detailedHypothesis(state);
     applyPaneFocus(
       this.output,
       this.#theme,
-      EXPERIMENTS_TITLE,
+      detail === null ? EXPERIMENTS_TITLE : `Hypothesis ${detail.hypothesis_id}`,
       focusedPane(state) === 'experiments',
     );
     const width = this.#availableWidth ?? this.renderer.terminalWidth;
@@ -169,7 +175,6 @@ export class ExperimentLogView {
     this.#renderedWidth = width;
     this.#clear();
 
-    const detail = detailedHypothesis(state);
     if (detail !== null) {
       this.#renderDetail(detail, state);
       if (previousDetailKey !== state.hypothesisDetail?.entryKey) this.#rows.scrollTo(0);
@@ -281,12 +286,9 @@ export class ExperimentLogView {
 
   #renderDetail(entry: HypothesisEntry, state: SessionState): void {
     const selectedRound = state.hypothesisDetail?.selectedRound ?? null;
-    // Only the title: `render` already set the frame and the border colour on
-    // the box this draws into.
-    this.output.title = paneTitle(
-      `Hypothesis ${entry.hypothesis_id}`,
-      focusedPane(state) === 'experiments',
-    );
+    // The frame, its colour, and the title are `render`'s: it is the one place
+    // that runs on every notification, so it is the one place that can keep
+    // them in step with what the panel is showing.
     this.#header.content = hypothesisMetadata(entry);
     const title = entry.title?.trim();
     if (title) this.#line(title, this.#theme.textStrong);

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -16,6 +16,7 @@ import {
   unownedExperimentRounds,
 } from '../session-model.js';
 import {formatFileChange} from './design-log.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {elapsedLabel} from './previews.js';
 import type {Theme} from './theme.js';
 
@@ -37,6 +38,7 @@ const HINT_MIN_WIDTH = 60;
 const CLAIM_MIN_WIDTH = 90;
 const MEASURED_MIN_WIDTH = 62;
 const KEPT_MIN_WIDTH = 104;
+const EXPERIMENTS_TITLE = 'Experiments';
 
 /**
  * Panel width at which the table still shows the claim, which is the row's
@@ -80,11 +82,11 @@ export class ExperimentLogView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
-      borderColor: theme.border,
+      borderStyle: paneBorderStyle(false),
+      borderColor: paneBorderColor(theme, false),
       backgroundColor: theme.elevatedSurface,
       visible: false,
-      title: ' Experiments ',
+      title: paneTitle(EXPERIMENTS_TITLE, false),
       onMouseUp: () => this.controller.focusPane('left'),
     });
     this.#header = new TextRenderable(renderer, {
@@ -154,9 +156,12 @@ export class ExperimentLogView {
       return;
     }
     this.output.visible = true;
-    const focused = focusedPane(state) === 'experiments';
-    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
-    this.output.title = focused ? ' ▸ Experiments ' : ' Experiments ';
+    applyPaneFocus(
+      this.output,
+      this.#theme,
+      EXPERIMENTS_TITLE,
+      focusedPane(state) === 'experiments',
+    );
     const width = this.#availableWidth ?? this.renderer.terminalWidth;
     if (state === this.#renderedState && width === this.#renderedWidth) return;
     const previousDetailKey = this.#renderedState?.hypothesisDetail?.entryKey ?? null;
@@ -276,7 +281,12 @@ export class ExperimentLogView {
 
   #renderDetail(entry: HypothesisEntry, state: SessionState): void {
     const selectedRound = state.hypothesisDetail?.selectedRound ?? null;
-    this.output.title = ` ${focusedTitlePrefix(state)}Hypothesis ${entry.hypothesis_id} `;
+    // Only the title: `render` already set the frame and the border colour on
+    // the box this draws into.
+    this.output.title = paneTitle(
+      `Hypothesis ${entry.hypothesis_id}`,
+      focusedPane(state) === 'experiments',
+    );
     this.#header.content = hypothesisMetadata(entry);
     const title = entry.title?.trim();
     if (title) this.#line(title, this.#theme.textStrong);
@@ -708,10 +718,6 @@ export function measuredDirection(entries: readonly HypothesisEntry[]): 'max' | 
     else if (direction !== candidate) return null;
   }
   return direction;
-}
-
-function focusedTitlePrefix(state: SessionState): string {
-  return focusedPane(state) === 'experiments' ? '▸ ' : '';
 }
 
 export function hypothesisMetadata(entry: HypothesisEntry): string {

--- a/clients/tui/src/ui/focus.test.ts
+++ b/clients/tui/src/ui/focus.test.ts
@@ -1,0 +1,86 @@
+import {describe, expect, it} from 'bun:test';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
+import {contrastRatio, listThemes, resolveTheme, type Theme} from './theme.js';
+
+const THEMES = listThemes().map(theme => [theme.name, theme] as const);
+
+describe('focus channels', () => {
+  it('reserves the marker cell so the label never moves', () => {
+    expect(paneTitle('Transcript', true)).toBe(' ▸ Transcript   ');
+    expect(paneTitle('Transcript', false)).toBe('   Transcript   ');
+    // Whitespace is symmetric about the label: three cells each side, the
+    // marker occupying one of the three on the left.
+    for (const focused of [true, false]) {
+      const title = paneTitle('Transcript', focused);
+      const lead = title.indexOf('Transcript');
+      const trail = title.length - lead - 'Transcript'.length;
+      expect(trail).toBe(lead);
+    }
+    for (const label of ['Transcript', 'Experiments', 'Hypothesis H-08', 'Message']) {
+      const focused = paneTitle(label, true);
+      const resting = paneTitle(label, false);
+      expect(focused.length).toBe(resting.length);
+      expect(focused.indexOf(label)).toBe(resting.indexOf(label));
+    }
+  });
+
+  it('keeps the same frame whether or not a pane holds focus', () => {
+    // Focus does not change the frame. A heavier weight would mean square
+    // corners, since Unicode has no heavy rounded corner, and that reads as a
+    // different kind of object rather than a louder one. The marker carries
+    // the non-colour signal instead.
+    expect(paneBorderStyle(true)).toBe(paneBorderStyle(false));
+    expect(paneBorderStyle(true)).toBe('rounded');
+  });
+
+  /**
+   * The property that keeps focus legible when a palette cannot carry it.
+   * Colour alone was the whole signal until this: `borderFocus` and `border`
+   * sit within 1.5x of each other in five of the eight built-in themes, and
+   * `high-contrast-light` had them inverted, so focusing a pane made it
+   * quieter. Any regression that puts the signal back into colour alone fails
+   * here rather than shipping.
+   */
+  it.each(
+    THEMES,
+  )('%s tells a focused pane from a resting one without using colour', (_name, theme: Theme) => {
+    const focused = {
+      title: paneTitle('Transcript', true),
+      borderStyle: paneBorderStyle(true),
+    };
+    const resting = {
+      title: paneTitle('Transcript', false),
+      borderStyle: paneBorderStyle(false),
+    };
+    const nonColorChannels = [
+      focused.title !== resting.title,
+      focused.borderStyle !== resting.borderStyle,
+    ].filter(Boolean);
+    expect(nonColorChannels.length).toBeGreaterThanOrEqual(1);
+    // The colour channel is allowed to be useless here, and in several
+    // themes it is. It must never be worse than useless: a focused border
+    // that is quieter than a resting one reads as focus being taken away.
+    const focusColor = paneBorderColor(theme, true);
+    const restingColor = paneBorderColor(theme, false);
+    expect(contrastRatio(focusColor, theme.canvas)).toBeGreaterThanOrEqual(
+      contrastRatio(restingColor, theme.canvas),
+    );
+  });
+
+  it('applies every channel to one frame', () => {
+    const theme = resolveTheme('dark');
+    const box = {title: '', borderStyle: 'rounded', borderColor: ''};
+    applyPaneFocus(box as never, theme, 'Agents', true);
+    expect(box).toEqual({
+      title: ' ▸ Agents   ',
+      borderStyle: paneBorderStyle(true),
+      borderColor: theme.borderFocus,
+    });
+    applyPaneFocus(box as never, theme, 'Agents', false);
+    expect(box).toEqual({
+      title: '   Agents   ',
+      borderStyle: paneBorderStyle(false),
+      borderColor: theme.border,
+    });
+  });
+});

--- a/clients/tui/src/ui/focus.ts
+++ b/clients/tui/src/ui/focus.ts
@@ -1,0 +1,90 @@
+import type {BorderStyle, BoxRenderable} from '@opentui/core';
+import type {Theme} from './theme.js';
+
+/**
+ * How a pane says it is the one taking keys.
+ *
+ * Three channels, in priority order: a marker in a reserved title gutter, the
+ * border style, then colour. Colour is last because it cannot carry the signal
+ * on its own. `borderFocus` and `border` sit within 1.5x of each other in five
+ * of the eight built-in themes, and the high-contrast pair collapses them by
+ * construction: those palettes are deliberately tiny, so there is no shade to
+ * move to. The first two channels hold in any palette, and in a terminal with
+ * no colour at all.
+ *
+ * This module owns how focus looks, never which surface has it: `focusedPane`
+ * is that authority, and each pane compares its own `PaneId` against it. A
+ * surface that is not a pane never wears the treatment. The command box is the
+ * case worth naming: it sits under the pane column and is shared by every pane
+ * in it rather than being one of them, so it takes the resting title, frame and
+ * colour and no focused variant. It calls in only to keep its label at the same
+ * column as the panes above it. Lighting it made the marked pane ambiguous,
+ * which is #433.
+ */
+
+/** Marks the title of the pane that currently takes keys. */
+const FOCUS_MARKER = '▸';
+
+/** Occupies the marker's cell while a pane is at rest. */
+const MARKER_GUTTER = ' ';
+
+/**
+ * Every pane keeps the rounded frame, focused or not.
+ *
+ * A heavier frame was tried as a second non-colour channel and dropped: the
+ * only heavier box-drawing weights are square (`┏┓┗┛`), because Unicode has no
+ * heavy rounded corner. The rounded arcs at U+256D-2570 are light-only. So the
+ * swap traded rounded corners for square ones, which is a change of shape
+ * rather than of weight, and reads as the pane becoming a different kind of
+ * object rather than a louder one.
+ *
+ * That leaves the reserved title marker as the non-colour channel. It is
+ * enough for WCAG 1.4.1, and unlike a frame weight it cannot be mistaken for a
+ * different component.
+ */
+const PANE_BORDER: BorderStyle = 'rounded';
+
+/**
+ * A pane title with the marker's cell reserved whether or not the pane holds
+ * focus.
+ *
+ * Prepending the marker instead slides the label two columns right, so the eye,
+ * which uses the title's left edge as a landmark, reads a focus change as the
+ * layout moving. Reserving the cell turns it into a glyph swap at a fixed
+ * column, and keeps a narrow pane's title truncating identically either way.
+ */
+export function paneTitle(label: string, focused: boolean): string {
+  // Symmetric: the gutter and the lead space together are two cells, and the
+  // label gets two on the other side, so the label sits centred in its own
+  // inset rather than pushed against the trailing edge.
+  return ` ${focused ? FOCUS_MARKER : MARKER_GUTTER} ${label}   `;
+}
+
+/**
+ * The frame a pane draws.
+ *
+ * Both styles are one cell per side, and OpenTUI invalidates only the raster
+ * when `borderStyle` changes, so a focus change cannot move the layout. A
+ * border of a different *width* would, which is why this channel is a style
+ * swap and not a thicker frame.
+ */
+export function paneBorderStyle(_focused: boolean): BorderStyle {
+  return PANE_BORDER;
+}
+
+/** Reinforces the two channels above, as far as a given palette allows. */
+export function paneBorderColor(theme: Theme, focused: boolean): string {
+  return focused ? theme.borderFocus : theme.border;
+}
+
+/** Applies every focus channel to one pane frame. */
+export function applyPaneFocus(
+  box: BoxRenderable,
+  theme: Theme,
+  label: string,
+  focused: boolean,
+): void {
+  box.title = paneTitle(label, focused);
+  box.borderStyle = paneBorderStyle(focused);
+  box.borderColor = paneBorderColor(theme, focused);
+}

--- a/clients/tui/src/ui/focus.ts
+++ b/clients/tui/src/ui/focus.ts
@@ -14,12 +14,14 @@ import type {Theme} from './theme.js';
  *
  * This module owns how focus looks, never which surface has it: `focusedPane`
  * is that authority, and each pane compares its own `PaneId` against it. A
- * surface that is not a pane never wears the treatment. The command box is the
- * case worth naming: it sits under the pane column and is shared by every pane
- * in it rather than being one of them, so it takes the resting title, frame and
- * colour and no focused variant. It calls in only to keep its label at the same
- * column as the panes above it. Lighting it made the marked pane ambiguous,
- * which is #433.
+ * surface that is not a pane never wears the treatment, and neither does a box
+ * inside a pane that already does: two lit frames, one nested in the other, are
+ * as ambiguous as two lit panes side by side. The chat's `Message` composer is
+ * that case, and the command box is the other worth naming, since it sits under
+ * the pane column and is shared by every pane in it rather than being one of
+ * them. Both take the resting title, frame and colour and no focused variant,
+ * and call in only to keep their labels at the same column as the panes around
+ * them. Lighting the command box made the marked pane ambiguous, which is #433.
  */
 
 /** Marks the title of the pane that currently takes keys. */

--- a/clients/tui/src/ui/focus.ts
+++ b/clients/tui/src/ui/focus.ts
@@ -4,13 +4,13 @@ import type {Theme} from './theme.js';
 /**
  * How a pane says it is the one taking keys.
  *
- * Three channels, in priority order: a marker in a reserved title gutter, the
- * border style, then colour. Colour is last because it cannot carry the signal
- * on its own. `borderFocus` and `border` sit within 1.5x of each other in five
- * of the eight built-in themes, and the high-contrast pair collapses them by
- * construction: those palettes are deliberately tiny, so there is no shade to
- * move to. The first two channels hold in any palette, and in a terminal with
- * no colour at all.
+ * Two channels, in priority order: a marker in a reserved title gutter, then
+ * colour. Colour is second because it cannot carry the signal on its own.
+ * `borderFocus` and `border` sit within 1.5x of each other in five of the eight
+ * built-in themes, and the high-contrast pair collapses them by construction:
+ * those palettes are deliberately tiny, so there is no shade to move to. The
+ * marker holds in any palette, and in a terminal with no colour at all. Frame
+ * weight is not a third channel; `PANE_BORDER` records why it was dropped.
  *
  * This module owns how focus looks, never which surface has it: `focusedPane`
  * is that authority, and each pane compares its own `PaneId` against it. A
@@ -63,16 +63,15 @@ export function paneTitle(label: string, focused: boolean): string {
 /**
  * The frame a pane draws.
  *
- * Both styles are one cell per side, and OpenTUI invalidates only the raster
- * when `borderStyle` changes, so a focus change cannot move the layout. A
- * border of a different *width* would, which is why this channel is a style
- * swap and not a thicker frame.
+ * The same frame at rest and in focus, which is why the parameter is unused. It
+ * is kept so callers read the same shape as the other helpers here, and so a
+ * future palette that can afford a third channel has somewhere to put it.
  */
 export function paneBorderStyle(_focused: boolean): BorderStyle {
   return PANE_BORDER;
 }
 
-/** Reinforces the two channels above, as far as a given palette allows. */
+/** Reinforces the marker above, as far as a given palette allows. */
 export function paneBorderColor(theme: Theme, focused: boolean): string {
   return focused ? theme.borderFocus : theme.border;
 }

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -5,6 +5,7 @@ import {
   chatPaneVisible,
   experimentLogVisible,
   type RoundFocus,
+  todoListFocused,
 } from '../session-model.js';
 import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 import {roundRailVisible} from './round-rail.js';
@@ -241,7 +242,9 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
-    if (controller.state.todosExpanded) {
+    // The same predicate the todo list's chrome is drawn from, so the marker
+    // and the keys can never disagree about where Up and Down land.
+    if (todoListFocused(controller.state)) {
       if (key.name === 'up' || key.name === 'down') {
         controller.selectNextTodo(key.name === 'down' ? 1 : -1);
         key.preventDefault();

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -1,5 +1,6 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
-import type {SessionState} from '../session-model.js';
+import {focusedPane, type RightPane, type SessionState} from '../session-model.js';
+import {applyPaneFocus} from './focus.js';
 import type {Theme} from './theme.js';
 
 type OverlayKind = NonNullable<SessionState['overlay']>['kind'];
@@ -36,6 +37,7 @@ export class OverlayView {
   #theme: Theme;
   #renderedKind: OverlayKind | null = null;
   #renderedContent = '';
+  #renderedPane: RightPane | null = null;
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -92,9 +94,22 @@ export class OverlayView {
     this.#hint.fg = theme.textSubtle;
     this.#renderedKind = null;
     this.#renderedContent = '';
+    this.#renderedPane = null;
   }
 
-  render(state: SessionState): void {
+  /**
+   * `pane` is the visualization the terminal is too narrow to split, drawn here
+   * because there is no column to put it in. It is the same surface as
+   * `RightPaneView` and takes the same keys, so it wears that pane's title and
+   * asks `focusedPane` the same question rather than appearing as a `Command`
+   * box with none of the focus treatment on the one thing taking keystrokes.
+   */
+  render(state: SessionState, pane: RightPane | null = null): void {
+    if (pane !== null) {
+      this.#renderPane(state, pane);
+      return;
+    }
+    this.#renderedPane = null;
     const overlay = state.overlay;
     if (overlay === null) {
       this.output.visible = false;
@@ -113,13 +128,36 @@ export class OverlayView {
     this.output.borderColor = borderFor(this.#theme, overlay.kind);
     this.output.title = ` ${TITLE[overlay.kind]} `;
     this.#clear();
+    this.#body(
+      overlay.content,
+      overlay.kind === 'error' ? this.#theme.conversation.failure.content : this.#theme.textPrimary,
+    );
+  }
+
+  #renderPane(state: SessionState, pane: RightPane): void {
+    this.output.visible = true;
+    this.#applyGeometry();
+    // Outside the cache below: focus moves without the content changing.
+    applyPaneFocus(this.output, this.#theme, pane.title, focusedPane(state) === 'performance');
+    if (pane === this.#renderedPane) return;
+    this.#renderedPane = pane;
+    // The next ordinary overlay repaints its own title and border rather than
+    // inheriting the pane's.
+    this.#renderedKind = null;
+    this.#renderedContent = '';
+    this.#clear();
+    if (pane.error !== null) this.#body(pane.error, this.#theme.conversation.failure.content);
+    else if (pane.pending && pane.content === '') {
+      this.#body('Loading...', this.#theme.textSubtle);
+    } else this.#body(pane.content, this.#theme.textPrimary);
+  }
+
+  /** One wrapped block in the scroll viewport, rebuilt per overlay or pane. */
+  #body(content: string, fg: string): void {
     this.#scroll.add(
       new TextRenderable(this.renderer, {
-        content: overlay.content,
-        fg:
-          overlay.kind === 'error'
-            ? this.#theme.conversation.failure.content
-            : this.#theme.textPrimary,
+        content,
+        fg,
         width: '100%',
         flexShrink: 0,
         wrapMode: 'word',

--- a/clients/tui/src/ui/right-pane.ts
+++ b/clients/tui/src/ui/right-pane.ts
@@ -1,5 +1,6 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
-import type {RightPane, SessionState} from '../session-model.js';
+import {focusedPane, type RightPane, type SessionState} from '../session-model.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import type {Theme} from './theme.js';
 
 /**
@@ -54,9 +55,9 @@ export class RightPaneView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
-      borderColor: theme.border,
-      title: ' Pane ',
+      borderStyle: paneBorderStyle(false),
+      borderColor: paneBorderColor(theme, false),
+      title: paneTitle('Pane', false),
       visible: false,
       onMouseUp: onFocusRequest,
     });
@@ -94,11 +95,11 @@ export class RightPaneView {
     }
     this.output.visible = true;
     this.output.width = width;
-    // The focused pane is the one that takes keys, so it carries the focus
-    // border colour and says so in its title.
-    const focused = state.layout.focus === 'right';
-    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
-    this.output.title = focused ? ` ▸ ${right.title} ` : ` ${right.title} `;
+    // The focused pane is the one that takes keys, and says so in its title
+    // marker, its frame, and its border colour. Every pane asks `focusedPane`,
+    // so exactly one of them can answer yes.
+    const focused = focusedPane(state) === 'performance';
+    applyPaneFocus(this.output, this.#theme, right.title, focused);
     if (right === this.#renderedPane) return;
     this.#renderedPane = right;
     this.#clear();

--- a/clients/tui/src/ui/theme.test.ts
+++ b/clients/tui/src/ui/theme.test.ts
@@ -152,10 +152,35 @@ describe('semantic roles', () => {
 
   it.each(
     themes.map(theme => [theme.name, theme] as const),
+  )('%s reserves the focus border for focus alone', (_name, theme: Theme) => {
+    // The focus border names the one pane the keys are on. A status colour that
+    // equals it turns a passing check or a warning into a claim about focus,
+    // which is what made a green command box read as the focused surface.
+    expect(theme.borderFocus).not.toBe(theme.border);
+    expect(theme.borderFocus).not.toBe(theme.borderStrong);
+    for (const status of [theme.success, theme.warning, theme.error] as const) {
+      expect(theme.borderFocus).not.toBe(status);
+    }
+  });
+
+  it.each(
+    themes.map(theme => [theme.name, theme] as const),
   )('%s keeps panel borders visible against the canvas', (_name, theme: Theme) => {
     for (const border of [theme.border, theme.borderStrong, theme.borderFocus] as const) {
       expect(contrastRatio(border, theme.canvas)).toBeGreaterThanOrEqual(1.7);
     }
+  });
+
+  it.each(
+    themes.map(theme => [theme.name, theme] as const),
+  )('%s never makes a focused border quieter than a resting one', (_name, theme: Theme) => {
+    // `high-contrast-light` shipped inverted: #0000cc reached 11.22 against a
+    // white canvas where the resting #333333 reached 12.63, so focusing a pane
+    // dimmed it. Colour is the weakest of the three focus channels, but it
+    // still may not point the wrong way.
+    expect(contrastRatio(theme.borderFocus, theme.canvas)).toBeGreaterThanOrEqual(
+      contrastRatio(theme.border, theme.canvas),
+    );
   });
 
   it('orients light and dark themes in opposite luminance directions', () => {

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -567,7 +567,11 @@ const HIGH_CONTRAST_LIGHT: ThemeSpec = {
   textStrong: '#000000',
   border: '#333333',
   borderStrong: '#000000',
-  borderFocus: '#0000cc',
+  // Navy, not the brighter #0000cc this used to be. Against a white canvas
+  // that blue was *quieter* than the resting #333333 border (11.22 against
+  // 12.63), so focusing a pane made it recede. Focus must never be quieter
+  // than rest; `focus.test.ts` pins that for every theme.
+  borderFocus: '#000080',
   accent: '#006466',
   info: '#0033cc',
   success: '#006400',

--- a/clients/tui/src/ui/todo-strip.ts
+++ b/clients/tui/src/ui/todo-strip.ts
@@ -2,7 +2,7 @@ import {BoxRenderable, type CliRenderer, TextRenderable} from '@opentui/core';
 import type {TodoItem} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
-import {visibleTodos} from '../session-model.js';
+import {focusedPane, visibleTodos} from '../session-model.js';
 import {paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import type {Theme} from './theme.js';
 
@@ -95,6 +95,7 @@ export class TodoStripView {
   #theme: Theme;
   #renderedTodos: TodoItem[] | null = null;
   #renderedExpanded = false;
+  #renderedFocused = false;
   #renderedSelection: number | null = null;
   #renderedWidth: number | null = null;
 
@@ -136,9 +137,13 @@ export class TodoStripView {
     // One source for the strip's height: siblings sized in this same paint read
     // it from `todoStripHeight` too, so the box cannot end up a row off them.
     this.output.height = todoStripHeight(state);
+    // The open list owns the arrow keys, so it is a pane like any other and
+    // asks the same authority whether it is the one holding them.
+    const focused = focusedPane(state) === 'todos';
     if (
       todos === this.#renderedTodos &&
       state.todosExpanded === this.#renderedExpanded &&
+      focused === this.#renderedFocused &&
       state.selectedTodoIndex === this.#renderedSelection &&
       width === this.#renderedWidth
     ) {
@@ -146,10 +151,11 @@ export class TodoStripView {
     }
     this.#renderedTodos = todos;
     this.#renderedExpanded = state.todosExpanded;
+    this.#renderedFocused = focused;
     this.#renderedSelection = state.selectedTodoIndex;
     this.#renderedWidth = width;
     this.#clear();
-    if (state.todosExpanded) this.#renderExpanded(todos, state.selectedTodoIndex);
+    if (state.todosExpanded) this.#renderExpanded(todos, state.selectedTodoIndex, focused);
     else this.#renderCollapsed(todos);
   }
 
@@ -164,7 +170,7 @@ export class TodoStripView {
     );
   }
 
-  #renderExpanded(todos: TodoItem[], selected: number | null): void {
+  #renderExpanded(todos: TodoItem[], selected: number | null, focused: boolean): void {
     const shown = todos.slice(0, MAX_EXPANDED_ITEMS);
     const hidden = todos.length - shown.length;
     const height = shown.length + (hidden > 0 ? 1 : 0) + 2;
@@ -179,12 +185,9 @@ export class TodoStripView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      // The open list owns the arrow keys, so it carries the focused pane's
-      // chrome: the operator can see where the keys are going without being
-      // told.
-      borderStyle: paneBorderStyle(true),
-      borderColor: paneBorderColor(this.#theme, true),
-      title: paneTitle(todoTitle(todos), true),
+      borderStyle: paneBorderStyle(focused),
+      borderColor: paneBorderColor(this.#theme, focused),
+      title: paneTitle(todoTitle(todos), focused),
     });
     this.output.add(list);
     for (const [index, todo] of shown.entries()) {

--- a/clients/tui/src/ui/todo-strip.ts
+++ b/clients/tui/src/ui/todo-strip.ts
@@ -3,6 +3,7 @@ import type {TodoItem} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
 import {visibleTodos} from '../session-model.js';
+import {paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import type {Theme} from './theme.js';
 
 const STATUS_MARKER: Record<string, string> = {
@@ -178,11 +179,12 @@ export class TodoStripView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
-      // The open list owns the arrow keys, so it carries the focus border: the
-      // operator can see where the keys are going without being told.
-      borderColor: this.#theme.borderFocus,
-      title: ` ${todoTitle(todos)} `,
+      // The open list owns the arrow keys, so it carries the focused pane's
+      // chrome: the operator can see where the keys are going without being
+      // told.
+      borderStyle: paneBorderStyle(true),
+      borderColor: paneBorderColor(this.#theme, true),
+      title: paneTitle(todoTitle(todos), true),
     });
     this.output.add(list);
     for (const [index, todo] of shown.entries()) {

--- a/docs/contributing/tui-conventions.md
+++ b/docs/contributing/tui-conventions.md
@@ -1,0 +1,134 @@
+# TUI conventions
+
+What a key does in the VibeSys TUI should be a citation, not a preference. This
+page records the sources so a binding argument resolves against prior art rather
+than taste, and so a reviewer can check a change against something.
+
+Read it in two parts. [Rules in force](#rules-in-force) describe what the code
+does today, so a change that breaks one is a regression. [Proposed: movement and
+naming](#proposed-movement-and-naming) is design that is not implemented, kept
+here so the argument is settled once rather than reopened per PR.
+
+There is no single TUI standard. There are four bodies of prior art that between
+them settle most questions.
+
+## Sources
+
+**IBM Common User Access.** Introduced in 1987 under Systems Application
+Architecture and documented in [Panel Design and User
+Interaction](https://www.edm2.com/index.php/Common_User_Access) (1987) and the
+[Advanced Interface Design Guide](http://www.susandoreydesigns.com/software/CommonUserAccessGUIDesign.pdf)
+(1990). CUA 91 was adopted by Windows 95, and GNOME and KDE still track it. It is
+the closest thing to a formal standard for keyboard-driven interfaces, and it is
+where Tab-between-fields, F1-for-help, and Esc-cancels come from.
+
+**WCAG 2.2.** Written for the web, but four criteria describe properties a
+terminal can hold and fail:
+
+| Criterion | Requirement | Why it applies here |
+| --- | --- | --- |
+| [1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color) | Colour is never the only carrier of information | Two of the eight themes are high-contrast and have almost no palette, so a colour-only signal says nothing in them |
+| [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible) | Keyboard focus has a visible indicator | The operator has to know where a keystroke lands before pressing it |
+| [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order) | Focus order is meaningful and predictable | Panes are a hierarchy, and movement has to match it |
+| [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard) | Everything is reachable by keyboard | A TUI has no other input |
+
+**De facto terminal conventions**, unwritten but near-universal across `less`,
+`vi`, `man`, `htop`, `tig`, `lazygit`, and `k9s`.
+
+**readline line editing.** `Ctrl+A`, `Ctrl+E`, `Ctrl+K`, `Ctrl+W`, `Ctrl+U` in
+any text input. This is what every shell does, so it is what fingers expect.
+
+## Rules in force
+
+### Focus is never carried by colour alone
+
+WCAG 1.4.1. A focused pane differs from a resting one by at least one channel
+that is not colour. That channel is the marker: `paneTitle` reserves a gutter
+cell in every pane title and swaps `▸` into it on focus. Colour reinforces it,
+`borderFocus` against `border`, and is never the only signal.
+
+Border weight is not one of the channels. `paneBorderStyle` returns `rounded`
+whether or not a pane holds focus. A heavier frame was tried and dropped: the
+only heavier box-drawing weights are square (`┏┓┗┛`), because Unicode has no
+heavy rounded corner, so the swap trades rounded corners for square ones. That
+is a change of shape rather than of weight, and reads as the pane becoming a
+different kind of object rather than a louder one.
+
+The gutter is reserved rather than inserted, so the marker swaps a glyph instead
+of pushing the title sideways. A title that moves on focus reads as the layout
+shifting rather than the pane lighting up.
+
+`focus.test.ts` holds this for every built-in theme, so it is a property rather
+than an intention. It also pins the direction of the colour channel: a focused
+border is never lower-contrast against the canvas than a resting one.
+
+### Esc goes back one level
+
+`Esc` cancels a modal, closes an overlay, leaves a drill-down, or returns pane
+focus to the left column. It never quits the application. This is CUA, and it is
+the one movement rule the current bindings already keep.
+
+### Nothing moves that does not have to
+
+Reserve space for anything that appears conditionally: focus markers, status
+lines, counts, and variable-width numbers. A row that appears and disappears
+resizes everything under it, and a list that jumps under the cursor costs more
+than the row saved.
+
+### Bindings are visible
+
+The active bindings are shown on the key-help line at the bottom of the screen,
+just above the command input, and that line changes with whichever surface is in
+front. A binding a person has to already know is a binding they do not have.
+
+## Proposed: movement and naming
+
+Nothing in this section is implemented. It is where the movement and naming
+arguments landed, recorded so they are not reopened per PR. A PR that adopts one
+of these lines moves it up into [Rules in force](#rules-in-force) in the same
+change.
+
+### Movement
+
+Today pane focus is `Ctrl+W`, which cycles the chat, the left column, and the
+visualization pane. Inside the left column, `←` and `→` move between the agent
+strip and the transcript, `↑` and `↓` move within whichever of the two holds
+focus, and `Tab` / `Shift+Tab` step through agents once the command input's
+completion has declined the key.
+
+CUA says the opposite: **arrows move within the focused pane, and Tab moves
+between panes**. A binding that makes an arrow key change which pane is focused
+makes the same key mean two levels of movement depending on where you are, which
+is what `←` and `→` do now. That is the asymmetry this rule would fix.
+
+The replacement keymap exists on the unmerged `adi/tui-keymap-defaults` branch,
+which has no PR: `DEFAULT_KEYMAP` binds `paneNext` to `Tab` and `Ctrl+Right`,
+and `panePrevious` to `Shift+Tab` and `Ctrl+Left`. Until that lands, `Ctrl+W` is
+the binding and the key-help line says so.
+
+### Naming
+
+Proposed prefixes and single keys, none of them bound today. The TUI's only
+prefix is `/`, and it means command (`/help`, `/theme`, `/open-round`), not
+search. There is no search and no `:` prefix. `F2`, `F3` and `F4` toggle todos,
+the latest prompt, and pane zoom.
+
+| Key | Proposed meaning | Source | Bound to today |
+| --- | --- | --- | --- |
+| `/` | Search within the focused content | `less`, `vi`, `man`, `htop`, `tig`, `k9s` | Command prefix |
+| `:` | Command | `vi` | Nothing |
+| `?` | Help | `less`, `htop`, `tig`, `lazygit` | Nothing (`/help` instead) |
+| `q` | Quit a read-only view | `less`, `man`, `htop` | Nothing |
+| `Tab` / `Shift+Tab` | Next / previous pane | CUA | Next / previous agent |
+| `F1` | Help | CUA | Nothing |
+
+`/` for search is about as strong as unwritten consensus gets, which is the
+argument for moving commands to `:`. It is a proposal rather than a rule because
+it renames every typed command, so it needs its own change and its own
+deprecation.
+
+## Applying this
+
+A PR that adds or moves a binding names the rule it follows. If no rule covers
+it, say so and propose one here in the same change, so the next person inherits
+a decision rather than a precedent.

--- a/docs/contributing/tui-conventions.md
+++ b/docs/contributing/tui-conventions.md
@@ -62,6 +62,28 @@ shifting rather than the pane lighting up.
 than an intention. It also pins the direction of the colour channel: a focused
 border is never lower-contrast against the canvas than a resting one.
 
+### One surface wears the focus treatment, and it is a pane
+
+`focusedPane` is the single authority for which one. Every pane compares its own
+`PaneId` against it, so at most one can answer yes, and a surface that is not a
+pane never asks. Two cases follow from that and are worth naming, because both
+were shipped wrong once:
+
+- A box nested inside a pane does not repeat the treatment. The chat's `Message`
+  composer sits inside the chat pane, so the pane frame carries the marker and
+  the composer keeps the resting frame. Which box holds the cursor is said by
+  the cursor and by the hint line under it.
+- A surface that takes the keys is a pane, whatever its shape. The expanded todo
+  list is a strip rather than a column, but `keybindings.ts` routes the arrow
+  keys to it, so it is a `PaneId` and the pane it opened over goes back to rest.
+  The same holds for a presentation swap: below `MIN_SPLIT_WIDTH` a
+  visualization is drawn through the overlay, and that overlay is then the
+  performance pane, with its title and its marker.
+
+Zoom is a separate question from focus. `visiblePaneIds` is the set the content
+row can be given to, and the todo list is deliberately not in it: it is as tall
+as its own contents, so `F4` over it leaves the layout alone.
+
 ### Esc goes back one level
 
 `Esc` cancels a modal, closes an overlay, leaves a drill-down, or returns pane


### PR DESCRIPTION
Closes #561. Regression of #433, which PR #434 recoloured rather than resolved.

## Problem

Two problems with one cause: nothing owned what focus means.

**Which surface is focused had no single authority.** `experiment-log` and the transcript asked `focusedPane(state)`, `agent-map` asked `state.roundFocus`, and `command-input` was driven by a pane-focus expression despite the command box being shared by every pane in its column. Two boxes lit at once.

**How focus is shown was carried by colour alone.** Across the eight built-in themes, focused-versus-resting border contrast is 4.33 at best and under 1.5 in five. `high-contrast-light` was inverted: focus at 11.22 against the canvas was *quieter* than the 12.63 resting border, so focusing a pane made it recede.

![The chat pane focused in the dark theme: its frame in borderFocus with a marker in the title gutter, the Experiments pane resting, the Command box grey. Captured before the composer fix below, so the nested Message box still carries a marker here](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr572.png)

## Solution

Every surface compares its own `PaneId` against `focusedPane`, documented in `focus.ts` as the sole authority. Focus then shows on two channels, colour last:

- A marker in a **reserved** title gutter, so focus swaps a glyph rather than inserting one and the label never shifts.
- `high-contrast-light` focus becomes navy `#000080` (16.01), removing the inversion.

A heavier frame was tried as a third channel and dropped. Unicode has no heavy rounded corner: the arcs at U+256D-2570 are light-only and the heavier weights are square, so the swap traded rounded corners for square ones. That reads as the pane becoming a different kind of object rather than a louder one. Focus never changes a pane's shape.

No other palette changes: every resting border already sits below the 3:1 non-text floor, so there is no headroom to quiet one further. The high-contrast palettes are deliberately small, so no retune fixes this, and colour cannot be the primary channel anyway: WCAG 1.4.1 and 2.4.7.

The command box calls the same helpers but only ever in the resting form. It takes the title so its label aligns with the panes above, never the marker.

**Review round.** The three findings were one bug: a surface wearing focus it did not own, or owning focus it did not show. One rule settles them. The treatment belongs to the frame of the pane `focusedPane` names, a box inside such a pane never repeats it, and a surface that takes the keys is a pane whatever its shape. The expanded todo list already receives Up and Down from `keybindings`, so `todos` becomes a `PaneId`, `focusedPane` names it, and the pane it opened over goes back to rest. Below the split width the fallback overlay takes the pane it stands in for instead of titling itself Command.

**Nested boxes.** The invariant now holds per box, not only per pane. `chat-composer.ts` takes the resting frame, so a focused chat pane carries `borderFocus` and the marker on its own frame alone, and which composer holds the cursor is said by the cursor and by the hint line under the box. "Exactly one box carries cyan" is true, including for the chat pane the screenshot shows.

**Conventions doc.** This branch also adds `docs/contributing/tui-conventions.md`. Review caught it presenting an unimplemented keymap as current policy and describing a border-weight focus channel that does not exist, so it is now split into **Rules in force**, each checkable against this tree, and **Proposed: movement and naming**, explicitly not implemented. Auditing the rest of the file found four more claims that were false: arrows and Tab were inverted (today `←`/`→` move between regions and `↑`/`↓`/`Tab` move within one), `/` was described as search when it is the command prefix and no search exists, and `?`, `q` and `F1` were documented with no handlers behind them. The Tab-based keymap it argues for lives on the unmerged `adi/tui-keymap-defaults`; `Ctrl+W` is what this tree binds.

A third commit corrects `focus.ts` itself. Its module docstring still claimed three channels including border style, and `paneBorderStyle` still explained the border as "a style swap", while the function ignores its argument and returns the rounded constant. `PANE_BORDER` already recorded the real history; the docstrings above it were where the doc's error came from. Comments only.

## Verification

`check_doc_links.py` passes on 326 files. Note it does not validate same-page anchors, tested by pointing a link at a heading that does not exist, so the two intra-page anchors were checked by hand. `focus.test.ts` pins the invariant **for every built-in theme**: a focused pane differs from a resting one by at least one non-colour channel, and no theme makes a focused border quieter than a resting one. Reverting the source while keeping the tests fails exactly the new assertions. The review round adds five renderer tests, all failing on the pre-fix tree: a no-op notification with the experiment-log detail open, the expanded todo list under each possible parent focus and against zoom, the fallback overlay below `splitFits`, and a focused chat pane with its composer at rest.

| Check | Result |
| --- | --- |
| `pnpm --filter @vibesys/tui test` | 673 pass, 0 fail, 28 files |
| `check:ts` / `check:clients` / `check:ts-architecture` | clean |

Rebased onto `main` at 84dfe92. That commit (#560) rewrote this same `overlay.ts` to draw its content in a `ScrollBoxRenderable` behind a reserved hint row, which conflicted with the narrow-width fallback above. Resolved by keeping #560's scroll architecture and routing the fallback through it: `#renderPane` calls `#applyGeometry()` and feeds the same `#body()` helper as an ordinary overlay, so the pane inherits scrolling and the `Esc to close / PgUp/PgDn` hint instead of the two literal lines it used to append. Both sides' tests are present and pass, including #560's `scrolls the overlay rather than the docked chat behind it`. The branch has since been rebased again, onto `main` at 8e09827, and that resolution carries forward unchanged.


