### PR TITLE
TUI: Sync chat trajectory evidence incrementally and show the wait

### DIFF
--- a/clients/tui/src/ui/activity-bar.ts
+++ b/clients/tui/src/ui/activity-bar.ts
@@ -5,8 +5,9 @@ import {visibleActiveExecutions} from '../session-model.js';
 import {agentRuntimeLabel} from './agent-runtime-label.js';
 import type {Theme} from './theme.js';
 
-const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-const SPINNER_INTERVAL_MS = 120;
+/** The one braille spinner every in-flight indicator animates. */
+export const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+export const SPINNER_INTERVAL_MS = 120;
 /** Status for executions visible in the selected agent conversation. */
 export class ActivityBarView {
   readonly output: TextRenderable;

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -471,6 +471,8 @@ export function createOpenTuiApp(
       roundStrip.destroy();
       agentMap.destroy();
       experimentLog.destroy();
+      chat.destroy();
+      chatPane.destroy();
       root.destroyRecursively();
       markdownStyle.destroy();
     },

--- a/clients/tui/src/ui/chat-composer.test.ts
+++ b/clients/tui/src/ui/chat-composer.test.ts
@@ -1,0 +1,129 @@
+import {afterEach, describe, expect, it, setSystemTime} from 'bun:test';
+import {BoxRenderable, type Renderable} from '@opentui/core';
+import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
+import type {SessionController} from '../session-controller.js';
+import {initialSessionState, type SessionState} from '../session-model.js';
+import {createChatDraft, pendingComposerTitle} from './chat-composer.js';
+import {ChatPaneView} from './chat-pane.js';
+import {createMarkdownStyle} from './styles.js';
+import {resolveTheme} from './theme.js';
+
+describe('pending composer title', () => {
+  it('shows a spinner frame and the elapsed wait', () => {
+    expect(pendingComposerTitle(0, 0)).toBe(' Message · ⠋ 0s ');
+    expect(pendingComposerTitle(1, 5_000)).toBe(' Message · ⠙ 5s ');
+  });
+
+  it('wraps the frame index so a long wait keeps animating', () => {
+    expect(pendingComposerTitle(10, 1_000)).toBe(pendingComposerTitle(0, 1_000));
+    expect(pendingComposerTitle(23, 1_000)).toBe(pendingComposerTitle(3, 1_000));
+  });
+});
+
+/**
+ * The spinner's state lives in the composer, but only the surfaces around it
+ * know whether they are on screen, so these drive a real `ChatPaneView` and
+ * read the title its box ended up with. A question that completes while the
+ * dock is hidden is the case `activate` alone cannot see: it does not run
+ * while hidden, so nothing stops the timer or moves the elapsed epoch.
+ */
+describe('composer spinner across a hidden surface', () => {
+  const cleanup: Array<() => void> = [];
+  const EPOCH = Date.UTC(2026, 8, 3, 12, 0, 0);
+
+  afterEach(() => {
+    for (const destroy of cleanup.splice(0).reverse()) destroy();
+    setSystemTime();
+  });
+
+  /** The composer only calls back on input, which none of these tests send. */
+  const controller = {
+    focusPane: () => {},
+    submitChat: () => {},
+  } as unknown as SessionController;
+
+  function stateWith(pending: boolean): SessionState {
+    return {...initialSessionState(), chatPending: pending};
+  }
+
+  function composerTitle(node: Renderable): string | null {
+    for (const child of node.getChildren()) {
+      if (child instanceof BoxRenderable && child.id.endsWith('-composer-box')) {
+        return child.title ?? null;
+      }
+      const found = composerTitle(child);
+      if (found !== null) return found;
+    }
+    return null;
+  }
+
+  interface Dock {
+    render: (pending: boolean, visible: boolean) => void;
+    title: () => string | null;
+    destroy: () => void;
+  }
+
+  async function dockedChat(): Promise<Dock> {
+    const testRenderer: TestRendererSetup = await createTestRenderer({width: 120, height: 24});
+    const theme = resolveTheme(null);
+    const markdownStyle = createMarkdownStyle(theme);
+    const view = new ChatPaneView(
+      testRenderer.renderer,
+      controller,
+      markdownStyle,
+      theme,
+      createChatDraft(),
+    );
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.destroy();
+      view.output.destroyRecursively();
+      markdownStyle.destroy();
+      testRenderer.renderer.destroy();
+    });
+    return {
+      render: (pending, visible) => view.render(stateWith(pending), visible, 40),
+      title: () => composerTitle(view.output),
+      destroy: () => view.destroy(),
+    };
+  }
+
+  it('clears the spinner when the answer lands while the dock is hidden', async () => {
+    const dock = await dockedChat();
+    setSystemTime(new Date(EPOCH));
+    dock.render(true, true);
+    expect(dock.title()).toBe(' Message · ⠋ 0s ');
+
+    dock.render(true, false);
+    dock.render(false, false);
+
+    expect(dock.title()).toBe(' Message ');
+  });
+
+  it('restarts the elapsed wait for the question asked after a hidden one', async () => {
+    const dock = await dockedChat();
+    setSystemTime(new Date(EPOCH));
+    dock.render(true, true);
+    setSystemTime(new Date(EPOCH + 30_000));
+    dock.render(true, false);
+    dock.render(false, false);
+
+    setSystemTime(new Date(EPOCH + 40_000));
+    dock.render(true, true);
+
+    // The new question's wait, not the one that ran out of sight.
+    expect(dock.title()).toBe(' Message · ⠋ 0s ');
+  });
+
+  it('animates again after a destroy rather than staying frozen', async () => {
+    const dock = await dockedChat();
+    setSystemTime(new Date(EPOCH));
+    dock.render(true, true);
+    dock.destroy();
+
+    setSystemTime(new Date(EPOCH + 7_000));
+    dock.render(true, true);
+
+    expect(dock.title()).toBe(' Message · ⠋ 0s ');
+  });
+});

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -7,6 +7,8 @@ import {
 } from '@opentui/core';
 import {suggestChatSlashCommands} from '../commands.js';
 import type {ChatMenuRow, SessionState} from '../session-model.js';
+import {SPINNER_FRAMES, SPINNER_INTERVAL_MS} from './activity-bar.js';
+import {elapsedLabel} from './previews.js';
 import {SuggestionMenu} from './suggestion-menu.js';
 import type {Theme} from './theme.js';
 
@@ -17,6 +19,14 @@ const EDITOR_HORIZONTAL_CHROME = 4;
 /** Rows the menu shows at once before it scrolls its selection into view. */
 const MAX_MENU_ROWS = 10;
 const MENU_CHROME = 2;
+
+const IDLE_TITLE = ' Message ';
+
+/** Composer title while a question is in flight: spinner plus wait time. */
+export function pendingComposerTitle(frame: number, elapsedMs: number): string {
+  const spinner = SPINNER_FRAMES[frame % SPINNER_FRAMES.length] ?? SPINNER_FRAMES[0];
+  return ` Message · ${spinner} ${elapsedLabel(elapsedMs)} `;
+}
 
 class ChatTextareaRenderable extends TextareaRenderable {
   override handleKeyPress(key: KeyEvent): boolean {
@@ -72,6 +82,11 @@ export class ChatComposerView {
   #theme: Theme;
   #renderedMenu: string | null = null;
   #lastState: SessionState | null = null;
+  #pending = false;
+  #onScreen = false;
+  #pendingSince = 0;
+  #frame = 0;
+  #timer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     renderer: CliRenderer,
@@ -96,7 +111,7 @@ export class ChatComposerView {
       border: true,
       borderStyle: 'rounded',
       borderColor: theme.border,
-      title: ' Message ',
+      title: IDLE_TITLE,
       paddingLeft: 1,
       paddingRight: 1,
       onMouseUp: this.onFocusRequest,
@@ -228,13 +243,66 @@ export class ChatComposerView {
       this.#syncSuggestions();
     }
     this.setFocused(focused);
-    this.#box.title = pending ? ' Message · awaiting agent ' : ' Message ';
     this.#hint.content = pending
       ? 'Awaiting the agent · Enter: queue follow-up'
       : focused
         ? 'Enter: send · Shift+Enter: newline'
         : 'Ctrl+W to type here';
     this.#resize();
+  }
+
+  /**
+   * Tracks the question in flight and whether this composer is on screen.
+   *
+   * Callers drive this on every render, before their own visibility gate, the
+   * way `ActivityBarView.render` syncs its timer whether or not the bar is
+   * shown: `activate` runs only while visible, so a question that lands while
+   * this surface is hidden would otherwise leave the interval running forever
+   * and the elapsed epoch stuck at the wait it started.
+   *
+   * The epoch moves only when a question starts, not when the surface returns,
+   * so hiding and reshowing mid-question keeps the wait the operator has
+   * actually been watching.
+   */
+  syncPending(pending: boolean, onScreen: boolean): void {
+    if (pending && !this.#pending) {
+      this.#pendingSince = Date.now();
+      this.#frame = 0;
+    }
+    this.#pending = pending;
+    this.#onScreen = onScreen;
+    this.#refreshTitle();
+    this.#syncTimer();
+  }
+
+  /**
+   * Releases the animation timer. Pending state is cleared with it, so a
+   * composer that is activated again after a destroyed render tree starts its
+   * next question from a fresh epoch rather than a dead one.
+   */
+  destroy(): void {
+    this.#pending = false;
+    this.#onScreen = false;
+    this.#syncTimer();
+  }
+
+  #syncTimer(): void {
+    if (!this.#pending || !this.#onScreen) {
+      if (this.#timer !== null) clearInterval(this.#timer);
+      this.#timer = null;
+      return;
+    }
+    if (this.#timer !== null) return;
+    this.#timer = setInterval(() => {
+      this.#frame = (this.#frame + 1) % SPINNER_FRAMES.length;
+      this.#refreshTitle();
+    }, SPINNER_INTERVAL_MS);
+  }
+
+  #refreshTitle(): void {
+    this.#box.title = this.#pending
+      ? pendingComposerTitle(this.#frame, Date.now() - this.#pendingSince)
+      : IDLE_TITLE;
   }
 
   isEmpty(): boolean {

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -124,6 +124,9 @@ export class ChatOverlayView {
 
   render(state: SessionState): void {
     this.output.visible = state.chatOpen;
+    // Ahead of the visibility gate: an answer that lands while the modal is
+    // closed still has to stop the composer's spinner.
+    this.#composer.syncPending(state.chatPending, state.chatOpen);
     if (!state.chatOpen) return;
     this.output.title = ` ${chatThreadHeading(state)} `;
     this.#composer.activate(Math.max(1, this.output.width - 4), true, state.chatPending);
@@ -146,5 +149,10 @@ export class ChatOverlayView {
 
   completeSuggestion(): boolean {
     return this.#composer.completeSuggestion();
+  }
+
+  /** Releases the composer's spinner timer when the app tears down. */
+  destroy(): void {
+    this.#composer.destroy();
   }
 }

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -140,6 +140,11 @@ export class ChatPaneView {
     this.#scroll.scrollBy(delta, 'viewport');
   }
 
+  /** Releases the composer's spinner timer when the app tears down. */
+  destroy(): void {
+    this.#composer.destroy();
+  }
+
   isComposerEmpty(): boolean {
     return this.#composer.isEmpty();
   }
@@ -158,6 +163,9 @@ export class ChatPaneView {
 
   render(state: SessionState, visible: boolean, width: number): void {
     this.output.visible = visible;
+    // Ahead of the visibility gate: an answer that lands while the dock is
+    // hidden still has to stop the composer's spinner.
+    this.#composer.syncPending(state.chatPending, visible);
     if (!visible) {
       return;
     }

--- a/src/server/chat/evidence.py
+++ b/src/server/chat/evidence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import threading
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -40,7 +41,7 @@ class TrajectoryEvidence:
         self._flush_logs = flush_logs
 
     def refresh(self, instructions: str) -> None:
-        """Replace chat evidence with a bounded snapshot of current run state."""
+        """Update chat evidence to a bounded snapshot of current run state."""
         trajectory_dir = self._shared_state_dir / "trajectory"
         if self._state_dir.is_symlink() or self._shared_state_dir.is_symlink():
             self._log(f"[warn] experiment chat state is a symlink: {self._state_dir}")
@@ -52,32 +53,64 @@ class TrajectoryEvidence:
             with _TRAJECTORY_SYNC_LOCK:
                 if trajectory_dir.is_symlink():
                     trajectory_dir.unlink()
-                elif trajectory_dir.exists():
-                    shutil.rmtree(trajectory_dir)
                 trajectory_dir.mkdir(parents=True, exist_ok=True)
-                self._write_snapshot(
+                # Converges to the same tree the old full rebuild produced:
+                # unchanged files are left alone, changed ones are rewritten,
+                # and anything this pass did not produce is pruned below.
+                current = self._write_snapshot(
                     self._project.state.portable_run_export(self._run_id),
                     trajectory_dir / "state",
                 )
-                self._copy_files(self._log_dir, trajectory_dir / "logs")
+                current |= self._copy_files(self._log_dir, trajectory_dir / "logs")
+                self._prune_stale(trajectory_dir, current)
         except (OSError, ValueError) as exc:
             self._log(f"[warn] could not refresh experiment chat trajectory: {exc}")
 
     @staticmethod
-    def _write_snapshot(snapshot: StateSnapshot, destination_root: Path) -> None:
+    def _write_snapshot(snapshot: StateSnapshot, destination_root: Path) -> set[Path]:
+        """Write changed state files, returning every destination now current."""
+        current: set[Path] = set()
         for state_file in snapshot.files:
             if state_file.relative_path.suffix not in _TRAJECTORY_SUFFIXES:
                 continue
             destination = destination_root.joinpath(*state_file.relative_path.parts)
+            current.add(destination)
+            # State files are held in memory already, so the skip compares the
+            # bytes themselves rather than a stat proxy.
+            if (
+                not destination.is_symlink()
+                and destination.is_file()
+                and destination.stat().st_size == len(state_file.contents)
+                and destination.read_bytes() == state_file.contents
+            ):
+                continue
             destination.parent.mkdir(parents=True, exist_ok=True)
             temporary = destination.with_name(f".{destination.name}.tmp")
             temporary.write_bytes(state_file.contents)
             temporary.replace(destination)
+        return current
 
     @staticmethod
-    def _copy_files(source_root: Path, destination_root: Path) -> None:
+    def _copy_files(source_root: Path, destination_root: Path) -> set[Path]:
+        """Copy changed log files, returning every destination now current.
+
+        Run logs are append-only: a writer adds bytes to the tail and never
+        rewrites an earlier one, so a destination whose size and mtime both
+        match its source holds the same content and is skipped without being
+        read. ``copy2`` carries the source mtime across so the next sync has
+        that comparison to make.
+
+        The assumption degrades on a filesystem with coarse timestamps: an
+        append that lands inside the destination's mtime granularity and leaves
+        the size unchanged (a rewrite of exactly as many bytes) would be missed
+        until the next write moves either. Nothing under ``log_dir`` rewrites
+        in place today, and a missed byte costs chat one stale evidence file,
+        never a wrong answer about state, so the skip is worth the full re-copy
+        of every log on every question that it replaces.
+        """
+        current: set[Path] = set()
         if not source_root.is_dir():
-            return
+            return current
         for source in sorted(source_root.rglob("*")):
             if (
                 not source.is_file()
@@ -86,7 +119,30 @@ class TrajectoryEvidence:
             ):
                 continue
             destination = destination_root / source.relative_to(source_root)
+            current.add(destination)
+            source_stat = source.stat()
+            if not destination.is_symlink() and destination.is_file():
+                destination_stat = destination.stat()
+                if (
+                    destination_stat.st_size == source_stat.st_size
+                    and destination_stat.st_mtime_ns == source_stat.st_mtime_ns
+                ):
+                    continue
             destination.parent.mkdir(parents=True, exist_ok=True)
             temporary = destination.with_name(f".{destination.name}.tmp")
-            shutil.copyfile(source, temporary)
+            shutil.copy2(source, temporary)
             temporary.replace(destination)
+        return current
+
+    @staticmethod
+    def _prune_stale(trajectory_dir: Path, current: set[Path]) -> None:
+        """Delete snapshot entries this sync did not produce."""
+        # Deepest first, so a directory is only considered once its own entries
+        # are gone; ``rmdir`` then removes exactly the ones left empty.
+        for entry in sorted(trajectory_dir.rglob("*"), reverse=True):
+            if entry.is_symlink() or entry.is_file():
+                if entry not in current:
+                    entry.unlink(missing_ok=True)
+            elif entry.is_dir():
+                with suppress(OSError):
+                    entry.rmdir()

--- a/tests/server/test_chat_evidence.py
+++ b/tests/server/test_chat_evidence.py
@@ -1,0 +1,88 @@
+"""Incremental trajectory-evidence sync for experiment chat."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from server.chat.evidence import TrajectoryEvidence
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _evidence(tmp_path: Path) -> tuple[TrajectoryEvidence, Path, Path]:
+    shared_state_dir = tmp_path / "workspace" / "_vibesys_chat"
+    shared_state_dir.mkdir(parents=True, exist_ok=True)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    project = MagicMock()
+    project.state.portable_run_export.return_value = SimpleNamespace(files=[])
+    evidence = TrajectoryEvidence(
+        state_dir=shared_state_dir,
+        shared_state_dir=shared_state_dir,
+        log_dir=log_dir,
+        project=project,
+        run_id="run-1",
+        log=lambda _message: None,
+        flush_logs=lambda: None,
+    )
+    return evidence, log_dir, shared_state_dir
+
+
+def test_refresh_skips_unchanged_files_and_prunes_stale_ones(tmp_path: Path) -> None:
+    evidence, log_dir, shared_state_dir = _evidence(tmp_path)
+    (log_dir / "run.log").write_text("round 1\n", encoding="utf-8")
+
+    evidence.refresh("instructions")
+
+    trajectory = shared_state_dir / "trajectory"
+    copied = trajectory / "logs" / "run.log"
+    first_stat = copied.stat()
+    stale = trajectory / "logs" / "stale.log"
+    stale.write_text("left over\n", encoding="utf-8")
+
+    evidence.refresh("instructions")
+
+    # The unchanged source is not rewritten in place, while a file the sync did
+    # not produce is pruned as the old full rebuild would have.
+    second_stat = copied.stat()
+    assert (second_stat.st_ino, second_stat.st_ctime_ns) == (
+        first_stat.st_ino,
+        first_stat.st_ctime_ns,
+    )
+    assert copied.read_text(encoding="utf-8") == "round 1\n"
+    assert not stale.exists()
+
+
+def test_refresh_recopies_a_log_that_grew(tmp_path: Path) -> None:
+    evidence, log_dir, shared_state_dir = _evidence(tmp_path)
+    source = log_dir / "run.log"
+    source.write_text("round 1\n", encoding="utf-8")
+
+    evidence.refresh("instructions")
+    with source.open("a", encoding="utf-8") as stream:
+        stream.write("round 2\n")
+    evidence.refresh("instructions")
+
+    copied = shared_state_dir / "trajectory" / "logs" / "run.log"
+    assert copied.read_text(encoding="utf-8") == "round 1\nround 2\n"
+    # copy2 carries the source mtime across, which is what makes the next
+    # sync's size-and-mtime comparison meaningful.
+    assert copied.stat().st_mtime_ns == source.stat().st_mtime_ns
+
+
+def test_refresh_prunes_a_directory_the_run_no_longer_produces(tmp_path: Path) -> None:
+    evidence, log_dir, shared_state_dir = _evidence(tmp_path)
+    (log_dir / "run.log").write_text("round 1\n", encoding="utf-8")
+
+    evidence.refresh("instructions")
+    stale_dir = shared_state_dir / "trajectory" / "logs" / "attempt-1"
+    stale_dir.mkdir(parents=True)
+    (stale_dir / "old.log").write_text("gone\n", encoding="utf-8")
+
+    evidence.refresh("instructions")
+
+    assert not stale_dir.exists()
+    assert (shared_state_dir / "trajectory" / "logs" / "run.log").is_file()


### PR DESCRIPTION
## Problem

Two independent costs on every experiment-chat question, both found and first
fixed by @AyanBinRafaih in #484:

1. **The trajectory snapshot was rebuilt from scratch per question.**
   `TrajectoryEvidence.refresh` `rmtree`d the whole `trajectory/` directory and
   re-copied every state file and every run log before the agent was invoked.
   The logs grow for the length of the run, so the cost of asking a question
   grows with the run, and it is paid while the operator is already waiting.

2. **Nothing on screen said a question was in flight.** The composer's title
   read a static ` Message · awaiting agent ` for however long the agent took,
   so a 30-second answer and a stuck one looked identical.

#484 is being split: its provider-session-reuse half is being rebuilt on the
`AgentSessionKey` / `SessionStore` contract that landed with #523, and depends
on nothing here. This PR carries the two halves that do not touch sessions, so
they can land on their own.

## Solution

### Incremental evidence sync

`refresh` no longer deletes the snapshot. It writes the state files whose bytes
differ, copies the log files whose size or mtime differs, and then prunes every
entry the pass did not produce, so it converges to exactly the tree the old
full rebuild produced. `shutil.copy2` replaces `copyfile` so the destination
carries the source mtime and the next sync has that comparison to make. The
sync lock and the symlink guards are unchanged.

The size-and-mtime skip rests on run logs being append-only, and the docstring
now says so, along with how it degrades: on a filesystem with coarse
timestamps, a same-size rewrite landing inside the mtime granularity would be
missed until the next write moves either. Nothing under `log_dir` rewrites in
place today, and the cost of being wrong is one stale evidence file, not a
wrong answer about run state.

### Composer spinner

The composer title carries the braille spinner and the elapsed wait while a
question is in flight. Both are reused rather than re-implemented: the frames
and cadence are now exported from `activity-bar.ts` (the same animation the
activity bar runs), and the wait is formatted by `elapsedLabel` from
`previews.ts`.

The timer is driven by `ChatComposerView.syncPending(pending, onScreen)`, which
both chat surfaces call from `render` **before** their visibility gate, the way
`ActivityBarView.render(state, visible)` syncs its timer whether or not the bar
is shown. That is the correctness point: `activate()` runs only while the
surface is visible, so a question that completes while the dock is hidden (the
terminal narrowed, the modal closed) would otherwise leave the interval running
for the life of the process and leave the elapsed epoch pinned to a wait that
already ended. The epoch moves only when a question starts, not when a surface
returns, so hiding and reshowing mid-question keeps the wait the operator has
actually been watching. `destroy()` clears the pending state along with the
timer, so a composer activated again after teardown starts its next question
from a fresh epoch instead of a dead one.

### Architecture

Ownership is unchanged on both sides. `TrajectoryEvidence` still owns the
snapshot directory and is still the only writer under the sync lock; the
composer still owns its own title, and the surfaces still own visibility.

```mermaid
flowchart LR
  Q["chat question"] --> R["TrajectoryEvidence.refresh"]
  R --> W["_write_snapshot<br/>skip byte-equal state files"]
  R --> C["_copy_files<br/>skip size+mtime-equal logs"]
  W --> P["_prune_stale<br/>drop what this pass did not produce"]
  C --> P

  Pane["ChatPaneView.render(state, visible)"] --> S["composer.syncPending(pending, onScreen)"]
  Modal["ChatOverlayView.render(state)"] --> S
  S --> T["spinner timer<br/>runs only while pending and on screen"]
  S --> E["elapsed epoch<br/>moves only on a new question"]
  App["app.destroy()"] --> D["pane/overlay destroy()"] --> S
```

## Verification

### Correctness properties

- The incremental sync converges to the same tree as the old full rewrite:
  unchanged files are left alone, changed files are rewritten through the same
  temp-file-and-replace, and stale files and the directories they emptied are
  removed.
- Writes stay atomic from a reader's point of view: every file still lands via
  `.<name>.tmp` then `replace`.
- The sync lock, the symlink guards, and the suffix allowlist are unchanged, so
  the set of files chat can see is unchanged.
- The spinner timer runs only while a question is pending *and* its surface is
  on screen. An answer arriving while the surface is hidden stops it.
- The elapsed wait is per question, not per render: a hidden-then-reshown
  surface reports the original wait, and a new question reports its own.
- `destroy()` leaves the composer able to animate again if it is activated
  afterwards.
- No third copy of the spinner frames or the elapsed formatter: both are
  imported from their existing owners.

### Testing

```
uv run pytest tests/server -q --no-cov            -> 236 passed
./scripts/check_format.sh                          -> 481 files already formatted
./scripts/check_lint.sh                            -> All checks passed
./scripts/check_types.sh                           -> All checks passed
clients/tui: bun test --max-concurrency 1 src      -> 500 passed, 0 failed (21 files)
pnpm check:clients                                 -> clean
pnpm check:ts                                       -> 71 files checked, no fixes
pnpm check:ts-architecture                          -> no dependency violations
CI=true pnpm install --offline --frozen-lockfile    -> lockfile up to date
```

New coverage:

- `tests/server/test_chat_evidence.py`: an unchanged log is not rewritten in
  place (same inode and ctime) while a file the sync did not produce is pruned;
  an appended log is re-copied and carries the source mtime forward; a
  directory the run no longer produces is removed.
- `clients/tui/src/ui/chat-composer.test.ts`: the pure title formatter, plus
  three `createTestRenderer` tests driving a real `ChatPaneView` through
  pending → hidden → complete. Confirmed against the pre-fix wiring: syncing
  the timer after the visibility gate fails the first two ("Received:
  ' Message · ⠋ 0s '" instead of ' Message ', and "' Message · ⠋ 40s '"
  instead of a fresh epoch), and a `destroy()` that clears only the interval
  fails the third.

Not covered: a live run measuring the sync's saved wall time per question. The
manual timing @AyanBinRafaih reported on #484 is the evidence there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
