### PR TITLE
Make the evolve loop select within the task's metric space

### DIFF
--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -2190,10 +2190,19 @@ def _load_metric_space_toml(input_path: Path) -> MetricSpace:
     return MetricSpace(objectives=tuple(objectives), relative_noise=value)
 
 
-def _resolve_objectives(args: argparse.Namespace) -> list[Objective]:
+def _resolve_metric_space(args: argparse.Namespace) -> MetricSpace:
+    """Build the run's metric space, letting ``--objective`` override its axes.
+
+    The tolerance always comes from the task file: it describes the workload's
+    measurement variation, which a command-line axis list does not change.
+    """
+    space = _load_metric_space_toml(args.input_bundle.task_root)
     if args.objective:
-        return list(args.objective)
-    return list(_load_metric_space_toml(args.input_bundle.task_root).objectives)
+        return MetricSpace(
+            objectives=tuple(args.objective),
+            relative_noise=space.relative_noise,
+        )
+    return space
 
 
 def _build_evolve_parser() -> argparse.ArgumentParser:
@@ -2362,7 +2371,7 @@ def _run_evolve(args: argparse.Namespace, integration: RunIntegration) -> None:
     from vibesys.loops.evolve.loop import run_evolve_loop  # noqa: PLC0415  # tracked: #288
 
     objective = _load_objective(bundle)
-    objectives = _resolve_objectives(args)
+    space = _resolve_metric_space(args)
 
     existing = False
     exp_name = args.exp_name
@@ -2370,9 +2379,12 @@ def _run_evolve(args: argparse.Namespace, integration: RunIntegration) -> None:
         exp_name = args.resume
         existing = True
         print(f"Resuming evolve run {exp_name} in {bundle.root}/")  # noqa: T201  # tracked: #288
-    if objectives:
-        spec = ", ".join(f"{o.name}({o.direction})" for o in objectives)
-        print(f"Pareto mode active: [{spec}]; frontier_bias={args.frontier_bias}")  # noqa: T201  # tracked: #288
+    if space.objectives:
+        spec = ", ".join(f"{o.name}({o.direction})" for o in space.objectives)
+        print(  # noqa: T201  # tracked: #288
+            f"Pareto mode active: [{spec}]; frontier_bias={args.frontier_bias}; "
+            f"tolerance={space.relative_noise:.0%}"
+        )
 
     search_policy, openevolve_config = _resolve_openevolve_options(args)
 
@@ -2406,7 +2418,7 @@ def _run_evolve(args: argparse.Namespace, integration: RunIntegration) -> None:
         backend=backend,
         modality=args.modality,
         domain=bundle.domain,
-        objectives=objectives,
+        space=space,
         frontier_bias=args.frontier_bias,
         bootstrap_max_attempts=args.bootstrap_max_attempts,
         keep_deployments=args.keep_deployments,

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import random
 import threading
+from collections.abc import Sequence  # noqa: TC003  # tracked: #288
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path  # noqa: TC003  # tracked: #288
@@ -50,7 +51,6 @@ from vibesys.domains.rendering import render_domain_section
 from vibesys.input_manifest import WorkspaceSource  # noqa: TC001  # tracked: #288
 from vibesys.loops.evolve.population import (
     Individual,
-    Objective,
     Population,
 )
 from vibesys.loops.evolve.search_policy import (
@@ -63,6 +63,7 @@ from vibesys.loops.evolve.search_policy import (
 )
 from vibesys.loops.evolve.state import EvolutionStateStore
 from vibesys.loops.gates import run_accuracy_gate
+from vibesys.loops.metrics import MetricSpace, Objective
 from vibesys.loops.profiler import invoke_profiler
 from vibesys.profilers import ProfilerKind, profiler_definition
 from vibesys.prompts import PROMPTS_DIR
@@ -253,7 +254,7 @@ def _run_mutator(  # noqa: PLR0913  # tracked: #288
     modality: str | None,
     domain_definition: DomainDefinition,
     is_cold_start: bool,
-    objectives: list[Objective] | None = None,
+    space: MetricSpace,
     failed_lessons: list[str] | None = None,
     num_failed_attempts: int = 0,
     repair_seed: bool = False,
@@ -275,7 +276,7 @@ def _run_mutator(  # noqa: PLR0913  # tracked: #288
         parent=parent,
         inspirations=inspirations,
         is_cold_start=is_cold_start,
-        objectives=objectives,
+        space=space,
         interface=_INTERFACE,
         domain_implementer=domain_implementer,
         runtime_notes=prompt_runtime_notes,
@@ -362,7 +363,7 @@ If the benchmark JSON does not contain a field, set its entry to `null` rather t
 """
 
 
-def _format_objectives_for_profiler(objectives: list[Objective]) -> str:
+def _format_objectives_for_profiler(objectives: Sequence[Objective]) -> str:
     return "\n".join(
         f"- `{o.name}` ({'maximize' if o.direction == 'max' else 'minimize'})" for o in objectives
     )
@@ -376,7 +377,7 @@ def _run_profiler(  # noqa: PLR0913  # tracked: #288
     modality: str | None,
     domain_definition: DomainDefinition,
     objective: str,
-    objectives: list[Objective] | None = None,
+    space: MetricSpace,
     runtime_notes: str | None = None,
 ) -> ProfilerSummary | None:
     if ctx.profiler_kind is ProfilerKind.NONE:
@@ -404,9 +405,9 @@ def _run_profiler(  # noqa: PLR0913  # tracked: #288
         profiler_support_name=definition.support_name,
         profiler_mcp_name=definition.mcp_name,
     )
-    if objectives:
+    if space.objectives:
         addendum = _PARETO_PROFILER_ADDENDUM.format(
-            objective_list=_format_objectives_for_profiler(objectives),
+            objective_list=_format_objectives_for_profiler(space.objectives),
         )
         system_prompt = base_prompt + addendum
     else:
@@ -467,7 +468,7 @@ def _evaluate_candidate(  # noqa: PLR0913  # tracked: #288
     parent: Individual,
     inspirations: list[Individual],
     objective: str,
-    objectives: list[Objective] | None,
+    space: MetricSpace,
     modality: str | None,
     domain_definition: DomainDefinition,
     pass_criteria: str,
@@ -517,7 +518,7 @@ def _evaluate_candidate(  # noqa: PLR0913  # tracked: #288
             modality=modality,
             domain_definition=domain_definition,
             is_cold_start=False,
-            objectives=objectives,
+            space=space,
             runtime_notes=cand_notes,
         )
 
@@ -572,7 +573,7 @@ def _evaluate_candidate(  # noqa: PLR0913  # tracked: #288
             modality=modality,
             domain_definition=domain_definition,
             objective=objective,
-            objectives=objectives,
+            space=space,
             runtime_notes=cand_notes,
         )
 
@@ -603,7 +604,7 @@ def _record_outcome(  # noqa: PLR0913  # tracked: #288
     *,
     generation: int,
     search_policy: SearchPolicy,
-    objectives: list[Objective] | None,
+    space: MetricSpace,
 ) -> Individual:
     """Assign an id, add the individual to the population, and persist it.
 
@@ -639,7 +640,7 @@ def _record_outcome(  # noqa: PLR0913  # tracked: #288
                 ),
                 policy_parent_id=outcome.policy_parent_id,
                 target_island=outcome.target_island,
-                objectives=objectives,
+                space=space,
             )
         metrics_repr = (
             " ".join(f"{k}={v:g}" for k, v in individual.metrics.items())
@@ -667,7 +668,7 @@ def _plan_candidate(  # noqa: PLR0913  # tracked: #288
     k_top_inspirations: int,
     k_random_inspirations: int,
     selection_temperature: float,
-    objectives: list[Objective] | None,
+    space: MetricSpace,
     frontier_bias: float,
     search_policy: SearchPolicy | None = None,
 ) -> SearchSelection | None:
@@ -688,7 +689,7 @@ def _plan_candidate(  # noqa: PLR0913  # tracked: #288
         k_top_inspirations=k_top_inspirations,
         k_random_inspirations=k_random_inspirations,
         selection_temperature=selection_temperature,
-        objectives=objectives,
+        space=space,
         frontier_bias=frontier_bias,
     )
     _persist_evolve_state(
@@ -714,7 +715,7 @@ def _run_generation_serial(  # noqa: PLR0913  # tracked: #288
     k_random_inspirations: int,
     selection_temperature: float,
     objective: str,
-    objectives: list[Objective] | None,
+    space: MetricSpace,
     frontier_bias: float,
     modality: str | None,
     domain_definition: DomainDefinition,
@@ -738,7 +739,7 @@ def _run_generation_serial(  # noqa: PLR0913  # tracked: #288
                 k_top_inspirations=k_top_inspirations,
                 k_random_inspirations=k_random_inspirations,
                 selection_temperature=selection_temperature,
-                objectives=objectives,
+                space=space,
                 frontier_bias=frontier_bias,
                 search_policy=search_policy,
             )
@@ -760,7 +761,7 @@ def _run_generation_serial(  # noqa: PLR0913  # tracked: #288
                 parent=parent,
                 inspirations=inspirations,
                 objective=objective,
-                objectives=objectives,
+                space=space,
                 modality=modality,
                 domain_definition=domain_definition,
                 pass_criteria=pass_criteria,
@@ -776,7 +777,7 @@ def _run_generation_serial(  # noqa: PLR0913  # tracked: #288
                 outcome,
                 generation=generation,
                 search_policy=search_policy,
-                objectives=objectives,
+                space=space,
             )
             if not outcome.passed:
                 # Dead-end mutation: revert the dirty tree back to the passing
@@ -800,7 +801,7 @@ def _evaluate_in_subcontext(  # noqa: PLR0913  # tracked: #288
     parent: Individual,
     inspirations: list[Individual],
     objective: str,
-    objectives: list[Objective] | None,
+    space: MetricSpace,
     modality: str | None,
     domain_definition: DomainDefinition,
     pass_criteria: str,
@@ -858,7 +859,7 @@ def _evaluate_in_subcontext(  # noqa: PLR0913  # tracked: #288
             parent=parent,
             inspirations=inspirations,
             objective=objective,
-            objectives=objectives,
+            space=space,
             modality=modality,
             domain_definition=domain_definition,
             pass_criteria=pass_criteria,
@@ -907,7 +908,7 @@ def _run_generation_parallel(  # noqa: PLR0913  # tracked: #288
     k_random_inspirations: int,
     selection_temperature: float,
     objective: str,
-    objectives: list[Objective] | None,
+    space: MetricSpace,
     frontier_bias: float,
     modality: str | None,
     domain_definition: DomainDefinition,
@@ -935,7 +936,7 @@ def _run_generation_parallel(  # noqa: PLR0913  # tracked: #288
             k_top_inspirations=k_top_inspirations,
             k_random_inspirations=k_random_inspirations,
             selection_temperature=selection_temperature,
-            objectives=objectives,
+            space=space,
             frontier_bias=frontier_bias,
             search_policy=search_policy,
         )
@@ -973,7 +974,7 @@ def _run_generation_parallel(  # noqa: PLR0913  # tracked: #288
                 parent=plan.parent,
                 inspirations=plan.inspirations,
                 objective=objective,
-                objectives=objectives,
+                space=space,
                 modality=modality,
                 domain_definition=domain_definition,
                 pass_criteria=pass_criteria,
@@ -997,7 +998,7 @@ def _run_generation_parallel(  # noqa: PLR0913  # tracked: #288
             outcomes[child_idx],
             generation=generation,
             search_policy=search_policy,
-            objectives=objectives,
+            space=space,
         )
         _persist_evolve_state(
             parent_ctx,
@@ -1015,7 +1016,7 @@ def _bootstrap_seed(  # noqa: PLR0913, PLR0915  # tracked: #288
     ctx: LoopContext,
     *,
     objective: str,
-    objectives: list[Objective] | None,
+    space: MetricSpace,
     modality: str | None,
     domain_definition: DomainDefinition,
     pass_criteria: str,
@@ -1087,7 +1088,7 @@ def _bootstrap_seed(  # noqa: PLR0913, PLR0915  # tracked: #288
                 modality=modality,
                 domain_definition=domain_definition,
                 is_cold_start=True,
-                objectives=objectives,
+                space=space,
                 failed_lessons=failed_lessons,
                 num_failed_attempts=num_failed_attempts,
                 repair_seed=wip_seed is not None,
@@ -1164,7 +1165,7 @@ def _bootstrap_seed(  # noqa: PLR0913, PLR0915  # tracked: #288
                 modality=modality,
                 domain_definition=domain_definition,
                 objective=objective,
-                objectives=objectives,
+                space=space,
                 runtime_notes=cand_notes,
             )
             ctx.snapshot_workspace("gen-0-seed")
@@ -1190,7 +1191,7 @@ def _bootstrap_seed(  # noqa: PLR0913, PLR0915  # tracked: #288
                     code=_candidate_code(ctx, commit) if search_policy.requires_code else "",
                     policy_parent_id=None,
                     target_island=None,
-                    objectives=objectives,
+                    space=space,
                 )
                 ctx.git.retain_candidate(f"individual-{seed.id}", commit)
             _persist_evolve_state(
@@ -1224,7 +1225,7 @@ def _initialize_search_policy(  # noqa: PLR0913  # tracked: #288
     requested: SearchPolicyName | str | None,
     seed: int | None,
     config: OpenEvolveSearchConfig | None,
-    objectives: list[Objective] | None,
+    space: MetricSpace,
 ) -> tuple[SearchPolicyName, SearchPolicy]:
     state_dir = state_store.namespace.external_directory("openevolve")
     if requested is None:
@@ -1244,7 +1245,7 @@ def _initialize_search_policy(  # noqa: PLR0913  # tracked: #288
         state_dir=state_dir,
         seed=seed,
         config=config,
-        objectives=objectives,
+        space=space,
     )
     for individual in population.passed:
         if not individual.commit:
@@ -1257,7 +1258,7 @@ def _initialize_search_policy(  # noqa: PLR0913  # tracked: #288
                 or (f"vibesys-{individual.parent_id}" if individual.parent_id is not None else None)
             ),
             target_island=individual.policy_target_island,
-            objectives=objectives,
+            space=space,
         )
     return policy_name, policy
 
@@ -1298,7 +1299,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     backend: ComputeBackend = DEFAULT_COMPUTE_BACKEND,
     modality: str | None = None,
     domain: DomainName | None = None,
-    objectives: list[Objective] | None = None,
+    space: MetricSpace,
     frontier_bias: float = 0.7,
     bootstrap_max_attempts: int = 5,
     keep_deployments: bool = False,
@@ -1314,13 +1315,17 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     Returns True if the loop completed normally; False on early
     exception / KeyboardInterrupt.
 
-    When ``objectives`` is non-empty the loop runs in **multi-objective
-    mode**: parent / inspiration sampling biases toward the Pareto
-    frontier with probability ``frontier_bias`` and the profiler is
-    expected to populate ``ProfilerSummary.metrics`` with values for
-    every objective name. When ``objectives`` is None the loop runs in
-    single-objective mode using ``perf_metric`` only — the legacy
-    behavior, kept for back-compat.
+    ``space`` is the run's metric space: the objective axes the task declares
+    and the relative tolerance below which two readings are indistinguishable.
+    It is persisted with the run and is the only thing that decides whether one
+    candidate beats another, so selection honors the declared tolerance.
+
+    When the space has axes the loop runs in **multi-objective mode**: parent /
+    inspiration sampling biases toward the Pareto frontier with probability
+    ``frontier_bias`` and the profiler is expected to populate
+    ``ProfilerSummary.metrics`` with values for every objective name. With no
+    axes the loop runs in single-objective mode using ``perf_metric`` only —
+    the legacy behavior, kept for back-compat.
     """
     if domain is None:
         raise ValueError("domain is required; declare [agent].domain in vibesys.input.toml")  # noqa: TRY003  # tracked: #288
@@ -1377,7 +1382,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
         bootstrap_max_attempts=bootstrap_max_attempts,
         keep_deployments=keep_deployments,
         max_parallelism=max_parallelism,
-        objectives=tuple(f"{item.name}:{item.direction}" for item in (objectives or [])),
+        objectives=tuple(f"{item.name}:{item.direction}" for item in space.objectives),
     )
     ctx = create_run_context(
         config=normalized_config,
@@ -1409,18 +1414,32 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     ctx.lprint(f"[log] evolutionary run: {ctx.run_log_path}")
     ctx.lprint(f"[log] project root: {ctx.project_root}")
     ctx.lprint(f"[log] objective: {objective.splitlines()[0] if objective else '(empty)'}")
-    if objectives:
-        spec = ", ".join(f"{o.name}({o.direction})" for o in objectives)
-        ctx.lprint(f"[log] pareto objectives: [{spec}], frontier_bias={frontier_bias}")
+    if space.objectives:
+        spec = ", ".join(f"{o.name}({o.direction})" for o in space.objectives)
+        ctx.lprint(
+            f"[log] pareto objectives: [{spec}], frontier_bias={frontier_bias}, "
+            f"tolerance={space.relative_noise:.0%}"
+        )
     else:
         ctx.lprint("[log] single-objective mode (no Pareto frontier)")
 
     state_store = EvolutionStateStore(ctx.state.portable(RunStateNamespace.EVOLVE))
     try:
         population = state_store.load_population()
+        # A resumed run whose task file has been edited selects by the new
+        # space from here on; say so rather than letting the change be silent.
+        if state_store.load_metric_space() not in {space, MetricSpace()}:
+            ctx.lprint(
+                "[log] this run recorded a different metric space; the task file "
+                f"wins and selection now uses {len(space.objectives)} axes within "
+                f"a {space.relative_noise:.0%} tolerance"
+            )
         # Materialize an empty population too, so a newly initialized run has
-        # one complete, inspectable persistence contract from the start.
+        # one complete, inspectable persistence contract from the start. The
+        # metric space is written the same way and in the same place: one
+        # record of how this run decides that a candidate is better.
         state_store.save_population(population)
+        state_store.save_metric_space(space)
         policy_name, policy = _initialize_search_policy(
             ctx,
             population,
@@ -1428,7 +1447,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
             requested=search_policy,
             seed=seed,
             config=openevolve_config,
-            objectives=objectives,
+            space=space,
         )
         _persist_evolve_state(
             ctx,
@@ -1455,7 +1474,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
             seed_individual = _bootstrap_seed(
                 ctx,
                 objective=objective,
-                objectives=objectives,
+                space=space,
                 modality=modality,
                 domain_definition=domain_definition,
                 pass_criteria=pass_criteria,
@@ -1512,7 +1531,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     k_random_inspirations=k_random_inspirations,
                     selection_temperature=selection_temperature,
                     objective=objective,
-                    objectives=objectives,
+                    space=space,
                     frontier_bias=frontier_bias,
                     modality=modality,
                     domain_definition=domain_definition,
@@ -1534,7 +1553,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     k_random_inspirations=k_random_inspirations,
                     selection_temperature=selection_temperature,
                     objective=objective,
-                    objectives=objectives,
+                    space=space,
                     frontier_bias=frontier_bias,
                     modality=modality,
                     domain_definition=domain_definition,
@@ -1551,8 +1570,8 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 label=f"evolve: complete generation {generation}",
             )
 
-        if objectives:
-            front = population.frontier(objectives)
+        if space.objectives:
+            front = population.frontier(space)
             if front:
                 ctx.lprint(f"\nFinal Pareto frontier ({len(front)} individuals):")
                 for ind in front:
@@ -1560,7 +1579,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         f"{o.name}={ind.metrics.get(o.name, 'n/a'):g}"
                         if isinstance(ind.metrics.get(o.name), (int, float))
                         else f"{o.name}=n/a"
-                        for o in objectives
+                        for o in space.objectives
                     )
                     ctx.lprint(
                         f"  #{ind.id}: {metrics_repr} "
@@ -1569,7 +1588,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
             else:
                 ctx.lprint("\nFrontier is empty (no individual reported all objective metrics).")
 
-        best = population.best()
+        best = population.best(space)
         if best is None and population.passed:
             # A profiler-disabled run has no scalar fitness. Prefer the latest
             # passing individual, matching the search-policy fallback.

--- a/src/vibesys/loops/evolve/population.py
+++ b/src/vibesys/loops/evolve/population.py
@@ -7,12 +7,12 @@ loop-owned state adapter converts populations to strict persisted contracts.
 
 The module supports two selection modes:
 
-- **Scalar** (objectives=None): rank by ``Individual.perf_metric``;
-  parent sampling is a softmax over normalized fitness. Used when the
-  caller doesn't provide an objective list (the default for
+- **Scalar** (a space with no configured axes): rank by
+  ``Individual.perf_metric``; parent sampling is a softmax over normalized
+  fitness. Used when the task declares no objectives (the default for
   back-compatibility with runs that predate Pareto support).
 
-- **Multi-objective Pareto** (objectives=[...]): keep a non-dominated
+- **Multi-objective Pareto** (a space with axes): keep a non-dominated
   *frontier* over ``Individual.metrics``; with probability
   ``frontier_bias`` parent selection draws uniformly from the frontier,
   otherwise it falls back to the scalar softmax over the *primary*
@@ -23,6 +23,16 @@ The two modes share data structures: every passing individual stores
 both ``perf_metric`` (back-compat scalar) and ``metrics`` (the dict the
 profiler reported). Mode is chosen at the call site, not at the data
 layer.
+
+## Comparison versus ranking
+
+Every question of the form "is this candidate better?" -- dominance, frontier
+membership, and the scalar champion -- is answered by the run's
+:class:`~vibesys.loops.metrics.MetricSpace`, so the task's declared measurement
+tolerance applies to selection. Parent sampling deliberately does not: the
+softmax over normalized fitness ranks the whole archive rather than comparing
+two candidates, and squashing near-ties there would flatten the very gradient
+the sampler exists to follow.
 """
 
 from __future__ import annotations
@@ -31,49 +41,18 @@ import math
 import random  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass, field
 
-from vibesys.loops.metrics import Objective
+from vibesys.loops.metrics import Measurement, MetricSpace, Objective
 
 __all__ = [
     "Individual",
-    "Objective",
     "Population",
 ]
 
-# ---------------------------------------------------------------------------
-# Dominance
-#
-# ``Objective`` now lives in ``vibesys.loops.metrics`` alongside the shared
-# metric space. It is re-exported here so this module and its importers keep
-# their existing surface. The selection logic below still compares exactly,
-# without a measurement tolerance; delegating it to ``MetricSpace`` is a
-# deliberate behavior change for the evolve loop and belongs in its own change.
-# ---------------------------------------------------------------------------
-
-
-def _dominates(a: Individual, b: Individual, objectives: list[Objective]) -> bool:
-    """True if ``a`` Pareto-dominates ``b`` under *objectives*.
-
-    Convention: a dominates b iff for every objective, a is at-least-as
-    good as b, AND for at least one objective, a is strictly better.
-    Both must have a value for every objective name; missing values are
-    treated as "incomparable" (neither dominates).
-    """
-    if not objectives:
-        return False
-    strictly_better_anywhere = False
-    for obj in objectives:
-        a_val = a.metrics.get(obj.name)
-        b_val = b.metrics.get(obj.name)
-        if a_val is None or b_val is None:
-            return False
-        a_eff = obj.signed(a_val)
-        b_eff = obj.signed(b_val)
-        if a_eff < b_eff:
-            return False  # a worse on this axis → can't dominate
-        if a_eff > b_eff:
-            strictly_better_anywhere = True
-    return strictly_better_anywhere
-
+# The axis ``best`` orders on when the task declares no objectives. Scalar mode
+# predates configurable objectives and has always read ``perf_metric`` as a
+# maximization axis; naming it here as an axis lets the run's tolerance apply
+# in that mode too, without any caller passing a direction.
+_SCALAR_AXIS = Objective(name="perf_metric", direction="max")
 
 # ---------------------------------------------------------------------------
 # Individual
@@ -168,42 +147,40 @@ class Population:
         ind.validate_fitness()
         self._individuals.append(ind)
 
-    def best(self) -> Individual | None:
-        """Return the passed individual with the highest ``perf_metric``.
+    def best(self, space: MetricSpace) -> Individual | None:
+        """Return the passed individual leading on the run's headline axis.
 
-        Single-objective view; for multi-objective use ``frontier``.
-        Ties broken by latest id (most recent wins).
+        Single-objective view; for multi-objective use ``frontier``. The axis
+        is the space's primary objective, or ``perf_metric`` when the task
+        declares none. Ties, including ties inside the declared tolerance, go
+        to the latest id (most recent wins), which the reversed iteration order
+        expresses to ``MetricSpace.best``.
         """
-        best: Individual | None = None
-        best_metric = float("-inf")
-        for ind in self.passed:
-            metric = ind.perf_metric
-            if metric is None:
-                continue
-            if best is None or metric > best_metric or (metric == best_metric and ind.id > best.id):
-                best = ind
-                best_metric = metric
-        return best
+        headline = _headline_space(space)
+        newest_first: list[Individual] = sorted(
+            self.passed, key=lambda individual: individual.id, reverse=True
+        )
+
+        def reading(individual: Individual) -> Measurement | None:
+            return _headline_reading(individual, headline)
+
+        return headline.best(newest_first, reading)
 
     # -- frontier ------------------------------------------------------------
 
-    def frontier(self, objectives: list[Objective]) -> list[Individual]:
+    def frontier(self, space: MetricSpace) -> list[Individual]:
         """Return the Pareto-non-dominated subset of passed individuals.
 
-        Only individuals with values for *every* objective name are
-        eligible — a partial-metric individual is incomparable on the
-        missing axis and silently dropped from the frontier.
+        Only individuals with values for *every* configured axis are eligible;
+        a partial-metric individual is incomparable on the missing axis and is
+        silently dropped from the frontier. Dominance is decided by *space*, so
+        a candidate within the declared tolerance of a frontier member is not
+        dominated by it.
         """
-        if not objectives:
-            return []
-        eligible = [i for i in self.passed if all(o.name in i.metrics for o in objectives)]
-        non_dominated: list[Individual] = []
-        for cand in eligible:
-            if not any(
-                _dominates(other, cand, objectives) for other in eligible if other.id != cand.id
-            ):
-                non_dominated.append(cand)  # noqa: PERF401  # tracked: #288
-        return non_dominated
+        return space.frontier(
+            [individual for individual in self.passed if space.complete(individual.metrics)],
+            lambda individual: individual.metrics,
+        )
 
     # -- selection -----------------------------------------------------------
 
@@ -212,25 +189,24 @@ class Population:
         *,
         rng: random.Random,
         temperature: float = 1.0,
-        objectives: list[Objective] | None = None,
+        space: MetricSpace,
         frontier_bias: float = 0.7,
     ) -> Individual | None:
         """Sample a parent from passed individuals.
 
         Two modes:
 
-        - **Pareto** (``objectives`` provided): with probability
-          ``frontier_bias`` draw uniformly from the frontier; otherwise
-          fall back to the scalar softmax. If the frontier is empty
-          (e.g. no individual has all required metrics yet) this also
-          falls back to scalar softmax — keeps the loop unblocked
-          early in a run before the profiler emits all axes.
-        - **Scalar** (``objectives=None``): softmax over normalized
+        - **Pareto** (*space* has axes): with probability ``frontier_bias``
+          draw uniformly from the frontier; otherwise fall back to the scalar
+          softmax. If the frontier is empty (e.g. no individual has all
+          required metrics yet) this also falls back to scalar softmax — keeps
+          the loop unblocked early in a run before the profiler emits all axes.
+        - **Scalar** (*space* has no axes): softmax over normalized
           ``perf_metric`` with ``temperature``. Lower temperature →
           greedy on the best; higher temperature → uniform.
         """
-        if objectives:
-            front = self.frontier(objectives)
+        if space.objectives:
+            front = self.frontier(space)
             if front and rng.random() < frontier_bias:
                 return rng.choice(front)
         return self._scalar_softmax_parent(rng=rng, temperature=temperature)
@@ -271,20 +247,20 @@ class Population:
         k_top: int,
         k_random: int,
         rng: random.Random,
-        objectives: list[Objective] | None = None,
+        space: MetricSpace,
     ) -> list[Individual]:
         """Pick a small set of peer individuals to show the mutator.
 
         Two modes:
 
-        - **Pareto** (``objectives`` provided): take up to ``k_top`` from
-          the frontier (parent excluded), then ``k_random`` random
-          others. Frontier members are sorted by the *primary*
-          objective (first in the list) so the strongest example on the
-          headline axis comes first; the rest of the frontier still
-          shows the mutator alternative axes. If the frontier is too
-          small, the slack is filled from off-frontier passers.
-        - **Scalar** (``objectives=None``): top-K-by-perf + random-K, as
+        - **Pareto** (*space* has axes): take up to ``k_top`` from the frontier
+          (parent excluded), then ``k_random`` random others. Frontier members
+          are sorted by the *primary* objective so the strongest example on the
+          headline axis comes first; the rest of the frontier still shows the
+          mutator alternative axes. If the frontier is too small, the slack is
+          filled from off-frontier passers. This ordering is a ranking, not a
+          comparison, so it reads signed axis values directly.
+        - **Scalar** (*space* has no axes): top-K-by-perf + random-K, as
           before.
 
         The parent is always excluded; duplicates are removed.
@@ -293,10 +269,10 @@ class Population:
         if not pool:
             return []
 
-        if objectives:
-            front_ids = {i.id for i in self.frontier(objectives) if i.id != parent_id}
+        primary = space.primary
+        if primary is not None:
+            front_ids = {i.id for i in self.frontier(space) if i.id != parent_id}
             front_pool = [i for i in pool if i.id in front_ids]
-            primary = objectives[0]
             front_pool.sort(
                 key=lambda i: primary.signed(i.metrics.get(primary.name, float("-inf"))),
                 reverse=True,
@@ -322,6 +298,28 @@ class Population:
         rest = [i for i in pool if i.id not in top_ids]
         rnd = rng.sample(rest, k=min(k_random, len(rest))) if rest else []
         return top + rnd
+
+
+def _headline_space(space: MetricSpace) -> MetricSpace:
+    """Return the space ``best`` orders in: the run's, or the scalar fallback.
+
+    A task that declares objectives names its headline axis first. One that
+    declares none is still measured with the run's tolerance, on the
+    back-compat ``perf_metric`` axis.
+    """
+    if space.primary is not None:
+        return space
+    return MetricSpace(objectives=(_SCALAR_AXIS,), relative_noise=space.relative_noise)
+
+
+def _headline_reading(individual: Individual, headline: MetricSpace) -> Measurement | None:
+    """Read *individual* on the headline axis of an already-resolved space."""
+    primary = headline.primary
+    assert primary is not None  # noqa: S101  # guaranteed by _headline_space
+    value = individual.metrics.get(primary.name, individual.perf_metric)
+    if value is None:
+        return None
+    return Measurement(metric=primary.name, value=value)
 
 
 def _require_finite_metric(value: float | None, field_name: str) -> None:

--- a/src/vibesys/loops/evolve/search_policy.py
+++ b/src/vibesys/loops/evolve/search_policy.py
@@ -24,7 +24,8 @@ from openevolve.config import DatabaseConfig
 from openevolve.database import Program, ProgramDatabase
 from pydantic import BaseModel, ConfigDict, Field
 
-from vibesys.loops.evolve.population import Individual, Objective, Population
+from vibesys.loops.evolve.population import Individual, Population  # noqa: TC001  # tracked: #288
+from vibesys.loops.metrics import MetricSpace, Objective
 
 
 class SearchPolicyName(StrEnum):  # noqa: D101  # tracked: #288
@@ -137,7 +138,7 @@ class SearchPolicy(Protocol):
         k_top_inspirations: int,
         k_random_inspirations: int,
         selection_temperature: float,
-        objectives: list[Objective] | None,
+        space: MetricSpace,
         frontier_bias: float,
     ) -> SearchSelection | None: ...
 
@@ -148,7 +149,7 @@ class SearchPolicy(Protocol):
         code: str,
         policy_parent_id: str | None,
         target_island: int | None,
-        objectives: list[Objective] | None,
+        space: MetricSpace,
     ) -> None: ...
 
     def finish_generation(self, generation: int) -> None: ...  # noqa: D102  # tracked: #288
@@ -169,13 +170,13 @@ class VibeSysSearchPolicy:
         k_top_inspirations: int,
         k_random_inspirations: int,
         selection_temperature: float,
-        objectives: list[Objective] | None,
+        space: MetricSpace,
         frontier_bias: float,
     ) -> SearchSelection | None:
         parent = population.select_parent(
             rng=rng,
             temperature=selection_temperature,
-            objectives=objectives,
+            space=space,
             frontier_bias=frontier_bias,
         )
         inspirations = population.select_inspirations(
@@ -183,7 +184,7 @@ class VibeSysSearchPolicy:
             k_top=k_top_inspirations,
             k_random=k_random_inspirations,
             rng=rng,
-            objectives=objectives,
+            space=space,
         )
         if parent is None:
             passers = population.passed
@@ -199,7 +200,7 @@ class VibeSysSearchPolicy:
         code: str,  # noqa: ARG002  # tracked: #288
         policy_parent_id: str | None,  # noqa: ARG002  # tracked: #288
         target_island: int | None,  # noqa: ARG002  # tracked: #288
-        objectives: list[Objective] | None,  # noqa: ARG002  # tracked: #288
+        space: MetricSpace,  # noqa: ARG002  # tracked: #288
     ) -> None:
         return None
 
@@ -239,7 +240,7 @@ class OpenEvolveSearchPolicy:
         state_dir: Path,
         seed: int | None,
         config: OpenEvolveSearchConfig | None,
-        objectives: list[Objective] | None = None,
+        space: MetricSpace,
     ) -> None:
         self.state_dir = state_dir
         self._snapshot_dir = self._resolve_snapshot_dir(state_dir)
@@ -251,7 +252,7 @@ class OpenEvolveSearchPolicy:
                 f"saved={saved_config}, requested={config}"
             )
         self.config = config or saved_config or OpenEvolveSearchConfig()
-        self._objective_signature = self._objectives_signature(objectives)
+        self._objective_signature = self._objectives_signature(space)
         saved_objectives = saved_state.objective_signature if saved_state else None
         if saved_objectives is not None and saved_objectives != self._objective_signature:
             raise ValueError(  # noqa: TRY003  # tracked: #288
@@ -339,11 +340,11 @@ class OpenEvolveSearchPolicy:
 
     @staticmethod
     def _objectives_signature(
-        objectives: list[Objective] | None,
+        space: MetricSpace,
     ) -> tuple[_PersistedObjective, ...]:
         return tuple(
             _PersistedObjective(name=objective.name, direction=objective.direction)
-            for objective in (objectives or [])
+            for objective in space.objectives
         )
 
     @contextmanager
@@ -436,10 +437,10 @@ class OpenEvolveSearchPolicy:
         k_top_inspirations: int,
         k_random_inspirations: int,
         selection_temperature: float,
-        objectives: list[Objective] | None,
+        space: MetricSpace,
         frontier_bias: float,
     ) -> SearchSelection | None:
-        del rng, selection_temperature, objectives, frontier_bias
+        del rng, selection_temperature, space, frontier_bias
         if not self._database.programs:
             return None
 
@@ -485,11 +486,11 @@ class OpenEvolveSearchPolicy:
         code: str,
         policy_parent_id: str | None,
         target_island: int | None,
-        objectives: list[Objective] | None,
+        space: MetricSpace,
     ) -> None:
         if not individual.passed or not individual.commit:
             return
-        if self._objectives_signature(objectives) != self._objective_signature:
+        if self._objectives_signature(space) != self._objective_signature:
             raise ValueError("OpenEvolve fitness objective changed during the run")  # noqa: TRY003  # tracked: #288
         if individual.id in self._admitted_individual_ids:
             return
@@ -500,7 +501,7 @@ class OpenEvolveSearchPolicy:
             self._admitted_individual_ids = prospective_ids
             return
         metrics = dict(individual.metrics)
-        metrics["combined_score"] = self._combined_score(individual, objectives)
+        metrics["combined_score"] = self._combined_score(individual, space)
         program = Program(
             id=program_id,
             code=code,
@@ -642,11 +643,13 @@ class OpenEvolveSearchPolicy:
     @staticmethod
     def _combined_score(
         individual: Individual,
-        objectives: list[Objective] | None,
+        space: MetricSpace,
     ) -> float:
-        if objectives:
-            primary = objectives[0]
+        primary = space.primary
+        if primary is not None:
             value = individual.metrics.get(primary.name)
             if value is not None:
+                # A ranking score for the upstream database, not a comparison:
+                # it must stay monotone in the primary axis.
                 return primary.signed(value)
         return float(individual.perf_metric or 0.0)

--- a/src/vibesys/loops/evolve/state.py
+++ b/src/vibesys/loops/evolve/state.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from vibesys.loops.evolve.population import Individual, Population
+from vibesys.loops.metrics import MetricSpace
 from vs_loop_state import IndividualRecord, PopulationSnapshot
 
 if TYPE_CHECKING:
     from vs_project import StateNamespace, StateSlot
 
 _POPULATION_FILE = "population.json"
+_METRICS_FILE = "metrics.json"
 
 
 def population_snapshot(population: Population) -> PopulationSnapshot:
@@ -71,6 +73,10 @@ class EvolutionStateStore:
             _POPULATION_FILE,
             PopulationSnapshot,
         )
+        self._metrics: StateSlot[MetricSpace] = namespace.slot(
+            _METRICS_FILE,
+            MetricSpace,
+        )
 
     def load_population(self) -> Population:
         """Load the population, starting empty only when it is absent."""
@@ -80,6 +86,18 @@ class EvolutionStateStore:
     def save_population(self, population: Population) -> None:
         """Validate and atomically save the complete population."""
         self._population.save(population_snapshot(population))
+
+    def load_metric_space(self) -> MetricSpace:
+        """Load the run's metric space.
+
+        State written before the space was persisted has no document; it loads
+        as the empty strict space, which is how those runs already compared.
+        """
+        return self._metrics.load_optional() or MetricSpace()
+
+    def save_metric_space(self, space: MetricSpace) -> None:
+        """Atomically record the axes and tolerance this run selects within."""
+        self._metrics.save(space)
 
     @property
     def namespace(self) -> StateNamespace:

--- a/src/vibesys/loops/metrics.py
+++ b/src/vibesys/loops/metrics.py
@@ -160,14 +160,25 @@ class MetricSpace(BaseModel):
             return MetricComparison.WORSE
         return MetricComparison.WITHIN_NOISE
 
-    def best(self, measurements: Sequence[Measurement]) -> Measurement | None:
-        """Return the best reading among *measurements* on a single axis."""
-        best: Measurement | None = None
-        for item in measurements:
-            if self.direction(item) is None:
+    def best[T](
+        self,
+        points: Sequence[T],
+        reading: Callable[[T], Measurement | None],
+    ) -> T | None:
+        """Return the member of *points* whose reading leads on its axis.
+
+        Ties, including ties within the tolerance, keep the earlier member, so
+        callers order *points* to express their own tie-break. Members with no
+        reading, or on an axis with no known direction, are skipped.
+        """
+        best: T | None = None
+        best_reading: Measurement | None = None
+        for point in points:
+            item = reading(point)
+            if item is None or self.direction(item) is None:
                 continue
-            if best is None or self.compare(item, best) is MetricComparison.BETTER:
-                best = item
+            if best_reading is None or self.compare(item, best_reading) is MetricComparison.BETTER:
+                best, best_reading = point, item
         return best
 
     def compare_to_best(
@@ -183,7 +194,10 @@ class MetricSpace(BaseModel):
         """
         if candidate is None or self.direction(candidate) is None:
             return MetricComparison.INCOMPARABLE
-        best = self.best([item for item in prior if item.metric == candidate.metric])
+        best = self.best(
+            [item for item in prior if item.metric == candidate.metric],
+            lambda item: item,
+        )
         if best is None:
             return MetricComparison.BETTER
         return self.compare(candidate, best)

--- a/tests/vibesys/loops/evolve/test_evolution_state_store.py
+++ b/tests/vibesys/loops/evolve/test_evolution_state_store.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from vibesys.loops.evolve.population import Individual, Population
 from vibesys.loops.evolve.state import EvolutionStateStore
+from vibesys.loops.metrics import MetricSpace, Objective
 from vibesys.run import RunState, RunStateNamespace
 from vs_project import EvolveRunConfiguration, Project, RunEnvironmentRecord
 
@@ -62,3 +63,30 @@ def test_evolution_state_store_distinguishes_empty_from_persisted(tmp_path) -> N
     store.save_population(population)
 
     assert store.load_population().all == population.all
+
+
+def test_metric_space_defaults_to_strict_before_a_run_records_one(tmp_path) -> None:  # noqa: ANN001
+    """State written before the space was persisted has no document.
+
+    It loads as the empty strict space, which is exactly how those runs already
+    compared, so a resumed pre-change run selects the way it always did.
+    """
+    assert _store(tmp_path).load_metric_space() == MetricSpace()
+
+
+def test_metric_space_round_trips_through_its_own_document(tmp_path) -> None:  # noqa: ANN001
+    store = _store(tmp_path)
+    space = MetricSpace(
+        objectives=(
+            Objective(name="tput", direction="max"),
+            Objective(name="lat_ms", direction="min"),
+        ),
+        relative_noise=0.05,
+    )
+
+    store.save_metric_space(space)
+
+    assert store.load_metric_space() == space
+    # The population is a separate document, so recording how a run compares
+    # does not rewrite what it has measured.
+    assert store.load_population().all == []

--- a/tests/vibesys/loops/evolve/test_evolutionary_loop.py
+++ b/tests/vibesys/loops/evolve/test_evolutionary_loop.py
@@ -42,7 +42,6 @@ from vibesys.loops.evolve.loop import (
 )
 from vibesys.loops.evolve.population import (
     Individual,
-    Objective,
     Population,
 )
 from vibesys.loops.evolve.search_policy import (
@@ -52,6 +51,7 @@ from vibesys.loops.evolve.search_policy import (
     VibeSysSearchPolicy,
 )
 from vibesys.loops.evolve.state import EvolutionStateStore
+from vibesys.loops.metrics import MetricSpace, Objective
 from vibesys.profilers import ProfilerKind
 from vibesys.run import GitTracker, LoopContext, RunState, RunStateNamespace
 from vibesys.sandbox.run_environment import CandidateRuntime, RunEnvironmentSpec
@@ -107,7 +107,7 @@ class _EvolveLoopKwargs(TypedDict, total=False):
     backend: ComputeBackend
     modality: str | None
     domain: DomainName | None
-    objectives: list[Objective] | None
+    space: MetricSpace
     frontier_bias: float
     bootstrap_max_attempts: int
     keep_deployments: bool
@@ -290,6 +290,7 @@ def _invoke_loop(
         "children_per_generation": 1,
         "seed": 0,
         "domain": DomainName.LLM_SERVING,
+        "space": MetricSpace(),
     }
     defaults.update(kwargs)
     with (
@@ -636,7 +637,7 @@ def test_final_project_tree_is_the_deterministic_scalar_best(tmp_path, ref_file)
     )
 
     assert result is True
-    best = _load_population(tmp_path).best()
+    best = _load_population(tmp_path).best(MetricSpace())
     assert best is not None and best.perf_metric == 100.0  # noqa: PT018  # tracked: #288
     project = _project_dir(tmp_path)
     assert (project / "mutant_2.py").is_file()
@@ -710,13 +711,15 @@ def test_accuracy_rejected_child_is_not_profiled_or_selected(tmp_path, ref_file)
 
 
 def test_pareto_mode_records_metrics_dict_on_individuals(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
-    """When objectives are configured the loop should pass `objectives` through
-    to selection AND copy `ProfilerSummary.metrics` onto every passing
-    Individual so the frontier can be computed across the run."""
-    objectives = [
-        Objective("tput", "max"),
-        Objective("lat_ms", "min"),
-    ]
+    """When axes are configured the loop should pass the space through to
+    selection AND copy `ProfilerSummary.metrics` onto every passing Individual
+    so the frontier can be computed across the run."""
+    space = MetricSpace(
+        objectives=(
+            Objective(name="tput", direction="max"),
+            Objective(name="lat_ms", direction="min"),
+        )
+    )
     profiler_responses = [
         ProfilerSummary(
             analysis="ok",
@@ -742,7 +745,7 @@ def test_pareto_mode_records_metrics_dict_on_individuals(tmp_path, ref_file):  #
         runner,
         max_generations=1,  # bootstrap seed + one gen-1 child
         children_per_generation=1,
-        objectives=objectives,
+        space=space,
         frontier_bias=1.0,
     )
     assert result is True
@@ -754,7 +757,7 @@ def test_pareto_mode_records_metrics_dict_on_individuals(tmp_path, ref_file):  #
     assert child.metrics == {"tput": 80.0, "lat_ms": 50.0}
 
     # The two individuals trade off — both should be on the frontier.
-    front_ids = {i.id for i in pop.frontier(objectives)}
+    front_ids = {i.id for i in pop.frontier(space)}
     assert front_ids == {seed.id, child.id}
 
 
@@ -792,12 +795,17 @@ def test_pareto_addendum_appears_in_profiler_prompt(tmp_path, ref_file):  # noqa
         return runner
 
     runner = _make_runner_with_profiler_capture()
-    objectives = [Objective("tput", "max"), Objective("lat_ms", "min")]
+    space = MetricSpace(
+        objectives=(
+            Objective(name="tput", direction="max"),
+            Objective(name="lat_ms", direction="min"),
+        )
+    )
     _invoke_bootstrap(
         tmp_path,
         ref_file,
         runner,
-        objectives=objectives,
+        space=space,
         frontier_bias=1.0,
     )
     assert len(captured_profiler_prompts) == 1
@@ -808,15 +816,14 @@ def test_pareto_addendum_appears_in_profiler_prompt(tmp_path, ref_file):  # noqa
 
 
 def test_no_objectives_keeps_metrics_empty_and_legacy_behavior(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
-    """Single-objective mode (no objectives passed) keeps `Individual.metrics`
-    empty even if the profiler stub doesn't supply one — preserves the
-    pre-Pareto behavior."""
+    """A space with no axes keeps `Individual.metrics` empty even if the
+    profiler stub doesn't supply one — preserves the pre-Pareto behavior."""
     runner = _make_runner()
     result = _invoke_bootstrap(
         tmp_path,
         ref_file,
         runner,
-        # Note: no `objectives` kwarg → single-objective mode.
+        # Note: an empty space → single-objective mode.
     )
     assert result is True
     pop = _load_population(tmp_path)
@@ -980,6 +987,7 @@ def test_search_policy_initialization_failure_closes_context(tmp_path):  # noqa:
             "objective",
             runs_dir=tmp_path / "exp_env",
             domain=DomainName.GENERIC,
+            space=MetricSpace(),
             search_policy="openevolve",
         )
 
@@ -998,7 +1006,7 @@ def test_programmatic_openevolve_config_infers_policy(tmp_path):  # noqa: ANN001
         requested=None,
         seed=1,
         config=config,
-        objectives=None,
+        space=MetricSpace(),
     )
 
     assert name.value == "openevolve"
@@ -1017,7 +1025,7 @@ def test_programmatic_openevolve_config_rejects_vibesys_policy(tmp_path):  # noq
             requested="vibesys",
             seed=1,
             config=OpenEvolveSearchConfig(),
-            objectives=None,
+            space=MetricSpace(),
         )
 
 
@@ -1191,7 +1199,7 @@ def test_plan_candidate_falls_back_to_latest_passer_then_none(tmp_path):  # noqa
             k_top_inspirations=1,
             k_random_inspirations=1,
             selection_temperature=0.5,
-            objectives=None,
+            space=MetricSpace(),
             frontier_bias=0.7,
         )
         is None
@@ -1207,7 +1215,7 @@ def test_plan_candidate_falls_back_to_latest_passer_then_none(tmp_path):  # noqa
         k_top_inspirations=1,
         k_random_inspirations=1,
         selection_temperature=0.5,
-        objectives=None,
+        space=MetricSpace(),
         frontier_bias=0.7,
     )
     assert plan is not None
@@ -1262,7 +1270,7 @@ def test_run_generation_parallel_bounds_concurrency_and_records_all(tmp_path, mo
         k_random_inspirations=1,
         selection_temperature=0.5,
         objective="obj",
-        objectives=None,
+        space=MetricSpace(),
         frontier_bias=0.7,
         modality="text_generation",
         domain_definition=_LLM_SERVING_DOMAIN,
@@ -1320,7 +1328,7 @@ def test_run_generation_parallel_skips_parent_without_commit(tmp_path, monkeypat
         k_random_inspirations=1,
         selection_temperature=0.5,
         objective="obj",
-        objectives=None,
+        space=MetricSpace(),
         frontier_bias=0.7,
         modality="text_generation",
         domain_definition=_LLM_SERVING_DOMAIN,
@@ -1355,7 +1363,7 @@ def test_evaluate_in_subcontext_skips_parent_without_commit():  # noqa: ANN201  
         parent=parentless,
         inspirations=[],
         objective="obj",
-        objectives=None,
+        space=MetricSpace(),
         modality="text_generation",
         domain_definition=_LLM_SERVING_DOMAIN,
         pass_criteria="crit",  # noqa: S106  # tracked: #288
@@ -1432,7 +1440,7 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
             parent=parent_ind,
             inspirations=[],
             objective="Maximize tok/s throughput.",
-            objectives=None,
+            space=MetricSpace(),
             modality="text_generation",
             domain_definition=_LLM_SERVING_DOMAIN,
             pass_criteria="be faster",  # noqa: S106  # tracked: #288

--- a/tests/vibesys/loops/evolve/test_evolutionary_population.py
+++ b/tests/vibesys/loops/evolve/test_evolutionary_population.py
@@ -13,11 +13,18 @@ from typing import Any
 
 import pytest
 
-from vibesys.loops.evolve.population import (
-    Individual,
-    Objective,
-    Population,
-    _dominates,
+from vibesys.loops.evolve.population import Individual, Population
+from vibesys.loops.metrics import MetricSpace, Objective
+
+
+def _space(*objectives: Objective, noise: float = 0.0) -> MetricSpace:
+    """The metric space a task declaring *objectives* would produce."""
+    return MetricSpace(objectives=objectives, relative_noise=noise)
+
+
+_TPUT_LAT = _space(
+    Objective(name="tput", direction="max"),
+    Objective(name="lat", direction="min"),
 )
 
 # ---------------------------------------------------------------------------
@@ -73,17 +80,17 @@ def test_passed_filter_excludes_no_commit_and_failed():  # noqa: ANN201  # track
 
 def test_best_picks_highest_perf_metric():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(1, 10.0), _passed(2, 12.0), _passed(3, 11.0)])
-    assert _selected_id(pop.best()) == 2
+    assert _selected_id(pop.best(MetricSpace())) == 2
 
 
 def test_best_returns_none_with_no_passed_individuals():  # noqa: ANN201  # tracked: #288
     pop = Population([_failed(1), _failed(2)])
-    assert pop.best() is None
+    assert pop.best(MetricSpace()) is None
 
 
 def test_best_breaks_ties_by_id():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(1, 10.0), _passed(2, 10.0)])
-    assert _selected_id(pop.best()) == 2
+    assert _selected_id(pop.best(MetricSpace())) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -92,24 +99,27 @@ def test_best_breaks_ties_by_id():  # noqa: ANN201  # tracked: #288
 
 
 def test_select_parent_empty_returns_none():  # noqa: ANN201  # tracked: #288
-    assert Population().select_parent(rng=random.Random(0)) is None  # noqa: S311  # tracked: #288
+    assert Population().select_parent(rng=random.Random(0), space=MetricSpace()) is None  # noqa: S311  # tracked: #288
 
 
 def test_select_parent_only_failed_returns_none():  # noqa: ANN201  # tracked: #288
     pop = Population([_failed(1), _failed(2)])
-    assert pop.select_parent(rng=random.Random(0)) is None  # noqa: S311  # tracked: #288
+    assert pop.select_parent(rng=random.Random(0), space=MetricSpace()) is None  # noqa: S311  # tracked: #288
 
 
 def test_select_parent_single_passed_returns_it():  # noqa: ANN201  # tracked: #288
     pop = Population([_failed(1), _passed(2, 10.0)])
-    assert _selected_id(pop.select_parent(rng=random.Random(0))) == 2  # noqa: S311  # tracked: #288
+    assert _selected_id(pop.select_parent(rng=random.Random(0), space=MetricSpace())) == 2  # noqa: S311  # tracked: #288
 
 
 def test_select_parent_low_temperature_concentrates_on_best():  # noqa: ANN201  # tracked: #288
     """A near-zero temperature should pick the best almost every time."""
     pop = Population([_passed(1, 1.0), _passed(2, 5.0), _passed(3, 10.0)])
     rng = random.Random(123)  # noqa: S311  # tracked: #288
-    counts = Counter(_selected_id(pop.select_parent(rng=rng, temperature=0.01)) for _ in range(200))
+    counts = Counter(
+        _selected_id(pop.select_parent(space=MetricSpace(), rng=rng, temperature=0.01))
+        for _ in range(200)
+    )
     # The best (id=3) should dominate.
     assert counts[3] > 180
 
@@ -119,7 +129,8 @@ def test_select_parent_high_temperature_spreads():  # noqa: ANN201  # tracked: #
     pop = Population([_passed(1, 1.0), _passed(2, 5.0), _passed(3, 10.0)])
     rng = random.Random(123)  # noqa: S311  # tracked: #288
     counts = Counter(
-        _selected_id(pop.select_parent(rng=rng, temperature=100.0)) for _ in range(600)
+        _selected_id(pop.select_parent(space=MetricSpace(), rng=rng, temperature=100.0))
+        for _ in range(600)
     )
     # All three should be picked a meaningful number of times.
     assert all(counts[i] > 100 for i in (1, 2, 3))
@@ -128,7 +139,9 @@ def test_select_parent_high_temperature_spreads():  # noqa: ANN201  # tracked: #
 def test_select_parent_uniform_when_all_perfs_equal():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(1, 7.0), _passed(2, 7.0), _passed(3, 7.0)])
     rng = random.Random(42)  # noqa: S311  # tracked: #288
-    counts = Counter(_selected_id(pop.select_parent(rng=rng)) for _ in range(300))
+    counts = Counter(
+        _selected_id(pop.select_parent(rng=rng, space=MetricSpace())) for _ in range(300)
+    )
     assert all(counts[i] > 50 for i in (1, 2, 3))
 
 
@@ -142,7 +155,7 @@ def test_select_inspirations_excludes_parent_and_dedupes():  # noqa: ANN201  # t
         [_passed(i, float(i)) for i in range(1, 8)]  # ids 1..7, perf 1..7
     )
     rng = random.Random(0)  # noqa: S311  # tracked: #288
-    picks = pop.select_inspirations(parent_id=7, k_top=2, k_random=2, rng=rng)
+    picks = pop.select_inspirations(parent_id=7, k_top=2, k_random=2, rng=rng, space=MetricSpace())
     ids = [i.id for i in picks]
     assert 7 not in ids  # parent excluded
     assert len(set(ids)) == len(ids)  # no dupes
@@ -151,7 +164,7 @@ def test_select_inspirations_excludes_parent_and_dedupes():  # noqa: ANN201  # t
 def test_select_inspirations_top_first_then_random():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(i, float(i)) for i in range(1, 8)])
     rng = random.Random(0)  # noqa: S311  # tracked: #288
-    picks = pop.select_inspirations(parent_id=1, k_top=2, k_random=2, rng=rng)
+    picks = pop.select_inspirations(parent_id=1, k_top=2, k_random=2, rng=rng, space=MetricSpace())
     # First two should be the top-2 highest-perf (ids 7 and 6).
     assert picks[0].id == 7
     assert picks[1].id == 6
@@ -167,6 +180,7 @@ def test_select_inspirations_handles_small_population():  # noqa: ANN201  # trac
         k_top=2,
         k_random=2,
         rng=random.Random(0),  # noqa: S311  # tracked: #288
+        space=MetricSpace(),
     )
     # Only one other passed individual exists; no dupes / no errors.
     assert [p.id for p in picks] == [2]
@@ -179,6 +193,7 @@ def test_select_inspirations_empty_when_only_parent_passed():  # noqa: ANN201  #
         k_top=3,
         k_random=3,
         rng=random.Random(0),  # noqa: S311  # tracked: #288
+        space=MetricSpace(),
     )
     assert picks == []
 
@@ -223,47 +238,6 @@ def test_objective_signed_min_negates():  # noqa: ANN201  # tracked: #288
     assert Objective("x", "min").signed(5.0) == -5.0
 
 
-def test_dominates_max_objective():  # noqa: ANN201  # tracked: #288
-    a = _multi(1, {"throughput": 100.0})
-    b = _multi(2, {"throughput": 80.0})
-    objs = [Objective("throughput", "max")]
-    assert _dominates(a, b, objs) is True
-    assert _dominates(b, a, objs) is False
-
-
-def test_dominates_min_objective():  # noqa: ANN201  # tracked: #288
-    a = _multi(1, {"latency_ms": 50.0})
-    b = _multi(2, {"latency_ms": 80.0})
-    objs = [Objective("latency_ms", "min")]
-    assert _dominates(a, b, objs) is True
-
-
-def test_dominates_requires_strictly_better_on_at_least_one():  # noqa: ANN201  # tracked: #288
-    """Equal on every axis → no domination either way."""
-    a = _multi(1, {"x": 5.0, "y": 5.0})
-    b = _multi(2, {"x": 5.0, "y": 5.0})
-    objs = [Objective("x", "max"), Objective("y", "max")]
-    assert _dominates(a, b, objs) is False
-    assert _dominates(b, a, objs) is False
-
-
-def test_dominates_two_axis_mixed_is_non_dominated():  # noqa: ANN201  # tracked: #288
-    """Throughput/latency tradeoff: neither dominates."""
-    a = _multi(1, {"tput": 100.0, "lat": 80.0})
-    b = _multi(2, {"tput": 80.0, "lat": 50.0})
-    objs = [Objective("tput", "max"), Objective("lat", "min")]
-    assert _dominates(a, b, objs) is False
-    assert _dominates(b, a, objs) is False
-
-
-def test_dominates_missing_metric_treats_as_incomparable():  # noqa: ANN201  # tracked: #288
-    a = _multi(1, {"tput": 100.0})  # missing 'lat'
-    b = _multi(2, {"tput": 80.0, "lat": 50.0})
-    objs = [Objective("tput", "max"), Objective("lat", "min")]
-    assert _dominates(a, b, objs) is False
-    assert _dominates(b, a, objs) is False
-
-
 def test_frontier_returns_only_non_dominated():  # noqa: ANN201  # tracked: #288
     pop = Population(
         [
@@ -273,8 +247,7 @@ def test_frontier_returns_only_non_dominated():  # noqa: ANN201  # tracked: #288
             _multi(4, {"tput": 90.0, "lat": 60.0}),  # frontier (middle)
         ]
     )
-    objs = [Objective("tput", "max"), Objective("lat", "min")]
-    front_ids = {i.id for i in pop.frontier(objs)}
+    front_ids = {i.id for i in pop.frontier(_TPUT_LAT)}
     assert front_ids == {1, 2, 4}
 
 
@@ -285,15 +258,14 @@ def test_frontier_excludes_individuals_missing_metrics():  # noqa: ANN201  # tra
             _multi(2, {"tput": 80.0}),  # missing 'lat'
         ]
     )
-    objs = [Objective("tput", "max"), Objective("lat", "min")]
-    front_ids = {i.id for i in pop.frontier(objs)}
+    front_ids = {i.id for i in pop.frontier(_TPUT_LAT)}
     # Only id=1 is fully metric'd.
     assert front_ids == {1}
 
 
 def test_frontier_empty_when_no_objectives():  # noqa: ANN201  # tracked: #288
     pop = Population([_multi(1, {"tput": 100.0})])
-    assert pop.frontier([]) == []
+    assert pop.frontier(MetricSpace()) == []
 
 
 # ---------------------------------------------------------------------------
@@ -310,10 +282,9 @@ def test_select_parent_pareto_mode_draws_from_frontier_with_full_bias():  # noqa
             _multi(3, {"tput": 50.0, "lat": 200.0}),  # dominated
         ]
     )
-    objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)  # noqa: S311  # tracked: #288
     counts = Counter(
-        _selected_id(pop.select_parent(rng=rng, objectives=objs, frontier_bias=1.0))
+        _selected_id(pop.select_parent(rng=rng, space=_TPUT_LAT, frontier_bias=1.0))
         for _ in range(200)
     )
     assert counts[3] == 0  # never the dominated one
@@ -330,13 +301,12 @@ def test_select_parent_pareto_mode_falls_back_to_scalar_when_bias_zero():  # noq
             _multi(2, {"tput": 80.0, "lat": 50.0}),
         ]
     )
-    objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)  # noqa: S311  # tracked: #288
     counts = Counter(
         _selected_id(
             pop.select_parent(
                 rng=rng,
-                objectives=objs,
+                space=_TPUT_LAT,
                 frontier_bias=0.0,
                 temperature=0.01,
             )
@@ -355,9 +325,8 @@ def test_select_parent_falls_back_when_frontier_is_empty():  # noqa: ANN201  # t
             _multi(2, {"tput": 80.0}),  # missing 'lat'
         ]
     )
-    objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)  # noqa: S311  # tracked: #288
-    pick = pop.select_parent(rng=rng, objectives=objs, frontier_bias=1.0)
+    pick = pop.select_parent(rng=rng, space=_TPUT_LAT, frontier_bias=1.0)
     # We get *some* individual via scalar fallback rather than None.
     assert pick is not None
     assert pick.id in (1, 2)
@@ -374,14 +343,13 @@ def test_select_inspirations_pareto_mode_pulls_from_frontier_first():  # noqa: A
             _multi(5, {"tput": 50.0, "lat": 110.0}),  # dominated
         ]
     )
-    objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)  # noqa: S311  # tracked: #288
     picks = pop.select_inspirations(
         parent_id=1,
         k_top=2,
         k_random=1,
         rng=rng,
-        objectives=objs,
+        space=_TPUT_LAT,
     )
     # First two slots are frontier members (excluding parent #1), sorted by
     # primary objective 'tput' descending: id=3 (tput=90) before id=2 (tput=80).
@@ -402,14 +370,13 @@ def test_select_inspirations_backfills_when_frontier_smaller_than_k_top():  # no
             _multi(4, {"tput": 60.0, "lat": 100.0}),  # dominated
         ]
     )
-    objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)  # noqa: S311  # tracked: #288
     picks = pop.select_inspirations(
         parent_id=1,
         k_top=3,
         k_random=0,
         rng=rng,
-        objectives=objs,
+        space=_TPUT_LAT,
     )
     ids = [p.id for p in picks]
     assert ids[0] == 2  # frontier first
@@ -445,7 +412,7 @@ def test_best_revalidates_mutated_fitness_before_ranking():  # noqa: ANN201  # t
     individual.perf_metric = float("nan")
 
     with pytest.raises(ValueError, match="perf_metric must be a finite number"):
-        population.best()
+        population.best(MetricSpace())
 
 
 def test_frontier_revalidates_mutated_metrics_before_comparison():  # noqa: ANN201  # tracked: #288
@@ -462,7 +429,7 @@ def test_frontier_revalidates_mutated_metrics_before_comparison():  # noqa: ANN2
     individual.metrics["throughput"] = float("inf")
 
     with pytest.raises(ValueError, match=r"metrics\['throughput'\] must be a finite number"):
-        population.frontier([Objective("throughput", "max")])
+        population.frontier(_space(Objective(name="throughput", direction="max")))
 
 
 def test_softmax_revalidates_mutated_fitness_before_sampling():  # noqa: ANN201  # tracked: #288
@@ -471,4 +438,97 @@ def test_softmax_revalidates_mutated_fitness_before_sampling():  # noqa: ANN201 
     individual.perf_metric = float("-inf")
 
     with pytest.raises(ValueError, match="perf_metric must be a finite number"):
-        population.select_parent(rng=random.Random(0))  # noqa: S311  # tracked: #288
+        population.select_parent(rng=random.Random(0), space=MetricSpace())  # noqa: S311  # tracked: #288
+
+
+# ---------------------------------------------------------------------------
+# Noise-aware selection
+# ---------------------------------------------------------------------------
+
+
+def _near_frontier() -> Population:
+    """Two candidates 3% apart on both axes: a tie only under a tolerance."""
+    return Population(
+        [
+            _multi(1, {"tput": 100.0, "lat": 80.0}),
+            _multi(2, {"tput": 97.0, "lat": 82.4}),
+        ]
+    )
+
+
+def _tput_lat(noise: float) -> MetricSpace:
+    return _space(
+        Objective(name="tput", direction="max"),
+        Objective(name="lat", direction="min"),
+        noise=noise,
+    )
+
+
+def test_frontier_retains_a_candidate_within_the_declared_tolerance():  # noqa: ANN201  # tracked: #288
+    """Behavior change: selection now honors the task's measurement tolerance.
+
+    Individual 2 is 3% behind on both axes. Compared exactly it is dominated;
+    within a declared 5% tolerance that difference is not a measured result, so
+    the candidate stays on the frontier and remains eligible as a parent.
+    """
+    assert {i.id for i in _near_frontier().frontier(_tput_lat(0.05))} == {1, 2}
+
+
+def test_a_zero_tolerance_reproduces_the_previous_exact_frontier():  # noqa: ANN201  # tracked: #288
+    """The pre-change behavior is the zero-tolerance case of the same rule."""
+    assert {i.id for i in _near_frontier().frontier(_tput_lat(0.0))} == {1}
+
+
+def test_a_candidate_beyond_the_tolerance_is_still_dominated():  # noqa: ANN201  # tracked: #288
+    """The tolerance widens the tie band; it does not disable dominance."""
+    assert {i.id for i in _near_frontier().frontier(_tput_lat(0.01))} == {1}
+
+
+def test_best_prefers_the_latest_of_two_readings_within_the_tolerance():  # noqa: ANN201  # tracked: #288
+    """Behavior change: a near-tie on the headline axis is a tie.
+
+    Individual 2 measures 2% lower, which a 5% tolerance calls
+    indistinguishable. ``Population.best`` breaks ties by latest id, which it
+    expresses to ``MetricSpace.best`` by ordering newest first.
+    """
+    population = Population([_passed(1, 100.0), _passed(2, 98.0)])
+    tolerant = _space(Objective(name="perf_metric", direction="max"), noise=0.05)
+
+    best = population.best(tolerant)
+
+    assert best is not None
+    assert best.id == 2
+
+
+def test_best_with_a_zero_tolerance_still_takes_the_strictly_higher_reading():  # noqa: ANN201  # tracked: #288
+    """The pre-change behavior: only an exact tie goes to the latest id."""
+    strict = Population([_passed(1, 100.0), _passed(2, 98.0)]).best(MetricSpace())
+    tied = Population([_passed(1, 100.0), _passed(2, 100.0)]).best(MetricSpace())
+
+    assert strict is not None
+    assert strict.id == 1
+    assert tied is not None
+    assert tied.id == 2
+
+
+def test_best_orders_on_the_primary_axis_when_the_task_declares_one():  # noqa: ANN201  # tracked: #288
+    """A minimized headline axis makes the lowest reading the champion."""
+    population = Population([_multi(1, {"latency_ms": 80.0}), _multi(2, {"latency_ms": 50.0})])
+
+    best = population.best(_space(Objective(name="latency_ms", direction="min")))
+
+    assert best is not None
+    assert best.id == 2
+
+
+def test_frontier_bias_can_still_reach_a_near_tie_parent():  # noqa: ANN201  # tracked: #288
+    """The retained near-tie is a real selection outcome, not just a listing."""
+    population = _near_frontier()
+    rng = random.Random(0)  # noqa: S311  # tracked: #288
+
+    picked = {
+        _selected_id(population.select_parent(rng=rng, space=_tput_lat(0.05), frontier_bias=1.0))
+        for _ in range(200)
+    }
+
+    assert picked == {1, 2}

--- a/tests/vibesys/loops/evolve/test_search_policy.py
+++ b/tests/vibesys/loops/evolve/test_search_policy.py
@@ -11,11 +11,12 @@ from pathlib import Path  # noqa: TC003  # tracked: #288
 
 import pytest
 
-from vibesys.loops.evolve.population import Individual, Objective, Population
+from vibesys.loops.evolve.population import Individual, Population
 from vibesys.loops.evolve.search_policy import (
     OpenEvolveSearchConfig,
     OpenEvolveSearchPolicy,
 )
+from vibesys.loops.metrics import MetricSpace, Objective
 
 
 class _IterationOrderSet(set[str]):
@@ -72,24 +73,26 @@ def test_dependency_is_pinned_to_requested_release() -> None:
 
 def test_initialization_persists_empty_policy_for_bootstrap_resume(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config()
-    OpenEvolveSearchPolicy(state_dir=tmp_path, seed=7, config=config)
+    OpenEvolveSearchPolicy(state_dir=tmp_path, seed=7, config=config, space=MetricSpace())
 
     assert OpenEvolveSearchPolicy.has_state(tmp_path)
     assert OpenEvolveSearchPolicy.persisted_config(tmp_path) == config
-    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=999, config=None)
+    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=999, config=None, space=MetricSpace())
     assert resumed._database.programs == {}  # noqa: SLF001  # tracked: #288
 
 
 def test_openevolve_selection_maps_programs_back_to_vibesys_individuals(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     population = Population([_individual(1)])
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=7, config=_config())
+    policy = OpenEvolveSearchPolicy(
+        state_dir=tmp_path, seed=7, config=_config(), space=MetricSpace()
+    )
     seed = population.passed[0]
     policy.record(
         seed,
         code="diff --git a/src/lib.rs b/src/lib.rs\n+seed",
         policy_parent_id=None,
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
 
     selection = policy.select(
@@ -98,7 +101,7 @@ def test_openevolve_selection_maps_programs_back_to_vibesys_individuals(tmp_path
         k_top_inspirations=1,
         k_random_inspirations=1,
         selection_temperature=0.5,
-        objectives=None,
+        space=MetricSpace(),
         frontier_bias=0.7,
     )
 
@@ -114,13 +117,15 @@ def test_openevolve_selection_maps_programs_back_to_vibesys_individuals(tmp_path
 def test_migrants_keep_vibesys_identity_and_state_resumes(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     seed = _individual(1)
     population = Population([seed])
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=3, config=_config())
+    policy = OpenEvolveSearchPolicy(
+        state_dir=tmp_path, seed=3, config=_config(), space=MetricSpace()
+    )
     policy.record(
         seed,
         code="seed patch",
         policy_parent_id=None,
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
     child = _individual(2, parent_id=1, generation=1, perf=11.0)
     population.add(child)
@@ -129,10 +134,12 @@ def test_migrants_keep_vibesys_identity_and_state_resumes(tmp_path) -> None:  # 
         code="child patch",
         policy_parent_id="vibesys-1",
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
 
-    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=3, config=_config())
+    resumed = OpenEvolveSearchPolicy(
+        state_dir=tmp_path, seed=3, config=_config(), space=MetricSpace()
+    )
     resumed._database.set_current_island(1)  # noqa: SLF001  # tracked: #288
     selection = resumed.select(
         population,
@@ -140,7 +147,7 @@ def test_migrants_keep_vibesys_identity_and_state_resumes(tmp_path) -> None:  # 
         k_top_inspirations=0,
         k_random_inspirations=0,
         selection_temperature=0.5,
-        objectives=None,
+        space=MetricSpace(),
         frontier_bias=0.7,
     )
 
@@ -155,18 +162,18 @@ def test_migrants_keep_vibesys_identity_and_state_resumes(tmp_path) -> None:  # 
 
 def test_resume_prunes_programs_evicted_before_save(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config(population_size=2, archive_size=2, num_islands=1)
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config)
+    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config, space=MetricSpace())
     for individual_id in range(1, 6):
         policy.record(
             _individual(individual_id),
             code=f"patch {individual_id}",
             policy_parent_id=None,
             target_island=0,
-            objectives=None,
+            space=MetricSpace(),
         )
 
     active_ids = set(policy._database.programs)  # noqa: SLF001  # tracked: #288
-    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config)
+    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config, space=MetricSpace())
 
     assert len(active_ids) <= 2
     assert set(resumed._database.programs) == active_ids  # noqa: SLF001  # tracked: #288
@@ -186,26 +193,26 @@ def test_replaying_population_does_not_readmit_evicted_individuals(tmp_path) -> 
     individuals = [
         _individual(individual_id, generation=individual_id - 1) for individual_id in range(1, 6)
     ]
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config)
+    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config, space=MetricSpace())
     for individual in individuals:
         policy.record(
             individual,
             code=f"patch {individual.id}",
             policy_parent_id=None,
             target_island=0,
-            objectives=None,
+            space=MetricSpace(),
         )
     expected_programs = set(policy._database.programs)  # noqa: SLF001  # tracked: #288
     expected_generations = list(policy._database.island_generations)  # noqa: SLF001  # tracked: #288
 
-    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=None)
+    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=None, space=MetricSpace())
     for individual in individuals:
         resumed.record(
             individual,
             code=f"patch {individual.id}",
             policy_parent_id=None,
             target_island=0,
-            objectives=None,
+            space=MetricSpace(),
         )
 
     assert set(resumed._database.programs) == expected_programs  # noqa: SLF001  # tracked: #288
@@ -213,33 +220,37 @@ def test_replaying_population_does_not_readmit_evicted_individuals(tmp_path) -> 
 
 
 def test_resume_rejects_changed_database_topology(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=_config(num_islands=2))
+    policy = OpenEvolveSearchPolicy(
+        state_dir=tmp_path, seed=4, config=_config(num_islands=2), space=MetricSpace()
+    )
     policy.record(
         _individual(1),
         code="seed",
         policy_parent_id=None,
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
 
     with pytest.raises(ValueError, match="does not match the resumed run"):
-        OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=_config(num_islands=3))
+        OpenEvolveSearchPolicy(
+            state_dir=tmp_path, seed=4, config=_config(num_islands=3), space=MetricSpace()
+        )
 
 
 def test_resume_rejects_changed_fitness_objective(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
-    objectives = [Objective("latency_ms", "min")]
+    space = MetricSpace(objectives=(Objective(name="latency_ms", direction="min"),))
     policy = OpenEvolveSearchPolicy(
         state_dir=tmp_path,
         seed=4,
         config=_config(),
-        objectives=objectives,
+        space=space,
     )
     policy.record(
         _individual(1, metrics={"latency_ms": 4.0}),
         code="seed",
         policy_parent_id=None,
         target_island=0,
-        objectives=objectives,
+        space=space,
     )
 
     with pytest.raises(ValueError, match="fitness objective does not match"):
@@ -247,18 +258,20 @@ def test_resume_rejects_changed_fitness_objective(tmp_path) -> None:  # noqa: AN
             state_dir=tmp_path,
             seed=4,
             config=None,
-            objectives=[Objective("latency_ms", "max")],
+            space=MetricSpace(objectives=(Objective(name="latency_ms", direction="max"),)),
         )
 
 
 def test_finish_generation_keeps_iteration_monotonic(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=_config())
+    policy = OpenEvolveSearchPolicy(
+        state_dir=tmp_path, seed=4, config=_config(), space=MetricSpace()
+    )
     policy.record(
         _individual(20),
         code="seed",
         policy_parent_id=None,
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
 
     policy.finish_generation(1)
@@ -271,20 +284,20 @@ def test_finish_generation_keeps_iteration_monotonic(tmp_path) -> None:  # noqa:
 
 def test_zero_migration_rate_disables_upstream_minimum_migrant(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config(migration_rate=0.0)
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config)
+    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config, space=MetricSpace())
     policy.record(
         _individual(1),
         code="seed",
         policy_parent_id=None,
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
     policy.record(
         _individual(2, parent_id=1, generation=1),
         code="child",
         policy_parent_id="vibesys-1",
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
 
     assert not any(
@@ -297,13 +310,13 @@ def test_empty_island_copy_resolves_through_vibesys_ancestry(tmp_path) -> None: 
     config = _config(migration_interval=50, migration_rate=0.0)
     seed = _individual(1)
     population = Population([seed])
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=2, config=config)
+    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=2, config=config, space=MetricSpace())
     policy.record(
         seed,
         code="seed",
         policy_parent_id=None,
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
     policy._database.set_current_island(1)  # noqa: SLF001  # tracked: #288
     policy._database.config.exploration_ratio = 1.0  # noqa: SLF001  # tracked: #288
@@ -315,7 +328,7 @@ def test_empty_island_copy_resolves_through_vibesys_ancestry(tmp_path) -> None: 
         k_top_inspirations=0,
         k_random_inspirations=0,
         selection_temperature=0.5,
-        objectives=None,
+        space=MetricSpace(),
         frontier_bias=0.7,
     )
 
@@ -331,9 +344,9 @@ def test_empty_island_copy_has_same_identity_after_resume(tmp_path) -> None:  # 
     config = _config(migration_interval=50, migration_rate=0.0)
     seed = _individual(1)
     population = Population([seed])
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=2, config=config)
-    policy.record(seed, code="seed", policy_parent_id=None, target_island=0, objectives=None)
-    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=999, config=None)
+    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=2, config=config, space=MetricSpace())
+    policy.record(seed, code="seed", policy_parent_id=None, target_island=0, space=MetricSpace())
+    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=999, config=None, space=MetricSpace())
     for candidate in (policy, resumed):
         candidate._database.set_current_island(1)  # noqa: SLF001  # tracked: #288
         candidate._database.config.exploration_ratio = 1.0  # noqa: SLF001  # tracked: #288
@@ -344,7 +357,7 @@ def test_empty_island_copy_has_same_identity_after_resume(tmp_path) -> None:  # 
         "k_top_inspirations": 0,
         "k_random_inspirations": 0,
         "selection_temperature": 0.5,
-        "objectives": None,
+        "space": MetricSpace(),
         "frontier_bias": 0.7,
     }
     uninterrupted_selection = policy.select(population, **selection_args)
@@ -358,14 +371,20 @@ def test_migration_has_same_program_identity_after_resume(tmp_path) -> None:  # 
     initial_dir = tmp_path / "initial"
     config = _config(num_islands=2, migration_interval=1, migration_rate=1.0)
     seed = _individual(1)
-    initial = OpenEvolveSearchPolicy(state_dir=initial_dir, seed=3, config=config)
-    initial.record(seed, code="seed", policy_parent_id=None, target_island=0, objectives=None)
+    initial = OpenEvolveSearchPolicy(
+        state_dir=initial_dir, seed=3, config=config, space=MetricSpace()
+    )
+    initial.record(seed, code="seed", policy_parent_id=None, target_island=0, space=MetricSpace())
     uninterrupted_dir = tmp_path / "uninterrupted"
     resumed_dir = tmp_path / "resumed"
     shutil.copytree(initial_dir, uninterrupted_dir)
     shutil.copytree(initial_dir, resumed_dir)
-    uninterrupted = OpenEvolveSearchPolicy(state_dir=uninterrupted_dir, seed=3, config=None)
-    resumed = OpenEvolveSearchPolicy(state_dir=resumed_dir, seed=999, config=None)
+    uninterrupted = OpenEvolveSearchPolicy(
+        state_dir=uninterrupted_dir, seed=3, config=None, space=MetricSpace()
+    )
+    resumed = OpenEvolveSearchPolicy(
+        state_dir=resumed_dir, seed=999, config=None, space=MetricSpace()
+    )
     child = _individual(2, parent_id=1, generation=1)
 
     uninterrupted.record(
@@ -373,14 +392,14 @@ def test_migration_has_same_program_identity_after_resume(tmp_path) -> None:  # 
         code="child",
         policy_parent_id="vibesys-1",
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
     resumed.record(
         child,
         code="child",
         policy_parent_id="vibesys-1",
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
 
     assert set(uninterrupted._database.programs) == set(resumed._database.programs)  # noqa: SLF001  # tracked: #288
@@ -393,14 +412,14 @@ def test_migration_has_same_program_identity_after_resume(tmp_path) -> None:  # 
 def test_resume_continues_upstream_random_stream_without_touching_global_rng(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config(num_islands=1, migration_rate=0.0)
     population = Population([_individual(individual_id) for individual_id in range(1, 6)])
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=19, config=config)
+    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=19, config=config, space=MetricSpace())
     for individual in population.passed:
         policy.record(
             individual,
             code=f"patch {individual.id}",
             policy_parent_id=None,
             target_island=0,
-            objectives=None,
+            space=MetricSpace(),
         )
 
     global_state = random.getstate()
@@ -409,11 +428,11 @@ def test_resume_continues_upstream_random_stream_without_touching_global_rng(tmp
         "k_top_inspirations": 0,
         "k_random_inspirations": 0,
         "selection_temperature": 0.5,
-        "objectives": None,
+        "space": MetricSpace(),
         "frontier_bias": 0.7,
     }
     policy.select(population, **selection_args)
-    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=19, config=None)
+    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=19, config=None, space=MetricSpace())
     program_ids = sorted(policy._database.programs)  # noqa: SLF001  # tracked: #288
     policy._database.config.exploration_ratio = 1.0  # noqa: SLF001  # tracked: #288
     resumed._database.config.exploration_ratio = 1.0  # noqa: SLF001  # tracked: #288
@@ -434,13 +453,13 @@ def test_selection_uses_lightweight_checkpoint_without_rewriting_programs(tmp_pa
     config = _config(num_islands=1, migration_rate=0.0)
     seed = _individual(1)
     population = Population([seed])
-    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=2, config=config)
+    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=2, config=config, space=MetricSpace())
     policy.record(
         seed,
         code="seed",
         policy_parent_id=None,
         target_island=0,
-        objectives=None,
+        space=MetricSpace(),
     )
     snapshot_before = (tmp_path / "CURRENT").read_text()
 
@@ -450,7 +469,7 @@ def test_selection_uses_lightweight_checkpoint_without_rewriting_programs(tmp_pa
         k_top_inspirations=0,
         k_random_inspirations=0,
         selection_temperature=0.5,
-        objectives=None,
+        space=MetricSpace(),
         frontier_bias=0.7,
     )
 
@@ -460,20 +479,20 @@ def test_selection_uses_lightweight_checkpoint_without_rewriting_programs(tmp_pa
 
 
 def test_primary_min_objective_is_signed_for_openevolve_fitness(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
-    objectives = [Objective("latency_ms", "min")]
+    space = MetricSpace(objectives=(Objective(name="latency_ms", direction="min"),))
     individual = _individual(1, perf=20.0, metrics={"latency_ms": 20.0})
     policy = OpenEvolveSearchPolicy(
         state_dir=tmp_path,
         seed=0,
         config=_config(num_islands=1),
-        objectives=objectives,
+        space=space,
     )
     policy.record(
         individual,
         code="latency patch",
         policy_parent_id=None,
         target_island=0,
-        objectives=objectives,
+        space=space,
     )
 
     assert policy._database.programs["vibesys-1"].metrics["combined_score"] == -20.0  # noqa: SLF001  # tracked: #288

--- a/tests/vibesys/loops/test_metrics.py
+++ b/tests/vibesys/loops/test_metrics.py
@@ -122,14 +122,24 @@ def test_best_and_compare_to_best_order_a_scalar_history() -> None:
     space = MetricSpace(objectives=(_OPS,), relative_noise=0.05)
     history = [_reading(100.0), _reading(90.0), _reading(99.0)]
 
-    assert space.best(history) == _reading(100.0)
-    assert space.best([]) is None
+    assert space.best(history, lambda item: item) == _reading(100.0)
+    assert space.best([], lambda item: item) is None
+    # Ties, including ties within the tolerance, keep the earlier member, so
+    # callers order their own tie-break.
+    assert space.best([_reading(100.0, "a"), _reading(103.0, "a")], _named_a) == _reading(
+        100.0, "a"
+    )
     # An empty history is advanced by anything measurable.
     assert space.compare_to_best(_reading(1.0), []) is MetricComparison.BETTER
     assert space.compare_to_best(None, history) is MetricComparison.INCOMPARABLE
     assert space.compare_to_best(_reading(1.0, "unconfigured"), []) is MetricComparison.INCOMPARABLE
     assert space.compare_to_best(_reading(104.0), history) is MetricComparison.WITHIN_NOISE
     assert space.compare_to_best(_reading(120.0), history) is MetricComparison.BETTER
+
+
+def _named_a(item: Measurement) -> Measurement:
+    """Read every member on one axis so the space can order them."""
+    return Measurement(metric="ops", value=item.value)
 
 
 def test_dominance_needs_every_axis_and_one_material_win() -> None:


### PR DESCRIPTION
## Problem

The evolve loop ignores a setting its task declares. `objectives.toml` carries
`[pareto] relative_noise`, the workload's measured benchmark variation, and the
agent loop honors it everywhere. Evolve never read it: `Population.frontier`,
`Population.best`, and `_dominates` in
`src/vibesys/loops/evolve/population.py` compared exactly, so a candidate a
fraction of a percent behind the frontier was discarded as dominated even when
the task had declared that difference to be noise. Over a run that quietly
narrows the archive to whichever candidate happened to measure highest, which
is the failure mode noise-aware dominance exists to prevent.

This is the follow-up #579 (merged) named in its own body:

> `Population.frontier`, `Population.best`, and `_dominates` in
> `evolve/population.py` still compare exactly, on the moved `Objective`. They
> should delegate to `MetricSpace` next. That is a deliberate behavior change —
> it makes the evolve loop noise-aware for the first time — and needs its own
> verification, so it is out of scope here.

#579 moved `Objective` into `src/vibesys/loops/metrics.py` and left a
re-export in `evolve/population.py` precisely so this change could follow.

## Solution

Evolve selection delegates every "is this candidate better?" question to the
run's `MetricSpace`, and the space is threaded and persisted the way the axes
already were.

- `Population.frontier(space)` calls `space.frontier` over the individuals
  whose metric row is complete for the configured axes.
- `Population.best(space)` calls `space.best` on the headline axis: the
  space's primary objective, or the back-compat `perf_metric` axis when the
  task declares none. Naming that fallback as an axis (`_SCALAR_AXIS`) lets the
  tolerance apply in scalar mode too, without any caller passing a direction.
- `_dominates` is deleted. Nothing else used it, and `MetricSpace.dominates` is
  already unit-tested in `tests/vibesys/loops/test_metrics.py`, so the five
  `_dominates` tests are dropped rather than duplicated one layer up.
- `objectives: list[Objective] | None` becomes `space: MetricSpace` through
  `run_evolve_loop` and its 11 helpers, the `SearchPolicy` protocol, and both
  policy implementations (11 signatures and 21 call sites in `loop.py`, 8 more
  in `search_policy.py`). The axes and the tolerance are one fact about the
  workload, so they travel as one value and neither can be forgotten.
- `headless.py` builds the space with `_resolve_metric_space`, which reads
  `objectives.toml` once through the loader #579 introduced. `--objective`
  still overrides the axes; the tolerance always comes from the task file,
  because a command-line axis list does not change how noisy the workload is.

**`MetricSpace.best` becomes generic** over the point type, matching
`frontier`: `best(points, reading)` returns the winning *member*, not just its
reading, which is what a caller holding `Individual`s needs. `compare_to_best`
passes the identity function. Ties, including ties inside the tolerance, keep
the earlier member, so a caller expresses its own tie-break by ordering the
input — `Population.best` iterates newest-first to preserve its documented
"latest id wins".

**The `Objective` re-export is removed.** Every importer
(`evolve/search_policy.py`, `evolve/loop.py`, and three test modules) now takes
it from `vibesys.loops.metrics`.

### Behavior change

Stated plainly, because this is the point of the PR:

1. **A candidate within the declared tolerance of the frontier is no longer
   dominated.** It stays in the archive and remains eligible as a parent and as
   an inspiration.
2. **`best` resolves near-ties the way `MetricSpace.best` defines.** Two
   readings within the tolerance are a tie, and `Population.best` breaks ties by
   latest id as it always documented — so a marginally *lower* newer reading can
   now become the champion where a marginally higher older one used to win.
3. **A zero tolerance reproduces the previous exact behavior**, so every run
   without `[pareto] relative_noise`, and every run resumed from state written
   before this change, selects exactly as before.

Parent sampling is deliberately unchanged: the softmax over normalized fitness
reads `Objective.signed` values directly. It ranks the whole archive rather
than comparing two candidates, and squashing near-ties there would flatten the
gradient the sampler exists to follow. The same reasoning keeps
`OpenEvolveSearchPolicy._combined_score` a raw signed value — it is a ranking
score handed to the upstream database.

### Architecture

```mermaid
flowchart TD
    T["objectives.toml<br/>[[objective]] + [pareto] relative_noise"]
    T -->|"_load_metric_space_toml, read once"| H["headless.py<br/>_resolve_metric_space"]
    CLI["--objective"] -.->|"overrides the axes only"| H
    H -->|"space=MetricSpace(...)"| L["run_evolve_loop"]
    L -->|"save_metric_space()<br/>the only write"| S[("EvolutionStateStore<br/>evolve/metrics.json")]
    S -->|"load_metric_space()<br/>on resume"| CHK{"differs from<br/>the task file?"}
    CHK -->|yes| LOG["log that the task file wins"]

    L -->|space| POL["SearchPolicy.select / .record"]
    POL --> POP["Population.select_parent<br/>Population.select_inspirations"]
    POP --> F["Population.frontier"]
    L -->|space| F
    L -->|space| B["Population.best"]

    F -->|"space.frontier / space.dominates"| M["MetricSpace"]
    B -->|"space.best on the headline axis"| M
    POP -.->|"softmax ranking:<br/>Objective.signed, no tolerance"| R["parent sampling"]
```

The space is written once, at run start, from the value `headless.py` loaded;
the task file wins there and nowhere else re-reads it. It is stored beside
`population.json` in the run's portable evolve namespace, so a run records both
what it measured and how it decides that a candidate is better. On resume the
loop reads the recorded space back and says so when the task file has changed,
rather than letting a silent edit alter selection mid-run.

**Compatibility.** A run whose state predates the field has no
`metrics.json`; it loads as the empty strict space, which is exactly how those
runs already compared.

**Label:** `bug`. The loop silently ignored a declared task setting and
produced a narrower archive than the configuration asked for. It is defensible
to call this an enhancement instead, since noise-aware evolve selection never
existed; I labelled it `bug` because the setting is documented, parsed, and
already honored by the other loop.

## Verification

Ran the loop and library suites plus format, lint, and type checks, and
demonstrated the behavior change at the merge base versus the head. No
persisted contract in `vs-loop-state` changed (the space is a `vibesys`-owned
document in the run's own namespace), and nothing under `clients/` is touched,
so binding regeneration was not applicable.

### Correctness properties

- **One comparison implementation, now for both loops.** Evolve holds no
  dominance or ordering arithmetic; `MetricSpace` answers every comparison.
  Ranking is kept distinct and documented as such.
- **The axes and the tolerance cannot separate.** They are one value from the
  loader to selection, so no call site can pass axes while dropping the
  tolerance — the failure mode #507 was made of.
- **Noise and direction stay inside `metrics.py`.** No evolve signature takes a
  tolerance or an axis direction. `_SCALAR_AXIS` declares an axis, the same way
  `headless.py` declares the ones in `objectives.toml`.
- **The space is written once and read from state.** `run_evolve_loop` is the
  only writer; resume reads it back to report a changed configuration.
- **A zero tolerance is exactly the old behavior**, pinned by tests for both
  `frontier` and `best`.
- **Backward-compatible persisted state.** A run without `metrics.json` loads
  the empty strict space; `population.json` is untouched by this change.

### Testing

**Base-versus-head demonstration.** Base is the merge base `3081f7fe`
(`origin/main`), in a temporary worktree removed afterwards. A two-individual
population where #2 is 3% behind on both axes, with the task declaring
`[pareto] relative_noise = 0.05`, plus a 2% near-tie for `best`:

| | base `3081f7fe` | head |
| --- | --- | --- |
| frontier | `[1]` — #2 discarded as dominated | `[1, 2]` — #2 retained |
| `best` on a 2% near-tie | `1` | `2` (tie → latest id) |
| frontier with a 0% tolerance | `[1]` | `[1]` — unchanged |

```
$ uv run python evolve_demo.py     # at 3081f7fe (base)
task declares [pareto] relative_noise = 0.05; #2 is 3% behind on both axes
frontier             : [1]
best (2% near-tie)   : 1

$ uv run python evolve_demo.py     # at head
task declares [pareto] relative_noise = 0.05; #2 is 3% behind on both axes
frontier             : [1, 2]
best (2% near-tie)   : 2
frontier at 0% noise : [1]
```

**Head.**

```
$ uv run pytest tests/vibesys/loops -q --no-cov
587 passed in 236.68s

$ uv run pytest libs/vs-loop-state/tests -q --no-cov
45 passed in 0.32s

$ ./scripts/check_format.sh
All checks passed!
476 files already formatted

$ ./scripts/check_lint.sh
All checks passed!

$ ./scripts/check_types.sh
All checks passed!
```

Also run, since the space loader and `MetricSpace.best` are shared with the
agent loop:

```
$ uv run pytest tests/entrypoints tests/server -q --no-cov
463 passed in 29.87s
```

**New tests.** Seven in
`tests/vibesys/loops/evolve/test_evolutionary_population.py` — the retained
near-tie on the frontier, the zero-tolerance reproduction, a candidate beyond
the tolerance still being dominated, the `best` near-tie and its
zero-tolerance counterpart, `best` on a minimized primary axis, and
frontier-biased parent sampling actually reaching the retained candidate — plus
two in `tests/vibesys/loops/evolve/test_evolution_state_store.py` for the
persisted space and its strict default, and one more in
`tests/vibesys/loops/test_metrics.py` pinning the tie-break of the generic
`MetricSpace.best`.

Refs #579, #507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
