### PR TITLE
Open reviews with a summary and reproduce bug fixes at the merge base

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -21,8 +21,12 @@ repository's contracts, architecture, tests, and affected callers.
    - Read the PR title, body, linked issue, base/head commits, changed files,
      existing review threads, and check results when available. Use the local
      branch or merge-base diff when reviewing unpublished work.
-   - Derive the intended behavior and correctness properties. Call out material
-     ambiguity instead of silently choosing an interpretation.
+   - Derive the intended behavior and correctness properties from the PR
+     body and the linked issue. Record each concrete claim (what changes,
+     what is fixed, what stays the same, what was tested) so the summary can
+     check it against the diff.
+   - Call out material ambiguity instead of silently choosing an
+     interpretation.
    - Do not submit a GitHub review, comment, approval, or change request unless
      the user explicitly asks for that external write.
 
@@ -38,6 +42,11 @@ repository's contracts, architecture, tests, and affected callers.
    - Look for coupled artifacts that should have changed but did not: tests,
      snapshots, schemas, generated types, package data, examples, contracts,
      migration or compatibility code, and user-facing documentation.
+   - Reconcile the claims with the code. For each claim from step 1, find
+     the diff hunks that implement it. Note claims with no implementing
+     change, changes the body does not mention, a fix that addresses a
+     different cause than the issue describes, a "no behavior change" claim
+     next to a behavior change, and tests that are named but absent.
 
 3. Apply the review guide.
    - Read [references/review-guide.md](references/review-guide.md) completely.
@@ -48,7 +57,25 @@ repository's contracts, architecture, tests, and affected callers.
      real interface and reuse boundary. Flag both misplaced shared behavior and
      abstractions that add indirection without protecting a boundary.
 
-4. Verify candidate findings.
+4. Reproduce the bug when the PR is a bug fix.
+   - Whenever practical, demonstrate the defect at the merge base and its
+     absence at the PR head. Use a temporary worktree
+     (`git worktree add <scratch>/pr-<N> <ref>`) so the user's checkout is
+     never mutated; remove it when done.
+   - Choose the narrowest deterministic reproduction: run the PR's own new
+     tests against the base source (they must fail there and pass at the
+     head), write a throwaway test or script from the issue's steps, or for
+     TUI rendering fixes render the affected view at a fixed width with the
+     `clients/tui` test harness. Drive the live TUI through the
+     `tui-bug-hunt` harness only when no cheaper reproduction exists and the
+     cost is justified.
+   - Report the reproduction as evidence: the command, the observed failure
+     at the base, and the observed result at the head. If a reproduction was
+     not possible, say why and treat the fix as unverified rather than
+     confirmed. A fix whose new tests also pass at the merge base has not
+     been demonstrated.
+
+5. Verify candidate findings.
    - Confirm that the reviewed change introduced or exposed the problem.
    - State the concrete input, state, platform, or execution path that triggers
      it and the observable consequence.
@@ -60,15 +87,25 @@ repository's contracts, architecture, tests, and affected callers.
    - Re-read the final diff and each cited line. Distinguish a proven defect
      from a residual risk that needs more evidence.
 
-5. Report the review.
-   - Lead with findings ordered by severity. Use `[P0]` through `[P3]`, a short
+6. Report the review.
+   - Always start with a summary of the PR: two to five sentences on what
+     the diff actually does, in terms of behavior and the modules it touches,
+     followed by a `Discrepancies` line. List every gap between what the PR
+     body or linked issue claims and what the source code does: unmentioned
+     changes, unimplemented claims, a different root cause, a wider or
+     narrower scope than the issue, or verification claims the diff does not
+     support. Write `Discrepancies: none` when the claims and the code
+     agree. A discrepancy that changes correctness or merge safety also
+     becomes a finding below.
+   - Then list findings ordered by severity. Use `[P0]` through `[P3]`, a short
      actionable title, one compact explanation, and the tightest changed-line
      range that demonstrates the issue.
    - Explain why the behavior is wrong and when it occurs; include a fix
      direction only when it clarifies the required contract. Do not write a
      patch unless the user also asks for implementation.
-   - Keep summaries brief. After findings, list assumptions or open questions,
-     checks run, and residual risks only when they add information.
+   - Keep summaries brief. After findings, report the reproduction outcome
+     for bug fixes, then list assumptions or open questions, checks run, and
+     residual risks only when they add information.
    - If there are no actionable findings, say so plainly and mention meaningful
      verification gaps. Do not invent low-value findings to populate a review.
 

--- a/.agents/skills/review-pr/references/review-guide.md
+++ b/.agents/skills/review-pr/references/review-guide.md
@@ -68,6 +68,10 @@ Ask of new abstractions:
 - Verify security boundaries: path traversal, command injection, unsafe
   deserialization, secret exposure, untrusted prompt or template interpolation,
   over-broad filesystem/network access, and trust decisions based on user input.
+- Flag any new state field whose value is determined by other fields in the
+  same model, and ask for a selector or predicate instead. Duplicate state
+  needs every writer to stay in sync, and the reviewed diff usually updates
+  only the writer it touched.
 
 ## Contracts And Compatibility
 
@@ -109,6 +113,9 @@ Ask of new abstractions:
 - Keep protocol data semantic and rendering/UI state in `clients/tui/`.
   Validate missing, duplicate, out-of-order, reconnect, and terminal events in
   session state transitions.
+- Protocol-defined closed sets (run status, event kinds, verdicts) must reach
+  the client as generated literal unions, not `string`, and client predicates
+  over them must branch exhaustively.
 - Respect strict TypeScript settings, including exact optional properties,
   unchecked indexed access, exhaustive control flow, and unused checks. Do not
   use assertions or `any` to bypass uncertain protocol states.
@@ -208,6 +215,13 @@ take the wrong action. Do not require prose churn for a purely internal change.
 - Map each stated correctness property to a test, type/schema check, or focused
   manual reproduction. A regression test should fail for the old behavior for
   the reason claimed.
+- For a bug fix, require a regression test that fails at the merge base at
+  the lowest layer that reproduces the reported symptom. Reject a test that
+  passes unchanged on the pre-fix code or that restates the fix's constants
+  in the test body. For TUI symptoms stated in terminal geometry, the layer
+  is the OpenTUI test renderer (`createTestRenderer`); a pure-function test
+  over a formatter is not evidence. See the regression-test table in
+  `docs/contributing/tui-architecture.md`.
 - Test application configuration and implementation separately, then add a
   focused wiring test when their connection changes.
 - Use shared contract tests for interchangeable sandboxes, compute backends,


### PR DESCRIPTION
## Problem

Split out of #580, which bundled this with contributing-doc changes, an `open-pr` change, and a new triage skill; each part is reviewable on its own. SIBLINGS

The `review-pr` skill let two classes of defect through in one day of use:

- Reviews opened straight into findings and never stated what the PR actually does, so nobody checked the PR body's claims against the code. #541 claimed to thread a tolerance through "the full projection call chain" while two of three call sites were untouched. That gap was visible only by reconciling the body with the diff, which the skill never asked for.
- Bug fixes were accepted on "suite passes" without demonstrating the defect at the merge base. #540, #521, #557, and #559 all needed a reviewer to reproduce them by hand, and #559's new tests passed unchanged on pre-fix code, so they proved nothing.

Two related rules were also missing from the review guide: nothing told a reviewer to flag a new state field derived from an existing one (#540's `terminal` beside `status`, #557's `runPaused`), and nothing required protocol-defined closed sets to reach the TUI as generated literal unions.

## Solution

Tighten `.agents/skills/review-pr/SKILL.md` and its `references/review-guide.md` around the rules that were applied by hand.

`SKILL.md`:

- Step 1 now records each concrete claim from the PR body and linked issue (what changes, what is fixed, what stays the same, what was tested) so the summary can check it against the diff.
- Step 2 adds a reconciliation pass: find the hunks implementing each claim, and note claims with no implementing change, changes the body never mentions, a fix addressing a different cause than the issue describes, a "no behavior change" claim sitting next to a behavior change, and tests named but absent.
- A new step 4 requires reproducing the bug for bug-fix PRs: demonstrate the defect at the merge base and its absence at the head in a temporary worktree (`git worktree add`), never in the user's checkout; pick the narrowest deterministic reproduction (the PR's own tests run against base source, a throwaway script from the issue's steps, or the `clients/tui` test harness at a fixed width), and reserve the live-TUI `tui-bug-hunt` harness for when nothing cheaper works. Report command, base failure, and head result; if reproduction was impossible, say so and treat the fix as unverified. A fix whose new tests also pass at the merge base counts as not demonstrated. The old steps 4 and 5 shift to 5 and 6.
- The report step now opens with a two-to-five-sentence summary of what the diff does and a `Discrepancies` line listing every gap between claims and code, or `Discrepancies: none`. A discrepancy affecting correctness or merge safety also becomes a finding. Findings still follow, then the reproduction outcome for bug fixes.

`references/review-guide.md`: flag new state fields determined by other fields in the same model and ask for a selector or predicate instead; require protocol-defined closed sets (run status, event kinds, verdicts) to reach the client as generated literal unions rather than `string`, with exhaustive client predicates; and require a bug fix's regression test to fail at the merge base at the lowest layer reproducing the symptom, with the OpenTUI test renderer as the layer for symptoms stated in terminal geometry.

`review-guide.md` points at the regression-test table added by the sibling contributing-docs PR (`docs/contributing/tui-architecture.md`). The two PRs are independent and either can merge first: the pointer names an existing file on `main`, and the guide states the rule itself rather than deferring to the table, so the sentence reads correctly whether or not the table has landed yet.

### Architecture

Skill text only. The skill lives under `.agents/skills/review-pr/` (surfaced through the existing `.claude/skills` symlink) and reads repository state through `gh` and `git`. The one new capability is a read-only reproduction step that operates in a temporary `git worktree` and removes it afterwards, so the user's checkout and branch are never mutated. No source code, contracts, or generated artifacts change. Deep code review stays this skill's job; PR-queue-level classification belongs to the sibling `triage-prs` skill.

## Verification

### Correctness properties

- The reproduction step never mutates the user's checkout: it operates only in a temporary worktree, which it removes.
- The skill still performs no external writes; submitting a GitHub review, comment, approval, or change request continues to require an explicit user request.
- A bug fix whose new tests pass at the merge base is reported as unverified, not confirmed.
- Step renumbering is self-consistent: steps run 1 through 6 with no duplicate or dangling references.
- The regression-test rule stated in `review-guide.md` matches the rule added to `docs/contributing/coding-best-practices.md` by the sibling docs PR, so reviewer and author read the same requirement.

### Testing

- `python3 scripts/check_doc_links.py`: 324 Markdown files checked, no broken links.
- Skill-text change with no executable surface, so no unit tests apply.
- Exercised in practice: six subagent reviews under these rules on the open queue, four with base-versus-head reproduction, which is how the #541 scope gap and the #559 non-failing tests were caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
