### PR TITLE
Declare benchmark result contracts for seven example tasks

### DIFF
--- a/examples/data-structures/kvstore-default/vibesys.input.toml
+++ b/examples/data-structures/kvstore-default/vibesys.input.toml
@@ -10,3 +10,7 @@ timeout_seconds = 120
 [benchmark]
 command = ["uv", "run", "python", "benchmark/benchmark.py"]
 timeout_seconds = 300
+
+[benchmark.result]
+json_argument = "--output-json"
+metric = "total_ops_per_sec"

--- a/examples/model-serving/Llama-3-8B-trn2/vibesys.input.toml
+++ b/examples/model-serving/Llama-3-8B-trn2/vibesys.input.toml
@@ -10,3 +10,7 @@ timeout_seconds = 120
 [benchmark]
 command = ["uv", "run", "python", "benchmark/benchmark.py"]
 timeout_seconds = 300
+
+[benchmark.result]
+json_argument = "--output-json"
+metric = "aggregate_throughput"

--- a/examples/model-serving/Llama-3-8B/vibesys.input.toml
+++ b/examples/model-serving/Llama-3-8B/vibesys.input.toml
@@ -10,3 +10,7 @@ timeout_seconds = 120
 [benchmark]
 command = ["uv", "run", "python", "benchmark/benchmark.py"]
 timeout_seconds = 300
+
+[benchmark.result]
+json_argument = "--output-json"
+metric = "aggregate_throughput"

--- a/examples/model-serving/llama-70b-2xh100/vibesys.input.toml
+++ b/examples/model-serving/llama-70b-2xh100/vibesys.input.toml
@@ -10,3 +10,7 @@ timeout_seconds = 300
 [benchmark]
 command = ["uv", "run", "python", "benchmark/benchmark.py"]
 timeout_seconds = 600
+
+[benchmark.result]
+json_argument = "--output-json"
+metric = "aggregate_throughput"

--- a/examples/model-serving/olmo-hybrid-prefix-caching-vllm/vibesys.input.toml
+++ b/examples/model-serving/olmo-hybrid-prefix-caching-vllm/vibesys.input.toml
@@ -11,6 +11,10 @@ timeout_seconds = 120
 command = ["uv", "run", "python", "benchmark/benchmark.py"]
 timeout_seconds = 300
 
+[benchmark.result]
+json_argument = "--output-json"
+metric = "aggregate_throughput_tok_per_sec"
+
 [[workspace.sources]]
 name = "vllm"
 repo = "https://github.com/vllm-project/vllm"

--- a/examples/model-serving/olmo-hybrid-prefix-caching/vibesys.input.toml
+++ b/examples/model-serving/olmo-hybrid-prefix-caching/vibesys.input.toml
@@ -10,3 +10,7 @@ timeout_seconds = 120
 [benchmark]
 command = ["uv", "run", "python", "benchmark/benchmark.py"]
 timeout_seconds = 300
+
+[benchmark.result]
+json_argument = "--output-json"
+metric = "aggregate_throughput_tok_per_sec"

--- a/examples/model-serving/qwen3-32b-code-edit/vibesys.input.toml
+++ b/examples/model-serving/qwen3-32b-code-edit/vibesys.input.toml
@@ -10,3 +10,7 @@ timeout_seconds = 120
 [benchmark]
 command = ["uv", "run", "python", "benchmark/benchmark.py"]
 timeout_seconds = 300
+
+[benchmark.result]
+json_argument = "--output-json"
+metric = "median_tok_per_sec"


### PR DESCRIPTION
## Problem

Every example task declares a `[benchmark] command` that VibeSys runs each round.
A task that does not also declare `[benchmark.result]` (or `result_protocol`) gets
that command executed and its output thrown away: `_run_framework_benchmark`
returns an empty `FrameworkBenchmarkOutcome` immediately when both are absent
(`src/vibesys/loops/agent/loop.py:1993`). The round record then carries only the
agent's self-reported `perf_metric`, so the framework spends the full benchmark
budget and still has nothing it measured itself to order candidates by.

13 of the example tasks were in that state. This is the input-bundle side of the
provenance work in #534 and #535: those issues make the TUI stop presenting an
unmeasured round as proven, and this PR removes the reason so many rounds are
unmeasured in the first place.

Seven of the 13 need nothing but the two manifest lines. The other six cannot be
expressed by the current scalar contract at all; they are listed below and left
untouched.

## Solution

Add a `[benchmark.result]` block to the seven tasks whose benchmark script already
satisfies the contract. Each of those scripts accepts `--output-json PATH` as a
plain argparse store (so the path is a separate argv element, which is what the
gate appends) and writes a **top-level** finite number under the key its
`OBJECTIVE.md` names.

Per-task audit of all 13 unspecified tasks. All 13 run
`uv run python benchmark/benchmark.py` and all 13 accept `--output-json PATH`; the
three `show-o2` scripts are byte-identical, as are the two `moonshine` and the two
`olmo` scripts.

| Task | Headline metric | Top-level & numeric | Direction | `objectives.toml` | Verdict |
| --- | --- | --- | --- | --- | --- |
| `data-structures/kvstore-default` | `total_ops_per_sec` | yes | max | none (default max correct) | **Landed here** |
| `model-serving/Llama-3-8B-trn2` | `aggregate_throughput` | yes | max | none (default max correct) | **Landed here** |
| `model-serving/Llama-3-8B` | `aggregate_throughput` | yes | max | present, name matches | **Landed here** (two-axis caveat) |
| `model-serving/llama-70b-2xh100` | `aggregate_throughput` | yes | max | present, name matches | **Landed here** (two-axis caveat) |
| `model-serving/olmo-hybrid-prefix-caching` | `aggregate_throughput_tok_per_sec` | yes | max | none | **Landed here** |
| `model-serving/olmo-hybrid-prefix-caching-vllm` | `aggregate_throughput_tok_per_sec` | yes | max | none | **Landed here** |
| `model-serving/qwen3-32b-code-edit` | `median_tok_per_sec` | yes | max | none | **Landed here** |
| `model-serving/Llama-3.1-8B-Instruct-MLX-8bit` | `latency_ms.p50` | no: `latency_ms` is a percentile dict | **min** | none | Blocked |
| `model-serving/moonshine-streaming` | `ttft.p50_ms` | no: `ttft` is a percentile dict | **min** | none | Blocked |
| `model-serving/moonshine-streaming-vllm` | `ttft.p50_ms` | no: `ttft` is a percentile dict | **min** | none | Blocked |
| `model-serving/show-o2-1.5B-HQ` | `latency.p50` | no: dict, and `latency` repeats under `warmup` | **min** | none | Blocked |
| `model-serving/show-o2-1.5B-HQ-h100` | `latency.p50` | no: dict, and `latency` repeats under `warmup` | **min** | none | Blocked |
| `model-serving/show-o2-1.5B-HQ-macbook` | `latency.p50` | no: dict, and `latency` repeats under `warmup` | **min** | none | Blocked |

The six blocked tasks each hit two independent limits of the scalar contract:

1. **Nested value.** The reader does a top-level `payload[metric]` lookup and falls
   back to a recursive exact-key search that must find exactly one match
   (`loop.py:2064-2081`). A dotted `metric = "latency.p50"` passes manifest
   validation but resolves to zero matches; a bare `"p50"` matches ambiguously; the
   parent key returns a dict and fails the numeric check. Declaring one would fail
   the gate every round.
2. **Direction.** `metric_direction` for a scalar spec is the task's
   `objectives.toml` direction for that name, else the hard-coded `"max"`
   (`loop.py:2126-2131`), and objectives are read only from `objectives.toml`
   (`src/entrypoints/headless.py:2164`). None of the six has one, so declaring a
   latency metric would have the framework retain the *slowest* candidate. That is
   worse than today's `INCOMPARABLE`, so these are deliberately left unspecified.

Substituting an existing top-level maximize key is not an option for them either:
it would silently replace the task's stated objective. MLX-8bit has
`token_throughput`, but its `OBJECTIVE.md` says minimize `latency_ms.p50`;
moonshine has `audio_s_per_s`, which its `OBJECTIVE.md` calls explicitly secondary
to TTFT.

**Two-axis caveat.** `Llama-3-8B` and `llama-70b-2xh100` are Pareto tasks whose
`objectives.toml` declares `aggregate_throughput` (max) and `p99_latency_ms` (min).
A scalar block makes the framework trust only the throughput axis; `p99_latency_ms`
stays agent-reported. `docs/cli-flags.md:580` advises omitting the scalar block for
multi-objective benchmarks and using `result_protocol = 2` instead. The scalar block
is still a strict improvement over discarding the output, and both scripts already
emit `p99_latency_ms` as a top-level number, so migrating them to the protocol later
is mechanical.

### Architecture

Manifest-only change: no framework code moves, and the existing benchmark gate reads
the top-level JSON key that each script already writes.

## Verification

`vibesys validate` is a static contract check; it does not execute the benchmark or
confirm the declared key exists in the output. The key/type/direction claims above
come from reading each script's dict construction and write path, plus one end-to-end
run of the task that runs in a sandbox. The model-serving benchmarks need serving
hardware and were audited by code reading only.

End-to-end check of `data-structures/kvstore-default`, invoked exactly the way the
gate does (flag and path as separate argv elements):

```
$ python3 benchmark/benchmark.py --duration 2 --warmup 0.5 --output-json /tmp/kv.json
Duration: 2.0s  Clients: 4
  Ops: put=26,070 get=79,419 delete=26,514
  Total: 132,003 (65,981 ops/s)
Results written to /tmp/kv.json

$ cat /tmp/kv.json
{
  "duration": 2.0006088439840823,
  "clients": 4,
  "put": 26070,
  "get": 79419,
  "delete": 26514,
  "total_ops_per_sec": 65981.4138065713
}
```

Flat object, `total_ops_per_sec` present at the top level as a finite float: exactly
what `_run_framework_benchmark` requires.

CI's `validate-examples` job iterates `examples/*/repositories/*/.vibesys/tasks/*` (the
repository-native overlays), not these flat bundles, and no test or doc enumerates the
13 manifests, so nothing else needed updating.

### Correctness properties

- All seven declared metrics resolve through the top-level lookup, so per-trial
  diagnostics that repeat a name cannot make the aggregate ambiguous. Only `olmo`
  repeats a top-level name (`num_requests`, also inside `config`), and the top-level
  lookup wins before the recursive search runs.
- Every declared metric has `direction = "max"`, which matches the scalar contract's
  fallback and, for `Llama-3-8B` and `llama-70b-2xh100`, matches their
  `objectives.toml` entry. No task gets a direction it did not already have.
- `json_argument` is a single option-style argv element on every script, so the
  appended `<flag> <path>` parses.
- Existing failure modes are preserved and remain correct gate failures:
  `Llama-3-8B` raises on a failed warm-up request and writes no JSON (exit 1);
  `Llama-3.1-8B-Instruct-MLX-8bit`, `olmo`, and `qwen3-32b-code-edit` `SystemExit` on
  missing deps or an empty dataset before any traffic. `qwen3-32b-code-edit` emits
  `median_tok_per_sec: NaN` when every request fails, which the gate rejects as
  non-finite; that is the right verdict for a run that measured nothing.
- `llama-70b-2xh100`, `olmo`, and the blocked `show-o2`/`moonshine` scripts catch all
  per-request errors and still exit 0 with a zero metric, so exit status alone is not
  a success signal; the metric value and `num_failed` are.
- No `objectives.toml` is added or changed, so no task's retention mode moves between
  scalar and Pareto.

### Testing

```
uv run vibesys validate examples/<task>   # all 13 tasks: 13/13 PASS
./scripts/check_format.sh                 # All checks passed! 476 files already formatted
./scripts/check_lint.sh                   # All checks passed!
uv run pytest tests/entrypoints -q --no-cov -k "manifest or input or validate"
                                          # 32 passed, 198 deselected
uv run pytest tests/architecture -q --no-cov
                                          # 270 passed (covers test_llama_mlx_8bit_bundle.py)
```

Plus the `kvstore-default` benchmark run shown above.

## Follow-up

For the six blocked latency tasks, either:

1. **Migrate them to `result_protocol = 2`.** The evaluator result protocol reports a
   complete metric row, and direction and unit come from the `hello` record rather than
   the manifest, so both blockers disappear at once. Each script emits a couple of JSONL
   records with the stdlib; no new dependency.
2. **Extend the scalar contract**: add a `direction` field to `BenchmarkResult` (or drop
   the hard-coded `"max"` fallback in favor of `INCOMPARABLE`) and support a nested path
   for `metric`. Smaller, but leaves the unit undeclared.

Option 1 is the better end state and also covers the two-axis caveat for `Llama-3-8B`
and `llama-70b-2xh100`. Either way, `docs/cli-flags.md` should state the current
maximize assumption, which it does not.

Making a result contract **required** in `vibesys validate`, so a benchmark whose output
would be discarded fails validation instead of silently wasting the run, is a separate
change and is deliberately not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
