### PR TITLE
Give every agent client the attribution the loop records

### DIFF
--- a/src/vibesys/agents/__init__.py
+++ b/src/vibesys/agents/__init__.py
@@ -17,11 +17,13 @@ if TYPE_CHECKING:
     from vs_sandbox import HostResource, ProjectPathPolicy
 
     from .client import AgentClient
+    from .contracts import AgentClientProtocol
     from .deepagents_runner import DeepAgentsClient
     from .session_store import SessionStore
 
 __all__ = [
     "AgentClient",
+    "AgentClientProtocol",
     "AgentProgress",
     "CandidateProgress",
     "DeepAgentsClient",
@@ -37,6 +39,10 @@ def __getattr__(name: str) -> Any:  # noqa: ANN401
         from .client import AgentClient  # noqa: PLC0415
 
         return AgentClient
+    if name == "AgentClientProtocol":
+        from .contracts import AgentClientProtocol  # noqa: PLC0415
+
+        return AgentClientProtocol
     if name == "DeepAgentsClient":
         from .deepagents_runner import DeepAgentsClient  # noqa: PLC0415
 
@@ -62,7 +68,7 @@ def build_agent_client(  # noqa: PLR0913
     project_path_policy: ProjectPathPolicy | None = None,
     require_host_sandbox: bool = False,
     session_store: SessionStore | None = None,
-) -> AgentClient:
+) -> AgentClientProtocol:
     """Build an agent service through the application composition module."""
     from .factory import build_agent_client as build  # noqa: PLC0415
 

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -216,17 +216,16 @@ class AgentClient:
         This is the application-configuration string, not the driver's Python
         class name, so it stays stable across implementation refactors.
         """
-        return getattr(self, "_driver_name", None)
+        return self._driver_name
 
     @property
     def provider(self) -> str | None:
         """Return the configured CLI provider (``"codex"``, ``"claude"``, ...)."""
-        return getattr(self, "_provider", None) or "codex"
+        return self._provider or "codex"
 
     def model_for_kind(self, kind: str) -> str | None:
         """Return the effective model for ``kind``, honoring role overrides."""
-        role_models: Mapping[str, str] = getattr(self, "_role_models", {})
-        return role_models.get(kind, getattr(self, "_model_name", None))
+        return self._role_models.get(kind, self._model_name)
 
     def set_log_file(self, stream: TextIO | None) -> None:
         """Direct subsequent application logs to ``stream``."""

--- a/src/vibesys/agents/contracts.py
+++ b/src/vibesys/agents/contracts.py
@@ -5,16 +5,24 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, TypeVar
+
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
     from datetime import timedelta
     from pathlib import Path
+    from typing import TextIO
 
-    from pydantic import BaseModel
+    from langchain_core.tools import BaseTool
 
+    from vibesys._agent_cli.base import MCPServerSpec as LegacyMCPServerSpec
+    from vibesys.agents.progress import AgentProgress
+    from vibesys.agents.session_key import AgentSessionKey
     from vs_sandbox import HostResource, ProjectPathPolicy
+
+T = TypeVar("T", bound=BaseModel)
 
 
 class SessionDisposition(StrEnum):
@@ -202,4 +210,99 @@ class AgentDriver(Protocol):
 
     def close(self) -> None:
         """Release driver resources. Implementations must be idempotent."""
+        ...
+
+
+class AgentClientProtocol(Protocol):
+    """The agent-service surface the run context and every loop depend on.
+
+    Each backend supplies one implementation: the CLI
+    :class:`~vibesys.agents.client.AgentClient`, the deterministic stub, the
+    deepagents runner, and the plain loop's tracker wrapper. Attribution
+    (``backend_name``, ``driver_name``, ``provider``, ``model_for_kind``) is
+    part of this contract because the loop stamps it onto every round record,
+    so a consumer never has to probe an implementation for it.
+    """
+
+    @property
+    def backend_name(self) -> str:
+        """Return the configured agent backend (``"cli"``, ``"stub"``, ...)."""
+        ...
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """Return the features this client's execution system can enforce."""
+        ...
+
+    @property
+    def driver_name(self) -> str | None:
+        """Return the stable configured driver name, or ``None`` when unnamed."""
+        ...
+
+    @property
+    def provider(self) -> str | None:
+        """Return the provider that runs this client's turns."""
+        ...
+
+    def model_for_kind(self, kind: str) -> str | None:
+        """Return the effective model for ``kind``, honoring role overrides."""
+        ...
+
+    def provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Name the provider conversation the next turn on ``session_key`` continues.
+
+        ``None`` means the next turn starts from no history at all.
+        """
+        ...
+
+    def last_turn_provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Name the provider conversation ``session_key``'s last turn ran in."""
+        ...
+
+    def invoke(  # noqa: PLR0913
+        self,
+        *,
+        kind: str,
+        workspace: Path,
+        system_prompt: str,
+        user_prompt: str,
+        response_cls: type[T],
+        fallback_factory: Callable[[], T],
+        round_label: str,
+        env: dict[str, str] | None = None,
+        invocation_id: str | None = None,
+        progress: AgentProgress | None = None,
+        mcp_servers: list[LegacyMCPServerSpec] | None = None,
+        tools: list[BaseTool] | None = None,
+        reuse_session: bool | None = None,
+        session_key: AgentSessionKey | None = None,
+    ) -> T:
+        """Run one turn and parse its structured response."""
+        ...
+
+    def invoke_text(  # noqa: PLR0913
+        self,
+        *,
+        kind: str,
+        workspace: Path,
+        system_prompt: str,
+        user_prompt: str,
+        round_label: str,
+        env: dict[str, str] | None = None,
+        invocation_id: str | None = None,
+        progress: AgentProgress | None = None,
+        mcp_servers: list[LegacyMCPServerSpec] | None = None,
+        tools: list[BaseTool] | None = None,
+        reuse_session: bool | None = None,
+        session_key: AgentSessionKey | None = None,
+    ) -> str:
+        """Run one conversational turn without a structured-output requirement."""
+        ...
+
+    def set_log_file(self, stream: TextIO | None) -> None:
+        """Direct subsequent application logs to ``stream``."""
+        ...
+
+    def close(self) -> None:
+        """Release client resources. Implementations must be idempotent."""
         ...

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -49,6 +49,21 @@ class DeepAgentsClient(AgentClient):
         """Deepagents exposes only its in-process LangChain tool transport."""
         return AgentCapabilities(in_process_tools=True, session_reuse=False)
 
+    @property
+    def driver_name(self) -> str | None:
+        """Deepagents runs its graph in process, so no CLI driver runs turns."""
+        return "deepagents"
+
+    @property
+    def provider(self) -> str | None:
+        """The configured LangChain model object is the provider."""
+        return "deepagents"
+
+    def model_for_kind(self, kind: str) -> str | None:
+        """Every role's graph is built from the one configured model."""
+        del kind
+        return self._model_name
+
     def close(self) -> None:
         """Deepagents owns no resources beyond each invocation."""
 

--- a/src/vibesys/agents/factory.py
+++ b/src/vibesys/agents/factory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from vibesys.agents.client import AgentClient, AgentDiagnosticLog
 from vibesys.constants import DEFAULT_AGENT_BACKEND
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import TextIO
 
+    from vibesys.agents.contracts import AgentClientProtocol
     from vibesys.agents.session_store import SessionStore
     from vibesys.config import Config
     from vibesys.constants import ComputeBackend
@@ -105,7 +106,7 @@ def build_agent_client(  # noqa: C901, PLR0912, PLR0913
     project_path_policy: ProjectPathPolicy | None = None,
     require_host_sandbox: bool = False,
     session_store: SessionStore | None = None,
-) -> AgentClient:
+) -> AgentClientProtocol:
     """Build the configured application-level agent service."""
     host_resources = tuple(host_resources)
     agent_cfg = config.agent
@@ -141,7 +142,7 @@ def build_agent_client(  # noqa: C901, PLR0912, PLR0913
     if backend == "stub":
         from vibesys.agents.stub_runner import StubAgentClient  # noqa: PLC0415
 
-        return cast("AgentClient", StubAgentClient())
+        return StubAgentClient()
 
     if backend != "cli":
         raise SystemExit(f"unknown agent backend: {backend!r}")  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/agents/stub_runner.py
+++ b/src/vibesys/agents/stub_runner.py
@@ -34,6 +34,21 @@ class StubAgentClient:
         """The deterministic stub does not expose external tools."""
         return AgentCapabilities(session_reuse=False)
 
+    @property
+    def driver_name(self) -> str | None:
+        """No driver runs a stub turn; the stub itself is the attribution."""
+        return "stub"
+
+    @property
+    def provider(self) -> str | None:
+        """No external provider runs a stub turn."""
+        return "stub"
+
+    def model_for_kind(self, kind: str) -> str | None:
+        """A stub turn runs no model, for any role."""
+        del kind
+        return None
+
     def close(self) -> None:
         """The deterministic stub owns no external resources."""
 

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -15,7 +15,7 @@ from typing import Any, TextIO, TypeVar, overload
 from pydantic import BaseModel
 
 from vibesys import backends, boot_trace
-from vibesys.agents import AgentClient, build_agent_client
+from vibesys.agents import AgentClientProtocol, build_agent_client
 from vibesys.agents.factory import (
     agent_driver_supports_mcp_servers,
     resolve_agent_driver,
@@ -122,10 +122,6 @@ def _execution_status(error: BaseException | None) -> EventStatus:
     if isinstance(error, (KeyboardInterrupt, SystemExit)):
         return EventStatus.INTERRUPTED
     return EventStatus.FAILED
-
-
-def _optional_string(value: object) -> str | None:
-    return value if isinstance(value, str) else None
 
 
 def _coerce_dir(raw: str | Path | None, label: str) -> Path | None:
@@ -947,9 +943,7 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
                 require_host_sandbox=not session.view.cli_sandboxed,
                 host_resources=agent_host_resources,
             )
-        close_agent_client = getattr(agent_client, "close", None)
-        if callable(close_agent_client):
-            teardown_stack.callback(close_agent_client)
+        teardown_stack.callback(agent_client.close)
 
         result = _RunContext(
             backend=backend,
@@ -1204,9 +1198,7 @@ def _assemble_candidate_context(  # noqa: PLR0913  # tracked: #288
         # context carries neither the profiler domain nor the task name.
         host_resources=parent.agent_host_resources,
     )
-    close_agent_client = getattr(agent_client, "close", None)
-    if callable(close_agent_client):
-        teardown_stack.callback(close_agent_client)
+    teardown_stack.callback(agent_client.close)
 
     paths = RunPaths(
         project_root=workspace,
@@ -1310,7 +1302,7 @@ class _RunContext:
         run_environment_session: RunEnvironmentSession,
         commands: RunCommands,
         device: DeviceLease,
-        agent_client: AgentClient,
+        agent_client: AgentClientProtocol,
         project: Project,
         state: RunState,
         run_id: str,
@@ -1475,10 +1467,9 @@ class _RunContext:
         (e.g. ``iteration=`` for plain-loop runner extensions) still work.
         """
         client = self.agent_client
-        model_for_kind = getattr(client, "model_for_kind", None)
-        driver = _optional_string(getattr(client, "driver_name", None))
-        provider = _optional_string(getattr(client, "provider", None))
-        model = _optional_string(model_for_kind(kind)) if callable(model_for_kind) else None
+        driver = client.driver_name
+        provider = client.provider
+        model = client.model_for_kind(kind)
         execution = self.integration.invocations.start(
             kind,
             round_label,

--- a/src/vibesys/loops/plain/runner_ext.py
+++ b/src/vibesys/loops/plain/runner_ext.py
@@ -1,6 +1,6 @@
 """Issue-tracker runner customization.
 
-Wraps any :class:`~vibesys.agents.client.AgentClient` and injects
+Wraps any :class:`~vibesys.agents.contracts.AgentClientProtocol` and injects
 tracker access for the ``judge`` and ``perf_eval`` phases. The wrapper
 picks the right transport (MCP server spec or in-process ``@tool`` callables)
 from the inner client's declared capabilities.
@@ -20,14 +20,14 @@ tools are needed there.
 from __future__ import annotations
 
 from pathlib import Path  # noqa: TC003
-from typing import Any, TypeVar
+from typing import Any, TextIO, TypeVar
 
 from langchain_core.tools import BaseTool  # noqa: TC002  # tracked: #288
 from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
 from vibesys.agents.client import AgentClient
-from vibesys.agents.contracts import AgentCapabilities  # noqa: TC001
+from vibesys.agents.contracts import AgentCapabilities, AgentClientProtocol  # noqa: TC001
 from vibesys.agents.progress import AgentProgress  # noqa: TC001
 from vibesys.agents.session_key import AgentSessionKey  # noqa: TC001
 from vibesys.loops.plain.mcp_config import build_issue_mcp_spec
@@ -58,7 +58,7 @@ class PlainLoopAgentClient(AgentClient):
 
     def __init__(  # noqa: ANN204, D107  # tracked: #288
         self,
-        inner: AgentClient,
+        inner: AgentClientProtocol,
         *,
         store: IssueBoard,
         max_issues_per_perf_eval: int,
@@ -76,11 +76,23 @@ class PlainLoopAgentClient(AgentClient):
         """Preserve the inner client's declared capabilities."""
         return self._inner.capabilities
 
-    def set_log_file(self, stream: Any) -> None:  # noqa: ANN401
+    @property
+    def driver_name(self) -> str | None:
+        """Attribute turns to the wrapped client, not to the wrapper."""
+        return self._inner.driver_name
+
+    @property
+    def provider(self) -> str | None:
+        """Attribute turns to the wrapped client, not to the wrapper."""
+        return self._inner.provider
+
+    def model_for_kind(self, kind: str) -> str | None:
+        """Report the wrapped client's model; the wrapper selects none."""
+        return self._inner.model_for_kind(kind)
+
+    def set_log_file(self, stream: TextIO | None) -> None:
         """Retarget inner-client logs when the run changes log files."""
-        setter = getattr(self._inner, "set_log_file", None)
-        if callable(setter):
-            setter(stream)
+        self._inner.set_log_file(stream)
 
     def close(self) -> None:
         """Close the inner client."""

--- a/src/vibesys/run/protocol.py
+++ b/src/vibesys/run/protocol.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from contextlib import AbstractContextManager
     from pathlib import Path
 
-    from vibesys.agents.client import AgentClient
+    from vibesys.agents.contracts import AgentClientProtocol
     from vibesys.agents.progress import AgentProgress
     from vibesys.constants import ComputeBackend
     from vibesys.input_manifest import WorkspaceSource
@@ -41,7 +41,7 @@ class LoopContext(Protocol):  # noqa: D101  # tracked: #288
 
     # -- collaborators --------------------------------------------------------
     events: EventJournal
-    agent_client: AgentClient
+    agent_client: AgentClientProtocol
     judge_backend: Any
     run_environment: Any
     run_environment_view: Any

--- a/tests/vibesys/agents/test_agent_driver_selection.py
+++ b/tests/vibesys/agents/test_agent_driver_selection.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from vibesys.agents import build_agent_client
+from vibesys.agents.client import AgentClient
 from vibesys.agents.drivers.agentshim import AgentShimDriver
 from vibesys.agents.drivers.mock import MockDriver
 from vibesys.agents.drivers.omnigent import OmnigentDriver, OmnigentDriverError
@@ -20,8 +21,6 @@ from vs_sandbox import HostResource, HostResourceAccess
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
-
-    from vibesys.agents.client import AgentClient
 
 
 def _config(**agent: object) -> Config:
@@ -37,7 +36,7 @@ def _build(  # noqa: PLR0913
     log_dir: Path | None = None,
     host_resources: Iterable[HostResource] = (),
 ) -> AgentClient:
-    return build_agent_client(
+    client = build_agent_client(
         config,
         agent_backend=None,
         cli_provider=None,
@@ -51,6 +50,10 @@ def _build(  # noqa: PLR0913
         log_dir=log_dir,
         host_resources=host_resources,
     )
+    # Every case here selects the cli backend, whose concrete client is what
+    # these tests inspect.
+    assert isinstance(client, AgentClient)
+    return client
 
 
 def test_agentshim_is_the_default_driver() -> None:

--- a/tests/vibesys/agents/test_agent_runners.py
+++ b/tests/vibesys/agents/test_agent_runners.py
@@ -2112,7 +2112,7 @@ class TestBuildAgentClient:
             use_docker=False,
         )
         assert runner.backend_name == "cli"
-        assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
+        assert runner.provider == "codex"
 
     def test_build_agent_client_cli_provider_from_config(self):  # noqa: ANN201  # tracked: #288
         runner = build_agent_client(
@@ -2128,7 +2128,7 @@ class TestBuildAgentClient:
             use_docker=False,
         )
         assert runner.backend_name == "cli"
-        assert runner._provider == "claude"  # noqa: SLF001  # tracked: #288
+        assert runner.provider == "claude"
 
     def test_build_agent_client_cli_defaults_to_codex(self):  # noqa: ANN201  # tracked: #288
         """When backend=cli and no provider specified, defaults to codex."""
@@ -2145,7 +2145,7 @@ class TestBuildAgentClient:
             use_docker=False,
         )
         assert runner.backend_name == "cli"
-        assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
+        assert runner.provider == "codex"
 
     def test_build_agent_client_cli_docker_returns_cli_runner(self):  # noqa: ANN201  # tracked: #288
         """cli backend + docker now returns a CliAgentRunner with docker_sandboxes."""
@@ -2428,12 +2428,12 @@ class TestBuildAgentClientBackendSelection:
     def test_default_backend_is_cli_with_empty_config(self):  # noqa: ANN201  # tracked: #288
         runner = self._build(_agent_config())
         assert isinstance(runner, AgentClient)
-        assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
+        assert runner.provider == "codex"
 
     def test_empty_agent_section_defaults_to_cli(self):  # noqa: ANN201  # tracked: #288
         runner = self._build(_agent_config())
         assert isinstance(runner, AgentClient)
-        assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
+        assert runner.provider == "codex"
 
     def test_agent_backend_flag_overrides_config(self):  # noqa: ANN201  # tracked: #288
         # An explicit --agent-backend flag wins over [agent].backend.
@@ -2443,4 +2443,4 @@ class TestBuildAgentClientBackendSelection:
     def test_config_can_select_cli_provider(self):  # noqa: ANN201  # tracked: #288
         runner = self._build(_agent_config(backend="cli", cli_provider="claude"))
         assert isinstance(runner, AgentClient)
-        assert runner._provider == "claude"  # noqa: SLF001  # tracked: #288
+        assert runner.provider == "claude"

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -10,8 +10,9 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
-from vibesys.agents import AgentClient
+from vibesys.agents import AgentClient, AgentClientProtocol
 from vibesys.agents.session_key import AgentSessionKey, SessionScope
+from vibesys.agents.stub_runner import StubAgentClient
 from vibesys.config import Config, as_config
 from vibesys.constants import ComputeBackend
 from vibesys.domains.base import DomainName
@@ -351,7 +352,7 @@ _THROUGHPUT_LATENCY = MetricSpace(
 def _invoke_orchestrate(
     tmp_path: Path,
     ref_file: str,
-    runner: MagicMock,
+    runner: AgentClientProtocol,
     *,
     _accuracy_gate_results: Sequence[str | None] | None = None,
     **kwargs: Unpack[_AgentLoopArguments],
@@ -4621,6 +4622,23 @@ def test_completed_round_records_which_implementer_produced_it(tmp_path, ref_fil
     assert round_one["implementer_model"] == "gpt-5.6-sol"
     # The record is portable state; a host-local session ID must never reach it.
     assert not [key for key in round_one if "session" in key]
+
+
+def test_stub_agent_round_records_its_own_attribution(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """The real stub client, not a mock, carries the attribution a round stores.
+
+    The `--stub-agent` smoke run in the release-wheel job exercises this path
+    with no mock in front of it, so the attribution the loop reads has to be
+    part of every client's contract rather than of one implementation.
+    """
+    runner = StubAgentClient()
+
+    _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1)
+
+    round_one = _round_payloads(tmp_path)[0]
+    assert round_one["implementer_driver"] == "stub"
+    assert round_one["implementer_provider"] == "stub"
+    assert round_one["implementer_model"] is None
 
 
 def test_round_records_stamp_who_produced_the_headline_metric(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288

--- a/tests/vibesys/loops/evolve/test_evolutionary_loop.py
+++ b/tests/vibesys/loops/evolve/test_evolutionary_loop.py
@@ -218,6 +218,11 @@ def _make_runner(  # noqa: ANN202, C901, PLR0913  # tracked: #288
 
     runner = MagicMock(spec=AgentClient)
     runner.backend_name = "deepagents"
+    # Every invocation event carries the client's attribution, so the mock
+    # supplies real strings the event payload can validate.
+    runner.driver_name = "mock"
+    runner.provider = "mock"
+    runner.model_for_kind.return_value = "mock-model"
 
     def _invoke(*, kind, response_cls, fallback_factory, system_prompt="", **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
         if response_cls is MutatorResponse:

--- a/tests/vibesys/loops/plain/test_plain_loop.py
+++ b/tests/vibesys/loops/plain/test_plain_loop.py
@@ -88,6 +88,11 @@ def _make_issue_runner(responses: list, *, backend_name: str = "deepagents") -> 
     """
     runner = MagicMock(spec=AgentClient)
     runner.backend_name = backend_name
+    # Every invocation event carries the client's attribution, so the mock
+    # supplies real strings the event payload can validate.
+    runner.driver_name = "mock"
+    runner.provider = "mock"
+    runner.model_for_kind.return_value = "mock-model"
     runner.capabilities = AgentCapabilities(
         mcp_servers=backend_name == "cli",
         in_process_tools=backend_name == "deepagents",
@@ -601,6 +606,9 @@ def test_judge_phase_calls_store_reload_after_invoke(  # noqa: ANN201  # tracked
 
     runner = MagicMock(spec=AgentClient)
     runner.backend_name = "deepagents"
+    runner.driver_name = "mock"
+    runner.provider = "mock"
+    runner.model_for_kind.return_value = "mock-model"
     runner.invoke.side_effect = tracking_invoke
     mock_build_runner.return_value = runner
 

--- a/tests/vibesys/test_agent_progress.py
+++ b/tests/vibesys/test_agent_progress.py
@@ -36,6 +36,11 @@ def _make_context(
     monkeypatch.setattr(ctx, "gpu_env", dict)
     client = MagicMock()
     client.invoke.return_value = _judge_fallback()
+    # Every invocation event carries the client's attribution, so the mock
+    # supplies real strings the event payload can validate.
+    client.driver_name = "mock"
+    client.provider = "mock"
+    client.model_for_kind.return_value = "mock-model"
     ctx.agent_client = client
     return ctx, client
 


### PR DESCRIPTION
## Problem

Every pull request currently fails the "Build and publish release wheels"
workflow. Its "Verify the installed wheel with a sanitized PATH" step runs
`vibesys --headless --stub-agent ...` against the installed wheel, and the run
dies at round-record construction on all four targets:

```
File ".../vibesys/loops/agent/loop.py", line 3249, in run_agent_loop
    implementer_driver=ctx.agent_client.driver_name,
AttributeError: 'StubAgentClient' object has no attribute 'driver_name'
```

(see the `linux-x86_64`, `linux-aarch64`, `macos-x86_64`, and `macos-arm64`
jobs of https://github.com/uw-syfi/vibesys/actions/runs/33813320755).

#523 by @AyanBinRafaih started stamping `implementer_driver`,
`implementer_provider`, and `implementer_model` onto every `RoundRecord` by
reading them off `ctx.agent_client`. Only the CLI `AgentClient` defines those
members. Nothing caught the gap because the agent-client "interface" was a
concrete class that the stub never implemented and the factory asserted with
`cast("AgentClient", StubAgentClient())`, while the two subclasses that skip
`AgentClient.__init__` (`DeepAgentsClient`, `PlainLoopAgentClient`) were kept
alive by `getattr(self, "_driver_name", None)` defenses inside the properties
themselves.

## Solution

Make the client surface the loop depends on an explicit shared interface, and
give every implementation the attribution the loop records.

- `AgentClientProtocol` (new, in `vibesys.agents.contracts`) declares
  `backend_name`, `capabilities`, `driver_name`, `provider`, `model_for_kind`,
  `provider_session_id`, `last_turn_provider_session_id`, `invoke`,
  `invoke_text`, `set_log_file`, and `close`. Attribution is part of
  the contract because the loop persists it on every round.
- `build_agent_client` returns the protocol and the `cast` is gone, so the type
  checker now verifies each backend's client against the surface consumers use.
  `_RunContext` and `LoopContext.agent_client` type against the protocol too.
- `StubAgentClient` reports `driver_name="stub"`, `provider="stub"`, and no
  model (a stub turn runs none). `DeepAgentsClient` reports itself for both
  names and its configured model. `PlainLoopAgentClient` delegates attribution
  to the client it wraps rather than inventing its own.
- With every implementation explicit, `AgentClient` drops its `getattr`
  defenses, `_RunContext.invoke_agent` reads the three fields directly instead
  of probing for them, and `_optional_string` (which coerced a missing
  attribute to `None`) is no longer needed. Run teardown likewise calls
  `agent_client.close` instead of probing for it.

Reviewers should look at the protocol's `invoke`/`invoke_text` signatures: they
mirror `AgentClient` exactly, which is what makes the stub's `**kwargs` form and
the plain-loop wrapper's extra `iteration=` kwarg conform.

### Architecture

```mermaid
flowchart TD
    Loop["agent loop / run context<br/>(records attribution per round)"] --> P
    P["AgentClientProtocol<br/>vibesys.agents.contracts"]
    Factory["build_agent_client<br/>(application configuration)"] -->|returns| P
    P -.implemented by.-> CLI["AgentClient (cli)"]
    P -.implemented by.-> Stub["StubAgentClient"]
    P -.implemented by.-> Deep["DeepAgentsClient"]
    P -.implemented by.-> Wrap["PlainLoopAgentClient<br/>(delegates to inner)"]
```

The direction of dependency is unchanged: loops depend on the contract, the
factory selects the implementation, and no consumer branches on a concrete
client type.

## Verification

### Correctness properties

- Every agent client exposes `driver_name`, `provider`, and `model_for_kind`,
  so `RoundRecord` attribution is well typed (`str | None`) for every backend
  rather than for one of them.
- A stub round records `implementer_driver="stub"`,
  `implementer_provider="stub"`, `implementer_model=null`; a `cli` round is
  unchanged (`agentshim`/`codex`/model, covered by the existing test).
- A wrapped client (plain loop) reports the wrapped client's attribution, not
  the wrapper's.
- The persisted record shape is unchanged, so this is not a state-format
  change; only previously-missing values are now present.
- The stub's attribution values appear in run state and invocation events only;
  nothing branches on them.

### Testing

- `uv run pytest tests/vibesys/loops/agent tests/vibesys/agents -q --no-cov` — 742 passed.
- `uv run pytest tests/vibesys/loops/plain tests/vibesys/loops/evolve tests/vibesys/test_context.py tests/vibesys/test_agent_progress.py tests/server -q --no-cov` — 486 passed.
- `uv run pytest tests -q --no-cov` — full suite green before the rebase onto
  `22748f58` (4957 passed, 2 environment skips); the suites above cover every
  file this branch touches after it.
- `./scripts/check_format.sh`, `./scripts/check_lint.sh`, `./scripts/check_types.sh` — all pass.
- Wheel-job equivalent, from a temporary project holding the smoke input that
  `scripts/verify_installed_release.py` writes:
  `uv run vibesys --headless --stub-agent --agent-backend cli --exp-name installed-release-smoke --max-rounds 1 --no-skills --backend cpu --profiler none`
  — exits 0 and the run's `agent/state.json` records
  `"implementer_driver": "stub"`, `"implementer_provider": "stub"`,
  `"implementer_model": null`. The same command fails with the reported
  `AttributeError` on `main`. Run it on a local filesystem: on this NFS
  workspace the orchestrator isolation check trips on an unrelated `.nfs*`
  silly-rename file before the round starts.
- New regression test
  `tests/vibesys/loops/agent/test_orchestrate.py::test_stub_agent_round_records_its_own_attribution`
  runs a real `StubAgentClient` (not a `MagicMock`) through the orchestrate
  harness and asserts the round record's attribution; it reproduces the
  `AttributeError` when the stub's properties are removed.
- Test mocks in the plain and evolve loop suites now set attribution strings;
  they previously relied on the coercion that `_optional_string` performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
