### PR TITLE
Derive whether a run has ended from a typed run status

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
               - 'src/server/api/schema.py'
               - 'src/server/events.py'
               - 'src/server/api/protocol.py'
+              - 'src/server/controller.py'
               - 'src/server/diagnostics.py'
               - 'src/server/settings.py'
               - 'scripts/fetch_bun.py'

--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -144,7 +144,14 @@ export type TuiTheme =
 export type ProtocolVersion14 = 1;
 export type RunId = string;
 export type Sequence = number;
-export type Status1 = string;
+/**
+ * Lifecycle status of one run, as frontends observe it.
+ *
+ * This is the authoritative closed set for the ``status`` field of
+ * ``RunSnapshot``; the generated TypeScript protocol types derive their union
+ * from it.
+ */
+export type RunStatus = "starting" | "running" | "paused" | "completed" | "failed";
 export type AgentKind = string | null;
 export type RoundLabel = string | null;
 export type ExecutionId = string;
@@ -329,7 +336,7 @@ export type Value1 =
   | unknown[];
 export type Kind23 = "todo_update";
 export type Content4 = string;
-export type Status2 = string;
+export type Status1 = string;
 export type Todos = TodoItemData[];
 export type Kind24 = "usage_update";
 export type InputTokens1 = number;
@@ -611,7 +618,7 @@ export interface RunSnapshot {
   protocol_version?: ProtocolVersion14;
   run_id: RunId;
   sequence: Sequence;
-  status: Status1;
+  status: RunStatus;
   agent_kind?: AgentKind;
   round_label?: RoundLabel;
   active_executions?: ActiveExecutions;
@@ -873,7 +880,7 @@ export interface TodoUpdateData {
 }
 export interface TodoItemData {
   content: Content4;
-  status: Status2;
+  status: Status1;
   [k: string]: unknown;
 }
 export interface UsageUpdateData {

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -2549,8 +2549,7 @@
           "type": "integer"
         },
         "status": {
-          "title": "Status",
-          "type": "string"
+          "$ref": "#/$defs/RunStatus"
         },
         "agent_kind": {
           "anyOf": [
@@ -2627,6 +2626,18 @@
       ],
       "title": "RunStartedData",
       "type": "object"
+    },
+    "RunStatus": {
+      "description": "Lifecycle status of one run, as frontends observe it.\n\nThis is the authoritative closed set for the ``status`` field of\n``RunSnapshot``; the generated TypeScript protocol types derive their union\nfrom it.",
+      "enum": [
+        "starting",
+        "running",
+        "paused",
+        "completed",
+        "failed"
+      ],
+      "title": "RunStatus",
+      "type": "string"
     },
     "ServerReadyData": {
       "properties": {

--- a/clients/backend-client/src/index.ts
+++ b/clients/backend-client/src/index.ts
@@ -24,6 +24,7 @@ export type {
   RequestInput,
   RunEvent,
   RunSnapshot,
+  RunStatus,
   ServerMessage,
   TuiDefaults,
 } from './protocol.js';

--- a/clients/backend-client/src/protocol.ts
+++ b/clients/backend-client/src/protocol.ts
@@ -4,6 +4,8 @@ export type ProtocolRequest = ProtocolDocument['request'];
 export type ProtocolResponse = ProtocolDocument['response'];
 export type RunEvent = ProtocolDocument['event'];
 export type RunSnapshot = ProtocolDocument['snapshot'];
+/** Run lifecycle statuses the backend reports. Source: `RunStatus` in `src/server/controller.py`. */
+export type RunStatus = RunSnapshot['status'];
 export type ServerMessage = ProtocolDocument['server_message'];
 export type Diagnostic = NonNullable<ProtocolResponse['diagnostic']>;
 export type HypothesisEntry = NonNullable<ProtocolResponse['experiments']>[number];

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -3,6 +3,7 @@ import type {RunEvent, RunSnapshot} from '@vibesys/backend-client';
 import {
   DEFAULT_CHAT_THREAD_ID,
   initialCoreState,
+  isTerminalRunStatus,
   latestDiagnosticChange,
   reconcileActiveExecutions,
   reduceEvent,
@@ -542,7 +543,7 @@ describe('core state projection', () => {
       },
     });
 
-    expect(state.terminal).toBe(true);
+    expect(isTerminalRunStatus(state.status)).toBe(true);
     expect(state.diagnostics).toMatchObject([
       {id: 'diag-1', summary: 'Agent failed.', severity: 'fatal', sequence: 3},
     ]);
@@ -660,6 +661,41 @@ describe('core state projection', () => {
 
     expect(state.experimentsRevision).toBe(12);
     expect('experimentLog' in state).toBe(false);
+  });
+});
+
+describe('run status terminality', () => {
+  it('classifies every run status the projection can hold', () => {
+    expect(isTerminalRunStatus('completed')).toBe(true);
+    expect(isTerminalRunStatus('failed')).toBe(true);
+    expect(isTerminalRunStatus('connecting')).toBe(false);
+    expect(isTerminalRunStatus('starting')).toBe(false);
+    expect(isTerminalRunStatus('running')).toBe(false);
+    expect(isTerminalRunStatus('paused')).toBe(false);
+  });
+
+  it('reads terminality from a bootstrapped snapshot', () => {
+    const snapshot = {run_id: 'run', status: 'completed', sequence: 4} satisfies RunSnapshot;
+
+    const state = reduceSnapshot(initialCoreState(), snapshot);
+
+    expect(isTerminalRunStatus(state.status)).toBe(true);
+  });
+
+  // A resumed run replays the previous process's failure ahead of its own
+  // start. Terminality is derived from the status, so the later `run_started`
+  // cannot leave the projection looking finished while the run is live.
+  it('is not terminal after a resumed run replays a failure then a start', () => {
+    const state = reduceEventBatch(initialCoreState(), [
+      baseEvent(1, 'run_failed'),
+      {
+        ...baseEvent(2, 'run_started'),
+        data: {kind: 'run_started', outer_loop: 'agent', input: '.', max_rounds: 3},
+      },
+    ]);
+
+    expect(state.status).toBe('running');
+    expect(isTerminalRunStatus(state.status)).toBe(false);
   });
 });
 

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -1,9 +1,11 @@
 import {describe, expect, it} from 'bun:test';
 import type {RunEvent, RunSnapshot} from '@vibesys/backend-client';
 import {
+  type CoreRunStatus,
+  type CoreState,
   DEFAULT_CHAT_THREAD_ID,
+  hasRunEnded,
   initialCoreState,
-  isTerminalRunStatus,
   latestDiagnosticChange,
   reconcileActiveExecutions,
   reduceEvent,
@@ -543,7 +545,7 @@ describe('core state projection', () => {
       },
     });
 
-    expect(isTerminalRunStatus(state.status)).toBe(true);
+    expect(hasRunEnded(state)).toBe(true);
     expect(state.diagnostics).toMatchObject([
       {id: 'diag-1', summary: 'Agent failed.', severity: 'fatal', sequence: 3},
     ]);
@@ -664,28 +666,31 @@ describe('core state projection', () => {
   });
 });
 
-describe('run status terminality', () => {
+describe('whether a run has ended', () => {
+  const withStatus = (status: CoreRunStatus): CoreState => ({...initialCoreState(), status});
+
   it('classifies every run status the projection can hold', () => {
-    expect(isTerminalRunStatus('completed')).toBe(true);
-    expect(isTerminalRunStatus('failed')).toBe(true);
-    expect(isTerminalRunStatus('connecting')).toBe(false);
-    expect(isTerminalRunStatus('starting')).toBe(false);
-    expect(isTerminalRunStatus('running')).toBe(false);
-    expect(isTerminalRunStatus('paused')).toBe(false);
+    expect(hasRunEnded(withStatus('completed'))).toBe(true);
+    expect(hasRunEnded(withStatus('failed'))).toBe(true);
+    expect(hasRunEnded(withStatus('connecting'))).toBe(false);
+    expect(hasRunEnded(withStatus('starting'))).toBe(false);
+    expect(hasRunEnded(withStatus('running'))).toBe(false);
+    expect(hasRunEnded(withStatus('paused'))).toBe(false);
   });
 
-  it('reads terminality from a bootstrapped snapshot', () => {
+  it('reads an ended run from a bootstrapped snapshot', () => {
     const snapshot = {run_id: 'run', status: 'completed', sequence: 4} satisfies RunSnapshot;
 
     const state = reduceSnapshot(initialCoreState(), snapshot);
 
-    expect(isTerminalRunStatus(state.status)).toBe(true);
+    expect(hasRunEnded(state)).toBe(true);
   });
 
   // A resumed run replays the previous process's failure ahead of its own
-  // start. Terminality is derived from the status, so the later `run_started`
-  // cannot leave the projection looking finished while the run is live.
-  it('is not terminal after a resumed run replays a failure then a start', () => {
+  // start. Whether the run has ended is derived from the status, so the later
+  // `run_started` cannot leave the projection looking finished while the run
+  // is live.
+  it('has not ended after a resumed run replays a failure then a start', () => {
     const state = reduceEventBatch(initialCoreState(), [
       baseEvent(1, 'run_failed'),
       {
@@ -695,7 +700,7 @@ describe('run status terminality', () => {
     ]);
 
     expect(state.status).toBe('running');
-    expect(isTerminalRunStatus(state.status)).toBe(false);
+    expect(hasRunEnded(state)).toBe(false);
   });
 });
 

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -1,4 +1,4 @@
-import type {Diagnostic, RunEvent, RunSnapshot} from '@vibesys/backend-client';
+import type {Diagnostic, RunEvent, RunSnapshot, RunStatus} from '@vibesys/backend-client';
 import {
   type AgentPhase,
   applyRunMapEvent,
@@ -117,14 +117,46 @@ export interface CoreDiagnostic {
   sequence: number;
 }
 
+/**
+ * Run status as core state carries it: every status the backend reports, plus
+ * the client-only `connecting` that precedes the first snapshot or event.
+ */
+export type CoreRunStatus = RunStatus | 'connecting';
+
+/** The statuses a run never leaves. Named once; `terminate` writes only these. */
+export type TerminalRunStatus = Extract<CoreRunStatus, 'completed' | 'failed'>;
+
+/**
+ * Whether a run status is one the run never leaves.
+ *
+ * Terminality is a function of the status, so core state stores the status
+ * alone and every reader asks this predicate. The switch is exhaustive: a new
+ * status in the protocol is a compile error here rather than a silent `false`.
+ */
+export function isTerminalRunStatus(status: CoreRunStatus): status is TerminalRunStatus {
+  switch (status) {
+    case 'completed':
+    case 'failed':
+      return true;
+    case 'connecting':
+    case 'starting':
+    case 'running':
+    case 'paused':
+      return false;
+    default: {
+      const unhandled: never = status;
+      return unhandled;
+    }
+  }
+}
+
 export interface CoreState {
   sequence: number;
-  status: string;
+  status: CoreRunStatus;
   agentKind: string | null;
   roundLabel: string | null;
   outerLoop: string | null;
   maxRounds: number | null;
-  terminal: boolean;
   rounds: RoundSummary[];
   phases: AgentPhase[];
   activeExecutions: Record<string, ActiveAgentExecution>;
@@ -162,7 +194,6 @@ export function initialCoreState(): CoreState {
     roundLabel: null,
     outerLoop: null,
     maxRounds: null,
-    terminal: false,
     rounds: [],
     phases: [],
     activeExecutions: {},
@@ -213,7 +244,6 @@ export function reduceSnapshot(state: CoreState, snapshot: RunSnapshot): CoreSta
     status: snapshot.status,
     agentKind: snapshot.agent_kind ?? null,
     roundLabel: snapshot.round_label ?? null,
-    terminal: snapshot.status === 'completed' || snapshot.status === 'failed',
     activeExecutions: activeExecutionsFromCheckpoint(snapshot.active_executions ?? []),
   };
 }
@@ -305,7 +335,6 @@ export function reduceEventPrefix(
     sequence: state.sequence,
     // The newer events own run termination.
     status: state.status,
-    terminal: state.terminal,
     agentKind: state.agentKind ?? older.agentKind,
     roundLabel: state.roundLabel ?? older.roundLabel,
     outerLoop: state.outerLoop ?? older.outerLoop,
@@ -539,7 +568,6 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
 
   if (event.type === 'run_started') {
     next.status = 'running';
-    next.terminal = false;
     if (data?.kind === 'run_started') next.maxRounds = data.max_rounds;
   }
   if (event.type === 'configuration_failed') return terminate(next, 'failed');
@@ -562,8 +590,8 @@ export function latestDiagnosticChange(
   );
 }
 
-function terminate(state: CoreState, status: string): CoreState {
-  return {...state, status, terminal: true, activeExecutions: {}};
+function terminate(state: CoreState, status: TerminalRunStatus): CoreState {
+  return {...state, status, activeExecutions: {}};
 }
 
 function activeExecutionsFromCheckpoint(

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -124,31 +124,7 @@ export interface CoreDiagnostic {
 export type CoreRunStatus = RunStatus | 'connecting';
 
 /** The statuses a run never leaves. Named once; `terminate` writes only these. */
-export type TerminalRunStatus = Extract<CoreRunStatus, 'completed' | 'failed'>;
-
-/**
- * Whether a run status is one the run never leaves.
- *
- * Terminality is a function of the status, so core state stores the status
- * alone and every reader asks this predicate. The switch is exhaustive: a new
- * status in the protocol is a compile error here rather than a silent `false`.
- */
-export function isTerminalRunStatus(status: CoreRunStatus): status is TerminalRunStatus {
-  switch (status) {
-    case 'completed':
-    case 'failed':
-      return true;
-    case 'connecting':
-    case 'starting':
-    case 'running':
-    case 'paused':
-      return false;
-    default: {
-      const unhandled: never = status;
-      return unhandled;
-    }
-  }
-}
+export type EndedRunStatus = Extract<CoreRunStatus, 'completed' | 'failed'>;
 
 export interface CoreState {
   sequence: number;
@@ -214,6 +190,31 @@ export function initialCoreState(): CoreState {
     chatTypedToolEvents: {},
     historyAfterSequence: 0,
   };
+}
+
+/**
+ * Whether the run has reached a status it never leaves.
+ *
+ * Whether a run has ended is a function of its status, so core state stores the
+ * status alone and every reader asks this predicate. The switch is exhaustive:
+ * a new status in the protocol is a compile error here rather than a silent
+ * `false`.
+ */
+export function hasRunEnded(state: CoreState): boolean {
+  switch (state.status) {
+    case 'completed':
+    case 'failed':
+      return true;
+    case 'connecting':
+    case 'starting':
+    case 'running':
+    case 'paused':
+      return false;
+    default: {
+      const unhandled: never = state.status;
+      return unhandled;
+    }
+  }
 }
 
 /** The transcript for one chat thread; unknown threads read as empty. */
@@ -590,7 +591,7 @@ export function latestDiagnosticChange(
   );
 }
 
-function terminate(state: CoreState, status: TerminalRunStatus): CoreState {
+function terminate(state: CoreState, status: EndedRunStatus): CoreState {
   return {...state, status, activeExecutions: {}};
 }
 

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -9,7 +9,7 @@ import {
   type StreamConnectionState,
   type SubscribeOptions,
 } from '@vibesys/backend-client';
-import {DEFAULT_CHAT_THREAD_ID, isTerminalRunStatus} from '@vibesys/core-state';
+import {DEFAULT_CHAT_THREAD_ID, hasRunEnded} from '@vibesys/core-state';
 import type {StartupTrace} from './boot-trace.js';
 import {helpText, parseChatCommand, parseCommand} from './commands.js';
 import {renderPerformanceCurve} from './performance-chart.js';
@@ -277,8 +277,7 @@ export class SocketSessionController implements SessionController {
       // messages and connection changes land.
       this.#stream.subscribe({
         cursor: () => this.#state.core.sequence,
-        shouldReconnect: () =>
-          !isTerminalRunStatus(this.#state.core.status) && !this.#streamProtocolError,
+        shouldReconnect: () => !hasRunEnded(this.#state.core) && !this.#streamProtocolError,
         onMessage: (message, {resumed}) => this.#onMessage(message, resumed),
         onConnectionState: state => this.#onConnectionState(state),
       }),

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -9,7 +9,7 @@ import {
   type StreamConnectionState,
   type SubscribeOptions,
 } from '@vibesys/backend-client';
-import {DEFAULT_CHAT_THREAD_ID} from '@vibesys/core-state';
+import {DEFAULT_CHAT_THREAD_ID, isTerminalRunStatus} from '@vibesys/core-state';
 import type {StartupTrace} from './boot-trace.js';
 import {helpText, parseChatCommand, parseCommand} from './commands.js';
 import {renderPerformanceCurve} from './performance-chart.js';
@@ -277,7 +277,8 @@ export class SocketSessionController implements SessionController {
       // messages and connection changes land.
       this.#stream.subscribe({
         cursor: () => this.#state.core.sequence,
-        shouldReconnect: () => !this.#state.core.terminal && !this.#streamProtocolError,
+        shouldReconnect: () =>
+          !isTerminalRunStatus(this.#state.core.status) && !this.#streamProtocolError,
         onMessage: (message, {resumed}) => this.#onMessage(message, resumed),
         onConnectionState: state => this.#onConnectionState(state),
       }),

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it, test} from 'bun:test';
 import type {RunEvent} from '@vibesys/backend-client';
-import {isTerminalRunStatus} from '@vibesys/core-state';
+import {hasRunEnded} from '@vibesys/core-state';
 import type {SessionState} from './session-model.js';
 import {
   applyActiveExecutionCheckpoint,
@@ -75,7 +75,7 @@ describe('event batch projection', () => {
     ]);
 
     expect(state.core.status).toBe('running');
-    expect(isTerminalRunStatus(state.core.status)).toBe(false);
+    expect(hasRunEnded(state.core)).toBe(false);
     expect(state.core.diagnostics).toHaveLength(1);
     expect(state.errorBanner).toEqual(before.errorBanner);
   });
@@ -714,13 +714,13 @@ describe('session event model', () => {
     });
   });
 
-  it('ignores replayed events and recognizes terminal state', () => {
+  it('ignores replayed events and recognizes an ended run', () => {
     let state = applyEvent(initialSessionState(), event(4, 'run_finished'));
     state = applyEvent(state, event(3, 'run_failed'));
 
     expect(state.core.status).toBe('completed');
     expect(state.core.sequence).toBe(4);
-    expect(isTerminalRunStatus(state.core.status)).toBe(true);
+    expect(hasRunEnded(state.core)).toBe(true);
   });
 
   it('shows structured configuration failures as terminal conversation entries', () => {
@@ -737,7 +737,7 @@ describe('session event model', () => {
     );
 
     expect(state.core.status).toBe('failed');
-    expect(isTerminalRunStatus(state.core.status)).toBe(true);
+    expect(hasRunEnded(state.core)).toBe(true);
     expect(state.overlay).toBeNull();
     expect(state.errorBanner).toMatchObject({
       title: 'Configuration failed',

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it, test} from 'bun:test';
 import type {RunEvent} from '@vibesys/backend-client';
+import {isTerminalRunStatus} from '@vibesys/core-state';
 import type {SessionState} from './session-model.js';
 import {
   applyActiveExecutionCheckpoint,
@@ -74,7 +75,7 @@ describe('event batch projection', () => {
     ]);
 
     expect(state.core.status).toBe('running');
-    expect(state.core.terminal).toBe(false);
+    expect(isTerminalRunStatus(state.core.status)).toBe(false);
     expect(state.core.diagnostics).toHaveLength(1);
     expect(state.errorBanner).toEqual(before.errorBanner);
   });
@@ -719,7 +720,7 @@ describe('session event model', () => {
 
     expect(state.core.status).toBe('completed');
     expect(state.core.sequence).toBe(4);
-    expect(state.core.terminal).toBe(true);
+    expect(isTerminalRunStatus(state.core.status)).toBe(true);
   });
 
   it('shows structured configuration failures as terminal conversation entries', () => {
@@ -736,7 +737,7 @@ describe('session event model', () => {
     );
 
     expect(state.core.status).toBe('failed');
-    expect(state.core.terminal).toBe(true);
+    expect(isTerminalRunStatus(state.core.status)).toBe(true);
     expect(state.overlay).toBeNull();
     expect(state.errorBanner).toMatchObject({
       title: 'Configuration failed',

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -14,8 +14,8 @@ import {
   type CoreState,
   DEFAULT_CHAT_THREAD_ID,
   type ExecutionTodos,
+  hasRunEnded,
   initialCoreState,
-  isTerminalRunStatus,
   latestDiagnosticChange,
   phasesForRound,
   type RoundSummary,
@@ -1039,7 +1039,7 @@ function selectExperimentIndexItem(
  * as hypothesis planning.
  */
 export function hypothesisPlanningActivity(state: SessionState): HypothesisPlanningActivity | null {
-  if (isTerminalRunStatus(state.core.status) || state.experimentLog === null) return null;
+  if (hasRunEnded(state.core) || state.experimentLog === null) return null;
   const phase = [...state.core.phases]
     .reverse()
     .find(

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_CHAT_THREAD_ID,
   type ExecutionTodos,
   initialCoreState,
+  isTerminalRunStatus,
   latestDiagnosticChange,
   phasesForRound,
   type RoundSummary,
@@ -1038,7 +1039,7 @@ function selectExperimentIndexItem(
  * as hypothesis planning.
  */
 export function hypothesisPlanningActivity(state: SessionState): HypothesisPlanningActivity | null {
-  if (state.core.terminal || state.experimentLog === null) return null;
+  if (isTerminalRunStatus(state.core.status) || state.experimentLog === null) return null;
   const phase = [...state.core.phases]
     .reverse()
     .find(

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1847,7 +1847,6 @@ describe('OpenTUI presentation', () => {
       core: {
         ...initialSessionState().core,
         status: 'failed',
-        terminal: true,
         transcript: [
           {
             id: 'configuration-error',
@@ -1881,7 +1880,6 @@ describe('OpenTUI presentation', () => {
       core: {
         ...initialSessionState().core,
         status: 'failed',
-        terminal: true,
         transcript: [
           {
             id: 'configuration-error',

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -7,6 +7,7 @@ import {
   type MouseEvent as TerminalMouseEvent,
   TextRenderable,
 } from '@opentui/core';
+import {isTerminalRunStatus} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
 import {visibleConversation} from '../session-model.js';
@@ -433,7 +434,8 @@ export class ConversationView {
         content: preview.content,
         syntaxStyle: this.#markdownStyle,
         conceal: true,
-        streaming: this.#markdownStreaming ?? !this.controller.state.core.terminal,
+        streaming:
+          this.#markdownStreaming ?? !isTerminalRunStatus(this.controller.state.core.status),
         width: '100%',
       }),
     );

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -7,7 +7,7 @@ import {
   type MouseEvent as TerminalMouseEvent,
   TextRenderable,
 } from '@opentui/core';
-import {isTerminalRunStatus} from '@vibesys/core-state';
+import {hasRunEnded} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
 import {visibleConversation} from '../session-model.js';
@@ -434,8 +434,7 @@ export class ConversationView {
         content: preview.content,
         syntaxStyle: this.#markdownStyle,
         conceal: true,
-        streaming:
-          this.#markdownStreaming ?? !isTerminalRunStatus(this.controller.state.core.status),
+        streaming: this.#markdownStreaming ?? !hasRunEnded(this.controller.state.core),
         width: '100%',
       }),
     );

--- a/src/entrypoints/launcher.py
+++ b/src/entrypoints/launcher.py
@@ -73,6 +73,7 @@ _REBUILD_WATCH_FILES: tuple[str, ...] = (
     "src/server/api/schema.py",
     "src/server/events.py",
     "src/server/api/protocol.py",
+    "src/server/controller.py",
     "src/server/diagnostics.py",
     "src/server/settings.py",
 )

--- a/src/server/api/protocol.py
+++ b/src/server/api/protocol.py
@@ -9,6 +9,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat
 
 from server.chat.options import ChatOptions
+from server.controller import RunStatus
 from server.diagnostics import Diagnostic, DiagnosticScope, exception_to_diagnostic
 from server.events import RunEvent
 from server.execution import ActiveAgentExecution
@@ -152,7 +153,7 @@ class RunSnapshot(ProtocolModel):  # noqa: D101  # tracked: #288
     protocol_version: Literal[1] = PROTOCOL_VERSION
     run_id: str
     sequence: int
-    status: str
+    status: RunStatus
     agent_kind: str | None = None
     round_label: str | None = None
     active_executions: list[ActiveAgentExecution] = Field(default_factory=list)

--- a/src/server/chat/manager.py
+++ b/src/server/chat/manager.py
@@ -344,7 +344,7 @@ class ChatManager:
     def _unavailable_reason(self) -> str:
         return (
             "the run has finished"
-            if self._run_status().is_terminal
+            if self._run_status().has_ended
             else "the run has not finished starting up"
         )
 

--- a/src/server/chat/manager.py
+++ b/src/server/chat/manager.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     import threading
 
     from server.chat.options import ChatRunSettings
+    from server.controller import RunStatus
     from server.journal import EventJournal
 
 _CHAT_DRAIN_TIMEOUT_SECONDS = 5.0
@@ -54,7 +55,7 @@ class ChatManager:
         condition: threading.Condition,
         journal: EventJournal,
         *,
-        run_status: Callable[[], str],
+        run_status: Callable[[], RunStatus],
     ) -> None:
         """Initialize chat routing over the shared server condition and journal."""
         self._condition = condition
@@ -341,10 +342,9 @@ class ChatManager:
             )
 
     def _unavailable_reason(self) -> str:
-        status = self._run_status()
         return (
             "the run has finished"
-            if status in {"completed", "failed"}
+            if self._run_status().is_terminal
             else "the run has not finished starting up"
         )
 

--- a/src/server/controller.py
+++ b/src/server/controller.py
@@ -33,7 +33,7 @@ class RunStatus(StrEnum):
     FAILED = "failed"
 
     @property
-    def is_terminal(self) -> bool:
+    def has_ended(self) -> bool:
         """Whether the run has settled into a status it never leaves."""
         match self:
             case RunStatus.COMPLETED | RunStatus.FAILED:
@@ -58,7 +58,7 @@ class ProjectRunState:
 
 
 class RunController:
-    """Coordinate run state, pause boundaries, steering, and terminal state."""
+    """Coordinate run state, pause boundaries, steering, and the ended state."""
 
     def __init__(
         self,
@@ -227,7 +227,7 @@ class RunController:
         return RunStatus.PAUSED if self._paused else self._run_status
 
     def run_status(self) -> RunStatus:
-        """Return the terminal-aware run status token."""
+        """Return the run status token, including whether the run has ended."""
         with self._condition:
             return self._run_status
 
@@ -238,9 +238,9 @@ class RunController:
         record_event: bool = True,
         diagnostic: Diagnostic | None = None,
     ) -> None:
-        """Transition the run to its terminal state exactly once."""
+        """Transition the run to its ended state exactly once."""
         with self._condition:
-            if self._run_status.is_terminal:
+            if self._run_status.has_ended:
                 return
             self._executions.interrupt_controlled_locked()
             self._run_status = RunStatus.FAILED if error else RunStatus.COMPLETED

--- a/src/server/controller.py
+++ b/src/server/controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING, Any
 
@@ -15,6 +16,30 @@ if TYPE_CHECKING:
     from server.execution import ExecutionHandle, ExecutionTracker
     from server.journal import EventJournal
     from vs_project import Project, StateSnapshot
+
+
+class RunStatus(StrEnum):
+    """Lifecycle status of one run, as frontends observe it.
+
+    This is the authoritative closed set for the ``status`` field of
+    ``RunSnapshot``; the generated TypeScript protocol types derive their union
+    from it.
+    """
+
+    STARTING = "starting"
+    RUNNING = "running"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the run has settled into a status it never leaves."""
+        match self:
+            case RunStatus.COMPLETED | RunStatus.FAILED:
+                return True
+            case RunStatus.STARTING | RunStatus.RUNNING | RunStatus.PAUSED:
+                return False
 
 
 @dataclass(frozen=True)
@@ -48,7 +73,7 @@ class RunController:
         self._pause_after_call = False
         self._paused = False
         self._pending_steer: list[str] = []
-        self._run_status = "starting"
+        self._run_status: RunStatus = RunStatus.STARTING
         self._project_run: ProjectRunState | None = None
 
     @property
@@ -76,7 +101,7 @@ class RunController:
             if project is not None and run_id is not None:
                 self._project_run = ProjectRunState(project, run_id)
             self._journal.attach(log_dir, run_id=run_id)
-            self._run_status = "running"
+            self._run_status = RunStatus.RUNNING
 
     def pause_after_call(self) -> None:
         """Request a pause after the current controlled invocation finishes."""
@@ -197,11 +222,11 @@ class RunController:
             kind, round_label = self._executions.current_locked()
         return f"{state} · {kind or 'starting'} · {round_label or 'no round yet'}"
 
-    def status_locked(self) -> str:
+    def status_locked(self) -> RunStatus:
         """Return run status while the caller holds the shared condition."""
-        return "paused" if self._paused else self._run_status
+        return RunStatus.PAUSED if self._paused else self._run_status
 
-    def run_status(self) -> str:
+    def run_status(self) -> RunStatus:
         """Return the terminal-aware run status token."""
         with self._condition:
             return self._run_status
@@ -215,10 +240,10 @@ class RunController:
     ) -> None:
         """Transition the run to its terminal state exactly once."""
         with self._condition:
-            if self._run_status in {"completed", "failed"}:
+            if self._run_status.is_terminal:
                 return
             self._executions.interrupt_controlled_locked()
-            self._run_status = "failed" if error else "completed"
+            self._run_status = RunStatus.FAILED if error else RunStatus.COMPLETED
             self._condition.notify_all()
         event_diagnostic = diagnostic
         if error is not None and event_diagnostic is not None:


### PR DESCRIPTION
## Problem

PR #540 (by @zatchbell1311-wq) fixed a display bug reported in #505: on a resumed run the TUI showed a
live run as finished. Its cause was duplicated state. `CoreState` carried both
`status: string` and `terminal: boolean` for one fact. `terminal` was always a
function of `status` (the snapshot bootstrap literally computed
`status === 'completed' || status === 'failed'`, and `terminate()` wrote both
together), but the `run_started` reducer wrote only `status`. A resumed run
replays the previous process's `run_failed` and then its own `run_started`, so
the projection ended with `status: 'running'` and the flag still set. Three
readers believed the stale copy: the disconnect banner's `shouldReconnect`
(`clients/tui/src/session-controller.ts`), the hypothesis-planning indicator
(`clients/tui/src/session-model.ts`), and the markdown streaming flag
(`clients/tui/src/ui/conversation.ts`).

#540's one-line fix was correct, but it left the shape that produced the bug:
every future reducer that touches `status` has to remember to touch the flag
too. `status` was also typed `string`, so nothing checked that a reader's
comparison against a status literal matched what the backend actually emits.

## Solution

Store the status alone and derive from it whether the run has ended, and make
the status a closed set that both languages check.

1. The boolean field is gone from `CoreState`, the initial state, the snapshot
   bootstrap, the prefix merge, and `terminate()`. `@vibesys/core-state` exports
   `hasRunEnded(state)`, and the three readers plus the tests call it. With no
   second field there is no write to forget: the inconsistent state
   `status: 'running'` alongside a run that reads as finished is now
   unrepresentable, and #540's fix is preserved structurally rather than by a
   reducer remembering a line.
2. The run status is a `StrEnum` on the backend model that owns it. `RunStatus`
   in `src/server/controller.py` (the module that assigns every value:
   `starting`, `running`, `completed`, `failed`, plus `paused` from
   `status_locked()`) now types `RunSnapshot.status`, and the regenerated
   bindings give `RunStatus` in `clients/backend-client/src/generated/`.
   `CoreState.status` is `CoreRunStatus = RunStatus | 'connecting'`, adding only
   the client-only pre-first-message state. `hasRunEnded` is an exhaustive
   `switch` whose `default` assigns to `never`, and `RunStatus.has_ended` is an
   exhaustive `match`, so adding a status without classifying it fails to
   compile in TypeScript and fails `ty check` in Python.

The predicate deliberately avoids the word "terminal": in a terminal UI that
word already names the emulator and the protocol's terminal events. The narrowed
type is `EndedRunStatus`; the Python property is `RunStatus.has_ended`.

Nothing user-visible changes. The wire format is identical (a `StrEnum` field
serializes to the same JSON string), `run_interrupted` still folds to `failed`,
and the ended set is still exactly `{completed, failed}`.

Two consequences worth a reviewer's eye:

- `src/server/api/protocol.py` now imports `server.controller`, so
  `controller.py` is an input to `generate:protocol`. It is added to the
  launcher's `_REBUILD_WATCH_FILES` and to the `tui` path filter in
  `.github/workflows/test.yml`, both of which document themselves as the full
  set of codegen inputs.
- The regenerated `protocol.generated.ts` renames one unrelated anonymous alias
  (`TodoItemData.status`: `Status2` to `Status1`) because a named `RunStatus`
  replaced the previous anonymous `Status1`. Generated output, no behavior
  change.

Nothing was deferred. The status types through the protocol end to end.

### Architecture

`RunController` owns the run-status fact; the protocol model re-exports it as
the frontend contract; core state folds it; the TUI only asks the predicate.

```mermaid
flowchart LR
  ctrl["server/controller.py<br/>RunStatus (StrEnum)<br/>.has_ended"] --> proto["server/api/protocol.py<br/>RunSnapshot.status: RunStatus"]
  proto --> gen["backend-client<br/>generated RunStatus union"]
  gen --> core["core-state<br/>CoreState.status: CoreRunStatus<br/>hasRunEnded()"]
  core --> ctl["tui/session-controller.ts<br/>shouldReconnect"]
  core --> mdl["tui/session-model.ts<br/>hypothesisPlanningActivity"]
  core --> conv["tui/ui/conversation.ts<br/>markdown streaming"]
```

## Verification

New tests cover the predicate over every status the projection can hold, the
snapshot bootstrap of a completed run, and the #540 replay order (`run_failed`
then `run_started` is `running` and has not ended). The three existing
assertions on the removed flag became assertions on the predicate, so the
regression #540 fixed is still guarded. Type checks are the other half of the
evidence: the TypeScript build and `ty check` both pass with the exhaustive
branches in place.

### Correctness properties

- Whether a run has ended is a function of `status` alone. No reducer can
  produce a state that is running and finished at once, because the second
  field no longer exists.
- The ended set is `{completed, failed}` in both languages, named once per
  language (`EndedRunStatus` / `RunStatus.has_ended`).
- Adding a status to `RunStatus` is a compile error in `hasRunEnded` and a type
  error in `RunStatus.has_ended` until it is classified.
- `CoreState.status` accepts exactly the backend statuses plus the client-only
  `connecting`; a typo in a status comparison is now a type error.
- The wire contract is unchanged: `RunSnapshot.status` still serializes to and
  parses from the same JSON strings, and the schema change is the additive
  narrowing of an open `string` to its five actual values.
- `run_interrupted` still folds to `failed`; no user-visible behavior changes.

### Testing

| Command | Result |
| --- | --- |
| `bun test --max-concurrency 1 src` (`clients/tui`) | 485 pass, 0 fail |
| `bun test --max-concurrency 1 src` (`clients/core-state`) | 70 pass, 0 fail |
| `pnpm check:clients` | pass (tsc, all three packages) |
| `pnpm check:ts` | pass (Biome, 70 files) |
| `pnpm check:ts-architecture` | pass (no dependency violations, 78 modules) |
| `pnpm --dir clients/backend-client generate:protocol` | regenerated; diff is the `RunStatus` enum plus the alias rename noted above |
| `./scripts/check_format.sh` | All checks passed (469 files) |
| `./scripts/check_lint.sh` | All checks passed |
| `./scripts/check_types.sh` (`uv run ty check`) | All checks passed |
| `uv run pytest tests/server` | 186 passed |
| `uv run pytest tests/entrypoints/test_launcher.py` | passed (run with `tests/server`: 231 passed) |

`ty` is this repository's Python type checker (`scripts/check_types.sh`); there
is no Pyright configuration in the repo, so `ty check` was run in its place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

