### PR TITLE
Model the run lifecycle as a state machine and publish every transition

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -148,10 +148,14 @@ export type Sequence = number;
  * Lifecycle status of one run, as frontends observe it.
  *
  * This is the authoritative closed set for the ``status`` field of
- * ``RunSnapshot``; the generated TypeScript protocol types derive their union
- * from it.
+ * ``RunSnapshot`` and of ``RunStatusChangedData``; the generated TypeScript
+ * protocol types derive their union from it.
+ *
+ * ``PAUSING`` and ``PAUSED`` are distinct because a pause is only applied at
+ * an invocation boundary: ``/pause`` records the request, and the run keeps
+ * executing the call already in flight until it reaches that boundary.
  */
-export type RunStatus = "starting" | "running" | "paused" | "completed" | "failed";
+export type RunStatus = "starting" | "running" | "pausing" | "paused" | "completed" | "failed";
 export type AgentKind = string | null;
 export type RoundLabel = string | null;
 export type ExecutionId = string;
@@ -181,6 +185,7 @@ export type EventType =
   | "run_started"
   | "experiments_changed"
   | "run_interrupted"
+  | "run_status_changed"
   | "chat"
   | "chat_thread_created"
   | "status_query"
@@ -225,6 +230,7 @@ export type Data =
       | ServerReadyData
       | RunStartedData
       | RunInterruptedData
+      | RunStatusChangedData
       | ExperimentsChangedData
       | ConfigurationFailedData
       | PhaseData
@@ -277,18 +283,19 @@ export type MaxRounds = number;
 export type Kind10 = "run_interrupted";
 export type Reason = string;
 export type Signal = string | null;
-export type Kind11 = "experiments_changed";
+export type Kind11 = "run_status_changed";
+export type Kind12 = "experiments_changed";
 export type Reason1 = "project_attached" | "active_hypothesis_changed" | "round_persisted";
-export type Kind12 = "configuration_failed";
+export type Kind13 = "configuration_failed";
 export type Code1 = string;
 export type Stage2 = string;
 export type Message = string;
 export type Usage = string | null;
 export type ExitCode = number;
-export type Kind13 = "phase";
+export type Kind14 = "phase";
 export type Phase = string;
 export type Attempt2 = number | null;
-export type Kind14 = "agent_output_chunk";
+export type Kind15 = "agent_output_chunk";
 export type Channel = "assistant" | "analysis" | "tool" | "diagnostic" | "prompt";
 export type Content1 = string;
 export type Progress = string | null;
@@ -296,49 +303,49 @@ export type AgentLabel = string | null;
 export type ElapsedSeconds = number;
 export type InputTokens = number;
 export type ContextWindow = number | null;
-export type Kind15 = "subprocess_output";
+export type Kind16 = "subprocess_output";
 export type ProcessId = string;
 export type ProcessKind = string;
 export type Stream1 = "stdout" | "stderr";
 export type Content2 = string;
-export type Kind16 = "judge_result";
+export type Kind17 = "judge_result";
 export type Verdict = "pass" | "fail";
 export type Feedback = string;
 export type Attempt3 = number;
-export type Kind17 = "benchmark_result";
+export type Kind18 = "benchmark_result";
 export type Metric = string;
 export type Value = number;
 export type Unit = string;
-export type Kind18 = "round_finished";
+export type Kind19 = "round_finished";
 export type Attempts = number;
 export type JudgeVerdict = "pass" | "fail" | "skipped";
 export type PerfMetric = number | null;
 export type PerfUnit = string | null;
-export type Kind19 = "tool_call";
+export type Kind20 = "tool_call";
 export type Tool1 = string;
 export type CallId = string | null;
-export type Kind20 = "tool_result";
+export type Kind21 = "tool_result";
 export type Tool2 = string;
 export type CallId1 = string | null;
 export type Content3 = string;
 export type IsError = boolean;
 export type Payload = (CommandResultPayload | JsonResultPayload) | null;
-export type Kind21 = "command";
+export type Kind22 = "command";
 export type Stdout = string;
 export type Stderr = string;
 export type ExitCode1 = number | null;
 export type Duration = number | null;
-export type Kind22 = "json";
+export type Kind23 = "json";
 export type Value1 =
   | {
       [k: string]: unknown;
     }
   | unknown[];
-export type Kind23 = "todo_update";
+export type Kind24 = "todo_update";
 export type Content4 = string;
 export type Status1 = string;
 export type Todos = TodoItemData[];
-export type Kind24 = "usage_update";
+export type Kind25 = "usage_update";
 export type InputTokens1 = number;
 export type ContextWindow1 = number | null;
 export type Model6 = string | null;
@@ -762,13 +769,28 @@ export interface RunInterruptedData {
   signal?: Signal;
   [k: string]: unknown;
 }
-export interface ExperimentsChangedData {
+/**
+ * One move of the run through its lifecycle.
+ *
+ * Carries the whole transition so a client folds the status instead of
+ * inferring it: ``status`` is the new value and ``previous`` the one it
+ * replaced. Which invocation boundary a pause landed on is on the event
+ * envelope (``agent_kind``, ``round_label``, ``execution_id``) like every
+ * other execution-scoped fact, not repeated here.
+ */
+export interface RunStatusChangedData {
   kind?: Kind11;
+  status: RunStatus;
+  previous: RunStatus;
+  [k: string]: unknown;
+}
+export interface ExperimentsChangedData {
+  kind?: Kind12;
   reason: Reason1;
   [k: string]: unknown;
 }
 export interface ConfigurationFailedData {
-  kind?: Kind12;
+  kind?: Kind13;
   code: Code1;
   stage: Stage2;
   message: Message;
@@ -777,13 +799,13 @@ export interface ConfigurationFailedData {
   [k: string]: unknown;
 }
 export interface PhaseData {
-  kind?: Kind13;
+  kind?: Kind14;
   phase: Phase;
   attempt?: Attempt2;
   [k: string]: unknown;
 }
 export interface AgentOutputChunkData {
-  kind?: Kind14;
+  kind?: Kind15;
   channel: Channel;
   content: Content1;
   status?: AgentStatusData | null;
@@ -805,7 +827,7 @@ export interface AgentStatusData {
   [k: string]: unknown;
 }
 export interface SubprocessOutputData {
-  kind?: Kind15;
+  kind?: Kind16;
   process_id: ProcessId;
   process_kind: ProcessKind;
   stream: Stream1;
@@ -813,21 +835,21 @@ export interface SubprocessOutputData {
   [k: string]: unknown;
 }
 export interface JudgeResultData {
-  kind?: Kind16;
+  kind?: Kind17;
   verdict: Verdict;
   feedback: Feedback;
   attempt: Attempt3;
   [k: string]: unknown;
 }
 export interface BenchmarkResultData {
-  kind?: Kind17;
+  kind?: Kind18;
   metric: Metric;
   value: Value;
   unit: Unit;
   [k: string]: unknown;
 }
 export interface RoundFinishedData {
-  kind?: Kind18;
+  kind?: Kind19;
   attempts: Attempts;
   judge_verdict: JudgeVerdict;
   perf_metric?: PerfMetric;
@@ -835,7 +857,7 @@ export interface RoundFinishedData {
   [k: string]: unknown;
 }
 export interface ToolCallData {
-  kind?: Kind19;
+  kind?: Kind20;
   tool: Tool1;
   call_id?: CallId;
   args?: Args;
@@ -846,7 +868,7 @@ export interface Args {
   [k: string]: unknown;
 }
 export interface ToolResultData {
-  kind?: Kind20;
+  kind?: Kind21;
   tool: Tool2;
   call_id?: CallId1;
   content: Content3;
@@ -858,7 +880,7 @@ export interface ToolResultData {
  * Structured result of a command-style tool execution.
  */
 export interface CommandResultPayload {
-  kind?: Kind21;
+  kind?: Kind22;
   stdout: Stdout;
   stderr: Stderr;
   exit_code?: ExitCode1;
@@ -869,12 +891,12 @@ export interface CommandResultPayload {
  * A tool result that is a JSON object or array, already parsed.
  */
 export interface JsonResultPayload {
-  kind?: Kind22;
+  kind?: Kind23;
   value: Value1;
   [k: string]: unknown;
 }
 export interface TodoUpdateData {
-  kind?: Kind23;
+  kind?: Kind24;
   todos?: Todos;
   [k: string]: unknown;
 }
@@ -884,7 +906,7 @@ export interface TodoItemData {
   [k: string]: unknown;
 }
 export interface UsageUpdateData {
-  kind?: Kind24;
+  kind?: Kind25;
   input_tokens: InputTokens1;
   context_window?: ContextWindow1;
   model?: Model6;

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -1069,6 +1069,7 @@
         "run_started",
         "experiments_changed",
         "run_interrupted",
+        "run_status_changed",
         "chat",
         "chat_thread_created",
         "status_query",
@@ -2404,6 +2405,7 @@
                   "round_finished": "#/$defs/RoundFinishedData",
                   "run_interrupted": "#/$defs/RunInterruptedData",
                   "run_started": "#/$defs/RunStartedData",
+                  "run_status_changed": "#/$defs/RunStatusChangedData",
                   "server_ready": "#/$defs/ServerReadyData",
                   "subprocess_output": "#/$defs/SubprocessOutputData",
                   "todo_update": "#/$defs/TodoUpdateData",
@@ -2446,6 +2448,9 @@
                 },
                 {
                   "$ref": "#/$defs/RunInterruptedData"
+                },
+                {
+                  "$ref": "#/$defs/RunStatusChangedData"
                 },
                 {
                   "$ref": "#/$defs/ExperimentsChangedData"
@@ -2628,16 +2633,40 @@
       "type": "object"
     },
     "RunStatus": {
-      "description": "Lifecycle status of one run, as frontends observe it.\n\nThis is the authoritative closed set for the ``status`` field of\n``RunSnapshot``; the generated TypeScript protocol types derive their union\nfrom it.",
+      "description": "Lifecycle status of one run, as frontends observe it.\n\nThis is the authoritative closed set for the ``status`` field of\n``RunSnapshot`` and of ``RunStatusChangedData``; the generated TypeScript\nprotocol types derive their union from it.\n\n``PAUSING`` and ``PAUSED`` are distinct because a pause is only applied at\nan invocation boundary: ``/pause`` records the request, and the run keeps\nexecuting the call already in flight until it reaches that boundary.",
       "enum": [
         "starting",
         "running",
+        "pausing",
         "paused",
         "completed",
         "failed"
       ],
       "title": "RunStatus",
       "type": "string"
+    },
+    "RunStatusChangedData": {
+      "description": "One move of the run through its lifecycle.\n\nCarries the whole transition so a client folds the status instead of\ninferring it: ``status`` is the new value and ``previous`` the one it\nreplaced. Which invocation boundary a pause landed on is on the event\nenvelope (``agent_kind``, ``round_label``, ``execution_id``) like every\nother execution-scoped fact, not repeated here.",
+      "properties": {
+        "kind": {
+          "const": "run_status_changed",
+          "default": "run_status_changed",
+          "title": "Kind",
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/RunStatus"
+        },
+        "previous": {
+          "$ref": "#/$defs/RunStatus"
+        }
+      },
+      "required": [
+        "status",
+        "previous"
+      ],
+      "title": "RunStatusChangedData",
+      "type": "object"
     },
     "ServerReadyData": {
       "properties": {

--- a/clients/backend-client/src/protocol.ts
+++ b/clients/backend-client/src/protocol.ts
@@ -4,7 +4,7 @@ export type ProtocolRequest = ProtocolDocument['request'];
 export type ProtocolResponse = ProtocolDocument['response'];
 export type RunEvent = ProtocolDocument['event'];
 export type RunSnapshot = ProtocolDocument['snapshot'];
-/** Run lifecycle statuses the backend reports. Source: `RunStatus` in `src/server/controller.py`. */
+/** Run lifecycle statuses the backend reports. Source: `RunStatus` in `src/server/run_lifecycle.py`. */
 export type RunStatus = RunSnapshot['status'];
 export type ServerMessage = ProtocolDocument['server_message'];
 export type Diagnostic = NonNullable<ProtocolResponse['diagnostic']>;

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -675,6 +675,7 @@ describe('whether a run has ended', () => {
     expect(hasRunEnded(withStatus('connecting'))).toBe(false);
     expect(hasRunEnded(withStatus('starting'))).toBe(false);
     expect(hasRunEnded(withStatus('running'))).toBe(false);
+    expect(hasRunEnded(withStatus('pausing'))).toBe(false);
     expect(hasRunEnded(withStatus('paused'))).toBe(false);
   });
 
@@ -697,6 +698,80 @@ describe('whether a run has ended', () => {
         ...baseEvent(2, 'run_started'),
         data: {kind: 'run_started', outer_loop: 'agent', input: '.', max_rounds: 3},
       },
+    ]);
+
+    expect(state.status).toBe('running');
+    expect(hasRunEnded(state)).toBe(false);
+  });
+});
+
+// The backend owns the run lifecycle and publishes every move through it. The
+// projection folds those events and holds no lifecycle flag of its own, so a
+// pause is visible for exactly as long as the backend says it lasts.
+describe('the run lifecycle', () => {
+  const statusEvent = (sequence: number, status: CoreRunStatus, previous: CoreRunStatus) =>
+    ({
+      ...baseEvent(sequence, 'run_status_changed'),
+      data: {kind: 'run_status_changed', status, previous},
+    }) as RunEvent;
+
+  it('folds a pause request, its boundary, and the resume', () => {
+    const requested = reduceEvent(initialCoreState(), statusEvent(1, 'pausing', 'running'));
+    expect(requested.status).toBe('pausing');
+
+    const paused = reduceEvent(requested, statusEvent(2, 'paused', 'pausing'));
+    expect(paused.status).toBe('paused');
+
+    const resumed = reduceEvent(paused, statusEvent(3, 'running', 'paused'));
+    expect(resumed.status).toBe('running');
+    expect(hasRunEnded(resumed)).toBe(false);
+  });
+
+  it('ends a run that was paused when it stopped', () => {
+    const state = reduceEventBatch(initialCoreState(), [
+      statusEvent(1, 'pausing', 'running'),
+      statusEvent(2, 'paused', 'pausing'),
+      statusEvent(3, 'completed', 'paused'),
+    ]);
+
+    expect(state.status).toBe('completed');
+    expect(hasRunEnded(state)).toBe(true);
+  });
+
+  it('drops the active executions of a run that ended while paused', () => {
+    const running = reduceSnapshot(initialCoreState(), {
+      run_id: 'run',
+      status: 'paused',
+      sequence: 1,
+      active_executions: [checkpoint('exec-1')],
+    } satisfies RunSnapshot);
+
+    const state = reduceEvent(running, statusEvent(2, 'failed', 'paused'));
+
+    expect(state.activeExecutions).toEqual({});
+  });
+
+  it('keeps an ended run ended against a snapshot no newer than the fold', () => {
+    const ended = reduceEventBatch(initialCoreState(), [
+      statusEvent(1, 'pausing', 'running'),
+      statusEvent(2, 'completed', 'pausing'),
+      baseEvent(3, 'run_finished'),
+    ]);
+
+    const stale = reduceSnapshot(ended, {
+      run_id: 'run',
+      status: 'running',
+      sequence: 3,
+    } satisfies RunSnapshot);
+
+    expect(stale.status).toBe('completed');
+  });
+
+  it('reads a resumed run as running from the transition after the replay', () => {
+    const state = reduceEventBatch(initialCoreState(), [
+      statusEvent(1, 'completed', 'running'),
+      baseEvent(2, 'run_finished'),
+      statusEvent(3, 'running', 'starting'),
     ]);
 
     expect(state.status).toBe('running');

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -201,17 +201,23 @@ export function initialCoreState(): CoreState {
  * `false`.
  */
 export function hasRunEnded(state: CoreState): boolean {
-  switch (state.status) {
+  return endedRunStatus(state.status) !== null;
+}
+
+/** The ended status `status` is, or `null` while the run can still move on. */
+function endedRunStatus(status: CoreRunStatus): EndedRunStatus | null {
+  switch (status) {
     case 'completed':
     case 'failed':
-      return true;
+      return status;
     case 'connecting':
     case 'starting':
     case 'running':
+    case 'pausing':
     case 'paused':
-      return false;
+      return null;
     default: {
-      const unhandled: never = state.status;
+      const unhandled: never = status;
       return unhandled;
     }
   }
@@ -240,6 +246,11 @@ export function reduceSnapshot(state: CoreState, snapshot: RunSnapshot): CoreSta
     state,
   );
   if (snapshot.sequence < registered.sequence) return registered;
+  // Boot issues the snapshot query and the subscription concurrently, so a
+  // snapshot can arrive after the events it was taken alongside. Once the fold
+  // has seen the run end, a snapshot no newer than the fold cannot un-end it;
+  // a genuinely newer one (a resumed run) still applies.
+  if (hasRunEnded(registered) && snapshot.sequence <= registered.sequence) return registered;
   return {
     ...registered,
     status: snapshot.status,
@@ -556,6 +567,9 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
     ];
   }
   if (data?.kind === 'experiments_changed') next.experimentsRevision = sequence;
+  // The backend owns the run's lifecycle and publishes every move through it,
+  // so the projection folds the status it is told rather than inferring one.
+  if (data?.kind === 'run_status_changed') next = applyRunStatus(next, data.status);
 
   const legacyToolChunk =
     data?.kind === 'agent_output_chunk' && data.channel === 'tool' && next.typedToolEvents;
@@ -589,6 +603,12 @@ export function latestDiagnosticChange(
     current.diagnostics.find((diagnostic, index) => diagnostic !== previous.diagnostics[index]) ??
     null
   );
+}
+
+/** Folds one backend-published status, ending the run when that status has. */
+function applyRunStatus(state: CoreState, status: CoreRunStatus): CoreState {
+  const ended = endedRunStatus(status);
+  return ended === null ? {...state, status} : terminate(state, ended);
 }
 
 function terminate(state: CoreState, status: EndedRunStatus): CoreState {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it, test} from 'bun:test';
-import type {RunEvent} from '@vibesys/backend-client';
-import {hasRunEnded} from '@vibesys/core-state';
+import type {RunEvent, RunStatus} from '@vibesys/backend-client';
+import {type CoreRunStatus, hasRunEnded} from '@vibesys/core-state';
 import type {SessionState} from './session-model.js';
 import {
   applyActiveExecutionCheckpoint,
@@ -1327,6 +1327,40 @@ describe('session event model', () => {
     expect(state.todosExpanded).toBe(false);
     expect(toggleTodos(state).todosExpanded).toBe(true);
     expect(toggleTodos(toggleTodos(state)).todosExpanded).toBe(false);
+  });
+
+  // The header carries exactly one status token, read from backend-owned core
+  // state. `/pause` is visible as `pausing…` until the backend says the pause
+  // landed, and the run's ended status replaces it rather than joining it.
+  it('renders one header status token per backend run status', () => {
+    const withStatus = (status: CoreRunStatus): string =>
+      statusText({
+        ...initialSessionState(),
+        core: {...initialSessionState().core, status},
+      });
+
+    expect(withStatus('running')).toBe('running · starting · no round yet');
+    expect(withStatus('pausing')).toBe('pausing… · starting · no round yet');
+    expect(withStatus('paused')).toBe('paused · starting · no round yet');
+    expect(withStatus('completed')).toBe('completed · starting · no round yet');
+  });
+
+  it('reads a pause from the backend and drops it when the run ends', () => {
+    const statusChange = (sequence: number, status: RunStatus, previous: RunStatus) =>
+      event(sequence, 'run_status_changed', {
+        kind: 'run_status_changed',
+        status,
+        previous,
+      });
+
+    let state = applyEvent(initialSessionState(), statusChange(1, 'pausing', 'running'));
+    expect(statusText(state)).toContain('pausing…');
+    state = applyEvent(state, statusChange(2, 'paused', 'pausing'));
+    expect(statusText(state)).toContain('paused');
+    state = applyEvent(state, statusChange(3, 'completed', 'paused'));
+
+    expect(statusText(state)).toContain('completed');
+    expect(statusText(state)).not.toContain('paused');
   });
 
   it('feeds usage updates into the status token meter', () => {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -11,6 +11,7 @@ import {
   type AgentPhase,
   type ChatThread,
   type CoreDiagnostic,
+  type CoreRunStatus,
   type CoreState,
   DEFAULT_CHAT_THREAD_ID,
   type ExecutionTodos,
@@ -1753,8 +1754,34 @@ export function showDetail(
   return {...state, overlay: {kind, content}};
 }
 
+/**
+ * How one backend run status reads in the header.
+ *
+ * The header shows exactly one status token, and it is this one: the backend
+ * owns the run's lifecycle, so there is no second flag to prefix. The switch is
+ * exhaustive, making a new status a compile error rather than a raw token.
+ */
+export function runStatusLabel(status: CoreRunStatus): string {
+  switch (status) {
+    case 'pausing':
+      // Requested, but the call already in flight has to finish first.
+      return 'pausing…';
+    case 'connecting':
+    case 'starting':
+    case 'running':
+    case 'paused':
+    case 'completed':
+    case 'failed':
+      return status;
+    default: {
+      const unhandled: never = status;
+      return unhandled;
+    }
+  }
+}
+
 export function statusText(state: SessionState): string {
-  const base = `${state.core.status} · ${state.core.agentKind ?? 'starting'} · ${state.core.roundLabel ?? 'no round yet'}`;
+  const base = `${runStatusLabel(state.core.status)} · ${state.core.agentKind ?? 'starting'} · ${state.core.roundLabel ?? 'no round yet'}`;
   if (state.core.usage === null) return base;
   const used = formatTokenCount(state.core.usage.inputTokens);
   const meter =

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -114,6 +114,24 @@ describe('OpenTUI presentation', () => {
     expect(frame).toContain('Type /help for commands');
   });
 
+  // A command ack for /pause or /steer submitted from the modal chat has to
+  // render over that modal, and under the theme picker.
+  it('stacks the command overlay above the chat modal and below the theme picker', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(initialSessionState());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('Command'));
+
+    const root = testRenderer.renderer.root;
+    const overlay = root.findDescendantById('overlay')?.zIndex;
+    const chatModal = root.findDescendantById('chat-overlay')?.zIndex;
+    const themePicker = root.findDescendantById('theme-picker')?.zIndex;
+
+    expect(overlay).toBeGreaterThan(chatModal ?? Number.POSITIVE_INFINITY);
+    expect(overlay).toBeLessThan(themePicker ?? Number.NEGATIVE_INFINITY);
+  });
+
   it('shows and dismisses a fatal error above the empty experiment log', async () => {
     const testRenderer = await createTestRenderer({width: 100, height: 24});
     const controller = new FakeController(initialSessionState());

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -41,7 +41,9 @@ export class OverlayView {
       borderStyle: 'rounded',
       borderColor: theme.info,
       backgroundColor: theme.elevatedSurface,
-      zIndex: 10,
+      // Above the chat modal (20), below the theme picker (30): a command ack
+      // submitted from the modal chat has to be visible over it.
+      zIndex: 25,
     });
   }
 

--- a/src/server/api/protocol.py
+++ b/src/server/api/protocol.py
@@ -9,10 +9,10 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat
 
 from server.chat.options import ChatOptions
-from server.controller import RunStatus
 from server.diagnostics import Diagnostic, DiagnosticScope, exception_to_diagnostic
 from server.events import RunEvent
 from server.execution import ActiveAgentExecution
+from server.run_lifecycle import RunStatus
 from server.settings import InteractiveSetupDefaults
 
 PROTOCOL_VERSION = 1

--- a/src/server/chat/manager.py
+++ b/src/server/chat/manager.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
     import threading
 
     from server.chat.options import ChatRunSettings
-    from server.controller import RunStatus
     from server.journal import EventJournal
+    from server.run_lifecycle import RunStatus
 
 _CHAT_DRAIN_TIMEOUT_SECONDS = 5.0
 _CHAT_THREAD_TITLE_MAX_CHARS = 40

--- a/src/server/controller.py
+++ b/src/server/controller.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import StrEnum
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING, Any
 
 from server.diagnostics import Diagnostic, DiagnosticScope, DiagnosticSeverity
-from server.events import EventStatus, EventType
+from server.events import EventStatus, EventType, RunStatusChangedData
+from server.run_lifecycle import RunStatus, RunTrigger, transition
 
 if TYPE_CHECKING:
     import threading
@@ -16,30 +16,6 @@ if TYPE_CHECKING:
     from server.execution import ExecutionHandle, ExecutionTracker
     from server.journal import EventJournal
     from vs_project import Project, StateSnapshot
-
-
-class RunStatus(StrEnum):
-    """Lifecycle status of one run, as frontends observe it.
-
-    This is the authoritative closed set for the ``status`` field of
-    ``RunSnapshot``; the generated TypeScript protocol types derive their union
-    from it.
-    """
-
-    STARTING = "starting"
-    RUNNING = "running"
-    PAUSED = "paused"
-    COMPLETED = "completed"
-    FAILED = "failed"
-
-    @property
-    def has_ended(self) -> bool:
-        """Whether the run has settled into a status it never leaves."""
-        match self:
-            case RunStatus.COMPLETED | RunStatus.FAILED:
-                return True
-            case RunStatus.STARTING | RunStatus.RUNNING | RunStatus.PAUSED:
-                return False
 
 
 @dataclass(frozen=True)
@@ -70,10 +46,8 @@ class RunController:
         self._condition = condition
         self._journal = journal
         self._executions = executions
-        self._pause_after_call = False
-        self._paused = False
         self._pending_steer: list[str] = []
-        self._run_status: RunStatus = RunStatus.STARTING
+        self._status: RunStatus = RunStatus.STARTING
         self._project_run: ProjectRunState | None = None
 
     @property
@@ -101,27 +75,56 @@ class RunController:
             if project is not None and run_id is not None:
                 self._project_run = ProjectRunState(project, run_id)
             self._journal.attach(log_dir, run_id=run_id)
-            self._run_status = RunStatus.RUNNING
+            self._apply_locked(RunTrigger.ATTACHED)
+
+    def _apply_locked(
+        self,
+        trigger: RunTrigger,
+        *,
+        agent_kind: str | None = None,
+        round_label: str | None = None,
+        execution_id: str | None = None,
+    ) -> RunStatus:
+        """Apply one lifecycle trigger and publish the change it caused.
+
+        The caller must already hold ``self._condition``. Mutating the status
+        and recording its event under the same lock is what keeps event order
+        and state order the same: a snapshot taken at any sequence agrees with
+        the fold of the events up to that sequence. A trigger the current
+        status absorbs changes nothing and publishes nothing.
+        """
+        previous = self._status
+        current = transition(previous, trigger)
+        if current is previous:
+            return current
+        self._status = current
+        self._journal.record(
+            EventType.RUN_STATUS_CHANGED,
+            data=RunStatusChangedData(status=current, previous=previous),
+            agent_kind=agent_kind,
+            round_label=round_label,
+            execution_id=execution_id,
+        )
+        self._condition.notify_all()
+        return current
 
     def pause_after_call(self) -> None:
         """Request a pause after the current controlled invocation finishes."""
         with self._condition:
-            self._pause_after_call = True
-        self._journal.record(EventType.CONTROL, "/pause", status=EventStatus.PENDING)
+            self._apply_locked(RunTrigger.PAUSE_REQUESTED)
+            self._journal.record(EventType.CONTROL, "/pause", status=EventStatus.PENDING)
 
     def resume(self) -> None:
         """Resume controlled invocations and clear a pending pause."""
         with self._condition:
-            self._paused = False
-            self._pause_after_call = False
-            self._condition.notify_all()
-        self._journal.record(EventType.CONTROL, "/resume", status=EventStatus.CONSUMED)
+            self._apply_locked(RunTrigger.RESUMED)
+            self._journal.record(EventType.CONTROL, "/resume", status=EventStatus.CONSUMED)
 
     def steer(self, text: str) -> None:
         """Queue operator guidance for the next controlled invocation."""
         with self._condition:
             self._pending_steer.append(text)
-        self._journal.record(EventType.CONTROL, f"/steer: {text}", status=EventStatus.PENDING)
+            self._journal.record(EventType.CONTROL, f"/steer: {text}", status=EventStatus.PENDING)
 
     def start_agent_execution(  # noqa: PLR0913
         self,
@@ -139,7 +142,7 @@ class RunController:
     ) -> ExecutionHandle:
         """Enter one invocation boundary, applying pause and steering state."""
         with self._condition:
-            while participates_in_run_control and self._paused:
+            while participates_in_run_control and self._status is RunStatus.PAUSED:
                 self._condition.wait()
             steering = (
                 self._pending_steer if consume_steering and participates_in_run_control else []
@@ -190,10 +193,11 @@ class RunController:
         del kind, round_label
         resolved_id = self._executions.resolve_legacy(execution_id)
         if resolved_id is None:
+            # A finish with no execution to match: the compatibility boundary
+            # was never entered on this thread. It is still an invocation
+            # boundary, so a pending pause lands here like anywhere else.
             with self._condition:
-                if self._pause_after_call:
-                    self._pause_after_call = False
-                    self._paused = True
+                self._reach_pause_boundary_locked()
             return
         with self._condition:
             active, controlled = self._executions.finish_locked(
@@ -201,19 +205,38 @@ class RunController:
             )
             if active is None:
                 return
-            should_pause = controlled and self._pause_after_call
-            if should_pause:
-                self._pause_after_call = False
-                self._paused = True
-                self._journal.record(
-                    EventType.CONTROL,
-                    "/pause",
-                    status=EventStatus.CONSUMED,
+            if controlled:
+                self._reach_pause_boundary_locked(
                     agent_kind=active.agent_kind,
                     round_label=active.round_label,
                     execution_id=resolved_id,
                 )
         self._executions.clear_legacy(resolved_id)
+
+    def _reach_pause_boundary_locked(
+        self,
+        *,
+        agent_kind: str | None = None,
+        round_label: str | None = None,
+        execution_id: str | None = None,
+    ) -> None:
+        """Apply the invocation boundary, pausing only if one was requested."""
+        reached = self._apply_locked(
+            RunTrigger.INVOCATION_FINISHED,
+            agent_kind=agent_kind,
+            round_label=round_label,
+            execution_id=execution_id,
+        )
+        if reached is not RunStatus.PAUSED:
+            return
+        self._journal.record(
+            EventType.CONTROL,
+            "/pause",
+            status=EventStatus.CONSUMED,
+            agent_kind=agent_kind,
+            round_label=round_label,
+            execution_id=execution_id,
+        )
 
     def status(self) -> str:
         """Return a compact human-readable run status."""
@@ -224,12 +247,33 @@ class RunController:
 
     def status_locked(self) -> RunStatus:
         """Return run status while the caller holds the shared condition."""
-        return RunStatus.PAUSED if self._paused else self._run_status
+        return self._status
 
     def run_status(self) -> RunStatus:
         """Return the run status token, including whether the run has ended."""
         with self._condition:
-            return self._run_status
+            return self._status
+
+    def settle(self, trigger: RunTrigger) -> bool:
+        """End the run without a terminal event, reporting whether it did.
+
+        The projection of a core terminal event calls this before appending
+        that event, so the status change is ordered ahead of it: a snapshot at
+        any sequence that contains the terminal event already reports an ended
+        status. ``finish`` then finds the run ended and records nothing twice.
+        """
+        with self._condition:
+            return self._settle_locked(trigger)
+
+    def _settle_locked(self, trigger: RunTrigger) -> bool:
+        """End the run exactly once, interrupting controlled work first."""
+        if self._status.has_ended:
+            return False
+        self._executions.interrupt_controlled_locked()
+        # An ended status is not PAUSED, so ending a paused run releases the
+        # thread parked at the pause wait instead of leaving it to re-wait.
+        self._apply_locked(trigger)
+        return True
 
     def finish(
         self,
@@ -239,12 +283,8 @@ class RunController:
         diagnostic: Diagnostic | None = None,
     ) -> None:
         """Transition the run to its ended state exactly once."""
-        with self._condition:
-            if self._run_status.has_ended:
-                return
-            self._executions.interrupt_controlled_locked()
-            self._run_status = RunStatus.FAILED if error else RunStatus.COMPLETED
-            self._condition.notify_all()
+        if not self.settle(RunTrigger.FAILED if error else RunTrigger.COMPLETED):
+            return
         event_diagnostic = diagnostic
         if error is not None and event_diagnostic is not None:
             event_diagnostic = event_diagnostic.model_copy(

--- a/src/server/events.py
+++ b/src/server/events.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, ValidationError, model_validator
 
 from server.diagnostics import Diagnostic
+from server.run_lifecycle import RunStatus
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -27,6 +28,7 @@ class EventType(StrEnum):  # noqa: D101  # tracked: #288
     RUN_STARTED = "run_started"
     EXPERIMENTS_CHANGED = "experiments_changed"
     RUN_INTERRUPTED = "run_interrupted"
+    RUN_STATUS_CHANGED = "run_status_changed"
     CHAT = "chat"
     CHAT_THREAD_CREATED = "chat_thread_created"
     STATUS_QUERY = "status_query"
@@ -174,6 +176,21 @@ class RunInterruptedData(EventPayload):  # noqa: D101  # tracked: #288
     kind: Literal["run_interrupted"] = "run_interrupted"
     reason: str
     signal: str | None = None
+
+
+class RunStatusChangedData(EventPayload):
+    """One move of the run through its lifecycle.
+
+    Carries the whole transition so a client folds the status instead of
+    inferring it: ``status`` is the new value and ``previous`` the one it
+    replaced. Which invocation boundary a pause landed on is on the event
+    envelope (``agent_kind``, ``round_label``, ``execution_id``) like every
+    other execution-scoped fact, not repeated here.
+    """
+
+    kind: Literal["run_status_changed"] = "run_status_changed"
+    status: RunStatus
+    previous: RunStatus
 
 
 class ExperimentsChangedData(EventPayload):  # noqa: D101  # tracked: #288
@@ -324,6 +341,7 @@ EventData = Annotated[
     | ServerReadyData
     | RunStartedData
     | RunInterruptedData
+    | RunStatusChangedData
     | ExperimentsChangedData
     | ConfigurationFailedData
     | PhaseData

--- a/src/server/integration.py
+++ b/src/server/integration.py
@@ -14,6 +14,7 @@ from server.chat.factory import (
 )
 from server.chat.options import ChatRunSettings
 from server.events import EventData, EventStatus, EventType, RunEvent
+from server.run_lifecycle import RunTrigger
 from vibesys.agents.factory import supported_cli_providers
 from vibesys.render.sink import output_sink
 from vibesys.run.event_journal import EventJournal as CoreEventJournal
@@ -36,6 +37,16 @@ if TYPE_CHECKING:
     from vs_project import Project
 
 _EVENT_DATA_ADAPTER = TypeAdapter(EventData)
+_TERMINAL_TRIGGERS: dict[EventType, RunTrigger] = {
+    EventType.RUN_FINISHED: RunTrigger.COMPLETED,
+    EventType.RUN_FAILED: RunTrigger.FAILED,
+}
+"""How a core terminal event ends the run the server reports.
+
+The core owns when a run stops; the controller owns the status frontends read.
+Settling the controller before the terminal event is appended is what orders
+the status change ahead of it in the journal.
+"""
 _PRESENTATION_EVENTS = frozenset(
     {
         EventType.AGENT_OUTPUT_CHUNK,
@@ -300,6 +311,9 @@ class RunIntegrationAdapter:
                 invocation_id=event.execution_id,
             )
             return
+        terminal_trigger = _TERMINAL_TRIGGERS.get(event_type)
+        if terminal_trigger is not None:
+            self.controller.settle(terminal_trigger)
         self.journal.append(
             RunEvent(
                 timestamp=event.timestamp,

--- a/src/server/journal.py
+++ b/src/server/journal.py
@@ -62,6 +62,7 @@ _LEGACY_LIFECYCLE_EVENTS = frozenset({EventType.INVOCATION_STARTED, EventType.IN
 _BOOTSTRAP_SPINE_TYPES = frozenset(
     {
         EventType.RUN_STARTED,
+        EventType.RUN_STATUS_CHANGED,
         EventType.RUN_FINISHED,
         EventType.RUN_FAILED,
         EventType.RUN_INTERRUPTED,

--- a/src/server/run_lifecycle.py
+++ b/src/server/run_lifecycle.py
@@ -1,0 +1,136 @@
+"""The run lifecycle: its statuses, its triggers, and the legal moves between.
+
+Pure module. It owns what a run's status may become and nothing else: no
+locks, no journal, no I/O. :class:`~server.controller.RunController` owns the
+current value and the side effects of changing it, so the rules here can be
+enumerated in a unit test without composing a server.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Final
+
+
+class RunStatus(StrEnum):
+    """Lifecycle status of one run, as frontends observe it.
+
+    This is the authoritative closed set for the ``status`` field of
+    ``RunSnapshot`` and of ``RunStatusChangedData``; the generated TypeScript
+    protocol types derive their union from it.
+
+    ``PAUSING`` and ``PAUSED`` are distinct because a pause is only applied at
+    an invocation boundary: ``/pause`` records the request, and the run keeps
+    executing the call already in flight until it reaches that boundary.
+    """
+
+    STARTING = "starting"
+    RUNNING = "running"
+    PAUSING = "pausing"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+    @property
+    def has_ended(self) -> bool:
+        """Whether the run has settled into a status it never leaves."""
+        match self:
+            case RunStatus.COMPLETED | RunStatus.FAILED:
+                return True
+            case RunStatus.STARTING | RunStatus.RUNNING | RunStatus.PAUSING | RunStatus.PAUSED:
+                return False
+
+
+class RunTrigger(StrEnum):
+    """What happened to a run, in the vocabulary the controller observes.
+
+    Triggers are facts, not commands: ``INVOCATION_FINISHED`` fires at every
+    controlled invocation boundary whether or not a pause is pending, and the
+    transition table decides whether that boundary is where a pause lands.
+    """
+
+    ATTACHED = "attached"
+    """Durable run storage was attached; the run may execute.
+
+    A run can be attached more than once (a later attach re-bootstraps the
+    journal), so this trigger is idempotent once the run is under way.
+    """
+
+    PAUSE_REQUESTED = "pause_requested"
+    """An operator asked to pause at the next invocation boundary."""
+
+    INVOCATION_FINISHED = "invocation_finished"
+    """A controlled invocation reached its boundary."""
+
+    RESUMED = "resumed"
+    """An operator asked to resume, cancelling any pending pause."""
+
+    COMPLETED = "completed"
+    """The run finished its work."""
+
+    FAILED = "failed"
+    """The run stopped because of an error or an interruption."""
+
+
+class IllegalRunTransitionError(Exception):
+    """A trigger the run's current status cannot accept."""
+
+    def __init__(self, current: RunStatus, trigger: RunTrigger) -> None:
+        """Name the rejected pair so the caller's log identifies the bug."""
+        super().__init__(
+            f"a run in status {current.value!r} cannot accept trigger {trigger.value!r}"
+        )
+        self.current = current
+        self.trigger = trigger
+
+
+_TRANSITIONS: Final[MappingProxyType[tuple[RunStatus, RunTrigger], RunStatus]] = MappingProxyType(
+    {
+        (RunStatus.STARTING, RunTrigger.ATTACHED): RunStatus.RUNNING,
+        (RunStatus.STARTING, RunTrigger.COMPLETED): RunStatus.COMPLETED,
+        (RunStatus.STARTING, RunTrigger.FAILED): RunStatus.FAILED,
+        (RunStatus.RUNNING, RunTrigger.ATTACHED): RunStatus.RUNNING,
+        (RunStatus.RUNNING, RunTrigger.PAUSE_REQUESTED): RunStatus.PAUSING,
+        (RunStatus.RUNNING, RunTrigger.INVOCATION_FINISHED): RunStatus.RUNNING,
+        (RunStatus.RUNNING, RunTrigger.RESUMED): RunStatus.RUNNING,
+        (RunStatus.RUNNING, RunTrigger.COMPLETED): RunStatus.COMPLETED,
+        (RunStatus.RUNNING, RunTrigger.FAILED): RunStatus.FAILED,
+        (RunStatus.PAUSING, RunTrigger.ATTACHED): RunStatus.PAUSING,
+        (RunStatus.PAUSING, RunTrigger.PAUSE_REQUESTED): RunStatus.PAUSING,
+        (RunStatus.PAUSING, RunTrigger.INVOCATION_FINISHED): RunStatus.PAUSED,
+        (RunStatus.PAUSING, RunTrigger.RESUMED): RunStatus.RUNNING,
+        (RunStatus.PAUSING, RunTrigger.COMPLETED): RunStatus.COMPLETED,
+        (RunStatus.PAUSING, RunTrigger.FAILED): RunStatus.FAILED,
+        (RunStatus.PAUSED, RunTrigger.ATTACHED): RunStatus.PAUSED,
+        (RunStatus.PAUSED, RunTrigger.PAUSE_REQUESTED): RunStatus.PAUSED,
+        (RunStatus.PAUSED, RunTrigger.INVOCATION_FINISHED): RunStatus.PAUSED,
+        (RunStatus.PAUSED, RunTrigger.RESUMED): RunStatus.RUNNING,
+        (RunStatus.PAUSED, RunTrigger.COMPLETED): RunStatus.COMPLETED,
+        (RunStatus.PAUSED, RunTrigger.FAILED): RunStatus.FAILED,
+    }
+)
+"""Every legal move out of a status that has not ended, as data.
+
+Absent pairs are illegal and raise. A status that has ended is absorbing and
+is deliberately not listed: :func:`transition` answers for it first.
+"""
+
+
+def transition(current: RunStatus, trigger: RunTrigger) -> RunStatus:
+    """Return the status ``trigger`` produces from ``current``.
+
+    An ended status absorbs every trigger, which is what makes ``finish``
+    idempotent and lets a late ``/resume`` or a boundary reached after the run
+    stopped be a no-op rather than an error.
+
+    Raises:
+        IllegalRunTransitionError: The pair is not in the table, so the caller
+            observed something the lifecycle says cannot happen.
+    """
+    if current.has_ended:
+        return current
+    result = _TRANSITIONS.get((current, trigger))
+    if result is None:
+        raise IllegalRunTransitionError(current, trigger)
+    return result

--- a/src/server/runtime.py
+++ b/src/server/runtime.py
@@ -120,6 +120,14 @@ class ServerRuntime:
                         retryability=DiagnosticRetryability.NEVER,
                     )
                     terminal_recorded = self._terminal_recorded_after(terminal_cursor)
+                    # End the run before its terminal event is recorded, so no
+                    # snapshot can report `running` at a sequence that already
+                    # contains that event.
+                    self.controller.finish(
+                        launcher_error,
+                        record_event=False,
+                        diagnostic=event_diagnostic,
+                    )
                     if not terminal_recorded:
                         self.journal.record(
                             EventType.RUN_INTERRUPTED,
@@ -130,11 +138,6 @@ class ServerRuntime:
                             ),
                             diagnostic=event_diagnostic,
                         )
-                    self.controller.finish(
-                        launcher_error,
-                        record_event=False,
-                        diagnostic=event_diagnostic,
-                    )
                     raise
                 except ConfigurationError as exc:
                     configuration_diagnostic = exc.diagnostic
@@ -150,6 +153,11 @@ class ServerRuntime:
                         severity=DiagnosticSeverity.FATAL,
                         retryability=DiagnosticRetryability.NEVER,
                     )
+                    self.controller.finish(
+                        exc,
+                        record_event=False,
+                        diagnostic=event_diagnostic,
+                    )
                     self.journal.record(
                         EventType.CONFIGURATION_FAILED,
                         event_diagnostic.summary,
@@ -161,11 +169,6 @@ class ServerRuntime:
                             usage=event_diagnostic.hint,
                             exit_code=configuration_diagnostic.exit_code,
                         ),
-                        diagnostic=event_diagnostic,
-                    )
-                    self.controller.finish(
-                        exc,
-                        record_event=False,
                         diagnostic=event_diagnostic,
                     )
                     transport.wait_for_subscriber_disconnect()

--- a/tests/server/test_execution_tracker.py
+++ b/tests/server/test_execution_tracker.py
@@ -254,7 +254,9 @@ def test_chat_execution_is_isolated_from_run_control(tmp_path):  # noqa: ANN001,
 
     assert parts.api.snapshot().agent_kind == "implementer"
     parts.controller.after_agent("chat", "experiment-chat", execution_id=chat.execution_id)
-    assert parts.api.snapshot().status == "running"
+    # A presentation-only execution is not a run-control boundary, so the
+    # pending pause is still pending rather than applied.
+    assert parts.api.snapshot().status == "pausing"
     parts.controller.after_agent("implementer", "round-1", execution_id=main.execution_id)
     assert parts.api.snapshot().status == "paused"
 

--- a/tests/server/test_journal.py
+++ b/tests/server/test_journal.py
@@ -39,10 +39,15 @@ def test_bootstrap_events_join_durable_history(tmp_path):  # noqa: ANN001, ANN20
     current.attach(tmp_path / "durable")
     current.journal.record(EventType.RUN_STARTED, status=EventStatus.ACTIVE)
 
+    # Each attach publishes the starting -> running transition, and the second
+    # session's lands after the first session's terminal event: a client that
+    # folds this history in order ends at `running`, not at the old `completed`.
     expected = [
         EventType.SERVER_STARTED,
+        EventType.RUN_STATUS_CHANGED,
         EventType.RUN_FINISHED,
         EventType.SERVER_STARTED,
+        EventType.RUN_STATUS_CHANGED,
         EventType.SERVER_READY,
         EventType.RUN_STARTED,
     ]

--- a/tests/server/test_run_controller.py
+++ b/tests/server/test_run_controller.py
@@ -3,10 +3,39 @@
 import threading
 import time
 
-from tests.server.support import build_server_parts
+from tests.server.support import ServerParts, build_server_parts
 
 from server.api.protocol import PauseCommand, ResumeCommand, SteerCommand
-from server.events import AgentExecutionStartedData, EventStatus, EventType
+from server.events import (
+    AgentExecutionStartedData,
+    EventStatus,
+    EventType,
+    RunEvent,
+    RunStatusChangedData,
+)
+from server.run_lifecycle import RunStatus
+from vibesys.run.events import CoreEventType
+from vibesys.run.events import EventStatus as CoreEventStatus
+
+
+def _status_changes(parts: ServerParts) -> list[tuple[RunStatus, RunStatus]]:
+    """Return every published transition as ``(previous, status)``."""
+    return [
+        (event.data.previous, event.data.status)
+        for event in parts.journal.read()
+        if isinstance(event.data, RunStatusChangedData)
+    ]
+
+
+def _folded_status(events: list[RunEvent], through_sequence: int) -> RunStatus | None:
+    """Fold the published transitions the way a client does."""
+    folded: RunStatus | None = None
+    for event in events:
+        if event.sequence > through_sequence:
+            break
+        if isinstance(event.data, RunStatusChangedData):
+            folded = event.data.status
+    return folded
 
 
 def test_pause_takes_effect_at_next_safe_point(tmp_path):  # noqa: ANN001, ANN201
@@ -101,6 +130,117 @@ def test_finish_is_idempotent_and_interrupts_controlled_executions(tmp_path):  #
         and event.execution_id == execution.execution_id
     )
     assert finished.status is EventStatus.INTERRUPTED
+
+
+def test_pause_is_pending_until_the_invocation_boundary(tmp_path):  # noqa: ANN001, ANN201
+    """`/pause` is a request: the call in flight keeps running until it ends."""
+    parts = build_server_parts(tmp_path)
+    execution = parts.controller.start_agent_execution("implementer", "round 1", "work")
+
+    parts.api.execute(PauseCommand())
+
+    assert parts.api.snapshot().status is RunStatus.PAUSING
+    parts.controller.after_agent("implementer", "round 1", execution_id=execution.execution_id)
+    assert parts.api.snapshot().status is RunStatus.PAUSED
+
+
+def test_every_transition_publishes_exactly_one_status_event(tmp_path):  # noqa: ANN001, ANN201
+    """The status a client folds is the status the controller holds."""
+    parts = build_server_parts(tmp_path)
+    execution = parts.controller.start_agent_execution("implementer", "round 1", "work")
+    parts.controller.pause_after_call()
+    # A repeated request changes nothing, so it publishes nothing.
+    parts.controller.pause_after_call()
+    parts.controller.after_agent("implementer", "round 1", execution_id=execution.execution_id)
+    parts.controller.resume()
+    parts.controller.finish()
+
+    assert _status_changes(parts) == [
+        (RunStatus.STARTING, RunStatus.RUNNING),
+        (RunStatus.RUNNING, RunStatus.PAUSING),
+        (RunStatus.PAUSING, RunStatus.PAUSED),
+        (RunStatus.PAUSED, RunStatus.RUNNING),
+        (RunStatus.RUNNING, RunStatus.COMPLETED),
+    ]
+    # The human-readable audit record survives alongside the typed one.
+    controls = [
+        (event.text, event.status)
+        for event in parts.journal.read()
+        if event.type is EventType.CONTROL
+    ]
+    assert controls == [
+        ("/pause", EventStatus.PENDING),
+        ("/pause", EventStatus.PENDING),
+        ("/pause", EventStatus.CONSUMED),
+        ("/resume", EventStatus.CONSUMED),
+    ]
+
+
+def test_resume_before_the_boundary_cancels_the_pending_pause(tmp_path):  # noqa: ANN001, ANN201
+    """A resume that beats the boundary leaves no pause to apply later."""
+    parts = build_server_parts(tmp_path)
+    execution = parts.controller.start_agent_execution("implementer", "round 1", "work")
+    parts.controller.pause_after_call()
+    parts.controller.resume()
+    parts.controller.after_agent("implementer", "round 1", execution_id=execution.execution_id)
+
+    assert parts.api.snapshot().status is RunStatus.RUNNING
+    assert _status_changes(parts) == [
+        (RunStatus.STARTING, RunStatus.RUNNING),
+        (RunStatus.RUNNING, RunStatus.PAUSING),
+        (RunStatus.PAUSING, RunStatus.RUNNING),
+    ]
+
+
+def test_finish_ends_a_paused_run_and_releases_the_pause_wait(tmp_path):  # noqa: ANN001, ANN201
+    """A run that ends while paused reports the ended status, not `paused`."""
+    parts = build_server_parts(tmp_path)
+    execution = parts.controller.start_agent_execution("implementer", "round 1", "work")
+    parts.controller.pause_after_call()
+    parts.controller.after_agent("implementer", "round 1", execution_id=execution.execution_id)
+    assert parts.api.snapshot().status is RunStatus.PAUSED
+
+    entered: list[str] = []
+    waiter = threading.Thread(
+        target=lambda: entered.append(parts.controller.before_agent("judge", "round 1", "review"))
+    )
+    waiter.start()
+    time.sleep(0.02)
+    assert waiter.is_alive()
+
+    parts.controller.finish()
+
+    waiter.join(timeout=1)
+    assert entered == ["review"]
+    assert parts.api.snapshot().status is RunStatus.COMPLETED
+    assert _status_changes(parts)[-1] == (RunStatus.PAUSED, RunStatus.COMPLETED)
+
+
+def test_pause_applies_without_a_matching_execution(tmp_path):  # noqa: ANN001, ANN201
+    """The compatibility boundary is still a boundary, and still publishes."""
+    parts = build_server_parts(tmp_path)
+    parts.controller.pause_after_call()
+
+    parts.controller.after_agent("implementer", "round 1")
+
+    assert parts.api.snapshot().status is RunStatus.PAUSED
+    assert _status_changes(parts)[-1] == (RunStatus.PAUSING, RunStatus.PAUSED)
+
+
+def test_snapshot_status_agrees_with_the_fold_at_the_terminal_event(tmp_path):  # noqa: ANN001, ANN201
+    """No sequence containing the terminal event can still read as running."""
+    parts = build_server_parts(tmp_path)
+    parts.integration.events.emit(CoreEventType.RUN_FINISHED, status=CoreEventStatus.COMPLETED)
+
+    snapshot = parts.api.snapshot()
+    assert snapshot.status is RunStatus.COMPLETED
+    events = parts.journal.read()
+    terminal = next(event for event in events if event.type is EventType.RUN_FINISHED)
+    assert _folded_status(events, terminal.sequence) is RunStatus.COMPLETED
+    assert _folded_status(events, snapshot.sequence) is snapshot.status
+    # The run ended once: the later `finish` from the runtime adds nothing.
+    parts.controller.finish()
+    assert [event.type for event in parts.journal.read()].count(EventType.RUN_FINISHED) == 1
 
 
 def test_finish_does_not_interrupt_presentation_only_chat(tmp_path):  # noqa: ANN001, ANN201

--- a/tests/server/test_run_lifecycle.py
+++ b/tests/server/test_run_lifecycle.py
@@ -1,0 +1,108 @@
+"""Exhaustive rules of the run lifecycle state machine."""
+
+import pytest
+
+from server.run_lifecycle import (
+    IllegalRunTransitionError,
+    RunStatus,
+    RunTrigger,
+    transition,
+)
+
+LEGAL: dict[tuple[RunStatus, RunTrigger], RunStatus] = {
+    (RunStatus.STARTING, RunTrigger.ATTACHED): RunStatus.RUNNING,
+    (RunStatus.STARTING, RunTrigger.COMPLETED): RunStatus.COMPLETED,
+    (RunStatus.STARTING, RunTrigger.FAILED): RunStatus.FAILED,
+    (RunStatus.RUNNING, RunTrigger.ATTACHED): RunStatus.RUNNING,
+    (RunStatus.RUNNING, RunTrigger.PAUSE_REQUESTED): RunStatus.PAUSING,
+    (RunStatus.RUNNING, RunTrigger.INVOCATION_FINISHED): RunStatus.RUNNING,
+    (RunStatus.RUNNING, RunTrigger.RESUMED): RunStatus.RUNNING,
+    (RunStatus.RUNNING, RunTrigger.COMPLETED): RunStatus.COMPLETED,
+    (RunStatus.RUNNING, RunTrigger.FAILED): RunStatus.FAILED,
+    (RunStatus.PAUSING, RunTrigger.ATTACHED): RunStatus.PAUSING,
+    (RunStatus.PAUSING, RunTrigger.PAUSE_REQUESTED): RunStatus.PAUSING,
+    (RunStatus.PAUSING, RunTrigger.INVOCATION_FINISHED): RunStatus.PAUSED,
+    (RunStatus.PAUSING, RunTrigger.RESUMED): RunStatus.RUNNING,
+    (RunStatus.PAUSING, RunTrigger.COMPLETED): RunStatus.COMPLETED,
+    (RunStatus.PAUSING, RunTrigger.FAILED): RunStatus.FAILED,
+    (RunStatus.PAUSED, RunTrigger.ATTACHED): RunStatus.PAUSED,
+    (RunStatus.PAUSED, RunTrigger.PAUSE_REQUESTED): RunStatus.PAUSED,
+    (RunStatus.PAUSED, RunTrigger.INVOCATION_FINISHED): RunStatus.PAUSED,
+    (RunStatus.PAUSED, RunTrigger.RESUMED): RunStatus.RUNNING,
+    (RunStatus.PAUSED, RunTrigger.COMPLETED): RunStatus.COMPLETED,
+    (RunStatus.PAUSED, RunTrigger.FAILED): RunStatus.FAILED,
+}
+"""The whole table, restated independently of the module under test."""
+
+ENDED = (RunStatus.COMPLETED, RunStatus.FAILED)
+LIVE = (RunStatus.STARTING, RunStatus.RUNNING, RunStatus.PAUSING, RunStatus.PAUSED)
+
+ILLEGAL = [
+    (current, trigger)
+    for current in LIVE
+    for trigger in RunTrigger
+    if (current, trigger) not in LEGAL
+]
+
+
+def test_every_status_is_either_ended_or_live() -> None:
+    """``has_ended`` partitions the enum, so a new member has to be placed."""
+    assert set(ENDED) | set(LIVE) == set(RunStatus)
+    assert not set(ENDED) & set(LIVE)
+    assert [status for status in RunStatus if status.has_ended] == list(ENDED)
+    assert [status for status in RunStatus if not status.has_ended] == list(LIVE)
+
+
+@pytest.mark.parametrize(("pair", "expected"), LEGAL.items(), ids=str)
+def test_legal_transition(pair: tuple[RunStatus, RunTrigger], expected: RunStatus) -> None:
+    """Every legal move produces the status the table names."""
+    current, trigger = pair
+    assert transition(current, trigger) is expected
+
+
+@pytest.mark.parametrize(("current", "trigger"), ILLEGAL, ids=str)
+def test_illegal_transition_raises(current: RunStatus, trigger: RunTrigger) -> None:
+    """Every move outside the table is rejected with the offending pair."""
+    with pytest.raises(IllegalRunTransitionError) as raised:
+        transition(current, trigger)
+    assert raised.value.current is current
+    assert raised.value.trigger is trigger
+
+
+def test_illegal_pairs_are_the_ones_we_expect() -> None:
+    """Nothing pause-related can happen before the run is attached.
+
+    Pinned so widening the table stays a deliberate edit.
+    """
+    assert set(ILLEGAL) == {
+        (RunStatus.STARTING, RunTrigger.PAUSE_REQUESTED),
+        (RunStatus.STARTING, RunTrigger.INVOCATION_FINISHED),
+        (RunStatus.STARTING, RunTrigger.RESUMED),
+    }
+
+
+@pytest.mark.parametrize("ended", ENDED, ids=str)
+@pytest.mark.parametrize("trigger", list(RunTrigger), ids=str)
+def test_ended_statuses_absorb_every_trigger(ended: RunStatus, trigger: RunTrigger) -> None:
+    """A run that has ended never leaves the status it ended in."""
+    assert transition(ended, trigger) is ended
+
+
+def test_pause_reaches_its_boundary_then_resumes() -> None:
+    """The canonical pause round trip, as the controller drives it."""
+    status = transition(RunStatus.STARTING, RunTrigger.ATTACHED)
+    assert status is RunStatus.RUNNING
+    status = transition(status, RunTrigger.PAUSE_REQUESTED)
+    assert status is RunStatus.PAUSING
+    status = transition(status, RunTrigger.INVOCATION_FINISHED)
+    assert status is RunStatus.PAUSED
+    status = transition(status, RunTrigger.RESUMED)
+    assert status is RunStatus.RUNNING
+
+
+def test_resume_before_the_boundary_cancels_the_pending_pause() -> None:
+    """A ``/resume`` that beats the boundary leaves nothing pending."""
+    status = transition(RunStatus.RUNNING, RunTrigger.PAUSE_REQUESTED)
+    status = transition(status, RunTrigger.RESUMED)
+    assert status is RunStatus.RUNNING
+    assert transition(status, RunTrigger.INVOCATION_FINISHED) is RunStatus.RUNNING


### PR DESCRIPTION
## Problem

PR #557 by @zatchbell1311-wq ("fix(tui): persist pause state in header and fix overlay
z-order", for #515) added a client-side `runPaused` flag, set when the `/pause` command
ack came back and cleared only on `/resume`. Review found three problems with it:

- The flag was set on the ack, but the ack only means the backend recorded the pause as
  *pending*. The agent call in flight keeps running until it reaches an invocation
  boundary, so the header read "paused" while the run was executing.
- Nothing cleared the flag when the run ended, so a run paused at any point read
  "paused · completed" for the rest of the session.
- It mirrored backend-authoritative state on the client, which
  [docs/contributing/tui-architecture.md](https://github.com/uw-syfi/vibesys/blob/main/docs/contributing/tui-architecture.md)
  forbids: "Only backend messages change core state."

A backend audit then found why a client had to guess in the first place:

- `RunController` kept the run's status in three places: `_run_status`
  (starting/running/completed/failed), `_paused` as an overlay `status_locked()` applied
  on top, and `_pause_after_call` for a requested-but-not-applied pause. Nothing named
  that third state, and nothing said which moves between them were legal.
- Not every transition published an event. `attach()`'s starting→running published
  nothing, the compatibility path in `after_agent` set `_paused` with no journal record
  and no notify, and no lifecycle event carried the status explicitly.
- Pause was only observable through `control` events whose command is free text
  ("/pause", "/resume", "/steer: …"), so a client could not distinguish pause-requested
  from paused from steer without parsing strings.
- Journal writes in `pause_after_call`, `resume`, `steer`, and `finish` happened after
  releasing the shared condition, so event order could disagree with state order.
- `finish()` never cleared `_paused`, so a run that ended while paused reported `paused`
  forever, and a thread parked on the pause wait re-waited after `finish`'s notify.
- The core emitted `run_finished` before `finish()` set the status, so a snapshot could
  say `running` at a sequence that already contained the terminal event. The client
  issues the snapshot query and the subscription concurrently at boot, so it races this.
- `clients/core-state` had no branch for `control` at all and applied the snapshot once
  at boot, so after `/pause` the TUI status stayed `running` for the whole session.
- Under `tests/server`, only one test asserted snapshot status transitions; none read
  control records, covered finish-while-paused, the compatibility pause path, the resume
  race, or snapshot-versus-event consistency.

This PR fixes the cause, so that class of bug cannot recur: the run lifecycle becomes a
small tested state machine, every move it makes is published as a typed event, and the
TUI derives its header from those events instead of a flag of its own.

It partially addresses #515: the pause indicator and the overlay z-order. #557's z-order
change is correct and independent of the flag, so it is carried over here with credit to
@zatchbell1311-wq. Merged PR #576 is the groundwork this builds on: it introduced
`RunStatus`, its `has_ended` property, the typed `RunSnapshot.status`, and
`hasRunEnded(state)` in `core-state`.

Out of scope, noted as a follow-up: client-side process-death detection. A backend that
dies without recording a terminal event still leaves the header on its last known status.

## Solution

**A pure state machine.** `src/server/run_lifecycle.py` owns `RunStatus` (moved out of
`controller.py`, keeping #576's `has_ended`, and widened with `PAUSING`), `RunTrigger`,
the legal moves as a `MappingProxyType` table, and `transition(current, trigger)`. It has
no I/O, no locks, and no journal, so its unit test enumerates the whole table. An ended
status is answered first and absorbs every trigger; anything not in the table raises
`IllegalRunTransitionError`.

It lives under `server/` rather than `src/vibesys/run/` because the pause boundary and
`RunSnapshot.status` are frontend-serving concerns, and
[coding-best-practices.md](https://github.com/uw-syfi/vibesys/blob/main/docs/contributing/coding-best-practices.md)
fixes the dependency direction as `entrypoints -> server -> vibesys`. `vibesys/` runs the
loop and knows nothing about pausing; putting the enum there would point the core at a
serving concern to no benefit.

`PAUSING` is the state that had no name: `/pause` is a request, and the run keeps
executing the call already in flight until it reaches an invocation boundary.

**One status in the controller.** `RunController` holds a single `RunStatus` instead of
`_run_status` plus two booleans, and every mutation goes through `transition`. Each
change publishes `run_status_changed` (new status plus the one it replaced) recorded
*while the shared condition is held*, which is what keeps event order and state order the
same. Execution identity at a pause boundary rides the event envelope
(`agent_kind`, `round_label`, `execution_id`) like every other execution-scoped fact
rather than being repeated in the payload. The `control` events stay exactly as they were,
as the human-readable audit record.

Two ordering bugs follow from that:

- The projection of a core terminal event now settles the controller *before* appending
  that event, and `runtime` ends the run before recording `run_interrupted` or
  `configuration_failed`. A snapshot at any sequence containing the terminal event
  therefore already reports an ended status.
- An ended status is not `PAUSED`, so `finish()` on a paused run both reports the ended
  status and releases the thread parked on the pause wait, with no extra bookkeeping.

The compatibility path in `after_agent` (no execution to match) now goes through the same
`_reach_pause_boundary_locked` helper as the normal path, so it publishes too. Callers
still reach it (`RunIntegrationAdapter.finish` accepts an optional `execution_id`), so it
is fixed rather than removed.

`run_status_changed` is added to the wire `EventType`, to the `EventData` union, and to
the journal's bootstrap spine, so a tail-bootstrapped client still folds the status.
Bindings regenerated with `pnpm --dir clients/backend-client generate:protocol`. No core
mirror is needed in `src/vibesys/run/events.py`: the core does not observe pausing.

**The frontend subscribes.** `core-state` folds `run_status_changed` into `core.status`.
`hasRunEnded` and the new `applyRunStatus` share one exhaustive classifier over the
widened union, so a new status is a compile error in both. The snapshot guard now also
rejects a snapshot no newer than a fold that has already seen the run end, using only
existing state (the fold's sequence is at least the terminal event's) rather than a new
field. The TUI header goes through one selector, `runStatusLabel`, which renders
`pausing` as `pausing…`; there is exactly one status token and no client-side flag.

`OverlayView`'s `zIndex` moves from 10 to 25 (above the chat modal at 20, below the theme
picker at 30), which is #557's change.

### Architecture

`server/run_lifecycle` owns the rules; `server/controller` owns the value and the side
effects; `server/journal` owns durability; `core-state` folds; `tui` renders. Nothing
below the controller writes the status, and nothing above it stores a second copy.

```mermaid
stateDiagram-v2
    [*] --> starting
    starting --> running: attached
    running --> pausing: pause_requested
    pausing --> paused: invocation_finished
    pausing --> running: resumed
    paused --> running: resumed
    running --> completed: completed
    running --> failed: failed
    pausing --> completed: completed
    pausing --> failed: failed
    paused --> completed: completed
    paused --> failed: failed
    starting --> completed: completed
    starting --> failed: failed
    completed --> [*]
    failed --> [*]
```

`attached` is idempotent once the run is under way (a later attach re-bootstraps the
journal), `invocation_finished` fires at every controlled boundary and is a no-op unless a
pause is pending, and `completed`/`failed` absorb every later trigger. The three pairs the
table rejects are `starting` with `pause_requested`, `invocation_finished`, or `resumed`:
nothing pause-related can happen before the run is attached, since the control socket does
not listen until after `attach()`.

```mermaid
sequenceDiagram
    participant TUI
    participant RunApi
    participant Controller as RunController
    participant Journal as EventJournal
    TUI->>RunApi: command.pause
    RunApi->>Controller: pause_after_call()
    Note over Controller: under the shared condition
    Controller->>Controller: transition(running, pause_requested) -> pausing
    Controller->>Journal: run_status_changed(pausing)
    Controller->>Journal: control "/pause" (pending)
    RunApi-->>TUI: ack(pause, pending)
    Journal-->>TUI: run_status_changed(pausing)
    Note over TUI: header reads "pausing…"
    Controller->>Controller: invocation boundary -> paused
    Controller->>Journal: run_status_changed(paused)
    Journal-->>TUI: run_status_changed(paused)
    Note over TUI: header reads "paused"
```

## Verification

Every command below was run in this worktree; results are the actual output.

### Correctness properties

- Every status change publishes exactly one `run_status_changed`, recorded while the
  shared condition is held, so event order and state order agree. A trigger the current
  status absorbs changes nothing and publishes nothing.
- Snapshot status equals the fold of the published events at the same sequence. In
  particular the status change is ordered ahead of `run_finished`, `run_failed`,
  `run_interrupted`, and `configuration_failed`, so no snapshot at a sequence containing
  a terminal event can still read `running`.
- Ended statuses absorb every trigger: `finish()` stays idempotent, a late `/resume` or a
  boundary reached after the run stopped is a no-op, and a run that ends while paused
  reports the ended status and releases the pause wait.
- There is no client-side lifecycle flag. `core.status` is written only by backend
  messages, and `hasRunEnded` / `applyRunStatus` / `runStatusLabel` branch exhaustively
  over the closed set, so a new status is a compile error in Python and TypeScript.
- `RunStatus` remains the single authoritative closed set; the TypeScript union is
  regenerated from it, not hand-written.
- Contract change is additive: a new event type and a new payload variant. Protocol
  version stays 1; clients that do not know `run_status_changed` ignore it and keep the
  snapshot behaviour they had.

### Testing

Regression tests fail at the merge base. Verified by restoring `origin/main`'s
`src/server/` and running the three symptoms expressed in merge-base vocabulary:

| Symptom | At the merge base |
| --- | --- |
| `/pause` visible as pending before the boundary | `assert <RunStatus.RUNNING: 'running'> == 'pausing'` |
| snapshot ended at the terminal event's sequence | `assert <RunStatus.RUNNING: 'running'> == 'completed'` |
| a paused run released by `finish()` | hangs; killed at 60s (the parked thread never wakes) |
| overlay above the chat modal | `Expected: > 20 / Received: 10` |

```
uv run pytest tests/server -q --no-cov
  232 passed in 18.58s

uv run pytest tests/server/test_run_lifecycle.py -q --no-cov
  40 passed in 1.04s

./scripts/check_format.sh   All checks passed! (473 files already formatted)
./scripts/check_lint.sh     All checks passed!
./scripts/check_types.sh    All checks passed!

clients/core-state $ bun test --max-concurrency 1 src
  75 pass, 0 fail, 247 expect() calls across 3 files

pnpm check:clients          pass (biome + tsc for all three packages)
pnpm check:ts               Checked 70 files in 184ms. No fixes applied.
pnpm check:ts-architecture  no dependency violations found (78 modules, 250 dependencies)
                            TypeScript package manifests respect dependency direction.
```

`clients/tui $ bun test --max-concurrency 1 src` does not complete in this sandbox: Bun
1.3.8 segfaults during OpenTUI renderer teardown *after* the tests run
(`panic: Segmentation fault`, exit 132). This reproduces on the unmodified tree with these
changes stashed, so it is a pre-existing sandbox failure, not a regression here. Running
the same files in groups completes and passes:

```
clients/tui $ bun test src/ui/app.test.ts
  121 pass, 0 fail
clients/tui $ bun test src/commands.test.ts src/session-controller.test.ts \
    src/session-model.test.ts src/boot-trace.test.ts
  188 pass, 0 fail
clients/tui $ bun test src/launcher.test.ts src/performance-chart.test.ts \
    src/runtime.test.ts src/startup-theme.test.ts
  26 pass, 0 fail
clients/tui $ bun test src/ui/activity-bar.test.ts src/ui/agent-graph.test.ts \
    src/ui/agent-runtime-label.test.ts src/ui/chat-pane.test.ts src/ui/clipboard.test.ts \
    src/ui/experiment-log.test.ts src/ui/previews.test.ts src/ui/right-pane.test.ts \
    src/ui/round-strip.test.ts src/ui/theme.test.ts src/ui/todo-strip.test.ts
  153 pass, 0 fail
```

488 TUI tests total, 0 failures. The launcher tests passed here; they did not hit the
"current working directory was deleted" failure this sandbox sometimes produces.

New tests:

- `tests/server/test_run_lifecycle.py`: every legal transition, every illegal one, both
  ended statuses absorbing every trigger, `has_ended` partitioning the enum, and the two
  canonical pause sequences.
- `tests/server/test_run_controller.py`: pause pending until the boundary, the full
  transition sequence with its `control` records, a resume that beats the boundary, a run
  that ends while paused (including the released wait), the compatibility boundary, and
  the snapshot agreeing with the fold at the terminal event.
- `clients/core-state/src/core-state.test.ts`: the pause/boundary/resume fold, ending
  while paused, active executions dropped, a stale snapshot not un-ending a run, and a
  resumed run reading as running after the replay.
- `clients/tui/src/session-model.test.ts`: header text per status, and a pause folded from
  events and replaced when the run ends.
- `clients/tui/src/ui/app.test.ts`: overlay `zIndex` above the chat modal and below the
  theme picker, through the OpenTUI test renderer.

Updated tests: `tests/server/test_execution_tracker.py` (a presentation-only execution is
not a run-control boundary, so the status there is now `pausing`, not `running`) and
`tests/server/test_journal.py` (each attach publishes its transition).

Manual: not run. The change is covered end to end by the server tests plus the projection
and header tests, and no prompt output is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
