### PR TITLE
Document single-source-of-truth, closed-set, and regression-test rules

### DIFF
--- a/docs/contributing/coding-best-practices.md
+++ b/docs/contributing/coding-best-practices.md
@@ -72,6 +72,18 @@ adapters or presentation layers that consume its results.
 - Introduce an abstraction when it creates a genuine ownership boundary,
   clarifies the direction of data flow, or removes meaningful duplication. Do
   not add indirection without a shared interface to protect.
+- Keep one source of truth per fact. Store the minimal state and derive the
+  rest with a named selector or predicate. Do not add a field whose value is a
+  function of existing fields, such as an `isEmpty` flag beside a list, a
+  count beside the collection it counts, or a boolean that restates which
+  member of an enum is active. Every extra writer is a place the copies can
+  drift. Cache a derived value only when profiling shows the derivation is
+  too costly, and then document what invalidates the cache.
+- Represent closed sets as enums in both languages: `StrEnum` or `Literal` in
+  Python, and a string-literal union in TypeScript. When the values cross the
+  backend boundary, the union comes from the generated protocol types, not a
+  hand-written copy. Predicates over a closed set should branch exhaustively
+  so that a new member is a compile error rather than a silent default.
 
 ## Python Code
 
@@ -197,11 +209,20 @@ failure cases.
   at the producer.
 - Prefer assertions about observable contracts over assertions tied to private
   implementation details.
+- A bug-fix PR must include a regression test that fails at the merge base
+  and passes at the head, written at the lowest layer that reproduces the
+  reported symptom. A test that only restates the fix's constants, or that
+  passes unchanged on the pre-fix code, is not evidence. For the TUI, a
+  symptom stated in terminal geometry (columns, rows, alignment, clipping,
+  overlap) must be reproduced through the OpenTUI test renderer
+  (`createTestRenderer` from `@opentui/core/testing`); a pure-function test
+  over a formatter is not accepted for such symptoms.
 
 ## Avoid
 
 - Large unrelated refactors.
 - Raw strings where repo enums, registries, or typed models already exist.
+- Stored copies of state that another field already determines.
 - Ad hoc parsing when TOML, YAML, Pydantic, or standard library parsers are
   available.
 - Silent acceptance of misspelled config or metadata.

--- a/docs/contributing/tui-architecture.md
+++ b/docs/contributing/tui-architecture.md
@@ -104,3 +104,19 @@ pnpm build:clients
 Each package also supports its own `check`, `test`, and `build` scripts. Package builds consume only
 public workspace exports. The release build uses the same dependency-aware build chain before pnpm
 deploys the self-contained TUI payload.
+
+### Regression tests for rendering bugs
+
+Pick the test layer by where the symptom lives, and require that the test fails at the merge base:
+
+| Symptom | Layer |
+| --- | --- |
+| String formatting or truncation arithmetic | Pure function test on the formatter |
+| Width, alignment, clipping, padding, or overlap (anything stated in columns or rows) | `createTestRenderer` from `@opentui/core/testing`: build the real view, render at a fixed size, and measure the emitted renderables (see `clients/tui/src/ui/app.test.ts` and `todo-strip.test.ts`) |
+| Theme contrast and legibility | Pure computation over theme tokens |
+| Wide characters, resize, streaming timing, keybindings through a PTY | The tmux harness in the `tui-bug-hunt` skill; not a CI regression test |
+
+The test renderer runs the real renderable tree and Yoga layout, so it reproduces layout-class bugs
+deterministically in CI. It does not run a terminal: text is measured in code units, and there is
+no PTY, input, or timing. A pure-function test that computes the expected width itself cannot
+reproduce a layout bug and is not accepted as evidence for one.


### PR DESCRIPTION
## Problem

Split out of #580, which bundled contributing-doc changes with three skill changes; each part is reviewable on its own. SIBLINGS

Two classes of defect got through review in one day because the contributing guide did not name the rule that would have caught them:

- Two contributor PRs stored a boolean beside the enum it was derived from (#540's `terminal` beside `status`, #557's `runPaused`). The copies drift as soon as one writer is updated and the other is not, and nothing in `docs/contributing/coding-best-practices.md` named the pattern.
- Bug fixes were accepted on the strength of "suite passes" without demonstrating the bug at the merge base (#540, #521, #557, #559). #559 added tests that also passed on the pre-fix code, so they were not evidence. For TUI rendering bugs there was also no stated mapping from a symptom to the test layer that can reproduce it, so pure-function formatter tests were offered for symptoms stated in columns and rows.

## Solution

Write the three rules into the contributing docs so authors and reviewers can cite a document instead of relitigating each case.

`docs/contributing/coding-best-practices.md`:

- Keep one source of truth per fact. Store minimal state, derive the rest with a named selector or predicate, and do not add a field that is a function of existing fields (an `isEmpty` flag beside a list, a count beside its collection, a boolean restating which enum member is active). Cache a derived value only when profiling justifies it, and document what invalidates the cache.
- Represent closed sets as enums in both languages: `StrEnum` or `Literal` in Python, a string-literal union in TypeScript, sourced from the generated protocol types when the values cross the backend boundary. Predicates over a closed set branch exhaustively so a new member is a compile error.
- A bug-fix PR must include a regression test that fails at the merge base and passes at the head, written at the lowest layer that reproduces the reported symptom. A test that restates the fix's constants, or that passes unchanged on pre-fix code, is not evidence.
- The `Avoid` list gains "stored copies of state that another field already determines".

`docs/contributing/tui-architecture.md` gains a `Regression tests for rendering bugs` subsection: a table mapping symptom class to test layer (formatter arithmetic to a pure function test; anything stated in columns or rows to `createTestRenderer` from `@opentui/core/testing`; theme contrast to pure computation over theme tokens; wide characters, resize, streaming timing, and keybindings through a PTY to the tmux harness in the `tui-bug-hunt` skill, which is not a CI regression test). The section states why the test renderer reproduces layout-class bugs (it runs the real renderable tree and Yoga layout) and what it does not cover (no PTY, no input, no timing; text measured in code units).

### Architecture

Documentation only. No code paths, contracts, or generated artifacts change. `CLAUDE.md` already directs agents to read `docs/contributing/coding-best-practices.md` before editing code, so the new rules reach agent contributors through the existing entry point. The TUI table sits next to the existing TUI testing guidance and is the target of a pointer added by the sibling `review-pr` PR; the two are independent and either can merge first.

## Verification

### Correctness properties

- Docs-only diff: no source, test, or configuration file changes, so repository behavior is unchanged.
- The new rules extend the existing `Design And Structure`, `Testing`, and `Avoid` sections and add one new subsection to the TUI architecture doc; they do not contradict existing guidance in either file.
- File and symbol references added (`clients/tui/src/ui/app.test.ts`, `todo-strip.test.ts`, `@opentui/core/testing`) resolve in the repository.

### Testing

- `python3 scripts/check_doc_links.py`: 324 Markdown files checked, no broken links.
- No other checks apply to a documentation-only change.
- The rules were applied by hand before being written down, across a day of reviews, labeling, and merges covering roughly two dozen open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
