### PR TITLE
Add a PR triage skill and tighten review and PR-authoring rules

### DIFF
--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -62,8 +62,29 @@ uv run pytest
    - Default to a draft PR unless the user explicitly asks for a ready PR.
    - Target the repository's default base branch unless the user specifies another base.
    - Use `.github/pull_request_template.md` and fill every section.
+   - Apply labels at creation (`gh pr create --label ...` or `gh pr edit
+     --add-label` right after). Pick from the repository's existing labels
+     (`gh label list`); do not create new ones. Every PR gets exactly one
+     kind label:
+     - `bug` when the `Problem` section describes existing incorrect
+       behavior, or the closing issue is labeled `bug`.
+     - `enhancement` for new capability, a new surface, new tooling, or a
+       redesign.
+     - `refactor` for a structural change with no intended behavior change.
+     - `documentation` for docs-only diffs.
+     Mirror the closing issue's area labels (`area/*`, `workload/*`,
+     `app/*`, and similar) when the PR closes an issue that carries them.
    - When opening a dependent series, create every PR with its complete body,
      then register the series as a native GitHub stack as described below.
+   - When the PR is a follow-up to someone else's merged or open PR (a more
+     robust fix for the same bug, a refactor that makes that bug
+     unrepresentable, or a hardening of its tests), notify the original
+     author. Link the original PR in the `Problem` section and @-mention its
+     author there, then post a short FYI comment on the original PR with
+     `gh pr comment <original> --body ...` that mentions the author, links
+     the follow-up, and says in one or two sentences why it is the more
+     robust fix. Keep the tone informational; it is a courtesy, not a
+     request for changes.
 
 ## Native GitHub Stacks
 
@@ -115,6 +136,6 @@ Keep the title concrete and behavior-oriented. Avoid generic titles such as "Upd
 
 ## Handoff
 
-End with the PR URL, draft/ready status, branch name, commit hash, and verification run. If any check was skipped or failed, state that plainly with the reason.
+End with the PR URL, draft/ready status, labels applied, branch name, commit hash, and verification run. If any check was skipped or failed, state that plainly with the reason.
 For stacked work, also report the stack number and PR order. For independent
 work created alongside a stack, state that remote stack membership is absent.

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -21,8 +21,12 @@ repository's contracts, architecture, tests, and affected callers.
    - Read the PR title, body, linked issue, base/head commits, changed files,
      existing review threads, and check results when available. Use the local
      branch or merge-base diff when reviewing unpublished work.
-   - Derive the intended behavior and correctness properties. Call out material
-     ambiguity instead of silently choosing an interpretation.
+   - Derive the intended behavior and correctness properties from the PR
+     body and the linked issue. Record each concrete claim (what changes,
+     what is fixed, what stays the same, what was tested) so the summary can
+     check it against the diff.
+   - Call out material ambiguity instead of silently choosing an
+     interpretation.
    - Do not submit a GitHub review, comment, approval, or change request unless
      the user explicitly asks for that external write.
 
@@ -38,6 +42,11 @@ repository's contracts, architecture, tests, and affected callers.
    - Look for coupled artifacts that should have changed but did not: tests,
      snapshots, schemas, generated types, package data, examples, contracts,
      migration or compatibility code, and user-facing documentation.
+   - Reconcile the claims with the code. For each claim from step 1, find
+     the diff hunks that implement it. Note claims with no implementing
+     change, changes the body does not mention, a fix that addresses a
+     different cause than the issue describes, a "no behavior change" claim
+     next to a behavior change, and tests that are named but absent.
 
 3. Apply the review guide.
    - Read [references/review-guide.md](references/review-guide.md) completely.
@@ -48,7 +57,25 @@ repository's contracts, architecture, tests, and affected callers.
      real interface and reuse boundary. Flag both misplaced shared behavior and
      abstractions that add indirection without protecting a boundary.
 
-4. Verify candidate findings.
+4. Reproduce the bug when the PR is a bug fix.
+   - Whenever practical, demonstrate the defect at the merge base and its
+     absence at the PR head. Use a temporary worktree
+     (`git worktree add <scratch>/pr-<N> <ref>`) so the user's checkout is
+     never mutated; remove it when done.
+   - Choose the narrowest deterministic reproduction: run the PR's own new
+     tests against the base source (they must fail there and pass at the
+     head), write a throwaway test or script from the issue's steps, or for
+     TUI rendering fixes render the affected view at a fixed width with the
+     `clients/tui` test harness. Drive the live TUI through the
+     `tui-bug-hunt` harness only when no cheaper reproduction exists and the
+     cost is justified.
+   - Report the reproduction as evidence: the command, the observed failure
+     at the base, and the observed result at the head. If a reproduction was
+     not possible, say why and treat the fix as unverified rather than
+     confirmed. A fix whose new tests also pass at the merge base has not
+     been demonstrated.
+
+5. Verify candidate findings.
    - Confirm that the reviewed change introduced or exposed the problem.
    - State the concrete input, state, platform, or execution path that triggers
      it and the observable consequence.
@@ -60,15 +87,25 @@ repository's contracts, architecture, tests, and affected callers.
    - Re-read the final diff and each cited line. Distinguish a proven defect
      from a residual risk that needs more evidence.
 
-5. Report the review.
-   - Lead with findings ordered by severity. Use `[P0]` through `[P3]`, a short
+6. Report the review.
+   - Always start with a summary of the PR: two to five sentences on what
+     the diff actually does, in terms of behavior and the modules it touches,
+     followed by a `Discrepancies` line. List every gap between what the PR
+     body or linked issue claims and what the source code does: unmentioned
+     changes, unimplemented claims, a different root cause, a wider or
+     narrower scope than the issue, or verification claims the diff does not
+     support. Write `Discrepancies: none` when the claims and the code
+     agree. A discrepancy that changes correctness or merge safety also
+     becomes a finding below.
+   - Then list findings ordered by severity. Use `[P0]` through `[P3]`, a short
      actionable title, one compact explanation, and the tightest changed-line
      range that demonstrates the issue.
    - Explain why the behavior is wrong and when it occurs; include a fix
      direction only when it clarifies the required contract. Do not write a
      patch unless the user also asks for implementation.
-   - Keep summaries brief. After findings, list assumptions or open questions,
-     checks run, and residual risks only when they add information.
+   - Keep summaries brief. After findings, report the reproduction outcome
+     for bug fixes, then list assumptions or open questions, checks run, and
+     residual risks only when they add information.
    - If there are no actionable findings, say so plainly and mention meaningful
      verification gaps. Do not invent low-value findings to populate a review.
 

--- a/.agents/skills/review-pr/references/review-guide.md
+++ b/.agents/skills/review-pr/references/review-guide.md
@@ -68,6 +68,10 @@ Ask of new abstractions:
 - Verify security boundaries: path traversal, command injection, unsafe
   deserialization, secret exposure, untrusted prompt or template interpolation,
   over-broad filesystem/network access, and trust decisions based on user input.
+- Flag any new state field whose value is determined by other fields in the
+  same model, and ask for a selector or predicate instead. Duplicate state
+  needs every writer to stay in sync, and the reviewed diff usually updates
+  only the writer it touched.
 
 ## Contracts And Compatibility
 
@@ -109,6 +113,9 @@ Ask of new abstractions:
 - Keep protocol data semantic and rendering/UI state in `clients/tui/`.
   Validate missing, duplicate, out-of-order, reconnect, and terminal events in
   session state transitions.
+- Protocol-defined closed sets (run status, event kinds, verdicts) must reach
+  the client as generated literal unions, not `string`, and client predicates
+  over them must branch exhaustively.
 - Respect strict TypeScript settings, including exact optional properties,
   unchecked indexed access, exhaustive control flow, and unused checks. Do not
   use assertions or `any` to bypass uncertain protocol states.
@@ -208,6 +215,13 @@ take the wrong action. Do not require prose churn for a purely internal change.
 - Map each stated correctness property to a test, type/schema check, or focused
   manual reproduction. A regression test should fail for the old behavior for
   the reason claimed.
+- For a bug fix, require a regression test that fails at the merge base at
+  the lowest layer that reproduces the reported symptom. Reject a test that
+  passes unchanged on the pre-fix code or that restates the fix's constants
+  in the test body. For TUI symptoms stated in terminal geometry, the layer
+  is the OpenTUI test renderer (`createTestRenderer`); a pure-function test
+  over a formatter is not evidence. See the regression-test table in
+  `docs/contributing/tui-architecture.md`.
 - Test application configuration and implementation separately, then add a
   focused wiring test when their connection changes.
 - Use shared contract tests for interchangeable sandboxes, compute backends,

--- a/.agents/skills/triage-prs/SKILL.md
+++ b/.agents/skills/triage-prs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: triage-prs
+description: Triage the open pull requests of the VibeSys repository. Inventory them, classify each by readiness (CI, merge conflicts, draft state, review state, stack position, PR template compliance, staleness), decide whether the author or a reviewer acts next, optionally apply routine labels such as bug, and report a prioritized maintainer queue. Use when a user asks to triage, prioritize, sort, summarize, or check the status of open PRs, find what is ready to merge or review, what is stale or blocked, what needs author action, or to label open PRs.
+---
+
+# Triage PRs
+
+## Overview
+
+Produce a maintainer's action queue for the open pull requests, not a review
+of each one. Classify from GitHub signals and PR bodies, then delegate deep
+code review of individual PRs to the `review-pr` skill when the user selects
+them.
+
+## Workflow
+
+1. Resolve scope and write permissions.
+   - Default to a read-only report. Labels, comments, review requests,
+     closing, readiness changes, and project fields are writes and need an
+     explicit user request. "Tag bug fixes with bug" or "label feature PRs"
+     is such a request.
+   - Confirm the repository with `gh repo view --json nameWithOwner`. Do not
+     switch branches or fetch PR heads; triage never needs a checkout.
+   - Restrict to a subset (author, label, path, PR list) when the user names
+     one.
+
+2. Collect signals.
+   - Run `scripts/pr_inventory.sh` from this skill directory. It prints one
+     JSON object per open PR with CI, mergeability, review, stack, template,
+     and closing-issue signals. Field meanings are in
+     [references/triage-signals.md](references/triage-signals.md).
+   - Re-query PRs whose `mergeable` is `UNKNOWN` after a short wait. GitHub
+     computes mergeability lazily.
+   - For PRs whose bucket depends on review content, read the latest
+     maintainer comment or review with `gh pr view N --comments`. Findings in
+     this repository are often plain comments with `[P0]` to `[P3]` prefixes.
+   - Read the `Problem` section of each PR body. Do not read diffs except to
+     resolve a classification question, such as whether a change is a bug fix
+     or a refactor.
+
+3. Classify.
+   - Assign exactly one bucket per PR using the precedence in
+     [references/triage-signals.md](references/triage-signals.md):
+     `blocked`, `needs-author`, `draft`, `stale`, `ready-to-merge`,
+     `needs-review`.
+   - Record the concrete blocker: failing check names, conflict, unanswered
+     findings, missing template section, open predecessor PR.
+   - Decide who acts next. Trust `waiting_on` unless the latest comment shows
+     otherwise.
+
+4. Run the cross-PR checks: overlapping files between open PRs, shared
+   commits, stacks that are claimed in the body but based on trunk, split
+   series and their order, superseded work, and large PRs with no review.
+
+5. Estimate review effort per PR from the logical change, not the diff
+   size. Use `size`, `large_files`, and `bulk_lines` from the inventory and
+   the rules in the reference. A mechanical rename, a regenerated schema, a
+   recorded fixture, or a vendored source tree inflates the diff without
+   adding review work; say so in the report.
+
+6. Apply requested writes.
+   - Labeling: follow the label rules in the reference. Ground `bug` in the
+     PR's `Problem` section or a closing issue labeled `bug`; ground
+     `enhancement` in a `Solution` that adds capability or a surface, and
+     `refactor` in a stated absence of behavior change. Skip borderline cases
+     and list them for the user.
+   - Before any comment, close, or review request, restate exactly which PRs
+     are affected. Never close or mark ready without a per-PR instruction.
+   - Re-read each edited PR with `gh pr view N --json labels` and report the
+     result.
+
+7. Report using the template in the reference. Lead with the maintainer's
+   ordered actions, then the queue table, cross-PR notes, and writes made.
+   End with the recommended review sequence: small targeted PRs first, then
+   old PRs that need a close or follow-up decision, then stacks bottom-up,
+   then larger work ordered by what it unblocks, with drafts and blocked PRs
+   as a watch list. State anything not verified after the sequence.
+
+## Boundaries
+
+- Triage judges readiness and ownership, not code quality. Say "needs
+  review" rather than guessing whether the code is correct.
+- Do not count passing checks as evidence of correctness; the queue tells
+  the maintainer where to spend review time.
+- Report unverified state (transient `UNKNOWN` mergeability, missing token
+  scopes for the project board, CI that has not run) instead of filling it
+  in.
+- Do not expose credentials, private logs, or sensitive paths.

--- a/.agents/skills/triage-prs/agents/openai.yaml
+++ b/.agents/skills/triage-prs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Triage PRs"
+  short_description: "Triage open VibeSys pull requests"
+  default_prompt: "Use $triage-prs to triage the open pull requests in this repository and report the maintainer action queue."

--- a/.agents/skills/triage-prs/references/triage-signals.md
+++ b/.agents/skills/triage-prs/references/triage-signals.md
@@ -1,0 +1,211 @@
+# Triage Signals
+
+Rules for turning `scripts/pr_inventory.sh` output into buckets, owners, and
+labels. Apply them in the order written; the first matching bucket wins.
+
+## Contents
+
+- [Signals](#signals)
+- [Buckets](#buckets)
+- [Who Acts Next](#who-acts-next)
+- [Cross-PR Checks](#cross-pr-checks)
+- [Review Effort](#review-effort)
+- [Review Sequence](#review-sequence)
+- [Labels](#labels)
+- [Writes](#writes)
+- [Report Template](#report-template)
+
+## Signals
+
+| Field | Meaning | Notes |
+| --- | --- | --- |
+| `mergeable` | GitHub's merge computation | `UNKNOWN` is transient. Re-query with `gh pr view N --json mergeable` after a few seconds; treat persistent `UNKNOWN` as unverified, not as clean. |
+| `ci` | Rollup of the head commit's checks | `none` usually means CI has not run for a fork or the head was force-pushed moments ago. |
+| `failing_checks` | Names of failed checks | Repository check names: `python-checks` (format, lint, boundaries, doc links), `typecheck`, `tui` (TypeScript lint, boundaries, generated bindings, tests, build), `queue-native`, `test (3.12)`, `sandbox-linux`, `sandbox-macos`, `ci-budget`, `validate-examples`, plus Codecov patch coverage. |
+| `waiting_on` | Heuristic owner of the next move | See [Who Acts Next](#who-acts-next). |
+| `is_trunk_base` / `stack` | Native stack membership | `stack` is populated only for PRs whose base is not trunk or whose body mentions stacking. Base not trunk with `stack: null` means an unregistered dependency. |
+| `template` | PR body headings from `.github/pull_request_template.md` | `unfilled: true` means an HTML comment from the template is still present. |
+| `closes` | Issues closed by the PR, with their labels | Populated from GitHub's closing references, not from body text. |
+| `touches_prompts` | Any file under `src/vibesys/prompts/` | Needs a CODEOWNERS approval before merge. |
+| `size`, `large_files`, `bulk_lines` | Diff size, files with 200 or more changed lines, and lines in generated, vendored, snapshot, fixture, or data paths | Inputs to [Review Effort](#review-effort). Diff size alone is not review effort. |
+| `last_other_party_at` | Latest non-author, non-bot comment or review | Compare with `last_commit_at` to see whether the author has responded. |
+
+Staleness uses `updated_at`:
+
+- quiet: no activity for 7 days
+- stale: no activity for 21 days
+- stale draft: draft with no activity for 30 days
+
+## Buckets
+
+1. `blocked`: base is not trunk and the base PR is still open, or the body
+   describes a dependency on another open PR. Nothing to do until the
+   predecessor merges; note the predecessor.
+2. `needs-author`: any of `ci == failing`, `mergeable == CONFLICTING`,
+   review findings or change requests newer than the last commit, missing
+   template sections, `unfilled: true`, or a maintainer question without an
+   author reply.
+3. `draft`: `draft == true` and not otherwise blocked. Report age only. Do not
+   review drafts unless the user asks.
+4. `stale`: not a draft, no activity for 21 days, and no open review thread
+   awaiting the maintainer. Candidate for a ping or close.
+5. `ready-to-merge`: not a draft, `ci == passing`, `mergeable == MERGEABLE`,
+   base is trunk or its predecessor has merged, an approving review or a
+   completed review with no open findings, and a CODEOWNERS approval when
+   `touches_prompts` is true.
+6. `needs-review`: everything else that is not a draft and has a clean CI and
+   merge state. This includes PRs where the author pushed after the last
+   review.
+
+Order the report by bucket in the order `ready-to-merge`, `needs-review`,
+`needs-author`, `blocked`, `stale`, `draft`. Within a bucket, order by oldest
+`updated_at` first so nothing waits indefinitely.
+
+## Who Acts Next
+
+- `author`: draft, failing CI, conflicts, or the last non-bot activity from
+  someone else is newer than the last commit.
+- `reviewer`: the author pushed after the last review or comment, or nobody
+  other than the author has acted yet.
+
+Review findings in this repository are often posted as ordinary comments with
+`[P0]` to `[P3]` prefixes rather than formal review objects. Read the latest
+maintainer comment when `waiting_on` looks wrong.
+
+## Cross-PR Checks
+
+- Overlapping files: group open PRs by changed path. Two non-stacked PRs from
+  different authors touching the same file will conflict; recommend a merge
+  order.
+- Claimed stacks: a body that says "stacked on" while `is_trunk_base` is true
+  means the diff against trunk includes the predecessor's commits. Ask for a
+  retarget or a native stack (`gh stack link`), see the `open-pr` skill.
+- Shared commits: several trunk-based PRs from one author whose commit lists
+  overlap (`gh pr view N --json commits -q '.commits[].oid'`). They are an
+  unregistered stack: merging one shrinks or conflicts the others. Report
+  the order and ask for independent branches or a native stack.
+- Split series: several PRs that close the same issue or share a title
+  prefix. Confirm the intended order and that the bottom PR targets trunk.
+- Superseded work: an older PR whose scope is covered by a newer merged or
+  open PR. Recommend closing with a pointer.
+- Large unreviewed PRs: more than 20 changed files without a review. Suggest a
+  split or a targeted review plan instead of a full read.
+
+## Review Effort
+
+Estimate the effort to review a PR from its logical change, not its diff
+size. Rate each PR `small`, `medium`, or `large`:
+
+- `small`: one logical change a reviewer can hold in their head, typically a
+  handful of files and under about 100 lines of hand-written code.
+- `medium`: one feature or fix spanning a few modules, or a small change
+  whose correctness depends on surrounding code the reviewer must read.
+- `large`: several logical changes, a new subsystem, or a change that
+  crosses package boundaries (server protocol plus client, loop plus
+  evaluator contract).
+
+Discount lines that add no review effort before rating:
+
+- `bulk_lines` counts generated, vendored, snapshot, fixture, and data paths
+  (recorded runs, protocol schemas, lockfiles, reference sources).
+- A mechanical rename, move, or reformat: confirm the mechanical part with
+  `git diff --stat` or a `-M` rename detection, then review only the
+  non-mechanical remainder.
+- Tests are cheaper to review than the code they cover, but a test file with
+  hundreds of lines still needs a skim for what it does not assert.
+
+Note the discount in the report, for example "3655 lines, of which 408 are
+the regenerated protocol schema and about 1200 are tests; logical change is
+a new rail view plus its state".
+
+## Review Sequence
+
+End every triage report with a recommended order in which to work through
+the reviewable PRs. Build it as follows:
+
+1. Start with `small` PRs in `needs-review` whose `waiting_on` is
+   `reviewer`. They clear quickly and unblock authors. Order them by age,
+   oldest first.
+2. Then the oldest PRs in any bucket that need a maintainer decision:
+   a stale PR to close or follow up, a conflicting PR whose author has
+   gone quiet, a PR whose linked issue was closed elsewhere. Age counts from
+   `created_at`; a PR older than 14 days with no maintainer response needs
+   attention regardless of size.
+3. Then stacks and dependent chains, bottom-up, so each predecessor merges
+   before the next is reviewed. Treat a chain as one queue item and name the
+   order.
+4. Then `medium` and `large` PRs in `needs-review`, ordered by how many
+   other open PRs they unblock (shared files, claimed stacks), then by age.
+5. Drafts and PRs in `needs-author` with a clear blocker go last, as a
+   watch list rather than review work.
+
+Break ties toward the PR that closes a `bug` issue. Give each entry one
+line: PR, effort with any discount, and why it sits there.
+
+## Labels
+
+Apply labels only when the user asks to label. Never remove a label unless
+the user names it.
+
+- `bug`: the `Problem` section describes existing incorrect behavior (wrong
+  output, crash, inconsistent persisted state, regression, clipped or
+  unreadable UI), or a closing issue is labeled `bug` and the PR is the fix.
+- `enhancement`: the repository's feature label. Apply to new capability, a
+  new surface, new tooling, or a redesign. When the closing issue carries
+  both `bug` and `enhancement`, decide from the PR's `Problem` section; a
+  redesign that incidentally fixes defects is `enhancement`, a fix that adds
+  a field or option on the way is `bug`.
+- `refactor`: structural change with no intended behavior change, such as
+  extracting a function, deduplicating constants, or moving code between
+  owners. A PR that states "no behavior change" in its body is a refactor
+  even when its title starts with `fix`.
+- `documentation`: docs-only diff.
+
+List borderline cases in the report instead of guessing. Mirror the linked
+issue's area labels only if the user asks for full labeling.
+
+## Writes
+
+Every write needs an explicit user request. Commands:
+
+```bash
+gh pr edit N --add-label bug
+gh pr edit N --add-reviewer login
+gh pr comment N --body "text"
+gh pr close N --comment "text"
+gh pr ready N
+```
+
+Project board fields for `uw-syfi/1` need a token with `read:project` and
+`project` scopes. If `gh api graphql` returns `INSUFFICIENT_SCOPES`, report
+that project state was not checked and continue.
+
+## Report Template
+
+```markdown
+## Actions for the maintainer
+1. Merge #N (title): reason.
+2. Review #N next: reason.
+3. Ping @author on #N: what is needed.
+
+## Queue
+| PR | Author | Bucket | Blocker | Next action |
+| --- | --- | --- | --- | --- |
+
+## Cross-PR notes
+- ...
+
+## Recommended review sequence
+1. #N (small, 2 files): oldest small bug fix, no reviewer yet.
+2. #N (stale, 26 days, conflicting): decide close or follow up.
+3. Stack #A then #B then #C: bottom-up, author addressed findings.
+4. #N (large diff, small logical change: 400 of 700 lines are a regenerated schema): ...
+Watch list: #N (draft), #N (CI failing, author notified).
+
+## Writes made
+- Labeled #N, #M with `bug`.
+- (or) None.
+
+## Not verified
+- Project board state (token lacks read:project).
+```

--- a/.agents/skills/triage-prs/scripts/pr_inventory.sh
+++ b/.agents/skills/triage-prs/scripts/pr_inventory.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Emit one JSON object per open pull request carrying the signals the
+# triage-prs skill classifies on. Read-only. Requires gh and jq.
+#
+# Usage: pr_inventory.sh [--repo owner/name] [--no-stacks]
+#
+# Fields per line (all timestamps ISO 8601):
+#   number, title, url, author, draft, labels, base, head, is_trunk_base,
+#   mergeable (MERGEABLE|CONFLICTING|UNKNOWN), review_decision,
+#   review_requests, created_at, updated_at, last_commit_at,
+#   last_other_party, last_other_party_at, waiting_on (author|reviewer),
+#   ci (passing|failing|pending|none), failing_checks, size,
+#   files (first 100 paths), large_files (>= 200 changed lines),
+#   bulk_lines (changed lines in generated, vendored, snapshot, fixture, or
+#   data paths, which inflate the diff without adding review effort),
+#   touches_prompts,
+#   template {problem, solution, verification, unfilled},
+#   closes [{number, labels}], mentions_stack,
+#   stack (native GitHub stack {id, position, size, base} or null).
+set -euo pipefail
+
+repo=""
+stacks=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) repo="$2"; shift 2 ;;
+    --no-stacks) stacks=0; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+if [ -z "$repo" ]; then
+  repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
+owner="${repo%/*}"
+name="${repo#*/}"
+default_branch="$(gh api "repos/$repo" --jq .default_branch)"
+
+read -r -d '' query <<'GQL' || true
+query($owner: String!, $name: String!, $endCursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: OPEN, first: 50, after: $endCursor,
+                 orderBy: {field: CREATED_AT, direction: DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number title url isDraft createdAt updatedAt body
+        author { login }
+        labels(first: 20) { nodes { name } }
+        baseRefName headRefName mergeable reviewDecision
+        reviewRequests(first: 10) {
+          nodes { requestedReviewer { ... on User { login } ... on Team { name } } }
+        }
+        reviews(last: 30) { nodes { author { login } state submittedAt } }
+        comments(last: 30) { nodes { author { login } createdAt } }
+        additions deletions changedFiles
+        files(first: 100) { nodes { path additions deletions } }
+        closingIssuesReferences(first: 10) {
+          nodes { number labels(first: 20) { nodes { name } } }
+        }
+        commits(last: 1) {
+          nodes {
+            commit {
+              committedDate
+              statusCheckRollup {
+                contexts(first: 60) {
+                  nodes {
+                    __typename
+                    ... on CheckRun { name conclusion status }
+                    ... on StatusContext { context state }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+GQL
+
+emit() {
+  gh api graphql --paginate -F owner="$owner" -F name="$name" -f query="$query" \
+  | jq -c --arg trunk "$default_branch" '
+    def is_bot: (. // "") | test("\\[bot\\]$|^codecov|^github-actions");
+    .data.repository.pullRequests.nodes[]
+    | . as $pr
+    | ($pr.commits.nodes[0].commit) as $commit
+    | ([$commit.statusCheckRollup.contexts.nodes[]?
+        | if .__typename == "CheckRun"
+          then {name: .name, result: .conclusion, done: (.status == "COMPLETED")}
+          else {name: .context, result: .state, done: (.state != "PENDING" and .state != "EXPECTED")}
+          end]) as $checks
+    | ([$pr.comments.nodes[] | {login: .author.login, at: .createdAt}]
+       + [$pr.reviews.nodes[] | {login: .author.login, at: .submittedAt}]
+       | map(select(.login != $pr.author.login and (.login | is_bot | not)))
+       | max_by(.at)) as $other
+    | ($commit.committedDate) as $last_commit_at
+    | (if ($checks | length) == 0 then "none"
+       elif any($checks[]; .result == "FAILURE" or .result == "ERROR"
+                           or .result == "TIMED_OUT" or .result == "CANCELLED") then "failing"
+       elif any($checks[]; .done | not) then "pending"
+       else "passing" end) as $ci
+    | {
+        number: $pr.number,
+        title: $pr.title,
+        url: $pr.url,
+        author: $pr.author.login,
+        draft: $pr.isDraft,
+        labels: [$pr.labels.nodes[].name],
+        base: $pr.baseRefName,
+        head: $pr.headRefName,
+        is_trunk_base: ($pr.baseRefName == $trunk),
+        mergeable: $pr.mergeable,
+        review_decision: $pr.reviewDecision,
+        review_requests: [$pr.reviewRequests.nodes[].requestedReviewer | (.login // .name)],
+        created_at: $pr.createdAt,
+        updated_at: $pr.updatedAt,
+        last_commit_at: $last_commit_at,
+        last_other_party: ($other.login // null),
+        last_other_party_at: ($other.at // null),
+        waiting_on: (if $pr.isDraft or $ci == "failing" or $pr.mergeable == "CONFLICTING" then "author"
+                     elif ($other.at // "") > $last_commit_at then "author"
+                     else "reviewer" end),
+        ci: $ci,
+        failing_checks: [$checks[] | select(.result == "FAILURE" or .result == "ERROR"
+                                            or .result == "TIMED_OUT" or .result == "CANCELLED") | .name],
+        size: {files: $pr.changedFiles, additions: $pr.additions, deletions: $pr.deletions},
+        files: [$pr.files.nodes[].path],
+        large_files: [$pr.files.nodes[] | select(.additions + .deletions >= 200)
+                      | {path, lines: (.additions + .deletions)}],
+        bulk_lines: ([$pr.files.nodes[] | select(.path | test(
+                        "(^|/)(generated|vendor|third_party|snapshots?|__snapshots__|fixtures?|reference|data)/|\\.(lock|snap|jsonl|csv|tsv|parquet|svg|png|txt)$"))
+                      | .additions + .deletions] | add // 0),
+        touches_prompts: any($pr.files.nodes[]; .path | startswith("src/vibesys/prompts/")),
+        template: {
+          problem: ($pr.body | test("(^|\\n)## Problem")),
+          solution: ($pr.body | test("(^|\\n)## Solution")),
+          verification: ($pr.body | test("(^|\\n)## Verification")),
+          unfilled: ($pr.body | test("<!--"))
+        },
+        closes: [$pr.closingIssuesReferences.nodes[] | {number, labels: [.labels.nodes[].name]}],
+        mentions_stack: ($pr.body | test("(?i)stacked|stack of|base branch:")),
+        stack: null
+      }'
+}
+
+if [ "$stacks" -eq 0 ]; then
+  emit
+  exit 0
+fi
+
+# Native stack membership is only visible through the REST pull endpoint, so
+# look it up per PR. A stack's bottom PR targets trunk, so every PR is checked.
+emit | while IFS= read -r line; do
+  number="$(jq -r .number <<<"$line")"
+  stack="$(gh api "repos/$repo/pulls/$number" --jq '.stack' 2>/dev/null | jq -c . 2>/dev/null || true)"
+  [ -z "$stack" ] && stack=null
+  jq -c --argjson stack "$stack" '.stack = $stack' <<<"$line"
+done

--- a/docs/contributing/coding-best-practices.md
+++ b/docs/contributing/coding-best-practices.md
@@ -72,6 +72,18 @@ adapters or presentation layers that consume its results.
 - Introduce an abstraction when it creates a genuine ownership boundary,
   clarifies the direction of data flow, or removes meaningful duplication. Do
   not add indirection without a shared interface to protect.
+- Keep one source of truth per fact. Store the minimal state and derive the
+  rest with a named selector or predicate. Do not add a field whose value is a
+  function of existing fields, such as an `isEmpty` flag beside a list, a
+  count beside the collection it counts, or a boolean that restates which
+  member of an enum is active. Every extra writer is a place the copies can
+  drift. Cache a derived value only when profiling shows the derivation is
+  too costly, and then document what invalidates the cache.
+- Represent closed sets as enums in both languages: `StrEnum` or `Literal` in
+  Python, and a string-literal union in TypeScript. When the values cross the
+  backend boundary, the union comes from the generated protocol types, not a
+  hand-written copy. Predicates over a closed set should branch exhaustively
+  so that a new member is a compile error rather than a silent default.
 
 ## Python Code
 
@@ -197,11 +209,20 @@ failure cases.
   at the producer.
 - Prefer assertions about observable contracts over assertions tied to private
   implementation details.
+- A bug-fix PR must include a regression test that fails at the merge base
+  and passes at the head, written at the lowest layer that reproduces the
+  reported symptom. A test that only restates the fix's constants, or that
+  passes unchanged on the pre-fix code, is not evidence. For the TUI, a
+  symptom stated in terminal geometry (columns, rows, alignment, clipping,
+  overlap) must be reproduced through the OpenTUI test renderer
+  (`createTestRenderer` from `@opentui/core/testing`); a pure-function test
+  over a formatter is not accepted for such symptoms.
 
 ## Avoid
 
 - Large unrelated refactors.
 - Raw strings where repo enums, registries, or typed models already exist.
+- Stored copies of state that another field already determines.
 - Ad hoc parsing when TOML, YAML, Pydantic, or standard library parsers are
   available.
 - Silent acceptance of misspelled config or metadata.

--- a/docs/contributing/tui-architecture.md
+++ b/docs/contributing/tui-architecture.md
@@ -104,3 +104,19 @@ pnpm build:clients
 Each package also supports its own `check`, `test`, and `build` scripts. Package builds consume only
 public workspace exports. The release build uses the same dependency-aware build chain before pnpm
 deploys the self-contained TUI payload.
+
+### Regression tests for rendering bugs
+
+Pick the test layer by where the symptom lives, and require that the test fails at the merge base:
+
+| Symptom | Layer |
+| --- | --- |
+| String formatting or truncation arithmetic | Pure function test on the formatter |
+| Width, alignment, clipping, padding, or overlap (anything stated in columns or rows) | `createTestRenderer` from `@opentui/core/testing`: build the real view, render at a fixed size, and measure the emitted renderables (see `clients/tui/src/ui/app.test.ts` and `todo-strip.test.ts`) |
+| Theme contrast and legibility | Pure computation over theme tokens |
+| Wide characters, resize, streaming timing, keybindings through a PTY | The tmux harness in the `tui-bug-hunt` skill; not a CI regression test |
+
+The test renderer runs the real renderable tree and Yoga layout, so it reproduces layout-class bugs
+deterministically in CI. It does not run a terminal: text is measured in code units, and there is
+no PTY, input, or timing. A pure-function test that computes the expected width itself cannot
+reproduce a layout bug and is not accepted as evidence for one.


### PR DESCRIPTION
## Problem

Maintainers had no repeatable way to triage the open pull request queue, and the review and PR-authoring skills let several classes of defect through in one day of use:

- Reviews opened with findings but never stated what a PR actually does or where the body's claims diverged from the code. #541 claimed to thread a tolerance through "the full projection call chain" while two of three call sites were untouched; #559 added tests that passed on the pre-fix code.
- Bug-fix PRs were accepted on the strength of "suite passes" without demonstrating the bug at the merge base (#540, #521, #557, #559 all needed a reviewer to reproduce them by hand).
- Two contributor PRs stored a boolean beside the enum it was derived from (#540's `terminal` beside `status`, #557's `runPaused`), and nothing in the contributing guide named that pattern.
- PRs were opened without labels, and follow-up PRs superseding a contributor's fix gave the original author no notice.

## Solution

Add a `triage-prs` skill and tighten the two existing PR skills and the contributing docs around the rules that were applied by hand today.

- `triage-prs` (new): `scripts/pr_inventory.sh` collects one JSON record per open PR in a single GraphQL pass plus a per-PR native-stack lookup (CI rollup, mergeability, review state, waiting-on heuristic, template compliance, closing issues with labels, per-file sizes and bulk-line discounts). `references/triage-signals.md` defines the bucket precedence, review-effort rating by logical rather than diff size, the recommended review sequence (small targeted PRs first, then old PRs needing a decision, then stacks bottom-up), cross-PR checks including shared-commit chains, and label rules.
- `review-pr`: every review opens with a summary and a `Discrepancies` line comparing PR and issue claims against the code; bug fixes must be reproduced at the merge base and confirmed at the head in a temporary worktree, at the lowest layer that reproduces the symptom; a regression test that passes on pre-fix code is not evidence.
- `open-pr`: apply exactly one kind label at creation from the existing label set, mirror the closing issue's area labels, and notify the original author with an FYI comment when a PR follows up on their work.
- `docs/contributing/coding-best-practices.md`: keep one source of truth per fact and derive the rest; represent closed sets as enums in both languages with exhaustive predicates; bug-fix regression tests must fail at the merge base. `docs/contributing/tui-architecture.md`: a table mapping rendering-bug symptom classes to the test layer that reproduces them.

### Architecture

Skills stay under `.agents/skills/` (mirrored by the `.claude/skills` symlink) and read only repository state through `gh` and `git`; the inventory script is read-only and every write (labels, comments, merges) requires an explicit user request per the skill text. Docs changes are guidance only; no code paths change.

## Verification

### Correctness properties

- `pr_inventory.sh` is read-only and emits one line per open PR; `mergeable == UNKNOWN` is reported as unverified, never as clean.
- Label rules in `triage-prs` and `open-pr` are identical.
- The review-pr reproduction step never mutates the user's checkout (temporary worktrees only).

### Testing

- `.agents/skills/triage-prs/scripts/pr_inventory.sh` run against this repository: 27 open PRs, 30 s, native stack membership resolved for both active stacks.
- `python3 scripts/check_doc_links.py`: 324 files, no broken links.
- Applied in practice today: the triage sequence, six subagent reviews (four with base-versus-head reproduction), labeling of 24 PRs, and six merges followed the rules as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
