### PR TITLE
Make an attempt's judge outcome a single immutable value

### DIFF
--- a/libs/vs-loop-state/src/vs_loop_state/__init__.py
+++ b/libs/vs-loop-state/src/vs_loop_state/__init__.py
@@ -6,6 +6,7 @@ all three loops. Project layout and filesystem persistence belong to
 """
 
 from vs_loop_state.agent import (
+    JudgeVerdict,
     RoundHistory,
     RoundRecord,
     parse_round_record,
@@ -29,6 +30,7 @@ from vs_loop_state.plain import (
 
 __all__ = [
     "IndividualRecord",
+    "JudgeVerdict",
     "PlainLoopCursor",
     "PlainPerformanceRecord",
     "PlainPerformanceSnapshot",

--- a/libs/vs-loop-state/src/vs_loop_state/agent.py
+++ b/libs/vs-loop-state/src/vs_loop_state/agent.py
@@ -17,6 +17,11 @@ aliased first field without a plain default conflicts with dataclass
 field-ordering rules (a later required field would "follow a default
 argument").
 
+``judge_verdict`` is the single source of truth for a round's review state.
+The on-disk key ``reviewed`` predates it and is kept only so legacy records
+still load; ``RoundRecord.reviewed`` derives the boolean instead of storing a
+second copy that can disagree with the verdict.
+
 ``RoundHistory`` owns only in-memory collection behavior and rollback-base
 resolution. The application-level project-state library owns persistence and
 the on-disk layout.
@@ -26,14 +31,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import ConfigDict, Field, TypeAdapter
+from pydantic import ConfigDict, Field, TypeAdapter, model_validator
 from pydantic.dataclasses import dataclass
 
 if TYPE_CHECKING:
     from collections.abc import Container
 
+#: A round's review state. ``deferred`` means no independent judge ran, so it
+#: is the only value compatible with an unreviewed round.
+JudgeVerdict = Literal["pass", "fail", "deferred"]
 
-@dataclass(config=ConfigDict(extra="forbid"))
+
+@dataclass(config=ConfigDict(extra="forbid", populate_by_name=True, serialize_by_alias=True))
 class RoundRecord:
     """One completed round of the agent loop."""
 
@@ -48,13 +57,19 @@ class RoundRecord:
     # these so a chain of skipped-profile rounds doesn't masquerade as a
     # real plateau.
     profile_skipped: bool = False
-    # False means the implementer was still investigating and sparse-review
-    # policy intentionally deferred both the independent judge and official
-    # framework gates. Such a round is provisional, not a failed attempt.
-    reviewed: bool = True
+    # Legacy encoding of the review state, persisted under the on-disk key
+    # ``reviewed``. It is authoritative only for records written before
+    # ``judge_verdict`` existed; otherwise ``_normalize_review`` keeps it equal
+    # to the verdict. Read it through the ``reviewed`` property, never here.
+    legacy_reviewed: bool = Field(default=True, alias="reviewed")
     hypothesis_id: str | None = None
     hypothesis_declared_outcome: str | None = None
-    judge_verdict: Literal["pass", "fail", "deferred"] | None = None
+    # The round's review state, decided by its final implementer attempt.
+    # ``deferred`` means sparse-review policy skipped both the independent
+    # judge and the official framework gates: such a round is provisional, not
+    # a failed attempt. ``None`` identifies a legacy record written before the
+    # framework recorded a verdict.
+    judge_verdict: JudgeVerdict | None = None
     hypothesis_outcome: str | None = None
     # Plan text carried alongside the id so a resolved hypothesis stays
     # readable after ``active_hypothesis.json`` has moved on. Only the live
@@ -96,6 +111,33 @@ class RoundRecord:
     perf_baseline_commit: str | None = None
     perf_baseline_metric: float | None = None
     perf_delta_pct: float | None = None
+
+    @model_validator(mode="after")
+    def _normalize_review(self) -> RoundRecord:
+        """Keep the review state expressible only through ``judge_verdict``.
+
+        A ``pass``/``fail`` verdict on an unreviewed record is contradictory:
+        it can only have come from an earlier implementer attempt of the same
+        round (issue #503), because the judge that would own it never ran for
+        the attempt this record describes. Normalize such a record to
+        ``deferred``, which is what the framework should have written, so a
+        resumed run and the server read path both project it as unreviewed
+        rather than rejecting a still-active hypothesis.
+        """
+        if self.judge_verdict is None:
+            # Legacy record: the boolean is all the review state there is.
+            return self
+        if self.judge_verdict != "deferred" and not self.legacy_reviewed:
+            self.judge_verdict = "deferred"
+        self.legacy_reviewed = self.judge_verdict != "deferred"
+        return self
+
+    @property
+    def reviewed(self) -> bool:
+        """Whether an independent judge ruled on this round's final attempt."""
+        if self.judge_verdict is None:
+            return self.legacy_reviewed
+        return self.judge_verdict != "deferred"
 
 
 _ROUND_RECORD_ADAPTER: TypeAdapter[RoundRecord] = TypeAdapter(RoundRecord)

--- a/libs/vs-loop-state/tests/test_vs_loop_state_agent.py
+++ b/libs/vs-loop-state/tests/test_vs_loop_state_agent.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from vs_loop_state import (
+    JudgeVerdict,
     RoundHistory,
     RoundRecord,
     parse_round_record,
@@ -109,6 +110,97 @@ def test_parse_round_record_rejects_unknown_fields() -> None:
                 "made_up_field": "surprise",
             }
         )
+
+
+def _judged_record(round_number: int, verdict: JudgeVerdict) -> RoundRecord:
+    return RoundRecord(
+        round_number=round_number,
+        commit=f"{round_number:040x}",
+        perf_metric=None,
+        perf_unit=None,
+        passed=verdict == "pass",
+        judge_verdict=verdict,
+    )
+
+
+def test_review_state_is_derived_from_the_verdict() -> None:
+    """``reviewed`` restates the verdict, so only the verdict is stored."""
+    assert _judged_record(1, "pass").reviewed is True
+    assert _judged_record(2, "fail").reviewed is True
+    assert _judged_record(3, "deferred").reviewed is False
+
+
+def test_serialized_record_keeps_the_reviewed_key() -> None:
+    payload = serialize_round_record(_judged_record(4, "deferred"))
+
+    assert payload["reviewed"] is False
+    assert payload["judge_verdict"] == "deferred"
+    assert parse_round_record(payload).reviewed is False
+
+
+def test_legacy_record_without_a_verdict_keeps_its_reviewed_flag() -> None:
+    """Records written before ``judge_verdict`` existed still load unchanged."""
+    reviewed = parse_round_record(
+        {"round": 1, "commit": None, "perf_metric": None, "perf_unit": None, "passed": True}
+    )
+    unreviewed = parse_round_record(
+        {
+            "round": 2,
+            "commit": None,
+            "perf_metric": None,
+            "perf_unit": None,
+            "passed": False,
+            "reviewed": False,
+        }
+    )
+
+    assert reviewed.judge_verdict is None
+    assert reviewed.reviewed is True
+    assert unreviewed.judge_verdict is None
+    assert unreviewed.reviewed is False
+    assert serialize_round_record(unreviewed)["reviewed"] is False
+
+
+@pytest.mark.parametrize("verdict", ["pass", "fail"])
+def test_unreviewed_record_with_a_verdict_normalizes_to_deferred(verdict: str) -> None:
+    """Repairs runs corrupted by the stale-verdict bug (issue #503).
+
+    Such a record can only have taken its verdict from an earlier implementer
+    attempt of the same round, so it must reproject as unreviewed instead of
+    resolving the hypothesis on evidence that describes a different attempt.
+    """
+    record = parse_round_record(
+        {
+            "round": 3,
+            "commit": "c" * 40,
+            "perf_metric": None,
+            "perf_unit": None,
+            "passed": False,
+            "reviewed": False,
+            "judge_verdict": verdict,
+            "hypothesis_outcome": "continue",
+        }
+    )
+
+    assert record.judge_verdict == "deferred"
+    assert record.reviewed is False
+    assert serialize_round_record(record)["judge_verdict"] == "deferred"
+
+
+def test_constructing_an_unreviewed_verdict_normalizes_it_too() -> None:
+    """The invariant holds for in-memory construction, not only for loads."""
+    record = RoundRecord(
+        round_number=4,
+        commit="d" * 40,
+        perf_metric=None,
+        perf_unit=None,
+        passed=False,
+        reviewed=False,
+        judge_verdict="pass",
+    )
+
+    assert record.judge_verdict == "deferred"
+    assert record.reviewed is False
 
 
 def test_round_history_starts_empty_and_appends_records() -> None:

--- a/src/vibesys/loops/agent/attempt.py
+++ b/src/vibesys/loops/agent/attempt.py
@@ -1,0 +1,90 @@
+"""Per-attempt values produced by the agent loop's implementer/judge retry.
+
+One round runs up to ``max_retries_per_round`` implementer attempts, and only
+the final attempt describes the round. Attempt-scoped facts therefore have a
+shorter lifetime than the round-scoped accumulators around them (the best
+accepted implementation, the completed official evaluation). Carrying them in
+mutable locals that outlive an iteration made the two lifetimes look alike and
+produced issue #503: the judge's verdict for attempt N survived into a record
+whose final attempt N+1 was never reviewed.
+
+``JudgeOutcome`` closes that gap by value: an attempt either was reviewed and
+therefore has a verdict, or was skipped and therefore has a reason instead. A
+verdict without a review is not constructible, so no reset discipline has to be
+remembered when a new attempt-scoped fact is added.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, assert_never
+
+from vibesys.schemas import Verdict
+
+if TYPE_CHECKING:
+    from vs_loop_state import JudgeVerdict
+
+
+class JudgeSkipReason(StrEnum):
+    """Why one implementer attempt received no independent judge verdict."""
+
+    #: The attempt ended before the judge decision point. Also the initial
+    #: value, so the outcome is bound even if no attempt runs.
+    NOT_REACHED = "not_reached"
+    #: The implementer turn produced no parseable structured response, so the
+    #: framework synthesized a fail-closed one that carries no reviewable
+    #: evidence.
+    UNPARSEABLE_IMPLEMENTATION = "unparseable_implementation"
+    #: Sparse-review policy deferred the audit to a later round.
+    SPARSE_REVIEW_POLICY = "sparse_review_policy"
+
+
+@dataclass(frozen=True, slots=True)
+class JudgeReviewed:
+    """An independent judge audited this attempt and returned ``verdict``."""
+
+    verdict: Verdict
+
+
+@dataclass(frozen=True, slots=True)
+class JudgeSkipped:
+    """No judge ran for this attempt, for ``reason``."""
+
+    reason: JudgeSkipReason
+
+
+#: One attempt's judge result. The two variants are exhaustive.
+type JudgeOutcome = JudgeReviewed | JudgeSkipped
+
+
+def attempt_was_reviewed(outcome: JudgeOutcome) -> bool:
+    """Return whether an independent judge ruled on this attempt."""
+    match outcome:
+        case JudgeReviewed():
+            return True
+        case JudgeSkipped():
+            return False
+        case _:  # pragma: no cover - exhaustiveness is enforced statically
+            assert_never(outcome)
+
+
+def recorded_judge_verdict(outcome: JudgeOutcome) -> JudgeVerdict:
+    """Return the persisted-record verdict for this attempt.
+
+    A skipped review is recorded as ``deferred`` rather than as a missing
+    value, so the round record states the review fact exactly once.
+    """
+    match outcome:
+        case JudgeReviewed(verdict=verdict):
+            match verdict:
+                case Verdict.PASS:
+                    return "pass"
+                case Verdict.FAIL:
+                    return "fail"
+                case _:  # pragma: no cover - exhaustiveness is enforced statically
+                    assert_never(verdict)
+        case JudgeSkipped():
+            return "deferred"
+        case _:  # pragma: no cover - exhaustiveness is enforced statically
+            assert_never(outcome)

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -28,6 +28,14 @@ from vibesys.domains.registry import resolve_domain
 from vibesys.domains.rendering import render_domain_section
 from vibesys.input_manifest import BenchmarkResult, WorkspaceSource  # noqa: TC001  # tracked: #288
 from vibesys.loops.agent import issue_board
+from vibesys.loops.agent.attempt import (
+    JudgeOutcome,
+    JudgeReviewed,
+    JudgeSkipped,
+    JudgeSkipReason,
+    attempt_was_reviewed,
+    recorded_judge_verdict,
+)
 from vibesys.loops.agent.hypotheses import (
     ResolutionEvidence,
     append_round,
@@ -2731,13 +2739,15 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         )
 
                 # --- Implementer / Judge retry loop ---
-                # A failed review can carry targeted feedback into the same
-                # persistent hypothesis on the next framework round.
+                # Round-scoped accumulators: these describe the round as a
+                # whole and intentionally survive every attempt (the best
+                # accepted implementation, the official evaluation the round
+                # completed, and the feedback carried forward). A failed review
+                # can carry targeted feedback into the same persistent
+                # hypothesis on the next framework round.
                 feedback: str | None = active_hypothesis.feedback
                 passed = False
                 review_started = False
-                final_attempt_reviewed = False
-                judge_verdict: Literal["pass", "fail", "deferred"] | None = None
                 framework_revalidation_required = active_hypothesis.gate_revalidation_pending
                 implementation: ImplementerResponse | None = None
                 single_agent_response: SingleAgentRoundResponse | None = None
@@ -2746,6 +2756,12 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 accepted_metrics: dict[str, float] = {}
                 accepted_evaluation_artifact: str | None = None
                 completed_official_evaluation_reason: str | None = None
+                # Attempt-scoped state: one immutable value describing the
+                # judge's treatment of the current attempt only. It is replaced
+                # wholesale at the top of every iteration and never updated in
+                # place, so an earlier attempt's verdict cannot survive into
+                # the round record (issue #503).
+                attempt_judge: JudgeOutcome = JudgeSkipped(JudgeSkipReason.NOT_REACHED)
                 # ``max_retries_per_round >= 1`` is validated at entry, so the
                 # loop always runs; the initializer keeps ``retry`` provably
                 # bound for the post-loop round bookkeeping.
@@ -2765,16 +2781,12 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     )
                 for retry in range(first_retry, max_retries_per_round + 1):
                     ctx.lprint(f"\n--- attempt {retry}/{max_retries_per_round} ---\n")
-                    final_attempt_reviewed = False
-                    # Reset alongside ``final_attempt_reviewed``: the persisted
-                    # record must reflect the final attempt, not an earlier
-                    # audit.  A cadence review of attempt N sets a verdict; if
-                    # the final attempt N+1 defers re-review (the sparse-review
-                    # break below), that stale verdict must not survive.
-                    # Otherwise the round is recorded with attempt N's
-                    # ``judge_verdict`` while ``reviewed=False``/outcome=continue,
-                    # and projection rejects a still-active hypothesis.
-                    judge_verdict = None
+                    # The persisted record must reflect this attempt, not an
+                    # earlier audit.  A cadence review of attempt N returns a
+                    # verdict; if the final attempt N+1 defers re-review (the
+                    # sparse-review break below), that verdict belongs to a
+                    # different implementation and must not survive.
+                    attempt_judge = JudgeSkipped(JudgeSkipReason.NOT_REACHED)
                     if inner_loop == "multi-agent":
                         prior_attempt_artifact_locations = tuple(
                             issue_board.display_path(path, ctx.workspace)
@@ -2820,6 +2832,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             # failure silently consume the whole round. When
                             # retries are exhausted the round still commits the
                             # fail-closed response, unreviewed, as before.
+                            attempt_judge = JudgeSkipped(JudgeSkipReason.UNPARSEABLE_IMPLEMENTATION)
                             ctx.lprint(
                                 f"[implementer] attempt {retry}/{max_retries_per_round} "
                                 "returned no parseable structured response; the framework "
@@ -2867,6 +2880,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             # due again.
                             review_due = False
                         if not review_due:
+                            attempt_judge = JudgeSkipped(JudgeSkipReason.SPARSE_REVIEW_POLICY)
                             issue_board.append_judge_skipped(
                                 progress_path,
                                 round_number,
@@ -2879,7 +2893,6 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             )
                             break
                         review_started = True
-                        final_attempt_reviewed = True
                         framework_revalidation_required = False
                         candidate_archive_conflict = _pareto_archive_conflict(
                             candidate_disposition=implementation.candidate_disposition,
@@ -2916,7 +2929,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             official_evaluation_reason=planned_official_reason,
                             pareto_archive_conflict=candidate_archive_conflict,
                         )
-                        judge_verdict = verdict.verdict.value
+                        attempt_judge = JudgeReviewed(verdict.verdict)
                         if verdict.verdict == Verdict.PASS:
                             validation_feedback = _run_framework_validation_gate(
                                 ctx,
@@ -3099,7 +3112,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             pareto_records=records,
                             objectives=objectives,
                         )
-                        judge_verdict = single_agent_response.verdict.value
+                        attempt_judge = JudgeReviewed(single_agent_response.verdict)
                         if single_agent_response.verdict == Verdict.PASS:
                             official_reason = _official_evaluation_reason(
                                 records=records,
@@ -3191,6 +3204,9 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         )
 
                 # --- Record round result & update carry-over ---
+                # Only the final attempt describes the round, so its outcome is
+                # the one the record and the lifecycle transition read.
+                final_attempt_reviewed = attempt_was_reviewed(attempt_judge)
                 commit = ctx.git.current_sha()
                 # `profile_skipped` is True when no fresh profile ran this round
                 # (cold-start or the orchestrator/framework decided to skip).
@@ -3433,12 +3449,13 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     perf_unit=perf_unit,
                     passed=passed,
                     profile_skipped=profile_skipped,
-                    reviewed=reviewed,
                     hypothesis_id=plan.hypothesis_id,
                     hypothesis_declared_outcome=(
                         declared_outcome.value if declared_outcome is not None else None
                     ),
-                    judge_verdict=(judge_verdict if judge_verdict is not None else "deferred"),
+                    # ``RoundRecord.reviewed`` derives from this verdict, so
+                    # the record cannot claim a verdict it never received.
+                    judge_verdict=recorded_judge_verdict(attempt_judge),
                     hypothesis_outcome=(
                         hypothesis_resolution.value
                         if hypothesis_resolution is not None

--- a/tests/vibesys/loops/agent/test_attempt.py
+++ b/tests/vibesys/loops/agent/test_attempt.py
@@ -1,0 +1,50 @@
+"""Tests for the agent loop's per-attempt judge outcome."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from vibesys.loops.agent.attempt import (
+    JudgeReviewed,
+    JudgeSkipped,
+    JudgeSkipReason,
+    attempt_was_reviewed,
+    recorded_judge_verdict,
+)
+from vibesys.schemas import Verdict
+
+
+@pytest.mark.parametrize(
+    ("verdict", "expected"),
+    [(Verdict.PASS, "pass"), (Verdict.FAIL, "fail")],
+)
+def test_reviewed_attempt_records_its_verdict(verdict: Verdict, expected: str) -> None:
+    outcome = JudgeReviewed(verdict)
+
+    assert attempt_was_reviewed(outcome) is True
+    assert recorded_judge_verdict(outcome) == expected
+
+
+@pytest.mark.parametrize("reason", list(JudgeSkipReason))
+def test_skipped_attempt_records_deferred_whatever_the_reason(reason: JudgeSkipReason) -> None:
+    """Every skip is unreviewed and deferred; the reason is diagnostic only."""
+    outcome = JudgeSkipped(reason)
+
+    assert attempt_was_reviewed(outcome) is False
+    assert recorded_judge_verdict(outcome) == "deferred"
+
+
+def test_a_skipped_attempt_cannot_carry_a_verdict() -> None:
+    """The two variants are disjoint, so 'verdict without review' has no value."""
+    assert not hasattr(JudgeSkipped(JudgeSkipReason.NOT_REACHED), "verdict")
+    assert not hasattr(JudgeReviewed(Verdict.PASS), "reason")
+
+
+def test_an_attempt_outcome_is_immutable() -> None:
+    """An attempt's result is replaced by the next attempt, never updated."""
+    outcome = JudgeReviewed(Verdict.PASS)
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(outcome, "verdict", Verdict.FAIL)  # noqa: B010  # tracked: #288

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -3006,6 +3006,56 @@ def test_cadence_review_is_not_duplicated_for_provisional_retry(tmp_path, ref_fi
     assert stable.resolution is None
 
 
+def test_gate_retry_does_not_persist_the_previous_attempts_pass(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A judged attempt's ``pass`` must not describe a later unjudged attempt.
+
+    Attempt 1 is judged, passes, and then fails the framework accuracy gate,
+    which spends a retry. Attempt 2 returns no parseable response, so the
+    framework synthesizes a fail-closed one that no judge reviews. The round
+    record describes attempt 2, so it must carry ``deferred`` rather than
+    attempt 1's stale ``pass`` (issue #503).
+    """
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                hypothesis_id="gate-retry",
+                hypothesis="the gate rejects a stale checkpoint",
+                task="Build",
+                pass_criteria="tests",  # noqa: S106  # tracked: #288
+                reasoning="start",
+            )
+        ],
+        judge_verdicts=["pass"],
+        implementer_parse_failures=[False, True],
+    )
+
+    result = _invoke_orchestrate(
+        tmp_path,
+        ref_file,
+        runner,
+        max_rounds=1,
+        max_retries_per_round=2,
+        _accuracy_gate_results=["checker rejected history"],
+    )
+
+    assert result is True
+    assert runner.counters["impl"] == 2
+    assert runner.counters["judge"] == 1
+    rounds = _round_payloads(tmp_path)
+    assert len(rounds) == 1
+    assert rounds[0]["passed"] is False
+    assert rounds[0]["reviewed"] is False
+    assert rounds[0]["judge_verdict"] == "deferred"
+
+    project = _created_project(tmp_path)
+    state = Project.open(project).state
+    unified = AgentRunStateStore(state.portable_namespace(_run_id(project), "agent")).load()
+    hypothesis = reproject_run_evidence(unified).by_id("gate-retry")
+    assert hypothesis is not None
+    assert hypothesis.review is HypothesisReview.DEFERRED
+    assert hypothesis.resolution is not HypothesisResolution.REJECTED
+
+
 def test_unreviewed_terminal_outcome_returns_control_to_designer(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[


### PR DESCRIPTION
## Problem

PR #521 (thanks @AyanBinRafaih) fixed issue #503: a round whose final implementer attempt skipped the
judge persisted the *previous* attempt's verdict. The round record then said
`judge_verdict="fail"` with `reviewed=False`, and `_review` (which trusts
`judge_verdict` first) reprojected the still-active hypothesis as `rejected` on
every `--resume` and in the server read path.

That fix added the one missing reset. The structure that produced the bug is
still there:

- In `run_agent_loop`'s implementer/judge retry loop, about nine mutable
  variables are declared before `for retry in range(...)`. Some describe the
  round (best accepted implementation, official evaluation) and some describe
  the current attempt (`final_attempt_reviewed`, `judge_verdict`). Nothing in
  the code distinguishes the two lifetimes, so every attempt-scoped variable
  has to be reset by hand at the top of each iteration. `judge_verdict` was
  not, and the next attempt-scoped variable added there inherits the same trap.
- `RoundRecord` stores `reviewed: bool` *and*
  `judge_verdict: "pass" | "fail" | "deferred" | None`: two fields for one
  fact, so they can disagree. Records already on disk from #503 still carry the
  contradictory pair and still reproject to `rejected` today, because #521
  changed only what new rounds write.

Both are closed by construction here, so the state cannot be expressed again.

## Solution

**One immutable value per attempt.** New `src/vibesys/loops/agent/attempt.py`
defines a tagged union: `JudgeReviewed(verdict)` or
`JudgeSkipped(reason)`, both frozen dataclasses, with `JudgeSkipReason` as a
`StrEnum`. There is no value that means "verdict without review", so the
mutable `final_attempt_reviewed`/`judge_verdict` pair is gone: the loop assigns
a single `attempt_judge: JudgeOutcome` at the top of each iteration and at each
point where the attempt's fate is decided (unparseable implementer response,
sparse-review deferral, judge verdict, single-agent verdict). The two consumers
after the loop, `attempt_was_reviewed` and `recorded_judge_verdict`, branch
exhaustively with `assert_never`, so a new variant is a type error rather than
a silent default.

The round-scoped accumulators stay where they are, but the declaration block is
now split and labelled so the lifetime difference is visible: "round-scoped
accumulators … intentionally survive every attempt" versus "attempt-scoped
state … replaced wholesale at the top of every iteration".

**One field per fact in the persisted record.** `RoundRecord.judge_verdict` is
now the single source of truth and `reviewed` is a computed property
(`deferred` or a legacy-absent verdict means not reviewed). The on-disk key
`reviewed` is preserved: it maps to `legacy_reviewed`, which is authoritative
only for records written before `judge_verdict` existed, and `serialize_by_alias`
keeps the persisted schema byte-compatible in both directions. The loop no
longer passes `reviewed=` at all; it passes the verdict and the boolean follows.

**Compatibility normalization.** A `model_validator(mode="after")` rewrites any
record that pairs a `pass`/`fail` verdict with `reviewed=False` to `deferred`.
That state is only reachable through the #503 bug, so the rewrite repairs the
corrupt runs on load: a resumed run and the server read path now project such a
round as unreviewed and leave the hypothesis unresolved, instead of rejecting
it. It runs on every construction, so in-memory writers get the invariant too.

Why this makes the bug unrepresentable: the loop cannot carry a verdict past
the attempt that produced it (no mutable verdict variable survives an
iteration), the record cannot state a verdict it did not receive (`reviewed` is
derived, not stored), and any record that already does is normalized at the
parse boundary.

**Relationship to #311.** Open PR #311 extracts `_resolve_round_outcome` from
the post-loop bookkeeping in the same function and takes `final_attempt_reviewed`
as a parameter. This PR deliberately keeps that name: it is now derived once,
immediately after the loop, from the final attempt's outcome
(`final_attempt_reviewed = attempt_was_reviewed(attempt_judge)`), and the
`reviewed = final_attempt_reviewed if inner_loop == "multi-agent" else True`
line #311 moves is untouched. The two changes should merge with a conflict only
in the surrounding context, and #311 needs no change to its helper signature.

No server or TUI behavior changes: `src/server/api/experiments.py` reads
`record.reviewed` (now the property) and `_judge_verdict` already emits `None`
for `deferred`. No protocol model changed, so
`clients/backend-client/src/generated/` needs no regeneration.

### Architecture

`vs-loop-state` owns the persisted contract; the loop package owns the
attempt-scoped value; the projections stay pure readers.

```mermaid
flowchart TD
    subgraph loop["run_agent_loop: retry loop (per attempt)"]
        A["attempt N: implementer"] --> B{"judge runs?"}
        B -- "no: unparseable / sparse review" --> S["JudgeSkipped(reason)"]
        B -- "yes" --> R["JudgeReviewed(verdict)"]
    end
    S --> O["attempt_judge (final attempt only)"]
    R --> O
    O --> V["recorded_judge_verdict()"]
    O --> W["attempt_was_reviewed()"]
    V --> REC["RoundRecord.judge_verdict (stored)"]
    W --> RES["ResolutionEvidence.reviewed"]
    REC --> PROP["RoundRecord.reviewed (derived)"]
    REC --> NORM["_normalize_review on load: pass/fail + unreviewed -> deferred"]
    PROP --> PROJ["hypotheses._review / server experiments projection"]
    NORM --> PROJ
```

## Verification

New tests cover the loop path #521 fixed but did not test, the compatibility
normalization of existing records, and the new type. The full agent-loop,
server, `vs-loop-state`, and `vs-project` suites pass unchanged, which is the
evidence that the record refactor is behavior-preserving for every current
reader of `reviewed`.

I also confirmed the new orchestrate test is discriminating: with the loop's
skip-path assignments removed, it fails with the stale `pass` persisted. And I
checked by hand that a `RoundRecord` nested in `AgentRunState` still dumps the
`reviewed` key and reloads under `model_validate_json(..., strict=True)`, which
is how `vs-project` persists the unified state file.

### Correctness properties

- A round record's `judge_verdict` always describes the round's **final**
  implementer attempt; an earlier attempt's verdict cannot survive into it.
- `reviewed` is exactly `judge_verdict in {"pass", "fail"}` for every record
  the framework writes; the pair can no longer disagree.
- A skipped review is recorded as `deferred`, never as an absent verdict, so
  `None` continues to mean "record predates the verdict field".
- Loading a record with a `pass`/`fail` verdict and `reviewed=False` yields
  `deferred`/unreviewed, repairing runs corrupted by #503; the hypothesis
  projects as `DEFERRED` and stays unresolved rather than `REJECTED`.
- Legacy records (no `judge_verdict`) keep their stored `reviewed` value and
  their existing legacy adapters in `hypotheses.py` unchanged.
- The persisted JSON schema is unchanged: `reviewed` and `judge_verdict` keys
  are still written and still accepted, in round-record payloads and in the
  agent run state.
- Observable server/TUI output is unchanged: `HypothesisRound.reviewed` and the
  `ROUND_FINISHED` event carry the same values as before.

### Testing

```
uv run pytest tests/vibesys/loops/agent -q --no-cov          # 322 passed
uv run pytest tests/server -q --no-cov                       # 186 passed
uv run pytest libs/vs-loop-state/tests -q --no-cov            # 45 passed
uv run pytest libs/vs-project/tests -q --no-cov               # 201 passed
./scripts/check_format.sh                                     # 471 files already formatted
./scripts/check_lint.sh                                       # All checks passed!
./scripts/check_types.sh                                      # All checks passed! (uv run ty check)
```

Type checking uses the repository's `scripts/check_types.sh` (`ty`), which is
what `docs/contributing/development.md` wires up for Python types; no separate
Pyright configuration exists in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
