### PR TITLE
Own metric comparison in one MetricSpace shared by the loops

### DIFF
--- a/libs/vs-loop-state/src/vs_loop_state/__init__.py
+++ b/libs/vs-loop-state/src/vs_loop_state/__init__.py
@@ -18,6 +18,7 @@ from vs_loop_state.evolve import (
     parse_population_snapshot,
     serialize_population_snapshot,
 )
+from vs_loop_state.metrics import MetricComparison
 from vs_loop_state.plain import (
     PlainLoopCursor,
     PlainPerformanceRecord,
@@ -31,6 +32,7 @@ from vs_loop_state.plain import (
 __all__ = [
     "IndividualRecord",
     "JudgeVerdict",
+    "MetricComparison",
     "PlainLoopCursor",
     "PlainPerformanceRecord",
     "PlainPerformanceSnapshot",

--- a/libs/vs-loop-state/src/vs_loop_state/agent.py
+++ b/libs/vs-loop-state/src/vs_loop_state/agent.py
@@ -22,6 +22,12 @@ The on-disk key ``reviewed`` predates it and is kept only so legacy records
 still load; ``RoundRecord.reviewed`` derives the boolean instead of storing a
 second copy that can disagree with the verdict.
 
+``perf_comparison`` records how the round's headline reading compared with
+its baseline. The framework decides that once, when the round is written,
+using the run's declared measurement tolerance; every later reader consumes
+the stored answer instead of recomputing it from a tolerance it would have to
+be handed.
+
 ``RoundHistory`` owns only in-memory collection behavior and rollback-base
 resolution. The application-level project-state library owns persistence and
 the on-disk layout.
@@ -33,6 +39,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import ConfigDict, Field, TypeAdapter, model_validator
 from pydantic.dataclasses import dataclass
+
+from vs_loop_state.metrics import MetricComparison  # noqa: TC001  # tracked: #288
 
 if TYPE_CHECKING:
     from collections.abc import Container
@@ -111,6 +119,12 @@ class RoundRecord:
     perf_baseline_commit: str | None = None
     perf_baseline_metric: float | None = None
     perf_delta_pct: float | None = None
+    # How this round's headline reading compared with ``perf_baseline_metric``
+    # under the run's declared measurement tolerance, decided once when the
+    # round was recorded. ``None`` identifies a record written before the
+    # framework stored the comparison; readers then re-derive it from the
+    # run's persisted metric space.
+    perf_comparison: MetricComparison | None = None
 
     @model_validator(mode="after")
     def _normalize_review(self) -> RoundRecord:

--- a/libs/vs-loop-state/src/vs_loop_state/metrics.py
+++ b/libs/vs-loop-state/src/vs_loop_state/metrics.py
@@ -1,0 +1,32 @@
+"""Vocabulary for ordering two benchmark results.
+
+This is the one persisted-state concept the loops share about measurement:
+how a candidate reading relates to the reading it is compared against. It
+lives here, rather than in ``vibesys``, so a round record can store the
+comparison the framework made without this library depending on loop code.
+
+Unlike ``hypothesis_outcome`` and ``candidate_disposition``, which name
+``vibesys``-owned vocabularies and are therefore persisted as plain strings,
+the ordering of two numbers is fully described here, so it is a real enum.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class MetricComparison(StrEnum):
+    """How one measurement relates to the measurement it is compared against.
+
+    ``WITHIN_NOISE`` and ``INCOMPARABLE`` are deliberately distinct.
+    ``WITHIN_NOISE`` means both readings exist on the same axis and their
+    difference does not exceed the declared measurement tolerance, so the
+    comparison ran and found no result. ``INCOMPARABLE`` means the comparison
+    could not run at all: a reading is missing, or the axis has no known
+    direction. Consumers that collapse them still have to say so explicitly.
+    """
+
+    BETTER = "better"
+    WORSE = "worse"
+    WITHIN_NOISE = "within_noise"
+    INCOMPARABLE = "incomparable"

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -37,6 +37,7 @@ from vibesys.constants import (
 from vibesys.domains.base import DomainName
 from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
 from vibesys.input_manifest import InputBundle, load_input_bundle, load_project_task
+from vibesys.loops.metrics import MetricSpace, Objective
 from vibesys.profilers import CLI_PROFILER_CHOICES, ProfilerKind, coerce_profiler_kind
 from vibesys.render.headless import HeadlessRenderer
 from vibesys.repository import (
@@ -71,7 +72,6 @@ from vs_project import (
 )
 
 if TYPE_CHECKING:
-    from vibesys.loops.evolve.population import Objective
     from vibesys.loops.evolve.search_policy import OpenEvolveSearchConfig
 
 __all__ = ["PROJECT_ROOT"]
@@ -2069,8 +2069,7 @@ def _run_agent(args: argparse.Namespace, integration: RunIntegration) -> None:
             print(f"Resuming VibeSys run {exp_name} in {bundle.root}/")  # noqa: T201  # tracked: #288
 
         with boot_trace.span("load_objectives_toml"):
-            objectives = _load_objectives_toml(bundle.task_root)
-            pareto_relative_noise = _load_pareto_relative_noise_toml(bundle.task_root)
+            metrics = _load_metric_space_toml(bundle.task_root)
 
         with boot_trace.span("run_environment_spec"):
             run_environment = run_environment_spec_from_args(
@@ -2095,8 +2094,7 @@ def _run_agent(args: argparse.Namespace, integration: RunIntegration) -> None:
         accuracy_timeout_seconds=bundle.manifest.accuracy.timeout_seconds,
         benchmark_timeout_seconds=bundle.manifest.benchmark.timeout_seconds,
         objective=objective,
-        objectives=objectives,
-        pareto_relative_noise=pareto_relative_noise,
+        metrics=metrics,
         max_rounds=args.max_rounds,
         max_retries_per_round=args.max_retries_per_round,
         judge_every=args.judge_every,
@@ -2135,10 +2133,8 @@ def _run_agent(args: argparse.Namespace, integration: RunIntegration) -> None:
 # ===========================================================================
 
 
-def _parse_cli_objective(spec: str):  # noqa: ANN202  # tracked: #288
+def _parse_cli_objective(spec: str) -> Objective:
     """Parse a ``--objective`` flag value (``name:direction``)."""
-    from vibesys.loops.evolve.population import Objective  # noqa: PLC0415  # tracked: #288
-
     if ":" not in spec:
         raise argparse.ArgumentTypeError(f"--objective {spec!r} must be 'name:max' or 'name:min'")  # noqa: TRY003  # tracked: #288
     name, _, direction = spec.partition(":")
@@ -2153,17 +2149,24 @@ def _parse_cli_objective(spec: str):  # noqa: ANN202  # tracked: #288
     return Objective(name=name, direction=direction)
 
 
-def _load_objectives_toml(input_path: Path) -> list[Objective]:
-    """Read loop-independent Pareto axes from an input bundle when present."""
-    from vibesys.loops.evolve.population import Objective  # noqa: PLC0415  # tracked: #288
+def _load_metric_space_toml(input_path: Path) -> MetricSpace:
+    """Read the run's metric space from the task's ``objectives.toml``.
 
+    The axes and the measurement tolerance are one fact about the workload and
+    are read together, once. ``run_agent_loop`` persists the returned space
+    into the run state, and every consumer that has to order two readings takes
+    it from there.
+
+    Exact comparison remains the default. Inputs with measured benchmark
+    variation can opt into a relative margin under ``[pareto]`` without
+    imposing one domain's noise level on every optimization workload.
+    """
     path = input_path / "objectives.toml"
     if not path.exists():
-        return []
+        return MetricSpace()
     data = tomllib.loads(path.read_text())
-    raw_list = data.get("objective") or []
     objectives = []
-    for entry in raw_list:
+    for entry in data.get("objective") or []:
         name = entry.get("name")
         direction = entry.get("direction")
         if not name or direction not in ("max", "min"):
@@ -2172,20 +2175,6 @@ def _load_objectives_toml(input_path: Path) -> list[Objective]:
                 f"must set name and direction (max|min)."
             )
         objectives.append(Objective(name=name, direction=direction))
-    return objectives
-
-
-def _load_pareto_relative_noise_toml(input_path: Path) -> float:
-    """Read the agent loop's variance-aware dominance margin.
-
-    Exact Pareto dominance remains the default. Inputs with measured benchmark
-    variation can opt into a relative margin under ``[pareto]`` without
-    imposing one domain's noise level on every optimization workload.
-    """
-    path = input_path / "objectives.toml"
-    if not path.exists():
-        return 0.0
-    data = tomllib.loads(path.read_text())
     raw_value = (data.get("pareto") or {}).get("relative_noise", 0.0)
     if isinstance(raw_value, bool):
         raise ValueError(f"Malformed pareto.relative_noise in {path}: {raw_value!r}")  # noqa: TRY003, TRY004  # tracked: #288
@@ -2198,13 +2187,13 @@ def _load_pareto_relative_noise_toml(input_path: Path) -> float:
             f"Malformed pareto.relative_noise in {path}: expected a finite value "
             f"in [0, 1), got {raw_value!r}"
         )
-    return value
+    return MetricSpace(objectives=tuple(objectives), relative_noise=value)
 
 
 def _resolve_objectives(args: argparse.Namespace) -> list[Objective]:
     if args.objective:
         return list(args.objective)
-    return _load_objectives_toml(args.input_bundle.task_root)
+    return list(_load_metric_space_toml(args.input_bundle.task_root).objectives)
 
 
 def _build_evolve_parser() -> argparse.ArgumentParser:

--- a/src/server/api/service.py
+++ b/src/server/api/service.py
@@ -38,6 +38,7 @@ from server.chat.options import ChatOptions, build_chat_options
 from server.events import EventType, RunEvent
 from vibesys.loops.agent.hypotheses import reproject_run_evidence
 from vibesys.loops.agent.state import AgentRunStateStore
+from vibesys.loops.metrics import MetricSpace, Objective
 from vs_project import ProjectStateError
 
 if TYPE_CHECKING:
@@ -301,11 +302,21 @@ class RunApi:
             local = project_run.project.state.local_namespace(
                 project_run.run_id, RunStateNamespace.AGENT
             )
+            # Unified state predating the persisted metric space: the run
+            # manifest records the axes but no tolerance, so legacy rounds are
+            # ordered exactly, which is what they were ordered by when written.
             return store.migrate_legacy(
                 rounds=project_run.project.state.load_rounds(project_run.run_id),
                 local_namespace=local,
-                legacy_directions=metric_directions(manifest.configuration.objectives),
+                legacy_space=MetricSpace(
+                    objectives=tuple(
+                        Objective(name=name, direction=direction)
+                        for name, direction in metric_directions(
+                            manifest.configuration.objectives
+                        ).items()
+                    )
+                ),
             )
-        return reproject_run_evidence(
-            state, legacy_directions=metric_directions(manifest.configuration.objectives)
-        )
+        # The run's own space and each round's own comparison travel with the
+        # state, so the read path needs no measurement configuration of its own.
+        return reproject_run_evidence(state)

--- a/src/vibesys/loops/agent/hypotheses.py
+++ b/src/vibesys/loops/agent/hypotheses.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, assert_never
 
 from vibesys.loops.agent.model import (
     AgentRunState,
@@ -13,6 +13,7 @@ from vibesys.loops.agent.model import (
     HypothesisReview,
     HypothesisStrategy,
 )
+from vibesys.loops.metrics import Measurement, MetricComparison, MetricSpace
 from vibesys.schemas import (
     HypothesisOutcome,
     HypothesisStrategyUpdate,
@@ -20,22 +21,26 @@ from vibesys.schemas import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
 
     from vs_loop_state import RoundRecord
 
 
 @dataclass(frozen=True)
 class ResolutionEvidence:
-    """Inputs the framework needs to finalize one hypothesis declaration."""
+    """Inputs the framework needs to finalize one hypothesis declaration.
+
+    ``comparison`` is the round's headline reading ordered against its causal
+    baseline. ``None`` means no official metric was recorded, which is a
+    different fact from ``MetricComparison.INCOMPARABLE``: one was recorded but
+    could not be ordered. Resolution consumes the comparison and never the
+    readings, the axis direction, or the measurement tolerance behind it.
+    """
 
     declared: HypothesisOutcome | None
     passed: bool
     reviewed: bool
-    official_metric: float | None
-    baseline_metric: float | None
-    direction: Literal["max", "min"] | None
-    noise_fraction: float = 0.0
+    comparison: MetricComparison | None
     benchmark_expected: bool = False
 
 
@@ -61,8 +66,8 @@ def resolve_hypothesis_outcome(
         elif resolution is None:
             if not evidence.benchmark_expected:
                 resolution = HypothesisResolution.PROVEN
-            elif evidence.official_metric is not None:
-                resolution = _resolve_metric_evidence(evidence)
+            elif evidence.comparison is not None:
+                resolution = _resolve_metric_evidence(evidence.comparison)
             elif evidence.declared is HypothesisOutcome.SUPPORTED:
                 resolution = HypothesisResolution.PROVEN
             else:
@@ -70,41 +75,35 @@ def resolve_hypothesis_outcome(
     return resolution
 
 
-def _resolve_metric_evidence(evidence: ResolutionEvidence) -> HypothesisResolution:
-    if (
-        evidence.official_metric is None
-        or evidence.baseline_metric in {None, 0}
-        or evidence.direction not in {"max", "min"}
-    ):
-        return HypothesisResolution.INCONCLUSIVE
-    baseline = evidence.baseline_metric
-    assert baseline is not None  # noqa: S101  # narrowed by the guard above
-    raw_delta = (evidence.official_metric - baseline) / abs(baseline) * 100
-    benefit = raw_delta if evidence.direction == "max" else -raw_delta
-    tolerance_pct = evidence.noise_fraction * 100
-    if benefit < -tolerance_pct:
-        return HypothesisResolution.DISPROVEN
-    if benefit > tolerance_pct:
-        return HypothesisResolution.PROVEN
-    return HypothesisResolution.INCONCLUSIVE
+def _resolve_metric_evidence(comparison: MetricComparison) -> HypothesisResolution:
+    match comparison:
+        case MetricComparison.BETTER:
+            return HypothesisResolution.PROVEN
+        case MetricComparison.WORSE:
+            return HypothesisResolution.DISPROVEN
+        case MetricComparison.WITHIN_NOISE | MetricComparison.INCOMPARABLE:
+            # A sub-noise delta and an unmeasurable one are both "the evidence
+            # does not decide this hypothesis".
+            return HypothesisResolution.INCONCLUSIVE
+    assert_never(comparison)
 
 
-def scalar_candidate_retained(
-    *,
-    metric: float | None,
-    direction: Literal["max", "min"] | None,
-    prior: Sequence[float],
-    noise_fraction: float = 0.0,
-) -> bool | None:
-    """Return whether an official scalar candidate advances the best checkpoint."""
-    if metric is None or direction not in {"max", "min"}:
-        return None
-    if not prior:
-        return True
-    best = max(prior) if direction == "max" else min(prior)
-    scale = abs(best) if best != 0 else 1.0
-    improvement = metric - best if direction == "max" else best - metric
-    return improvement > scale * noise_fraction
+def scalar_candidate_retained(comparison: MetricComparison) -> bool | None:
+    """Return whether an official scalar candidate advances the best checkpoint.
+
+    *comparison* orders the candidate against the best prior official reading,
+    which callers obtain from ``MetricSpace.compare_to_best``. An empty history
+    compares as ``BETTER`` there, so the first trusted checkpoint is retained.
+    """
+    match comparison:
+        case MetricComparison.BETTER:
+            return True
+        case MetricComparison.WORSE | MetricComparison.WITHIN_NOISE:
+            # Retention requires a real advance: matching the best checkpoint
+            # within noise is not one.
+            return False
+        case MetricComparison.INCOMPARABLE:
+            return None
 
 
 def metric_baseline(
@@ -186,7 +185,6 @@ def append_round(
     record: RoundRecord,
     *,
     keep_active: bool,
-    legacy_directions: Mapping[str, Literal["max", "min"]] | None = None,
 ) -> AgentRunState:
     """Append one completed round to the active hypothesis."""
     active = state.active_hypothesis
@@ -204,7 +202,7 @@ def append_round(
         updated_active,
         record,
         prior_rounds=state.rounds,
-        legacy_directions=legacy_directions,
+        space=state.metrics,
     )
     index = next(
         index
@@ -270,9 +268,16 @@ def project_round_evidence(
     record: RoundRecord,
     *,
     prior_rounds: Sequence[RoundRecord],
-    legacy_directions: Mapping[str, Literal["max", "min"]] | None = None,
+    space: MetricSpace,
 ) -> Hypothesis:
-    """Return a hypothesis updated with one completed round's evidence."""
+    """Return a hypothesis updated with one completed round's evidence.
+
+    The round's own ``perf_comparison`` decides its resolution. *space* is the
+    owning run's persisted metric space; callers holding an ``AgentRunState``
+    pass ``state.metrics``. It is used to re-derive a comparison for records
+    written before the framework stored one, and to order retention against
+    the best prior official reading.
+    """
     if record.hypothesis_id != hypothesis.hypothesis_id:
         raise ValueError("round hypothesis_id must match its owning hypothesis")  # noqa: TRY003
     if any(item.round_number == record.round_number for item in hypothesis.rounds):
@@ -281,7 +286,8 @@ def project_round_evidence(
     updated.rounds.append(record)
     updated.declared_outcome = _declared_outcome(record.hypothesis_declared_outcome)
     updated.review = _review(record)
-    measurement = _measurement(record, prior_rounds, legacy_directions)
+    measurement = _measurement(record, prior_rounds, space)
+    comparison = round_comparison(record, measurement, space)
     if record.judge_verdict is not None:
         updated.resolution = resolve_hypothesis_outcome(
             ResolutionEvidence(
@@ -289,11 +295,7 @@ def project_round_evidence(
                 passed=record.passed,
                 reviewed=updated.review
                 not in {HypothesisReview.PENDING, HypothesisReview.DEFERRED},
-                official_metric=record.perf_metric if record.official_evaluation else None,
-                baseline_metric=(measurement.baseline_value if measurement is not None else None),
-                direction=(
-                    measurement.direction if measurement is not None else record.perf_direction
-                ),
+                comparison=comparison,
                 benchmark_expected=record.official_evaluation,
             )
         )
@@ -305,20 +307,74 @@ def project_round_evidence(
         )
     if measurement is not None:
         updated.measurement = measurement
-    retained = _retained(record, prior_rounds, legacy_directions)
+    retained = _retained(record, prior_rounds, space)
     if retained is not None:
         updated.candidate_retained = retained
     if record.judge_verdict is None:
-        _correct_legacy_resolution(updated, record, measurement)
+        _correct_legacy_resolution(updated, record, measurement, comparison)
     return Hypothesis.model_validate(updated.model_dump())
 
 
-def reproject_run_evidence(
-    state: AgentRunState,
-    *,
-    legacy_directions: Mapping[str, Literal["max", "min"]] | None = None,
-) -> AgentRunState:
-    """Rebuild hypothesis summaries from their authoritative round evidence."""
+def round_comparison(
+    record: RoundRecord,
+    measurement: HypothesisMeasurement | None,
+    space: MetricSpace,
+) -> MetricComparison | None:
+    """Return how one round's headline reading compared with its baseline.
+
+    ``None`` means the round recorded no official metric, so there was nothing
+    to order. A record that carries ``perf_comparison`` answers for itself: the
+    framework decided it once, when the round was written, and re-deriving it
+    later from a possibly re-configured space would let a resumed run disagree
+    with what it recorded. Older records have the comparison derived from
+    *space* instead.
+    """
+    if not record.official_evaluation or record.perf_metric is None:
+        return None
+    if record.perf_comparison is not None:
+        return record.perf_comparison
+    if measurement is None:
+        return MetricComparison.INCOMPARABLE
+    return space.compare(
+        _reading(measurement, measurement.value),
+        _reading(measurement, measurement.baseline_value),
+    )
+
+
+def _reading(
+    measurement: HypothesisMeasurement,
+    value: float | None,
+) -> Measurement | None:
+    if value is None:
+        return None
+    return Measurement(
+        metric=measurement.metric,
+        value=value,
+        direction=measurement.direction,
+    )
+
+
+def adopt_metric_space(state: AgentRunState, space: MetricSpace) -> AgentRunState:
+    """Record the run's metric space and re-derive evidence within it.
+
+    Called once when a run starts, with the axes and tolerance the task
+    declares. Every later reader takes the space from the returned state, so a
+    resumed run, its persisted hypothesis resolutions, and the server read path
+    agree without any of them re-reading the task file.
+    """
+    updated = state.clone()
+    updated.metrics = space
+    return reproject_run_evidence(updated)
+
+
+def reproject_run_evidence(state: AgentRunState) -> AgentRunState:
+    """Rebuild hypothesis summaries from their authoritative round evidence.
+
+    Every round answers with the comparison it recorded, and ``state.metrics``
+    supplies the space for records written before the framework stored one, so
+    reprojection on ``--resume`` and in the server read path reproduces exactly
+    what the loop recorded.
+    """
     updated = state.clone()
     updated.hypotheses = [
         hypothesis.model_copy(
@@ -352,7 +408,7 @@ def reproject_run_evidence(
             updated.hypotheses[index],
             record,
             prior_rounds=prior_rounds,
-            legacy_directions=legacy_directions,
+            space=state.metrics,
         )
         prior_rounds.append(record)
     return _validated_state(updated)
@@ -366,7 +422,14 @@ def _correct_legacy_resolution(
     hypothesis: Hypothesis,
     record: RoundRecord,
     measurement: HypothesisMeasurement | None,
+    comparison: MetricComparison | None,
 ) -> None:
+    """Re-decide a legacy record's self-declared ``proven`` from its evidence.
+
+    Records written before the framework resolved outcomes carry the
+    implementer's own label. Only the measurement may overrule it, and it does
+    so through the same comparison every other reader consumes.
+    """
     if record.judge_verdict is not None or hypothesis.resolution is not HypothesisResolution.PROVEN:
         return
     if (
@@ -376,16 +439,15 @@ def _correct_legacy_resolution(
     ):
         hypothesis.resolution = HypothesisResolution.INCONCLUSIVE
         return
-    if measurement is None:
+    if measurement is None or comparison is None:
         return
-    assert measurement.delta_pct is not None  # noqa: S101  # guarded above
-    benefit = measurement.delta_pct
-    if measurement.direction == "min":
-        benefit = -benefit
-    if benefit < 0:
-        hypothesis.resolution = HypothesisResolution.DISPROVEN
-    elif benefit == 0:
-        hypothesis.resolution = HypothesisResolution.INCONCLUSIVE
+    match comparison:
+        case MetricComparison.BETTER:
+            pass
+        case MetricComparison.WORSE:
+            hypothesis.resolution = HypothesisResolution.DISPROVEN
+        case MetricComparison.WITHIN_NOISE | MetricComparison.INCOMPARABLE:
+            hypothesis.resolution = HypothesisResolution.INCONCLUSIVE
 
 
 def _declared_outcome(value: str | None) -> HypothesisOutcome | None:
@@ -419,11 +481,17 @@ def _resolution(value: str | None) -> HypothesisResolution | None:
 def _measurement(
     record: RoundRecord,
     prior_rounds: Sequence[RoundRecord],
-    legacy_directions: Mapping[str, Literal["max", "min"]] | None,
+    space: MetricSpace,
 ) -> HypothesisMeasurement | None:
     if not record.official_evaluation or record.perf_metric is None or record.perf_unit is None:
         return None
-    direction = record.perf_direction or _configured_legacy_direction(record, legacy_directions)
+    direction = space.direction(
+        Measurement(
+            metric=record.perf_unit,
+            value=record.perf_metric,
+            direction=record.perf_direction,
+        )
+    )
     baseline = _baseline(record, prior_rounds)
     baseline_value = record.perf_baseline_metric
     if baseline_value is None and baseline is not None:
@@ -463,7 +531,7 @@ def _baseline(record: RoundRecord, prior_rounds: Sequence[RoundRecord]) -> Round
 def _retained(
     record: RoundRecord,
     prior_rounds: Sequence[RoundRecord],
-    legacy_directions: Mapping[str, Literal["max", "min"]] | None,
+    space: MetricSpace,
 ) -> bool | None:
     if record.candidate_retained is not None:
         retained = record.candidate_retained
@@ -475,31 +543,23 @@ def _retained(
         retained = False
     elif not record.official_evaluation or record.perf_metric is None:
         retained = None
+    elif record.perf_unit is None:
+        # An official reading with no axis cannot be ordered against anything.
+        retained = None
     else:
-        direction = record.perf_direction or _configured_legacy_direction(
-            record,
-            legacy_directions,
+        candidate = Measurement(
+            metric=record.perf_unit,
+            value=record.perf_metric,
+            direction=record.perf_direction,
         )
+        axis = space.direction(candidate)
         comparable = [
-            prior.perf_metric
+            Measurement(metric=record.perf_unit, value=prior.perf_metric, direction=axis)
             for prior in prior_rounds
             if prior.official_evaluation
             and prior.passed
             and prior.perf_metric is not None
             and prior.perf_unit == record.perf_unit
         ]
-        retained = scalar_candidate_retained(
-            metric=record.perf_metric,
-            direction=direction,
-            prior=comparable,
-        )
+        retained = scalar_candidate_retained(space.compare_to_best(candidate, comparable))
     return retained
-
-
-def _configured_legacy_direction(
-    record: RoundRecord,
-    directions: Mapping[str, Literal["max", "min"]] | None,
-) -> Literal["max", "min"] | None:
-    if record.judge_verdict is not None or record.perf_unit is None or directions is None:
-        return None
-    return directions.get(record.perf_unit)

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -38,6 +38,7 @@ from vibesys.loops.agent.attempt import (
 )
 from vibesys.loops.agent.hypotheses import (
     ResolutionEvidence,
+    adopt_metric_space,
     append_round,
     apply_strategy_updates,
     metric_baseline,
@@ -52,12 +53,16 @@ from vibesys.loops.agent.model import (
     HypothesisResolution,
 )
 from vibesys.loops.agent.state import AgentRunStateStore
-from vibesys.loops.evolve.population import Objective  # noqa: TC001  # tracked: #288
 from vibesys.loops.gates import (
     GATE_FEEDBACK_TAIL_CHARS,
     GATE_LOG_TAIL_CHARS,
     GATE_RECORD_TAIL_CHARS,
     run_accuracy_gate,
+)
+from vibesys.loops.metrics import (
+    Measurement,
+    MetricSpace,
+    Objective,
 )
 from vibesys.loops.profiler import mcp_spec as profiler_mcp_spec
 from vibesys.profilers import (
@@ -249,9 +254,6 @@ def _metric_value(record: RoundRecord, metric_name: str | None) -> float | None:
 # ---------------------------------------------------------------------------
 
 
-_DEFAULT_PARETO_RELATIVE_NOISE = 0.0
-
-
 def _record_candidate_metrics(record: RoundRecord) -> dict[str, float]:
     """Return the comparable objective row associated with *record*.
 
@@ -301,50 +303,11 @@ def _provisional_candidate_retained(
     return None
 
 
-def _noise_aware_dominates(
-    a: dict[str, float],
-    b: dict[str, float],
-    objectives: list[Objective],
-    *,
-    relative_noise: float = _DEFAULT_PARETO_RELATIVE_NOISE,
-) -> bool:
-    """Return whether *a* materially dominates *b* outside benchmark noise.
-
-    A candidate dominates only when it is no worse than ``b`` within the
-    declared relative noise on every configured axis and better by more than
-    that noise on at least one. Missing axes make points incomparable. This
-    intentionally retains near-equal alternatives instead of converting a
-    sub-noise fluctuation into an automatic rollback.
-    """
-    if not objectives:
-        return False
-    materially_better = False
-    for objective in objectives:
-        a_value = a.get(objective.name)
-        b_value = b.get(objective.name)
-        if a_value is None or b_value is None:
-            return False
-        a_effective = objective.signed(a_value)
-        b_effective = objective.signed(b_value)
-        tolerance = abs(b_effective) * relative_noise
-        if a_effective < b_effective - tolerance:
-            return False
-        if a_effective > b_effective + tolerance:
-            materially_better = True
-    return materially_better
-
-
-def _trusted_candidate_records(
-    records: list[RoundRecord], objectives: list[Objective]
-) -> list[RoundRecord]:
+def _trusted_candidate_records(records: list[RoundRecord], space: MetricSpace) -> list[RoundRecord]:
     """Return reviewed checkpoints with complete comparable objective rows."""
-    objective_names = {objective.name for objective in objectives}
-    if not objective_names:
-        return []
     trusted: list[RoundRecord] = []
     for record in records:
-        metrics = _record_candidate_metrics(record)
-        if not objective_names.issubset(metrics):
+        if not space.complete(_record_candidate_metrics(record)):
             continue
         if not record.commit or not record.passed or not record.reviewed:
             continue
@@ -356,52 +319,31 @@ def _trusted_candidate_records(
 
 def _pareto_frontier_records(
     records: list[RoundRecord],
-    objectives: list[Objective],
-    *,
-    relative_noise: float = _DEFAULT_PARETO_RELATIVE_NOISE,
+    space: MetricSpace,
 ) -> list[RoundRecord]:
     """Compute the noise-aware frontier over independently reviewed points."""
-    candidates = _trusted_candidate_records(records, objectives)
-    return [
-        candidate
-        for candidate in candidates
-        if not any(
-            other is not candidate
-            and _noise_aware_dominates(
-                _record_candidate_metrics(other),
-                _record_candidate_metrics(candidate),
-                objectives,
-                relative_noise=relative_noise,
-            )
-            for other in candidates
-        )
-    ]
+    return space.frontier(
+        _trusted_candidate_records(records, space),
+        _record_candidate_metrics,
+    )
 
 
 def _pareto_archive_dominators(
     candidate_metrics: dict[str, float],
     records: list[RoundRecord],
-    objectives: list[Objective],
-    *,
-    relative_noise: float = _DEFAULT_PARETO_RELATIVE_NOISE,
+    space: MetricSpace,
 ) -> list[RoundRecord]:
     """Return trusted archive points that dominate a proposed candidate row."""
-    objective_names = {objective.name for objective in objectives}
-    if not objective_names or not objective_names.issubset(candidate_metrics):
+    if not space.complete(candidate_metrics):
         return []
     return [
         record
-        for record in _trusted_candidate_records(records, objectives)
-        if _noise_aware_dominates(
-            _record_candidate_metrics(record),
-            candidate_metrics,
-            objectives,
-            relative_noise=relative_noise,
-        )
+        for record in _trusted_candidate_records(records, space)
+        if space.dominates(_record_candidate_metrics(record), candidate_metrics)
     ]
 
 
-def _format_metric_row(metrics: dict[str, float], objectives: list[Objective]) -> str:
+def _format_metric_row(metrics: dict[str, float], objectives: Sequence[Objective]) -> str:
     return ", ".join(
         f"{objective.name}={metrics[objective.name]:.6g} ({objective.direction})"
         for objective in objectives
@@ -409,13 +351,9 @@ def _format_metric_row(metrics: dict[str, float], objectives: list[Objective]) -
     )
 
 
-def _pareto_archive_summary(
-    records: list[RoundRecord],
-    objectives: list[Objective],
-    *,
-    relative_noise: float = _DEFAULT_PARETO_RELATIVE_NOISE,
-) -> str:
+def _pareto_archive_summary(records: list[RoundRecord], space: MetricSpace) -> str:
     """Render trusted frontier parents and any measured points awaiting review."""
+    objectives = space.objectives
     if not objectives:
         return (
             "No objective axes are configured. Use objectives.toml to enable "
@@ -427,11 +365,11 @@ def _pareto_archive_summary(
         + ", ".join(f"{objective.name}:{objective.direction}" for objective in objectives),
         (
             "Dominance is variance-aware: a point removes another only when it is no worse "
-            f"within {relative_noise:.0%} on every axis and better by more than "
-            f"{relative_noise:.0%} on at least one."
+            f"within {space.relative_noise:.0%} on every axis and better by more than "
+            f"{space.relative_noise:.0%} on at least one."
         ),
     ]
-    frontier = _pareto_frontier_records(records, objectives, relative_noise=relative_noise)
+    frontier = _pareto_frontier_records(records, space)
     if frontier:
         lines.append("Trusted frontier parents:")
         for record in frontier:
@@ -447,9 +385,7 @@ def _pareto_archive_summary(
     else:
         lines.append("Trusted frontier parents: none recorded yet.")
 
-    trusted_rounds = {
-        record.round_number for record in _trusted_candidate_records(records, objectives)
-    }
+    trusted_rounds = {record.round_number for record in _trusted_candidate_records(records, space)}
     pending = [
         record
         for record in records
@@ -480,16 +416,16 @@ def _pareto_archive_conflict(
     candidate_disposition: CandidateDisposition,
     candidate_metrics: dict[str, float],
     records: list[RoundRecord],
-    objectives: list[Objective],
+    space: MetricSpace,
 ) -> str | None:
     """Explain why a claimed frontier row is dominated by the live archive."""
     if candidate_disposition is not CandidateDisposition.PARETO_FRONTIER:
         return None
-    dominators = _pareto_archive_dominators(candidate_metrics, records, objectives)
+    dominators = _pareto_archive_dominators(candidate_metrics, records, space)
     if not dominators:
         return None
     rows = "; ".join(
-        f"round {record.round_number} ({_format_metric_row(_record_candidate_metrics(record), objectives)})"
+        f"round {record.round_number} ({_format_metric_row(_record_candidate_metrics(record), space.objectives)})"
         for record in dominators
     )
     return (
@@ -1509,7 +1445,7 @@ def _run_single_agent_round(  # noqa: PLR0913  # tracked: #288
     official_evaluation_reason: str | None = None,
     framework_benchmark_enabled: bool = False,
     pareto_records: list[RoundRecord] | None = None,
-    objectives: list[Objective] | None = None,
+    space: MetricSpace,
 ) -> SingleAgentRoundResponse:
     """Invoke one agent that plays implementer + judge + profiler.
 
@@ -1616,7 +1552,7 @@ def _run_single_agent_round(  # noqa: PLR0913  # tracked: #288
         candidate_disposition=response.candidate_disposition,
         candidate_metrics=dict(response.candidate_metrics),
         records=pareto_records or [],
-        objectives=objectives or [],
+        space=space,
     )
     if response.verdict is Verdict.PASS and archive_conflict:
         response = response.model_copy(
@@ -2313,8 +2249,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     runs_dir: Path | None,
     task_name: str | None = None,
     task_root: Path | None = None,
-    objectives: list[Objective] | None = None,
-    pareto_relative_noise: float = _DEFAULT_PARETO_RELATIVE_NOISE,
+    metrics: MetricSpace,
     workspace_sources: tuple[WorkspaceSource, ...] = (),
     evaluator_path: Path | None = None,
     evaluator_package_root: Path | None = None,
@@ -2383,8 +2318,6 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
         raise ValueError(f"judge_every must be >= 1, got {judge_every}")  # noqa: TRY003  # tracked: #288
     if official_eval_every < 1:
         raise ValueError(f"official_eval_every must be >= 1, got {official_eval_every}")  # noqa: TRY003  # tracked: #288
-    if not 0 <= pareto_relative_noise < 1:
-        raise ValueError(f"pareto_relative_noise must be in [0, 1), got {pareto_relative_noise}")  # noqa: TRY003  # tracked: #288
     if memory_layout not in issue_board.MEMORY_LAYOUTS:
         raise ValueError(  # noqa: TRY003  # tracked: #288
             f"Unknown memory_layout {memory_layout!r}; "
@@ -2397,19 +2330,22 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     # Resolve the registered domain once (fail fast on an unknown name). The
     # per-role files carry language, tooling, and use-case-specific contracts.
     domain_definition = resolve_domain(domain)
-    objectives = list(objectives or [])
+    objectives = list(metrics.objectives)
     # Either result contract means a framework-owned benchmark runs this round,
     # which is what the prompts and the official-evaluation record key off.
     framework_benchmark_configured = benchmark_result is not None or (
         benchmark_result_protocol is not None
     )
-    legacy_metric_directions: dict[str, Literal["max", "min"]] = {
+    # Axes recorded in the run manifest. The server reads them back to build a
+    # metric space for runs whose unified state predates one; they include the
+    # framework benchmark's own axis, which is not a frontier axis.
+    manifest_axes: dict[str, Literal["max", "min"]] = {
         objective.name: objective.direction for objective in objectives
     }
     if benchmark_result is not None:
         # The legacy scalar result contract predates explicit directions and
         # has always defined its reported metric as a maximization objective.
-        legacy_metric_directions.setdefault(benchmark_result.metric, "max")
+        manifest_axes.setdefault(benchmark_result.metric, "max")
     if modality is None and domain_definition.name is DomainName.LLM_SERVING:
         modality = "text_generation"
     run_environment = run_environment or make_run_environment_spec()
@@ -2449,9 +2385,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
         inner_model=normalized_config.agent.inner.model,
         inner_reasoning_effort=normalized_config.agent.inner.reasoning_effort,
         operator_constraints=operator_constraints,
-        objectives=tuple(
-            f"{name}:{direction}" for name, direction in legacy_metric_directions.items()
-        ),
+        objectives=tuple(f"{name}:{direction}" for name, direction in manifest_axes.items()),
     )
     ctx = create_run_context(
         config=normalized_config,
@@ -2510,8 +2444,14 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     agent_run_state = state_store.migrate_legacy(
         rounds=legacy_records,
         local_namespace=local_agent_state,
-        legacy_directions=legacy_metric_directions,
+        legacy_space=metrics,
     )
+    # The one write of the run's metric space. Everything downstream -- round
+    # projection, retention, the Pareto frontier, ``--resume`` reprojection,
+    # and the server read path -- takes it from the persisted state, so the
+    # launching task file wins here and nowhere else re-reads it. Rounds that
+    # already recorded a comparison keep it; only their derivation changes.
+    agent_run_state = adopt_metric_space(agent_run_state, metrics)
     active_hypothesis = agent_run_state.active_hypothesis
     if active_hypothesis is not None and _backfill_revert_commit(
         active_hypothesis, agent_run_state.rounds
@@ -2549,11 +2489,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
             ctx.switch_log_file(f"round{round_number:03d}")
             issue_board.write_pareto_archive(
                 progress_path,
-                _pareto_archive_summary(
-                    records,
-                    objectives,
-                    relative_noise=pareto_relative_noise,
-                ),
+                _pareto_archive_summary(records, agent_run_state.metrics),
             )
             round_progress = RoundProgress(round_number, max_rounds)
             ctx.lprint(f"\n{'=' * 60}\n  {round_progress.label()}\n{'=' * 60}\n")
@@ -2903,7 +2839,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             candidate_disposition=implementation.candidate_disposition,
                             candidate_metrics=dict(implementation.candidate_metrics),
                             records=records,
-                            objectives=objectives,
+                            space=agent_run_state.metrics,
                         )
                         ctx.reselect_gpu()
                         verdict = _run_judge(
@@ -3115,7 +3051,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             official_evaluation_reason=planned_official_reason,
                             framework_benchmark_enabled=framework_benchmark_configured,
                             pareto_records=records,
-                            objectives=objectives,
+                            space=agent_run_state.metrics,
                         )
                         attempt_judge = JudgeReviewed(single_agent_response.verdict)
                         if single_agent_response.verdict == Verdict.PASS:
@@ -3399,15 +3335,40 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 baseline_metric = (
                     _metric_value(parent_record, metric_name) if parent_record is not None else None
                 )
+                # The round's headline reading is ordered against its causal
+                # baseline exactly once, here, and stored on the record. Every
+                # later reader -- resume reprojection and the server -- consumes
+                # the stored answer instead of re-deriving it.
+                space = agent_run_state.metrics
+                official_reading = (
+                    Measurement(
+                        metric=metric_name,
+                        value=official_metric,
+                        direction=metric_direction,
+                    )
+                    if metric_name is not None and official_metric is not None
+                    else None
+                )
+                perf_comparison = (
+                    space.compare(
+                        official_reading,
+                        Measurement(
+                            metric=metric_name,
+                            value=baseline_metric,
+                            direction=metric_direction,
+                        )
+                        if metric_name is not None and baseline_metric is not None
+                        else None,
+                    )
+                    if official_evaluation and official_metric is not None
+                    else None
+                )
                 hypothesis_resolution = resolve_hypothesis_outcome(
                     ResolutionEvidence(
                         declared=declared_outcome,
                         passed=passed,
                         reviewed=reviewed,
-                        official_metric=(official_metric if official_evaluation else None),
-                        baseline_metric=baseline_metric,
-                        direction=metric_direction,
-                        noise_fraction=pareto_relative_noise,
+                        comparison=perf_comparison,
                         benchmark_expected=framework_benchmark_configured,
                     )
                 )
@@ -3420,21 +3381,22 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     candidate_retained = not _pareto_archive_dominators(
                         accepted_metrics,
                         records,
-                        objectives,
-                        relative_noise=pareto_relative_noise,
+                        space,
                     )
                 elif official_evaluation:
-                    prior_values = [
-                        value
+                    prior_readings = [
+                        Measurement(
+                            metric=metric_name,
+                            value=value,
+                            direction=metric_direction,
+                        )
                         for record in records
-                        if record.official_evaluation
+                        if metric_name is not None
+                        and record.official_evaluation
                         and (value := _metric_value(record, metric_name)) is not None
                     ]
                     candidate_retained = scalar_candidate_retained(
-                        metric=official_metric,
-                        direction=metric_direction,
-                        prior=prior_values,
-                        noise_fraction=pareto_relative_noise,
+                        space.compare_to_best(official_reading, prior_readings)
                     )
                 else:
                     candidate_retained = _provisional_candidate_retained(disposition)
@@ -3498,6 +3460,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     ),
                     perf_baseline_metric=baseline_metric,
                     perf_delta_pct=perf_delta_pct,
+                    perf_comparison=perf_comparison,
                 )
                 # Compute the completed lifecycle transition in memory so its
                 # exact representation can enter the write-ahead journal before
@@ -3552,7 +3515,6 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     state_before_round,
                     completed_record,
                     keep_active=next_active_hypothesis is not None,
-                    legacy_directions=legacy_metric_directions,
                 )
                 state_transition = state_store.transition(next_agent_run_state)
                 ctx.begin_completed_round(

--- a/src/vibesys/loops/agent/model.py
+++ b/src/vibesys/loops/agent/model.py
@@ -7,6 +7,7 @@ from typing import Annotated, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, model_validator
 
+from vibesys.loops.metrics import MetricSpace
 from vibesys.schemas import (
     CandidateDisposition,
     HypothesisOutcome,
@@ -120,12 +121,22 @@ class Hypothesis(BaseModel):
 
 
 class AgentRunState(BaseModel):
-    """The single authoritative state aggregate for an agent-loop run."""
+    """The single authoritative state aggregate for an agent-loop run.
+
+    ``metrics`` is the run's metric space: the objective axes and the
+    measurement tolerance, written once when the run starts from the task's
+    ``objectives.toml``. Every consumer that has to order two readings -- the
+    loop, the hypothesis projection, checkpoint retention, the Pareto frontier,
+    and the server read path -- reads it from here rather than being handed a
+    tolerance through a call chain. State written before this field existed
+    loads as the empty strict space, which is the behavior those runs had.
+    """
 
     model_config = ConfigDict(extra="forbid", validate_assignment=True)
 
     schema_version: Literal[1] = 1
     active_hypothesis_id: str | None = None
+    metrics: MetricSpace = Field(default_factory=MetricSpace)
     hypotheses: list[Hypothesis] = Field(default_factory=list)
 
     @model_validator(mode="after")

--- a/src/vibesys/loops/agent/state.py
+++ b/src/vibesys/loops/agent/state.py
@@ -21,6 +21,7 @@ from vibesys.loops.agent.model import (
     HypothesisReview,
     HypothesisStrategy,
 )
+from vibesys.loops.metrics import MetricSpace
 from vibesys.schemas import (
     CandidateDisposition,
     HypothesisOutcome,
@@ -28,7 +29,7 @@ from vibesys.schemas import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
 
     from vs_loop_state import RoundRecord
     from vs_project import StateNamespace, StateSlot, StateTransition
@@ -74,15 +75,21 @@ class AgentRunStateStore:
         *,
         rounds: Sequence[RoundRecord],
         local_namespace: StateNamespace,
-        legacy_directions: Mapping[str, Literal["max", "min"]] | None = None,
+        legacy_space: MetricSpace,
     ) -> AgentRunState:
-        """Build unified state from legacy files without modifying either format."""
+        """Build unified state from legacy files without modifying either format.
+
+        An existing ``state.json`` carries the run's own metric space and
+        answers for itself. *legacy_space* applies only where there is none:
+        unified state written before the space was persisted, and the older
+        ledger and active-checkpoint files. The loop passes the space the task
+        declares and adopts it immediately after this call; the server, which
+        cannot read the task directory, passes the axes recorded in the run
+        manifest, which carries no tolerance and therefore compares exactly.
+        """
         existing = self.load_optional()
         if existing is not None:
-            return reproject_run_evidence(
-                existing,
-                legacy_directions=legacy_directions,
-            )
+            return reproject_run_evidence(_with_legacy_space(existing, legacy_space))
         ledger = self._namespace.load_optional(
             self._LEGACY_LEDGER_FILE,
             _LegacyHypothesisLedger,
@@ -95,7 +102,7 @@ class AgentRunStateStore:
             rounds=rounds,
             ledger=ledger,
             active=active,
-            legacy_directions=legacy_directions,
+            legacy_space=legacy_space,
         )
 
     def cleanup_legacy(
@@ -125,6 +132,13 @@ class AgentRunStateStore:
     def namespace(self) -> StateNamespace:
         """Return the namespace used for durable Git snapshots."""
         return self._namespace
+
+
+def _with_legacy_space(state: AgentRunState, legacy_space: MetricSpace) -> AgentRunState:
+    """Supply a space to unified state written before one was persisted."""
+    if state.metrics != MetricSpace():
+        return state
+    return state.model_copy(update={"metrics": legacy_space}, deep=True)
 
 
 class _LegacyHypothesisStrategy(StrEnum):
@@ -192,7 +206,7 @@ def _migrate_legacy_state(
     rounds: Sequence[RoundRecord],
     ledger: _LegacyHypothesisLedger | None,
     active: _LegacyActiveHypothesis | None,
-    legacy_directions: Mapping[str, Literal["max", "min"]] | None,
+    legacy_space: MetricSpace,
 ) -> AgentRunState:
     ordered_rounds = sorted(rounds, key=lambda record: record.round_number)
     records_by_id = {
@@ -218,7 +232,7 @@ def _migrate_legacy_state(
         )
         for identifier in identifiers
     ]
-    state = AgentRunState(hypotheses=hypotheses)
+    state = AgentRunState(metrics=legacy_space, hypotheses=hypotheses)
     prior_rounds: list[RoundRecord] = []
     for round_record in ordered_rounds:
         identifier = round_record.hypothesis_id or _legacy_unassigned_id(round_record.round_number)
@@ -233,7 +247,7 @@ def _migrate_legacy_state(
             hypothesis,
             normalized_record,
             prior_rounds=prior_rounds,
-            legacy_directions=legacy_directions,
+            space=state.metrics,
         )
         index = next(
             index for index, item in enumerate(state.hypotheses) if item.hypothesis_id == identifier

--- a/src/vibesys/loops/evolve/population.py
+++ b/src/vibesys/loops/evolve/population.py
@@ -30,37 +30,24 @@ from __future__ import annotations
 import math
 import random  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass, field
-from typing import Literal
+
+from vibesys.loops.metrics import Objective
+
+__all__ = [
+    "Individual",
+    "Objective",
+    "Population",
+]
 
 # ---------------------------------------------------------------------------
-# Objective spec + dominance
+# Dominance
+#
+# ``Objective`` now lives in ``vibesys.loops.metrics`` alongside the shared
+# metric space. It is re-exported here so this module and its importers keep
+# their existing surface. The selection logic below still compares exactly,
+# without a measurement tolerance; delegating it to ``MetricSpace`` is a
+# deliberate behavior change for the evolve loop and belongs in its own change.
 # ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class Objective:
-    """One axis of the fitness frontier.
-
-    ``name`` is the key in ``Individual.metrics`` the profiler must
-    report. ``direction`` is ``"max"`` or ``"min"``; the framework
-    flips the sign when comparing min-objectives so dominance logic can
-    treat every axis as "higher is better" internally.
-    """
-
-    name: str
-    direction: Literal["max", "min"]
-
-    def __post_init__(self) -> None:  # noqa: D105  # tracked: #288
-        if self.direction not in ("max", "min"):
-            raise ValueError(f"Objective.direction must be 'max' or 'min', got {self.direction!r}")  # noqa: TRY003  # tracked: #288
-
-    def signed(self, value: float) -> float:
-        """Return *value* flipped to "higher is better" semantics.
-
-        Used by the dominance helper so callers don't have to branch on
-        direction. Min objectives are negated; max objectives pass through.
-        """
-        return value if self.direction == "max" else -value
 
 
 def _dominates(a: Individual, b: Individual, objectives: list[Objective]) -> bool:

--- a/src/vibesys/loops/metrics.py
+++ b/src/vibesys/loops/metrics.py
@@ -1,0 +1,242 @@
+"""Objective axes and metric comparison shared by optimization loops.
+
+A run measures its candidates in a **metric space**: a set of directed
+objective axes plus the relative benchmark tolerance below which two readings
+are indistinguishable. :class:`MetricSpace` owns every question that needs both
+of those facts -- "is this reading better?", "does this row dominate that
+one?", "which rows are on the frontier?", "which reading is best?" -- so that
+noise and direction appear as parameters here and nowhere else. Callers hand it
+measurements and consume a :class:`MetricComparison`; they do not assemble a
+comparison out of a value, a direction, and a tolerance.
+
+The space is built once from the task's ``objectives.toml`` and persisted with
+the run, so the loop, ``--resume`` reprojection, and the server read path all
+compare within the same space instead of being handed a tolerance through a
+call chain (issue #507).
+
+``MetricComparison`` itself is defined in ``vs_loop_state`` and re-exported
+here: a round record stores the comparison the framework made, and that library
+must not import loop code.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, model_validator
+from pydantic.dataclasses import dataclass
+
+from vs_loop_state import MetricComparison
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+
+__all__ = ["Measurement", "MetricComparison", "MetricSpace", "Objective"]
+
+
+@dataclass(frozen=True, config=ConfigDict(extra="forbid"))
+class Objective:
+    """One directed axis of the fitness frontier.
+
+    ``name`` is the key in a metric row the profiler must report.
+    ``direction`` is ``"max"`` or ``"min"``; the framework flips the sign when
+    comparing min-objectives so dominance logic can treat every axis as
+    "higher is better" internally.
+    """
+
+    name: str
+    direction: Literal["max", "min"]
+
+    def signed(self, value: float) -> float:
+        """Return *value* flipped to "higher is better" semantics.
+
+        Used by the dominance helper so callers don't have to branch on
+        direction. Min objectives are negated; max objectives pass through.
+        """
+        return value if self.direction == "max" else -value
+
+
+@dataclass(frozen=True, config=ConfigDict(extra="forbid"))
+class Measurement:
+    """One benchmark reading, named by the axis it was taken on.
+
+    ``direction`` is data about the reading, not a comparison parameter: a
+    record written before its axis was declared in ``objectives.toml`` carries
+    the direction the framework used at the time. When it is absent the space's
+    configured axis supplies it.
+    """
+
+    metric: str
+    value: float
+    direction: Literal["max", "min"] | None = None
+
+
+class MetricSpace(BaseModel):
+    """The directed axes and measurement tolerance one run compares within.
+
+    ``relative_noise`` is the run's declared benchmark variation, read from
+    ``[pareto] relative_noise``. A reading is better than a baseline only when
+    its direction-signed improvement exceeds ``abs(baseline) * relative_noise``;
+    symmetrically for worse. A zero fraction therefore reproduces strict
+    comparison, and so does a zero baseline, for which a relative tolerance has
+    no scale.
+
+    The default is the empty strict space. It is the compatibility value for
+    run state written before the space was persisted, and the only sanctioned
+    way to get a zero tolerance: no function anywhere takes a tolerance
+    argument that could silently default to it.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    objectives: tuple[Objective, ...] = ()
+    relative_noise: Annotated[FiniteFloat, Field(ge=0.0, lt=1.0)] = 0.0
+
+    @model_validator(mode="after")
+    def _unique_axes(self) -> MetricSpace:
+        names = [objective.name for objective in self.objectives]
+        if len(set(names)) != len(names):
+            raise ValueError("objective names must be unique")  # noqa: TRY003  # tracked: #288
+        return self
+
+    # -- axes ---------------------------------------------------------------
+
+    @property
+    def primary(self) -> Objective | None:
+        """Return the axis that names the run's headline metric, if any."""
+        return self.objectives[0] if self.objectives else None
+
+    def axis(self, metric: str | None) -> Objective | None:
+        """Return the configured axis named *metric*, if the space has one."""
+        if metric is None:
+            return None
+        return next((item for item in self.objectives if item.name == metric), None)
+
+    def direction(self, measurement: Measurement | None) -> Literal["max", "min"] | None:
+        """Resolve which way is better for *measurement*.
+
+        The reading's own direction wins, so a record measured before its axis
+        was configured keeps the meaning it was written with; otherwise the
+        configured axis decides.
+        """
+        if measurement is None:
+            return None
+        if measurement.direction is not None:
+            return measurement.direction
+        axis = self.axis(measurement.metric)
+        return axis.direction if axis is not None else None
+
+    # -- comparison ---------------------------------------------------------
+
+    def compare(
+        self,
+        candidate: Measurement | None,
+        baseline: Measurement | None,
+    ) -> MetricComparison:
+        """Order *candidate* against *baseline* within this space.
+
+        A missing reading, mismatched axes, or an axis with no known direction
+        yields ``INCOMPARABLE``: the framework must not read a verdict out of
+        evidence it does not have.
+        """
+        direction = self.direction(candidate)
+        if (
+            candidate is None
+            or baseline is None
+            or direction is None
+            or candidate.metric != baseline.metric
+        ):
+            return MetricComparison.INCOMPARABLE
+        improvement = (
+            candidate.value - baseline.value
+            if direction == "max"
+            else baseline.value - candidate.value
+        )
+        tolerance = abs(baseline.value) * self.relative_noise
+        if improvement > tolerance:
+            return MetricComparison.BETTER
+        if improvement < -tolerance:
+            return MetricComparison.WORSE
+        return MetricComparison.WITHIN_NOISE
+
+    def best(self, measurements: Sequence[Measurement]) -> Measurement | None:
+        """Return the best reading among *measurements* on a single axis."""
+        best: Measurement | None = None
+        for item in measurements:
+            if self.direction(item) is None:
+                continue
+            if best is None or self.compare(item, best) is MetricComparison.BETTER:
+                best = item
+        return best
+
+    def compare_to_best(
+        self,
+        candidate: Measurement | None,
+        prior: Sequence[Measurement],
+    ) -> MetricComparison:
+        """Order *candidate* against the best of *prior* on the same axis.
+
+        An empty history is ``BETTER``: the first trusted reading advances an
+        archive that holds nothing. A candidate whose direction is unknown is
+        ``INCOMPARABLE`` even then, because nothing about it can be ordered.
+        """
+        if candidate is None or self.direction(candidate) is None:
+            return MetricComparison.INCOMPARABLE
+        best = self.best([item for item in prior if item.metric == candidate.metric])
+        if best is None:
+            return MetricComparison.BETTER
+        return self.compare(candidate, best)
+
+    # -- frontier -----------------------------------------------------------
+
+    def dominates(self, a: Mapping[str, float], b: Mapping[str, float]) -> bool:
+        """Return whether row *a* materially dominates row *b*.
+
+        A row dominates only when it is no worse than *b* within the declared
+        tolerance on every configured axis and better by more than that
+        tolerance on at least one. A missing axis makes the rows incomparable.
+        This intentionally retains near-equal alternatives instead of
+        converting a sub-noise fluctuation into an automatic rollback.
+        """
+        if not self.objectives:
+            return False
+        materially_better = False
+        for objective in self.objectives:
+            comparison = self.compare(
+                _reading(objective, a),
+                _reading(objective, b),
+            )
+            match comparison:
+                case MetricComparison.INCOMPARABLE | MetricComparison.WORSE:
+                    return False
+                case MetricComparison.BETTER:
+                    materially_better = True
+                case MetricComparison.WITHIN_NOISE:
+                    pass
+        return materially_better
+
+    def frontier[T](
+        self,
+        points: Sequence[T],
+        row: Callable[[T], Mapping[str, float]],
+    ) -> list[T]:
+        """Return the members of *points* that nothing else dominates."""
+        return [
+            point
+            for point in points
+            if not any(
+                other is not point and self.dominates(row(other), row(point)) for other in points
+            )
+        ]
+
+    def complete(self, row: Mapping[str, float]) -> bool:
+        """Return whether *row* carries a value for every configured axis."""
+        return bool(self.objectives) and all(objective.name in row for objective in self.objectives)
+
+
+def _reading(objective: Objective, row: Mapping[str, float]) -> Measurement | None:
+    value = row.get(objective.name)
+    if value is None:
+        return None
+    return Measurement(metric=objective.name, value=value, direction=objective.direction)

--- a/tests/entrypoints/test_headless.py
+++ b/tests/entrypoints/test_headless.py
@@ -18,8 +18,7 @@ if TYPE_CHECKING:
 from entrypoints.headless import (
     _extract_flag,
     _extract_loop_selection,
-    _load_objectives_toml,
-    _load_pareto_relative_noise_toml,
+    _load_metric_space_toml,
     _parse_cli_objective,
     _prepare_experiment_repository,
     _render_configuration_error,
@@ -36,6 +35,7 @@ from vibesys.constants import ComputeBackend
 from vibesys.domains.base import DomainName
 from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
 from vibesys.input_manifest import load_input_bundle
+from vibesys.loops.metrics import MetricSpace, Objective
 from vibesys.profilers import ProfilerKind
 from vibesys.run.events import CoreEventType
 from vibesys.run.integration import LocalRunIntegration
@@ -1684,23 +1684,23 @@ def test_parse_cli_objective_rejects_malformed_specs(spec: str, message: str) ->
 
 
 def test_objective_files_are_optional_and_validated(tmp_path: Path) -> None:
-    assert _load_objectives_toml(tmp_path) == []
-    assert _load_pareto_relative_noise_toml(tmp_path) == 0.0
+    """The axes and the tolerance are one fact, read together or not at all."""
+    assert _load_metric_space_toml(tmp_path) == MetricSpace()
 
     (tmp_path / "objectives.toml").write_text(
         '[[objective]]\nname = "latency"\ndirection = "min"\n[pareto]\nrelative_noise = 0.03\n'
     )
-    assert [(item.name, item.direction) for item in _load_objectives_toml(tmp_path)] == [
-        ("latency", "min")
-    ]
-    assert _load_pareto_relative_noise_toml(tmp_path) == 0.03
+    assert _load_metric_space_toml(tmp_path) == MetricSpace(
+        objectives=(Objective(name="latency", direction="min"),),
+        relative_noise=0.03,
+    )
 
 
 @pytest.mark.parametrize("value", ["true", "-0.1", "1.0", '"noisy"'])
 def test_pareto_relative_noise_rejects_invalid_values(tmp_path: Path, value: str) -> None:
     (tmp_path / "objectives.toml").write_text(f"[pareto]\nrelative_noise = {value}\n")
     with pytest.raises(ValueError, match=r"pareto\.relative_noise"):
-        _load_pareto_relative_noise_toml(tmp_path)
+        _load_metric_space_toml(tmp_path)
 
 
 def test_render_configuration_error_prints_usage(

--- a/tests/server/test_experiments.py
+++ b/tests/server/test_experiments.py
@@ -18,7 +18,7 @@ from vibesys.loops.agent.model import (
 )
 from vibesys.loops.agent.state import AgentRunStateStore
 from vibesys.schemas import HypothesisOutcome, OrchestratorPlan
-from vs_loop_state import RoundRecord
+from vs_loop_state import MetricComparison, RoundRecord
 from vs_project import AgentRunConfiguration, Project, RunEnvironmentRecord
 
 if TYPE_CHECKING:
@@ -58,6 +58,7 @@ class _RoundFields(TypedDict, total=False):
     perf_baseline_commit: str | None
     perf_baseline_metric: float | None
     perf_delta_pct: float | None
+    perf_comparison: MetricComparison | None
 
 
 class _HypothesisFields(TypedDict, total=False):

--- a/tests/server/test_experiments.py
+++ b/tests/server/test_experiments.py
@@ -17,6 +17,7 @@ from vibesys.loops.agent.model import (
     HypothesisStrategy,
 )
 from vibesys.loops.agent.state import AgentRunStateStore
+from vibesys.loops.metrics import MetricSpace, Objective
 from vibesys.schemas import HypothesisOutcome, OrchestratorPlan
 from vs_loop_state import MetricComparison, RoundRecord
 from vs_project import AgentRunConfiguration, Project, RunEnvironmentRecord
@@ -413,6 +414,75 @@ def test_service_rebuilds_legacy_measurement_and_resolution_from_round_evidence(
         regression.perf_direction,
         regression.perf_baseline_value,
     ) == ("ops_s", "max", 100.0)
+
+
+def test_service_projects_a_within_noise_delta_as_inconclusive(tmp_path: Path) -> None:
+    """Regression for #507: the read path must use the run's stored tolerance.
+
+    The server reprojects hypothesis evidence on every read. It has no access
+    to the task's ``objectives.toml``, so the tolerance has to travel with the
+    run state; otherwise a 1% delta under a 5% noise model reaches the client
+    as ``proven`` while the round record says the run learned nothing.
+    """
+    configuration = _configuration().model_copy(update={"objectives": ("ops_s:max",)})
+    project, run_id = _project_run(tmp_path / "project", configuration)
+    portable = project.state.portable_namespace(run_id, "agent")
+    AgentRunStateStore(portable).save(
+        AgentRunState(
+            metrics=MetricSpace(
+                objectives=(Objective(name="ops_s", direction="max"),),
+                relative_noise=0.05,
+            ),
+            hypotheses=[
+                _hypothesis(
+                    "H-parent",
+                    1,
+                    rounds=[
+                        _round(
+                            1,
+                            commit="a" * 40,
+                            hypothesis_id="H-parent",
+                            hypothesis_declared_outcome="nominated",
+                            judge_verdict="pass",
+                            passed=True,
+                            official_evaluation=True,
+                            perf_metric=100.0,
+                            perf_unit="ops_s",
+                            perf_direction="max",
+                        )
+                    ],
+                ),
+                _hypothesis(
+                    "H-within-noise",
+                    2,
+                    parent_round=1,
+                    parent_commit="a" * 40,
+                    rounds=[
+                        _round(
+                            2,
+                            commit="b" * 40,
+                            hypothesis_id="H-within-noise",
+                            hypothesis_parent_round=1,
+                            hypothesis_parent_commit="a" * 40,
+                            hypothesis_declared_outcome="nominated",
+                            hypothesis_outcome="inconclusive",
+                            judge_verdict="pass",
+                            passed=True,
+                            official_evaluation=True,
+                            perf_metric=101.0,
+                            perf_unit="ops_s",
+                            perf_direction="max",
+                        )
+                    ],
+                ),
+            ],
+        )
+    )
+    parts = build_server_parts(project.state.log_directory(run_id), project=project, run_id=run_id)
+    entries = parts.api.execute(ExperimentQuery()).experiments
+
+    entry = next(item for item in entries if item.hypothesis_id == "H-within-noise")
+    assert entry.resolved_outcome == "inconclusive"
 
 
 def test_service_returns_authoritative_empty_log_after_attach(tmp_path: Path) -> None:

--- a/tests/vibesys/loops/agent/test_agent_state_store.py
+++ b/tests/vibesys/loops/agent/test_agent_state_store.py
@@ -12,6 +12,7 @@ from vibesys.loops.agent.model import (
     HypothesisStrategy,
 )
 from vibesys.loops.agent.state import AgentRunStateStore
+from vibesys.loops.metrics import MetricSpace, Objective
 from vibesys.schemas import HypothesisStrategyUpdate, OrchestratorPlan
 from vs_loop_state import RoundRecord
 from vs_project import (
@@ -73,6 +74,11 @@ class _LegacyActive(BaseModel):
     gate_approved_candidate_retention_reason: str = ""
     gate_candidate_commit: str | None = None
     gate_accuracy_passed: bool = False
+
+
+def _ops_space() -> MetricSpace:
+    """The space a run measuring ``ops`` declares in its objectives file."""
+    return MetricSpace(objectives=(Objective(name="ops", direction="max"),))
 
 
 def _project(tmp_path):  # noqa: ANN001, ANN202
@@ -184,7 +190,7 @@ def test_legacy_migration_unifies_ledger_active_and_rounds_without_writing(tmp_p
     migrated = store.migrate_legacy(
         rounds=[first],
         local_namespace=local,
-        legacy_directions={"ops": "max"},
+        legacy_space=_ops_space(),
     )
 
     assert store.load_optional() is None
@@ -222,10 +228,14 @@ def test_existing_unified_state_wins_over_legacy_inputs(tmp_path) -> None:  # no
     )
     store.save(unified)
 
-    assert store.migrate_legacy(rounds=[], local_namespace=local) == unified
+    assert (
+        store.migrate_legacy(rounds=[], local_namespace=local, legacy_space=MetricSpace())
+        == unified
+    )
 
 
-def test_existing_unified_state_is_reprojected_when_directions_become_available(tmp_path) -> None:  # noqa: ANN001
+def test_unified_state_written_before_a_metric_space_adopts_the_legacy_one(tmp_path) -> None:  # noqa: ANN001
+    """State that declares no space is reprojected in the caller's fallback."""
     project = _project(tmp_path)
     portable = project.state.portable_namespace("run-1", "agent")
     local = project.state.local_namespace("run-1", "agent")
@@ -270,7 +280,7 @@ def test_existing_unified_state_is_reprojected_when_directions_become_available(
     reprojected = store.migrate_legacy(
         rounds=[],
         local_namespace=local,
-        legacy_directions={"ops": "max"},
+        legacy_space=_ops_space(),
     )
 
     hypothesis = reprojected.by_id("H-1")
@@ -312,6 +322,7 @@ def test_stale_legacy_ledger_active_without_checkpoint_is_not_resurrected(tmp_pa
     migrated = AgentRunStateStore(portable).migrate_legacy(
         rounds=[completed],
         local_namespace=local,
+        legacy_space=MetricSpace(),
     )
 
     assert migrated.active_hypothesis_id is None
@@ -333,7 +344,7 @@ def test_legacy_migration_normalizes_rounds_without_hypothesis_ids(tmp_path) -> 
     migrated = AgentRunStateStore(portable).migrate_legacy(
         rounds=[record],
         local_namespace=local,
-        legacy_directions={"ops": "max"},
+        legacy_space=_ops_space(),
     )
 
     assert len(migrated.hypotheses) == 1
@@ -385,6 +396,7 @@ def test_legacy_migration_replays_strategy_updates_from_active_plan(tmp_path) ->
     migrated = AgentRunStateStore(portable).migrate_legacy(
         rounds=[first],
         local_namespace=local,
+        legacy_space=MetricSpace(),
     )
 
     prior = migrated.by_id("H-1")

--- a/tests/vibesys/loops/agent/test_hypotheses.py
+++ b/tests/vibesys/loops/agent/test_hypotheses.py
@@ -23,6 +23,7 @@ from vibesys.loops.agent.model import (
     HypothesisResolution,
     HypothesisStrategy,
 )
+from vibesys.loops.metrics import Measurement, MetricComparison, MetricSpace, Objective
 from vibesys.schemas import (
     HypothesisOutcome,
     HypothesisStrategyUpdate,
@@ -273,6 +274,7 @@ def test_legacy_performance_remains_visible_without_objective_direction() -> Non
         Hypothesis(hypothesis_id="H-1", plan=_plan("H-1"), started_round=1),
         record,
         prior_rounds=[],
+        space=MetricSpace(),
     )
 
     assert projected.measurement is not None
@@ -287,6 +289,7 @@ def test_legacy_resolution_fails_closed_without_objective_direction() -> None:
         Hypothesis(hypothesis_id="H-1", plan=_plan("H-1"), started_round=1),
         record,
         prior_rounds=[],
+        space=MetricSpace(),
     )
 
     assert projected.resolution is HypothesisResolution.INCONCLUSIVE
@@ -296,12 +299,13 @@ def test_legacy_resolution_fails_closed_without_objective_direction() -> None:
     "direction",
     ["max", "min"],
 )
-def test_reprojection_uses_legacy_direction_for_resolution_and_retention(
+def test_reprojection_uses_the_stored_space_for_resolution_and_retention(
     direction: Literal["max", "min"],
 ) -> None:
     baseline = _legacy_evidence_round(1, 100.0)
     regression = _legacy_evidence_round(2, 90.0, parent_round=1)
     state = AgentRunState(
+        metrics=MetricSpace(objectives=(Objective(name="ops", direction=direction),)),
         hypotheses=[
             Hypothesis(
                 hypothesis_id="H-1",
@@ -309,10 +313,10 @@ def test_reprojection_uses_legacy_direction_for_resolution_and_retention(
                 started_round=1,
                 rounds=[baseline, regression],
             )
-        ]
+        ],
     )
 
-    reprojected = reproject_run_evidence(state, legacy_directions={"ops": direction})
+    reprojected = reproject_run_evidence(state)
 
     hypothesis = reprojected.by_id("H-1")
     assert hypothesis is not None
@@ -348,36 +352,41 @@ def test_metric_baseline_prefers_exact_parent_commit_and_fails_closed() -> None:
     )
 
 
-def test_resolution_and_retention_respect_objective_direction_and_noise() -> None:
-    maximize = resolve_hypothesis_outcome(
-        ResolutionEvidence(
-            declared=HypothesisOutcome.NOMINATED,
-            passed=True,
-            reviewed=True,
-            official_metric=90.0,
-            baseline_metric=100.0,
-            direction="max",
-            benchmark_expected=True,
-        )
-    )
-    minimize = resolve_hypothesis_outcome(
-        ResolutionEvidence(
-            declared=HypothesisOutcome.NOMINATED,
-            passed=True,
-            reviewed=True,
-            official_metric=90.0,
-            baseline_metric=100.0,
-            direction="min",
-            benchmark_expected=True,
-        )
+def _declared(comparison: MetricComparison | None) -> ResolutionEvidence:
+    return ResolutionEvidence(
+        declared=HypothesisOutcome.NOMINATED,
+        passed=True,
+        reviewed=True,
+        comparison=comparison,
+        benchmark_expected=True,
     )
 
-    assert maximize is HypothesisResolution.DISPROVEN
-    assert minimize is HypothesisResolution.PROVEN
-    assert (
-        scalar_candidate_retained(
-            metric=100.2, direction="max", prior=[100.0], noise_fraction=0.005
-        )
-        is False
+
+def test_resolution_consumes_the_comparison_rather_than_the_readings() -> None:
+    """Resolution never sees a value, an axis direction, or a tolerance."""
+    assert resolve_hypothesis_outcome(_declared(MetricComparison.BETTER)) is (
+        HypothesisResolution.PROVEN
     )
-    assert scalar_candidate_retained(metric=90.0, direction="min", prior=[100.0]) is True
+    assert resolve_hypothesis_outcome(_declared(MetricComparison.WORSE)) is (
+        HypothesisResolution.DISPROVEN
+    )
+    assert resolve_hypothesis_outcome(_declared(MetricComparison.WITHIN_NOISE)) is (
+        HypothesisResolution.INCONCLUSIVE
+    )
+    assert resolve_hypothesis_outcome(_declared(MetricComparison.INCOMPARABLE)) is (
+        HypothesisResolution.INCONCLUSIVE
+    )
+    # ``None`` is a different fact: no official metric was recorded at all, so
+    # a nomination stays undecided rather than being ruled against.
+    assert resolve_hypothesis_outcome(_declared(None)) is HypothesisResolution.INCONCLUSIVE
+
+
+def test_retention_consumes_the_comparison_against_the_best_prior() -> None:
+    space = MetricSpace(objectives=(Objective(name="ops", direction="max"),), relative_noise=0.005)
+    candidate = Measurement(metric="ops", value=100.2)
+    prior = [Measurement(metric="ops", value=100.0)]
+
+    assert scalar_candidate_retained(space.compare_to_best(candidate, prior)) is False
+    assert scalar_candidate_retained(space.compare_to_best(candidate, [])) is True
+    assert scalar_candidate_retained(space.compare_to_best(None, prior)) is None
+

--- a/tests/vibesys/loops/agent/test_hypotheses.py
+++ b/tests/vibesys/loops/agent/test_hypotheses.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from vibesys.loops.agent.hypotheses import (
     ResolutionEvidence,
+    adopt_metric_space,
     append_round,
     apply_strategy_updates,
     metric_baseline,
@@ -54,6 +55,7 @@ def _round(  # noqa: PLR0913
     declared: str | None = "nominated",
     direction: Literal["max", "min"] = "max",
     retained: bool | None = True,
+    comparison: MetricComparison | None = None,
 ) -> RoundRecord:
     return RoundRecord(
         round_number=number,
@@ -73,6 +75,7 @@ def _round(  # noqa: PLR0913
         official_evaluation=metric is not None,
         perf_direction=direction if metric is not None else None,
         candidate_retained=retained,
+        perf_comparison=comparison,
     )
 
 
@@ -390,3 +393,155 @@ def test_retention_consumes_the_comparison_against_the_best_prior() -> None:
     assert scalar_candidate_retained(space.compare_to_best(candidate, [])) is True
     assert scalar_candidate_retained(space.compare_to_best(None, prior)) is None
 
+
+_NOISY_OPS = MetricSpace(
+    objectives=(Objective(name="total_ops_per_sec", direction="max"),),
+    relative_noise=0.05,
+)
+
+
+def _within_noise_run() -> AgentRunState:
+    """Two official rounds one percent apart, in a five percent metric space."""
+    state = AgentRunState(metrics=_NOISY_OPS)
+    baseline = append_round(
+        start_hypothesis(state, _plan("H-base"), started_round=1),
+        _round(1, 100.0, hypothesis_id="H-base"),
+        keep_active=False,
+    )
+    started = start_hypothesis(
+        baseline,
+        _plan("H-1"),
+        started_round=2,
+        parent_round=1,
+        parent_commit=f"{1:040x}",
+    )
+    return append_round(
+        started,
+        _round(
+            2,
+            101.0,
+            hypothesis_id="H-1",
+            parent_round=1,
+            parent_commit=f"{1:040x}",
+            outcome="inconclusive",
+            comparison=MetricComparison.WITHIN_NOISE,
+        ),
+        keep_active=False,
+    )
+
+
+def test_append_round_resolves_a_within_noise_delta_as_inconclusive() -> None:
+    """Regression for #507: a 1% delta under a 5% model is not a proven result.
+
+    ``append_round`` is the loop's own writer, so a tolerance it cannot reach
+    silently records the opposite verdict from the one the round observed.
+    """
+    hypothesis = _within_noise_run().by_id("H-1")
+
+    assert hypothesis is not None
+    assert hypothesis.measurement is not None
+    assert hypothesis.measurement.delta_pct == pytest.approx(1.0)
+    assert hypothesis.resolution is HypothesisResolution.INCONCLUSIVE
+
+
+def test_resume_reprojection_agrees_with_the_recorded_round_outcome() -> None:
+    """Regression for #507: ``--resume`` must not contradict the round record."""
+    completed = _within_noise_run()
+    live = completed.by_id("H-1")
+    resumed = reproject_run_evidence(completed).by_id("H-1")
+
+    assert live is not None
+    assert resumed is not None
+    assert resumed.resolution is live.resolution
+    assert [record.hypothesis_outcome for record in resumed.rounds] == ["inconclusive"]
+    assert resumed.resolution is HypothesisResolution.INCONCLUSIVE
+
+
+def test_retention_and_resolution_share_one_tolerance_boundary() -> None:
+    """The chosen semantics: tolerance is ``abs(baseline) * relative_noise``.
+
+    Retention and resolution used to scale the tolerance differently. They now
+    ask the same space the same question, boundary included: a delta exactly at
+    the tolerance is not a result.
+    """
+    space = MetricSpace(objectives=(Objective(name="ops", direction="max"),), relative_noise=0.05)
+    baseline = [Measurement(metric="ops", value=100.0)]
+    at_tolerance = space.compare_to_best(Measurement(metric="ops", value=105.0), baseline)
+    beyond = space.compare_to_best(Measurement(metric="ops", value=105.01), baseline)
+
+    assert resolve_hypothesis_outcome(_declared(at_tolerance)) is (
+        HypothesisResolution.INCONCLUSIVE
+    )
+    assert scalar_candidate_retained(at_tolerance) is False
+    assert resolve_hypothesis_outcome(_declared(beyond)) is HypothesisResolution.PROVEN
+    assert scalar_candidate_retained(beyond) is True
+
+
+def test_adopting_a_metric_space_rewrites_the_stored_space_and_evidence() -> None:
+    """The run's launch configuration is written once; readers take it from state."""
+    strict_run = _strip_stored_comparisons(
+        _within_noise_run().model_copy(
+            update={
+                "metrics": MetricSpace(
+                    objectives=(Objective(name="total_ops_per_sec", direction="max"),)
+                )
+            },
+            deep=True,
+        )
+    )
+    reprojected = reproject_run_evidence(strict_run).by_id("H-1")
+    assert reprojected is not None
+    assert reprojected.resolution is HypothesisResolution.PROVEN
+
+    adopted = adopt_metric_space(strict_run, _NOISY_OPS)
+    hypothesis = adopted.by_id("H-1")
+
+    assert adopted.metrics == _NOISY_OPS
+    assert hypothesis is not None
+    assert hypothesis.resolution is HypothesisResolution.INCONCLUSIVE
+
+
+def test_state_written_before_the_metric_space_loads_as_the_empty_strict_space() -> None:
+    legacy = AgentRunState.model_validate({"schema_version": 1, "hypotheses": []})
+
+    assert legacy.metrics == MetricSpace()
+
+
+def test_a_record_without_a_stored_comparison_is_re_derived_from_the_space() -> None:
+    """Compatibility path for rounds written before the comparison was stored."""
+    stripped = _strip_stored_comparisons(_within_noise_run())
+    assert [record.perf_comparison for record in stripped.rounds] == [None, None]
+
+    hypothesis = reproject_run_evidence(stripped).by_id("H-1")
+
+    assert hypothesis is not None
+    assert hypothesis.resolution is HypothesisResolution.INCONCLUSIVE
+
+
+def test_a_stored_comparison_survives_a_space_whose_tolerance_changed() -> None:
+    """The round answers for itself, so a re-configured space cannot rewrite it.
+
+    Editing ``objectives.toml`` between resumes changes how later rounds are
+    ordered, not how recorded ones were: a delta the run judged to be noise
+    stays noise. Stripping the stored answer is what puts a round back under
+    the space's control.
+    """
+    recorded = _within_noise_run()
+    strict = MetricSpace(objectives=_NOISY_OPS.objectives)
+
+    resolved = adopt_metric_space(recorded, strict).by_id("H-1")
+    re_derived = adopt_metric_space(_strip_stored_comparisons(recorded), strict).by_id("H-1")
+
+    assert resolved is not None
+    assert resolved.resolution is HypothesisResolution.INCONCLUSIVE
+    assert re_derived is not None
+    assert re_derived.resolution is HypothesisResolution.PROVEN
+
+
+def _strip_stored_comparisons(state: AgentRunState) -> AgentRunState:
+    """Return *state* as a run written before comparisons were persisted."""
+    payload = state.model_dump()
+    for hypothesis in payload["hypotheses"]:
+        for record in hypothesis["rounds"]:
+            record["perf_comparison"] = None
+    return AgentRunState.model_validate(payload)

--- a/tests/vibesys/loops/agent/test_interface_modes.py
+++ b/tests/vibesys/loops/agent/test_interface_modes.py
@@ -19,6 +19,7 @@ from vibesys.domains.registry import resolve_domain
 from vibesys.domains.rendering import render_domain_section
 from vibesys.errors import ConfigurationError
 from vibesys.loops.agent.loop import _effective_profiler_definition
+from vibesys.loops.metrics import MetricSpace
 from vibesys.profilers import ProfilerKind
 from vibesys.prompts import PROMPTS_DIR, render_template
 
@@ -83,6 +84,7 @@ def test_loop_constants_and_rejects_unknown_interface():  # noqa: ANN201  # trac
             benchmark_command="benchmark",
             objective="o",
             runs_dir=Path("/tmp/vibesys-test-runs"),  # noqa: S108
+            metrics=MetricSpace(),
             interface="native",
         )
 

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -24,7 +24,6 @@ from vibesys.loops.agent.loop import (
     _candidate_evidence_is_fresh,
     _invoke_read_only_role,
     _missing_implementer_response,
-    _noise_aware_dominates,
     _official_evaluation_reason,
     _pareto_archive_summary,
     _pareto_frontier_records,
@@ -36,7 +35,7 @@ from vibesys.loops.agent.loop import (
 )
 from vibesys.loops.agent.model import Hypothesis, HypothesisResolution, HypothesisReview
 from vibesys.loops.agent.state import AgentRunStateStore
-from vibesys.loops.evolve.population import Objective
+from vibesys.loops.metrics import MetricSpace, Objective
 from vibesys.profilers import ProfilerKind, ProfilerPreflightResult
 from vibesys.prompts import PROMPTS_DIR
 from vibesys.run import GitTracker, RepositoryVisibility
@@ -274,8 +273,7 @@ class _AgentLoopArguments(TypedDict, total=False):
     runs_dir: Path | None
     task_name: str | None
     task_root: Path | None
-    objectives: list[Objective] | None
-    pareto_relative_noise: float
+    metrics: MetricSpace
     workspace_sources: tuple[WorkspaceSource, ...]
     evaluator_path: Path | None
     evaluator_package_root: Path | None
@@ -307,6 +305,14 @@ class _AgentLoopArguments(TypedDict, total=False):
     repo_visibility: RepositoryVisibility
 
 
+_THROUGHPUT_LATENCY = MetricSpace(
+    objectives=(
+        Objective(name="throughput", direction="max"),
+        Objective(name="latency", direction="min"),
+    )
+)
+
+
 def _invoke_orchestrate(
     tmp_path: Path,
     ref_file: str,
@@ -327,6 +333,7 @@ def _invoke_orchestrate(
         "max_rounds": 5,
         "max_retries_per_round": 2,
         "domain": DomainName.LLM_SERVING,
+        "metrics": MetricSpace(),
     }
     defaults.update(kwargs)
     with (
@@ -419,6 +426,7 @@ def test_project_configuration_captures_effective_agent_behavior(tmp_path: Path)
             memory_layout="directories",
             operator_constraints=("Preserve ordering",),
             domain=DomainName.GENERIC,
+            metrics=MetricSpace(),
             run_environment=make_run_environment_spec(
                 use_modal=True,
                 modal_gpu="A100-80GB",
@@ -796,34 +804,23 @@ def test_typed_unknown_retention_is_not_trusted_as_pareto_state():  # noqa: ANN2
         candidate_retained=None,
     )
 
-    assert (
-        _pareto_frontier_records(
-            [record],
-            [Objective("throughput", "max"), Objective("latency", "min")],
-        )
-        == []
-    )
+    assert _pareto_frontier_records([record], _THROUGHPUT_LATENCY) == []
 
 
 def test_noise_aware_dominance_preserves_sub_noise_alternatives():  # noqa: ANN201  # tracked: #288
-    objectives = [Objective("throughput", "max"), Objective("latency", "min")]
+    space = MetricSpace(objectives=_THROUGHPUT_LATENCY.objectives, relative_noise=0.03)
 
-    assert not _noise_aware_dominates(
+    assert not space.dominates(
         {"throughput": 102.0, "latency": 101.0},
         {"throughput": 100.0, "latency": 100.0},
-        objectives,
-        relative_noise=0.03,
     )
-    assert _noise_aware_dominates(
+    assert space.dominates(
         {"throughput": 110.0, "latency": 101.0},
         {"throughput": 100.0, "latency": 100.0},
-        objectives,
-        relative_noise=0.03,
     )
 
 
 def test_pareto_frontier_keeps_throughput_latency_tradeoff_and_drops_dominated_point():  # noqa: ANN201  # tracked: #288
-    objectives = [Objective("throughput", "max"), Objective("latency", "min")]
 
     def candidate(round_number: int, throughput: float, latency: float) -> RoundRecord:
         return RoundRecord(
@@ -843,7 +840,10 @@ def test_pareto_frontier_keeps_throughput_latency_tradeoff_and_drops_dominated_p
     throughput_parent = candidate(2, 140.0, 100.0)
     dominated = candidate(3, 90.0, 110.0)
 
-    frontier = _pareto_frontier_records([latency_parent, throughput_parent, dominated], objectives)
+    frontier = _pareto_frontier_records(
+        [latency_parent, throughput_parent, dominated],
+        _THROUGHPUT_LATENCY,
+    )
 
     assert [record.round_number for record in frontier] == [1, 2]
 
@@ -851,7 +851,6 @@ def test_pareto_frontier_keeps_throughput_latency_tradeoff_and_drops_dominated_p
 def test_live_archive_rejects_stale_frontier_claim_for_dominated_candidate():  # noqa: ANN201  # tracked: #288
     from vibesys.loops.agent.loop import _pareto_archive_conflict  # noqa: PLC0415  # tracked: #288
 
-    objectives = [Objective("throughput", "max"), Objective("latency", "min")]
     trusted = RoundRecord(
         61,
         "a" * 40,
@@ -867,7 +866,7 @@ def test_live_archive_rejects_stale_frontier_claim_for_dominated_candidate():  #
         candidate_disposition=CandidateDisposition.PARETO_FRONTIER,
         candidate_metrics={"throughput": 7258.5, "latency": 9601.6},
         records=[trusted],
-        objectives=objectives,
+        space=_THROUGHPUT_LATENCY,
     )
 
     assert conflict is not None
@@ -878,7 +877,6 @@ def test_live_archive_rejects_stale_frontier_claim_for_dominated_candidate():  #
 def test_live_archive_preserves_real_throughput_latency_tradeoff():  # noqa: ANN201  # tracked: #288
     from vibesys.loops.agent.loop import _pareto_archive_conflict  # noqa: PLC0415  # tracked: #288
 
-    objectives = [Objective("throughput", "max"), Objective("latency", "min")]
     trusted = RoundRecord(
         6,
         "a" * 40,
@@ -895,14 +893,13 @@ def test_live_archive_preserves_real_throughput_latency_tradeoff():  # noqa: ANN
             candidate_disposition=CandidateDisposition.PARETO_FRONTIER,
             candidate_metrics={"throughput": 140.0, "latency": 100.0},
             records=[trusted],
-            objectives=objectives,
+            space=_THROUGHPUT_LATENCY,
         )
         is None
     )
 
 
 def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa: ANN201  # tracked: #288
-    objectives = [Objective("throughput", "max"), Objective("latency", "min")]
     trusted = RoundRecord(
         49,
         "a" * 40,
@@ -929,7 +926,7 @@ def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa:
         candidate_retention_reason="higher-throughput tradeoff",
     )
 
-    summary = _pareto_archive_summary([trusted, pending], objectives)
+    summary = _pareto_archive_summary([trusted, pending], _THROUGHPUT_LATENCY)
 
     assert "Trusted frontier parents" in summary
     assert "round 49" in summary
@@ -2045,7 +2042,12 @@ def test_official_protocol_benchmark_row_becomes_the_round_metrics(tmp_path, ref
             max_rounds=1,
             judge_every=10,
             benchmark_result_protocol=2,
-            objectives=[Objective("total_ops_per_sec", "max"), Objective("p99_latency_ns", "min")],
+            metrics=MetricSpace(
+                objectives=(
+                    Objective(name="total_ops_per_sec", direction="max"),
+                    Objective(name="p99_latency_ns", direction="min"),
+                )
+            ),
         )
 
     rounds = _round_payloads(tmp_path)
@@ -2053,6 +2055,9 @@ def test_official_protocol_benchmark_row_becomes_the_round_metrics(tmp_path, ref
     assert rounds[0]["perf_unit"] == "total_ops_per_sec"
     assert rounds[0]["metrics"] == {"total_ops_per_sec": 41250.3, "p99_latency_ns": 812.0}
     assert rounds[0]["official_evaluation"] is True
+    # Every official round is written with the comparison the framework made,
+    # so no later reader has to re-derive it. Round one has no causal baseline.
+    assert rounds[0]["perf_comparison"] == "incomparable"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vibesys/loops/test_metrics.py
+++ b/tests/vibesys/loops/test_metrics.py
@@ -1,0 +1,169 @@
+"""Tests for the metric space shared by the optimization loops."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+from pydantic import ValidationError
+
+from vibesys.loops.metrics import Measurement, MetricComparison, MetricSpace, Objective
+
+_OPS = Objective(name="ops", direction="max")
+_LATENCY = Objective(name="latency", direction="min")
+
+
+def _reading(value: float, metric: str = "ops") -> Measurement:
+    return Measurement(metric=metric, value=value)
+
+
+def test_relative_noise_is_validated_to_the_configurable_range() -> None:
+    assert MetricSpace().relative_noise == 0.0
+    assert MetricSpace(relative_noise=0.05).relative_noise == 0.05
+    for invalid in (-0.01, 1.0, 1.5):
+        with pytest.raises(ValidationError):
+            MetricSpace(relative_noise=invalid)
+
+
+def test_the_space_is_frozen_and_its_axes_are_unique() -> None:
+    assert MetricSpace.model_config["frozen"] is True
+    with pytest.raises(ValidationError):
+        MetricSpace(objectives=(_OPS, Objective(name="ops", direction="min")))
+
+
+def test_the_axis_supplies_the_direction_a_reading_omits() -> None:
+    space = MetricSpace(objectives=(_OPS,))
+
+    assert space.direction(_reading(1.0)) == "max"
+    # A reading measured before its axis was configured keeps its own meaning.
+    assert space.direction(Measurement(metric="ops", value=1.0, direction="min")) == "min"
+    assert space.direction(_reading(1.0, "unknown")) is None
+    assert space.direction(None) is None
+
+
+@pytest.mark.parametrize("direction", ["max", "min"])
+def test_a_delta_exactly_at_the_tolerance_is_within_noise(
+    direction: Literal["max", "min"],
+) -> None:
+    """The tolerance is inclusive: only a delta beyond it is a real result."""
+    space = MetricSpace(
+        objectives=(Objective(name="ops", direction=direction),), relative_noise=0.05
+    )
+
+    assert space.compare(_reading(105.0), _reading(100.0)) is MetricComparison.WITHIN_NOISE
+    assert space.compare(_reading(95.0), _reading(100.0)) is MetricComparison.WITHIN_NOISE
+    beyond = MetricComparison.BETTER if direction == "max" else MetricComparison.WORSE
+    assert space.compare(_reading(105.01), _reading(100.0)) is beyond
+
+
+@pytest.mark.parametrize("direction", ["max", "min"])
+def test_direction_decides_which_side_of_the_baseline_is_better(
+    direction: Literal["max", "min"],
+) -> None:
+    space = MetricSpace(
+        objectives=(Objective(name="ops", direction=direction),), relative_noise=0.05
+    )
+
+    higher = space.compare(_reading(120.0), _reading(100.0))
+    lower = space.compare(_reading(80.0), _reading(100.0))
+
+    assert higher is (MetricComparison.BETTER if direction == "max" else MetricComparison.WORSE)
+    assert lower is (MetricComparison.WORSE if direction == "max" else MetricComparison.BETTER)
+
+
+def test_a_zero_noise_space_compares_strictly() -> None:
+    space = MetricSpace(objectives=(_OPS,))
+
+    assert space.compare(_reading(100.000001), _reading(100.0)) is MetricComparison.BETTER
+    assert space.compare(_reading(99.999999), _reading(100.0)) is MetricComparison.WORSE
+    assert space.compare(_reading(100.0), _reading(100.0)) is MetricComparison.WITHIN_NOISE
+
+
+def test_a_zero_baseline_leaves_no_scale_so_the_comparison_is_strict() -> None:
+    """The tolerance is relative, so at a zero baseline it is zero too."""
+    space = MetricSpace(objectives=(_OPS,), relative_noise=0.5)
+
+    assert space.compare(_reading(0.5), _reading(0.0)) is MetricComparison.BETTER
+    assert space.compare(_reading(-0.5), _reading(0.0)) is MetricComparison.WORSE
+    assert space.compare(_reading(0.0), _reading(0.0)) is MetricComparison.WITHIN_NOISE
+
+
+def test_a_negative_baseline_scales_the_tolerance_by_its_magnitude() -> None:
+    space = MetricSpace(objectives=(_OPS,), relative_noise=0.1)
+    minimizing = MetricSpace(
+        objectives=(Objective(name="ops", direction="min"),), relative_noise=0.1
+    )
+
+    assert space.compare(_reading(-95.0), _reading(-100.0)) is MetricComparison.WITHIN_NOISE
+    assert space.compare(_reading(-85.0), _reading(-100.0)) is MetricComparison.BETTER
+    assert space.compare(_reading(-115.0), _reading(-100.0)) is MetricComparison.WORSE
+    assert minimizing.compare(_reading(-85.0), _reading(-100.0)) is MetricComparison.WORSE
+
+
+@pytest.mark.parametrize(
+    ("candidate", "baseline"),
+    [
+        (None, _reading(100.0)),
+        (_reading(100.0), None),
+        (_reading(100.0, "unconfigured"), _reading(100.0, "unconfigured")),
+        (_reading(100.0), _reading(100.0, "latency")),
+    ],
+)
+def test_missing_or_mismatched_evidence_is_incomparable(
+    candidate: Measurement | None,
+    baseline: Measurement | None,
+) -> None:
+    space = MetricSpace(objectives=(_OPS,), relative_noise=0.05)
+
+    assert space.compare(candidate, baseline) is MetricComparison.INCOMPARABLE
+
+
+def test_best_and_compare_to_best_order_a_scalar_history() -> None:
+    space = MetricSpace(objectives=(_OPS,), relative_noise=0.05)
+    history = [_reading(100.0), _reading(90.0), _reading(99.0)]
+
+    assert space.best(history) == _reading(100.0)
+    assert space.best([]) is None
+    # An empty history is advanced by anything measurable.
+    assert space.compare_to_best(_reading(1.0), []) is MetricComparison.BETTER
+    assert space.compare_to_best(None, history) is MetricComparison.INCOMPARABLE
+    assert space.compare_to_best(_reading(1.0, "unconfigured"), []) is MetricComparison.INCOMPARABLE
+    assert space.compare_to_best(_reading(104.0), history) is MetricComparison.WITHIN_NOISE
+    assert space.compare_to_best(_reading(120.0), history) is MetricComparison.BETTER
+
+
+def test_dominance_needs_every_axis_and_one_material_win() -> None:
+    space = MetricSpace(objectives=(_OPS, _LATENCY), relative_noise=0.03)
+    baseline = {"ops": 100.0, "latency": 100.0}
+
+    assert space.dominates({"ops": 110.0, "latency": 101.0}, baseline)
+    # Better on one axis, materially worse on the other.
+    assert not space.dominates({"ops": 110.0, "latency": 110.0}, baseline)
+    # Everything within noise is not a dominating point.
+    assert not space.dominates({"ops": 102.0, "latency": 101.0}, baseline)
+    # A missing axis makes the rows incomparable rather than dominated.
+    assert not space.dominates({"ops": 110.0}, baseline)
+    assert not space.dominates({"ops": 110.0, "latency": 90.0}, {"ops": 100.0})
+
+
+def test_a_space_with_no_axes_dominates_nothing() -> None:
+    assert not MetricSpace().dominates({"ops": 110.0}, {"ops": 100.0})
+    assert not MetricSpace().complete({"ops": 110.0})
+
+
+def test_the_frontier_keeps_every_tradeoff_and_drops_dominated_points() -> None:
+    space = MetricSpace(objectives=(_OPS, _LATENCY))
+    rows = [
+        {"ops": 100.0, "latency": 80.0},
+        {"ops": 140.0, "latency": 100.0},
+        {"ops": 90.0, "latency": 110.0},
+    ]
+
+    assert space.frontier(rows, lambda row: row) == rows[:2]
+
+
+def test_completeness_requires_a_value_on_every_configured_axis() -> None:
+    space = MetricSpace(objectives=(_OPS, _LATENCY))
+
+    assert space.complete({"ops": 1.0, "latency": 2.0, "extra": 3.0})
+    assert not space.complete({"ops": 1.0})


### PR DESCRIPTION
## Problem

Issue #507: hypothesis evidence projection rebuilt `ResolutionEvidence` with
`noise_fraction=0.0` instead of the task's configured `pareto.relative_noise`.
A within-noise benchmark delta therefore resolved as PROVEN or DISPROVEN in the
persisted `Hypothesis` while the round record said INCONCLUSIVE, and `--resume`
reproduced the contradiction.

Open PR #541 by @zatchbell1311-wq threads a `noise_fraction` parameter through
`project_round_evidence`, `reproject_run_evidence`, and the state store's legacy
migration. Reviewing #541 at its head, the bug still reproduces: `append_round`
in `src/vibesys/loops/agent/hypotheses.py`, which the loop calls after every
completed round, still calls the projection with no noise fraction, and the
server read path (`_agent_run_state` in `src/server/api/service.py`) passes
nothing and has no way to obtain the value, because it was not persisted
anywhere. Writing this PR surfaced a third silent site on `main`:
`_pareto_archive_conflict` called `_pareto_archive_dominators` with no
tolerance, so the live-archive guard shown to the implementer and judge
compared exactly while the run was configured for noise.

The root cause is structural, not a missing argument. Two facts about how a run
measures its candidates were scattered:

- **The axes.** `Objective` lived inside the evolve loop
  (`src/vibesys/loops/evolve/population.py`) and the agent loop imported it
  across a loop boundary. Comparison helpers took `objectives: list[Objective]`
  in nine signatures, and a second, parallel copy travelled as
  `legacy_directions: Mapping[str, Literal["max","min"]]` through eight more,
  every one of them defaulted to `None`.
- **The tolerance.** Read once from `objectives.toml` in
  `src/entrypoints/headless.py`, passed into `run_agent_loop`, then
  hand-threaded through seven signatures behind
  `= 0.0` / `= _DEFAULT_PARETO_RELATIVE_NOISE` defaults.

Callers therefore assembled a comparison out of a value, an axis direction, and
a tolerance, and then branched on the numbers themselves. The question
"is this delta beyond bench noise?" was implemented three times with three
different formulas: `_resolve_metric_evidence` (percent of baseline) and
`scalar_candidate_retained` (scale of the best prior, with an absolute fallback
of `1.0` at a zero best) in `hypotheses.py`, and `_noise_aware_dominates`
(per-axis on signed values) in `loop.py`. Forgetting one of the pieces was
silent, and three call sites forgot.

## Solution

Give the run a **metric space**, make it the only thing that answers ordering
questions, and persist each round's answer so no reader has to ask again.

### 1. One shared module owns the axes, the tolerance, and the comparison

New `src/vibesys/loops/metrics.py`, sibling of `gates.py` whose docstring
already reads "shared by optimization loops". It owns:

- `Objective`, moved out of `evolve/population.py` (thin re-export left there
  so the evolve loop and its tests are untouched by this PR).
- `Measurement`: one benchmark reading, named by the axis it was taken on.
- `MetricSpace`: a frozen Pydantic model holding `objectives` and
  `relative_noise`, with `compare`, `best`, `compare_to_best`, `dominates`,
  `frontier`, and `complete`. **Noise and axis direction appear as parameters
  in this module and nowhere else in the repository.**
- `MetricComparison`, re-exported (see §3 for where it is defined).

I kept `within_noise` rather than renaming it `equivalent`, because the
docstring distinction from `incomparable` is load-bearing: `within_noise` means
the comparison ran and found no result, `incomparable` means it could not run.
Every consumer that collapses them to one outcome does so explicitly, in an
exhaustive `match`.

### 2. Decisions consume the ordering, not the comparator

- `ResolutionEvidence` carries `comparison: MetricComparison | None` instead of
  `official_metric`, `baseline_metric`, `direction`, and a tolerance. `None`
  and `INCOMPARABLE` are kept distinct: no official metric was recorded, versus
  one was recorded but could not be ordered.
- `scalar_candidate_retained(comparison)` is a four-way mapping over the
  comparison against the best prior, which callers get from
  `space.compare_to_best`.
- The Pareto and archive-conflict code calls `space.dominates` /
  `space.frontier`. `_noise_aware_dominates` is deleted.
- `_correct_legacy_resolution`, which re-decided a legacy `proven` from the sign
  of `delta_pct`, now branches on the same comparison.

### 3. Each round records its own comparison

`RoundRecord.perf_comparison` (in `libs/vs-loop-state`) stores the ordering the
framework decided when the round was written. `MetricComparison` is therefore
defined in `vs_loop_state/metrics.py` and re-exported from
`vibesys/loops/metrics.py`, keeping the dependency direction library ← vibesys.
Unlike `hypothesis_outcome` and `candidate_disposition`, which name
`vibesys`-owned vocabularies and are persisted as plain strings, the ordering
of two numbers is fully describable in the library, so it is a real enum there.

`append_round`, `reproject_run_evidence`, `migrate_legacy` and the server read
path consume the stored answer. `legacy_directions`, itself a threaded copy of
the axes, disappears from all four; `reproject_run_evidence(state)` and the
server's `_agent_run_state` now take no measurement configuration at all.

**Tradeoff, stated deliberately:** editing `objectives.toml` between resumes
changes how *later* rounds are ordered, not how recorded ones were. A delta the
run judged to be noise stays noise, even if the operator narrows the tolerance
and resumes. This is the same "task file wins at run start" rule the run has
always had, now applied per round instead of per read, and it is what stops a
resumed run from disagreeing with what it recorded.
`test_a_stored_comparison_survives_a_space_whose_tolerance_changed` pins it.

### 4. The space is written once and read from state

`AgentRunState.metrics` holds it. `headless.py` reads the axes and the
tolerance together in one loader (`_load_metric_space_toml`, replacing
`_load_objectives_toml` and `_load_pareto_relative_noise_toml`, which parsed the
same file twice). `run_agent_loop` takes a `MetricSpace` in place of
`objectives` plus a float and adopts it once, via `adopt_metric_space`.

**Compatibility.** State written before `metrics` existed loads as the empty
strict space; records written before `perf_comparison` existed load as `None`
and have their comparison re-derived from the space. Both reproduce the
behavior those runs already had. `schema_version` stays `1`: the changes are
additive. For unified state that predates the field, `migrate_legacy` accepts a
fallback space — the loop passes what the task declares, and the server, which
cannot read a task directory, passes the axes recorded in the run manifest,
which carries no tolerance and therefore compares exactly.

### 5. Chosen semantics

The three old formulas disagreed, so this PR picks one rule with no special
cases: the tolerance is `abs(baseline) * relative_noise`, compared against the
direction-signed improvement. A delta *at* the tolerance is `within_noise`;
only a delta beyond it is a result. Relative to `main`:

| Case | Before | Now |
| --- | --- | --- |
| Per-axis Pareto dominance | `abs(baseline) * noise` | unchanged |
| Resolution, nonzero baseline | percent of baseline vs `noise * 100` | same boundary, no percent detour |
| Resolution, **zero** baseline | always INCONCLUSIVE | tolerance is 0, so strict comparison decides |
| Retention, **zero** best prior | absolute tolerance of `1.0 * noise` | tolerance is 0, so strict comparison decides |
| Missing value / unknown direction | INCONCLUSIVE / `None` | `INCOMPARABLE`, mapped to the same outcomes |

Both changed rows are the exactly-zero-baseline corner, where a *relative*
tolerance has no scale to apply. `tests/vibesys/loops/test_metrics.py` pins the
choice and `test_retention_and_resolution_share_one_tolerance_boundary` pins
that resolution and retention now agree at the boundary.

### Architecture

```mermaid
flowchart TD
    T["objectives.toml<br/>[[objective]] + [pareto] relative_noise"]
    T -->|"read once: _load_metric_space_toml"| H["headless.py"]
    H -->|"metrics=MetricSpace(...)"| L["run_agent_loop"]
    L -->|"adopt_metric_space()<br/>the only write"| S[("AgentRunState.metrics<br/>state.json")]

    L -->|"space.compare(reading, baseline)<br/>once per official round"| REC[("RoundRecord.perf_comparison<br/>inside state.json")]

    REC -->|stored ordering| AR["append_round"]
    REC -->|stored ordering| RE["reproject_run_evidence<br/>(--resume)"]
    REC -->|stored ordering| SV["server _agent_run_state"]

    S -.->|"space, for records<br/>written before the field"| AR
    S -.-> RE
    S -.-> SV
    S -->|"dominates / frontier / compare_to_best"| P["Pareto archive,<br/>retention, archive guard"]

    AR --> D["resolve_hypothesis_outcome<br/>scalar_candidate_retained"]
    RE --> D
    SV --> D
    D --> O["HypothesisResolution"]
```

Solid arrows are the normal path: the ordering travels with the round. Dashed
arrows are the compatibility path for records written before `perf_comparison`.

### Coordination

PR #577 (`vic/attempt-judge-outcome`) and #578 merged into `main` while this was
in progress; this branch is rebased on `main` and both rebases were
conflict-free. PR #311 extracts `_resolve_round_outcome` from the
`run_agent_loop` region between the retry loop and the round record; its removed
block ends immediately before the comparison and record-write sites this PR
edits, and it touches no measurement argument.

### Follow-up

`Population.frontier`, `Population.best`, and `_dominates` in
`evolve/population.py` still compare exactly, on the moved `Objective`. They
should delegate to `MetricSpace` next. That is a deliberate behavior change —
it makes the evolve loop noise-aware for the first time — and needs its own
verification, so it is out of scope here.

## Verification

Reproduced the bug at the merge base and confirmed the fix at head, then ran the
loop, server, entrypoint, and library suites plus format, lint, type, and
doc-link checks. No protocol model changed (`AgentRunState` and `RoundRecord`
are persisted state, not server protocol types; nothing under `clients/` is
touched), so binding regeneration and the TUI checks were not applicable.

### Correctness properties

- **One comparison implementation.** `MetricSpace.compare` is the only place
  two readings are ordered. `_resolve_metric_evidence`,
  `scalar_candidate_retained`, `_correct_legacy_resolution`, the Pareto
  frontier, and the archive guard contain no tolerance arithmetic and branch
  exhaustively over `MetricComparison`.
- **Noise and direction never leave `metrics.py`.** No signature outside that
  module takes a tolerance or an axis direction. The count went from 7
  tolerance parameters (all defaulted to `0.0`) plus 8 directions-map
  parameters (all defaulted to `None`) plus 9 `objectives: list[Objective]`
  parameters, to zero of each and one `MetricSpace` value. Decision functions
  take neither: they take a `MetricComparison`.
- **Records carry their comparison.** Every official round is written with the
  ordering the framework made; readers consume it and never re-derive it from a
  space that may have been re-configured since.
- **The loop outcome, the persisted resolution, `--resume`, and the server
  agree for the same records.** Regression-tested end to end for a 1% delta in a
  5% space.
- **A zero-noise space compares strictly**, so runs without
  `[pareto] relative_noise` behave exactly as before.
- **Backward-compatible persisted state.** `state.json` without `metrics`,
  records without `perf_comparison`, and legacy-file migration all load and
  compare exactly; `schema_version` is unchanged and both additions are
  additive.
- **Validation is single-owner.** The `[0, 1)` range and axis-name uniqueness
  are enforced by `MetricSpace`; `run_agent_loop`'s duplicate range check is
  removed and `headless.py` keeps only its file-scoped "malformed
  `pareto.relative_noise` in `<path>`" diagnostics.

### Testing

**Base-versus-head reproduction.** Base is the merge base `24a89cf4`
(`origin/main`), in a temporary worktree removed afterwards. Two official rounds
1% apart, task configured for 5% noise:

| | base `24a89cf4` | head |
| --- | --- | --- |
| round observed by the loop | `inconclusive` | `inconclusive` |
| `append_round` persisted | **`proven`** | `inconclusive` |
| reproject (resume / server) | **`proven`** | `inconclusive` |

The three end-to-end regression tests, run at base with this branch's test files
copied in:

```
$ uv run pytest \
    tests/vibesys/loops/agent/test_hypotheses.py::test_append_round_resolves_a_within_noise_delta_as_inconclusive \
    tests/vibesys/loops/agent/test_hypotheses.py::test_resume_reprojection_agrees_with_the_recorded_round_outcome \
    tests/server/test_experiments.py::test_service_projects_a_within_noise_delta_as_inconclusive \
    -q --no-cov
E   ImportError: cannot import name 'adopt_metric_space' from 'vibesys.loops.agent.hypotheses'
E   ModuleNotFoundError: No module named 'vibesys.loops.metrics'
2 errors in 2.00s
```

They cannot pass at base: the shared space they assert on does not exist there,
and the behavior they pin is the behavior the table above shows is wrong. All
three pass at head.

**Head.**

```
$ uv run pytest tests/vibesys/loops -q --no-cov
583 passed in 223.65s

$ uv run pytest tests/server -q --no-cov
233 passed in 20.40s

$ uv run pytest libs/vs-loop-state/tests libs/vs-project/tests tests/entrypoints -q --no-cov
476 passed in 18.07s

$ ./scripts/check_format.sh
All checks passed!
476 files already formatted

$ ./scripts/check_lint.sh
All checks passed!

$ ./scripts/check_types.sh
All checks passed!

$ uv run python scripts/check_doc_links.py
Checked 324 Markdown file(s); no broken links.
```

**New tests.** `tests/vibesys/loops/test_metrics.py` (19 cases: range and
uniqueness validation, frozenness, the axis supplying a reading's direction, the
tolerance boundary in both directions, zero and negative baselines, strict
comparison at zero noise, missing and mismatched axes, scalar history ordering,
dominance with a missing axis and with no axes, and the frontier). Plus eight
cases in `tests/vibesys/loops/agent/test_hypotheses.py` — including both
directions of the stored-comparison compatibility path — and one in
`tests/server/test_experiments.py`.

Refs #507, #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
