### PR TITLE
TUI: advertise expected agent roles in run_started

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -285,6 +285,7 @@ export type Kind9 = "run_started";
 export type OuterLoop = string;
 export type Input = string;
 export type MaxRounds = number;
+export type ExpectedRoles = string[];
 export type Kind10 = "run_interrupted";
 export type Reason = string;
 export type Signal = string | null;
@@ -816,6 +817,7 @@ export interface RunStartedData {
   outer_loop: OuterLoop;
   input: Input;
   max_rounds: MaxRounds;
+  expected_roles?: ExpectedRoles;
   [k: string]: unknown;
 }
 export interface RunInterruptedData {

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -2820,6 +2820,14 @@
         "max_rounds": {
           "title": "Max Rounds",
           "type": "integer"
+        },
+        "expected_roles": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Expected Roles",
+          "type": "array"
         }
       },
       "required": [

--- a/clients/core-state/src/core-state-prefix.test.ts
+++ b/clients/core-state/src/core-state-prefix.test.ts
@@ -268,6 +268,9 @@ describe('prefix merges across the chunk boundary', () => {
     expect(full.status).toBe('running');
     expect(merged.status).toBe('connecting');
     expect(merged.outerLoop).toBe('plain');
+    // `runStartedEvent` advertises no roles, so this also pins the legacy
+    // table fallback for recordings that predate `expected_roles`.
+    expect(full.expectedRoles).toBeNull();
     expect(full.phases.map(phase => phase.kind)).toEqual(['implementer', 'judge', 'perf_eval']);
     expect(merged.phases.map(phase => phase.kind)).toEqual(['implementer']);
     expect(merged.transcript.map(entry => entry.content)).toEqual(['work more']);
@@ -414,6 +417,7 @@ function generateRunEvents(seed: number, options: {typedTools: boolean}, rounds 
       outer_loop: 'agent',
       input: '/synthetic/target',
       max_rounds: rounds,
+      expected_roles: [...AGENT_KINDS],
     },
   });
 

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -132,6 +132,11 @@ export interface CoreState {
   agentKind: string | null;
   roundLabel: string | null;
   outerLoop: string | null;
+  /**
+   * The agent roles the backend advertised in `run_started`; null on
+   * recordings that predate the field (see `expectedRolesForSeeding`).
+   */
+  expectedRoles: readonly string[] | null;
   maxRounds: number | null;
   rounds: RoundSummary[];
   phases: AgentPhase[];
@@ -169,6 +174,7 @@ export function initialCoreState(): CoreState {
     agentKind: null,
     roundLabel: null,
     outerLoop: null,
+    expectedRoles: null,
     maxRounds: null,
     rounds: [],
     phases: [],
@@ -350,6 +356,7 @@ export function reduceEventPrefix(
     agentKind: state.agentKind ?? older.agentKind,
     roundLabel: state.roundLabel ?? older.roundLabel,
     outerLoop: state.outerLoop ?? older.outerLoop,
+    expectedRoles: state.expectedRoles ?? older.expectedRoles,
     maxRounds: state.maxRounds ?? older.maxRounds,
     rounds: mergeRoundLists(older.rounds, state.rounds),
     phases: mergePhaseLists(older.phases, state.phases),
@@ -541,6 +548,7 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
   if (event.round_label) next.roundLabel = event.round_label;
   const runMap = applyRunMapEvent(next, event);
   next.outerLoop = runMap.outerLoop;
+  next.expectedRoles = runMap.expectedRoles;
   next.rounds = runMap.rounds;
   next.phases = runMap.phases;
 

--- a/clients/core-state/src/run-map.test.ts
+++ b/clients/core-state/src/run-map.test.ts
@@ -1,6 +1,11 @@
 import {describe, expect, it} from 'bun:test';
 import type {RunEvent} from '@vibesys/backend-client';
-import {applyRunMapEvent, type RunMapState, roundAgentElapsedMs} from './run-map.js';
+import {
+  applyRunMapEvent,
+  expectedRolesForSeeding,
+  type RunMapState,
+  roundAgentElapsedMs,
+} from './run-map.js';
 
 describe('run map projection', () => {
   it('tracks concurrent same-role executions independently', () => {
@@ -80,8 +85,93 @@ describe('run map projection', () => {
   });
 });
 
+describe('expected phase seeding', () => {
+  it('seeds pending placeholders for every advertised role, even ones the legacy table never knew', () => {
+    let state = applyRunMapEvent(
+      initialRunMap(),
+      runStarted('swarm', ['scout', 'implementer', 'reviewer']),
+    );
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_started', 'a'));
+
+    expect(state.phases.map(phase => [phase.kind, phase.status])).toEqual([
+      ['scout', 'pending'],
+      ['implementer', 'active'],
+      ['reviewer', 'pending'],
+    ]);
+  });
+
+  it('lets a known loop advertise a role the legacy table lacks without a client edit', () => {
+    let state = applyRunMapEvent(
+      initialRunMap(),
+      runStarted('agent', ['orchestrator', 'implementer', 'judge', 'profiler', 'benchmark']),
+    );
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_started', 'a'));
+
+    expect(state.phases.map(phase => phase.kind)).toEqual([
+      'orchestrator',
+      'implementer',
+      'judge',
+      'profiler',
+      'benchmark',
+    ]);
+  });
+
+  it('falls back to the legacy table for a run_started without advertised roles', () => {
+    let state = applyRunMapEvent(initialRunMap(), runStarted('plain'));
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_started', 'a'));
+
+    expect(state.phases.map(phase => phase.kind)).toEqual(['implementer', 'judge', 'perf_eval']);
+  });
+
+  it('treats an empty advertised list as absent and uses the fallback', () => {
+    let state = applyRunMapEvent(initialRunMap(), runStarted('plain', []));
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_started', 'a'));
+
+    expect(state.phases.map(phase => phase.kind)).toEqual(['implementer', 'judge', 'perf_eval']);
+  });
+
+  it('still tracks observed phases for an unknown loop with no advertised roles', () => {
+    let state = applyRunMapEvent(initialRunMap(), runStarted('mystery'));
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_started', 'a'));
+
+    // The graceful-degradation contract: no role set is known, so nothing is
+    // seeded, and consumers can observe the condition through the selector.
+    expect(expectedRolesForSeeding(state)).toBeNull();
+    expect(state.phases.map(phase => [phase.kind, phase.status])).toEqual([
+      ['implementer', 'active'],
+    ]);
+  });
+
+  it('folds the advertised roles onto the state for consumers and prefix merges', () => {
+    const state = applyRunMapEvent(initialRunMap(), runStarted('plain', ['implementer', 'judge']));
+
+    expect(state.expectedRoles).toEqual(['implementer', 'judge']);
+    expect(expectedRolesForSeeding(state)).toEqual(['implementer', 'judge']);
+  });
+});
+
+function initialRunMap(): RunMapState {
+  return {outerLoop: null, expectedRoles: null, rounds: [], phases: []};
+}
+
+function runStarted(outerLoop: string, expectedRoles?: string[]): RunEvent {
+  return {
+    sequence: 1,
+    timestamp: '2026-01-01T00:00:00Z',
+    type: 'run_started',
+    status: 'active',
+    data: {
+      kind: 'run_started',
+      outer_loop: outerLoop,
+      input: '/target',
+      max_rounds: 3,
+      ...(expectedRoles === undefined ? {} : {expected_roles: expectedRoles}),
+    },
+  };
+}
+
 function emptyRunMap(): RunMapState {
-  return {outerLoop: 'agent', rounds: [], phases: []};
+  return {outerLoop: 'agent', expectedRoles: null, rounds: [], phases: []};
 }
 
 function requiredRound(state: RunMapState): RunMapState['rounds'][number] {

--- a/clients/core-state/src/run-map.ts
+++ b/clients/core-state/src/run-map.ts
@@ -39,18 +39,26 @@ export interface AgentPhase {
 
 export interface RunMapState {
   outerLoop: string | null;
+  /**
+   * The agent roles the backend advertised in `run_started`; null on
+   * recordings that predate the field, where `legacyExpectedRoles` applies.
+   */
+  expectedRoles: readonly string[] | null;
   rounds: RoundSummary[];
   phases: AgentPhase[];
 }
 
 export function applyRunMapEvent(state: RunMapState, event: RunEvent): RunMapState {
-  const outerLoop =
-    event.type === 'run_started' && event.data?.kind === 'run_started'
-      ? event.data.outer_loop
-      : state.outerLoop;
+  const started =
+    event.type === 'run_started' && event.data?.kind === 'run_started' ? event.data : null;
+  const outerLoop = started === null ? state.outerLoop : started.outer_loop;
+  const expectedRoles =
+    started?.expected_roles !== undefined && started.expected_roles.length > 0
+      ? started.expected_roles
+      : state.expectedRoles;
   const rounds = applyRoundEvent(state.rounds, state.phases, event);
-  const phases = applyPhaseEvent({...state, outerLoop, rounds}, event);
-  return {outerLoop, rounds, phases};
+  const phases = applyPhaseEvent({...state, outerLoop, expectedRoles, rounds}, event);
+  return {outerLoop, expectedRoles, rounds, phases};
 }
 
 export function roundNumberFromLabel(label: string | null | undefined): number | null {
@@ -165,8 +173,9 @@ function applyPhaseEvent(state: RunMapState, event: RunEvent): AgentPhase[] {
   if (!kind) return state.phases;
   const roundNumber = roundNumberFromLabel(event.round_label);
   let phases = state.phases;
-  if (roundNumber !== null && state.outerLoop !== null) {
-    phases = seedExpectedPhases(state.outerLoop, phases, roundNumber);
+  const roles = expectedRolesForSeeding(state);
+  if (roundNumber !== null && roles !== null) {
+    phases = seedExpectedPhases(roles, phases, roundNumber);
   }
   if (event.type === 'run_failed' || event.type === 'run_interrupted') {
     return phases.map(phase =>
@@ -231,22 +240,42 @@ function applyRoundEvent(
 }
 
 function seedExpectedPhases(
-  outerLoop: string,
+  roles: readonly string[],
   current: AgentPhase[],
   roundNumber: number,
 ): AgentPhase[] {
   let phases = current;
-  for (const kind of expectedRoles(outerLoop)) {
+  for (const kind of roles) {
     phases = ensurePhase(phases, kind, roundNumber);
   }
   return phases;
 }
 
-function expectedRoles(outerLoop: string): string[] {
+/**
+ * The roles a round seeds pending placeholders for: the set the backend
+ * advertised in `run_started`, else the legacy table for recordings that
+ * predate the advertised contract. Null when neither knows the loop, in which
+ * case nothing is seeded and the round degrades gracefully to the phases its
+ * events actually carry (`ensurePhase` still creates each observed role).
+ */
+export function expectedRolesForSeeding(
+  state: Pick<RunMapState, 'outerLoop' | 'expectedRoles'>,
+): readonly string[] | null {
+  if (state.expectedRoles !== null) return state.expectedRoles;
+  if (state.outerLoop === null) return null;
+  return legacyExpectedRoles(state.outerLoop);
+}
+
+/**
+ * Role tables for recordings whose `run_started` predates the backend's
+ * advertised `expected_roles` contract. Frozen: the backend now owns which
+ * roles a loop runs, so this table must never gain new loops or roles.
+ */
+function legacyExpectedRoles(outerLoop: string): readonly string[] | null {
   if (outerLoop === 'agent') return ['orchestrator', 'implementer', 'judge', 'profiler'];
   if (outerLoop === 'plain') return ['implementer', 'judge', 'perf_eval'];
   if (outerLoop === 'evolve') return ['implementer', 'judge', 'profiler'];
-  return [];
+  return null;
 }
 
 function ensurePhase(phases: AgentPhase[], kind: string, roundNumber: number | null): AgentPhase[] {

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -2594,6 +2594,11 @@ def dispatch(argv: list[str], integration: RunIntegration | None = None) -> None
             unsubscribe = run_integration.events.subscribe(HeadlessRenderer().handle)
         with boot_trace.span("run_started_event"):
             max_rounds = getattr(args, "max_rounds", getattr(args, "max_iterations", 1))
+            expected_roles = expected_agent_roles(loop_kind)
+            if args.profiler is ProfilerKind.NONE:
+                # A disabled profiler never runs (see loop.py's profiler-kind
+                # gate), so don't seed a placeholder for it.
+                expected_roles = tuple(role for role in expected_roles if role != "profiler")
             run_integration.events.emit(
                 CoreEventType.RUN_STARTED,
                 status=EventStatus.ACTIVE,
@@ -2601,7 +2606,7 @@ def dispatch(argv: list[str], integration: RunIntegration | None = None) -> None
                     outer_loop=loop_kind,
                     input=str(args.input_bundle.root),
                     max_rounds=max_rounds,
-                    expected_roles=expected_agent_roles(loop_kind),
+                    expected_roles=expected_roles,
                 ),
             )
         runner(args, run_integration)

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -38,6 +38,7 @@ from vibesys.domains.base import DomainName
 from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
 from vibesys.input_manifest import InputBundle, load_input_bundle, load_project_task
 from vibesys.loops.metrics import MetricSpace, Objective
+from vibesys.loops.roles import expected_agent_roles
 from vibesys.profilers import CLI_PROFILER_CHOICES, ProfilerKind, coerce_profiler_kind
 from vibesys.render.headless import HeadlessRenderer
 from vibesys.repository import (
@@ -2600,6 +2601,7 @@ def dispatch(argv: list[str], integration: RunIntegration | None = None) -> None
                     outer_loop=loop_kind,
                     input=str(args.input_bundle.root),
                     max_rounds=max_rounds,
+                    expected_roles=expected_agent_roles(loop_kind),
                 ),
             )
         runner(args, run_integration)

--- a/src/server/events.py
+++ b/src/server/events.py
@@ -170,6 +170,10 @@ class RunStartedData(EventPayload):  # noqa: D101  # tracked: #288
     outer_loop: str
     input: str
     max_rounds: int
+    # The agent roles the loop can run per round (vibesys.loops.roles), so
+    # frontends seed placeholders from the contract instead of a client-side
+    # table. Empty on events recorded before the field existed.
+    expected_roles: tuple[str, ...] = ()
 
 
 class RunInterruptedData(EventPayload):  # noqa: D101  # tracked: #288

--- a/src/vibesys/loops/roles.py
+++ b/src/vibesys/loops/roles.py
@@ -6,7 +6,9 @@ sites pass to ``LoopContext.invoke``. ``run_started`` advertises this
 sequence to frontends, which seed one pending placeholder per role for each
 round. Conditional roles are included (``profiler`` runs only when profiling
 is enabled and requested) because a pending placeholder is the correct
-display for a role that may still run.
+display for a role that may still run. ``entrypoints.headless`` drops
+``profiler`` from the advertised tuple when the resolved profiler kind is
+``ProfilerKind.NONE``, since it is then guaranteed not to run.
 
 Kept free of loop imports: ``entrypoints.headless`` reads it while emitting
 ``run_started``, before any loop module is loaded, and the loop packages

--- a/src/vibesys/loops/roles.py
+++ b/src/vibesys/loops/roles.py
@@ -1,0 +1,35 @@
+"""The advertised loop-to-agent-roles contract.
+
+Single authoritative mapping from ``--outer-loop`` kind to the agent roles
+that loop can run as per-round executions: the ``kind=`` values its call
+sites pass to ``LoopContext.invoke``. ``run_started`` advertises this
+sequence to frontends, which seed one pending placeholder per role for each
+round. Conditional roles are included (``profiler`` runs only when profiling
+is enabled and requested) because a pending placeholder is the correct
+display for a role that may still run.
+
+Kept free of loop imports: ``entrypoints.headless`` reads it while emitting
+``run_started``, before any loop module is loaded, and the loop packages
+intentionally avoid heavy package-level imports.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+EXPECTED_AGENT_ROLES: Mapping[str, tuple[str, ...]] = {
+    "agent": ("orchestrator", "implementer", "judge", "profiler"),
+    "plain": ("implementer", "judge", "perf_eval"),
+    "evolve": ("implementer", "judge", "profiler"),
+}
+
+
+def expected_agent_roles(outer_loop: str) -> tuple[str, ...]:
+    """Return the per-round agent roles ``outer_loop`` can invoke."""
+    try:
+        return EXPECTED_AGENT_ROLES[outer_loop]
+    except KeyError as exc:
+        raise ValueError(f"Unknown outer loop {outer_loop!r}.") from exc  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/run/events.py
+++ b/src/vibesys/run/events.py
@@ -98,6 +98,10 @@ class RunStartedData(EventPayload):  # noqa: D101
     outer_loop: str
     input: str
     max_rounds: int
+    # The agent roles the loop can run per round (vibesys.loops.roles), so
+    # frontends seed placeholders from the contract instead of a client-side
+    # table. Empty on events recorded before the field existed.
+    expected_roles: tuple[str, ...] = ()
 
 
 class ExperimentsChangedData(EventPayload):  # noqa: D101

--- a/tests/entrypoints/test_headless.py
+++ b/tests/entrypoints/test_headless.py
@@ -36,8 +36,9 @@ from vibesys.domains.base import DomainName
 from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
 from vibesys.input_manifest import load_input_bundle
 from vibesys.loops.metrics import MetricSpace, Objective
+from vibesys.loops.roles import EXPECTED_AGENT_ROLES
 from vibesys.profilers import ProfilerKind
-from vibesys.run.events import CoreEventType
+from vibesys.run.events import CoreEventType, RunStartedData
 from vibesys.run.integration import LocalRunIntegration
 from vibesys.sandbox.run_environment import run_environment_record
 from vs_project import (
@@ -1871,3 +1872,31 @@ def test_non_microservice_task_is_unaffected_by_trace_arguments(tmp_path: Path) 
     cli._apply_bundle_profiler_default(args)  # noqa: SLF001
 
     assert args.profiler is ProfilerKind.AUTO
+
+
+def test_expected_role_registry_covers_every_outer_loop() -> None:
+    """The advertised contract must name every loop dispatch can select."""
+    import entrypoints.headless as cli  # noqa: PLC0415
+
+    assert set(EXPECTED_AGENT_ROLES) == set(cli._OUTER_LOOPS)  # noqa: SLF001
+    assert set(EXPECTED_AGENT_ROLES) == set(cli._LOOP_COMMANDS)  # noqa: SLF001
+    assert all(EXPECTED_AGENT_ROLES.values())
+
+
+@pytest.mark.parametrize("loop", ["agent", "plain", "evolve"])
+def test_dispatch_advertises_expected_roles_on_run_started(loop: str, tmp_path: Path) -> None:
+    import entrypoints.headless as cli  # noqa: PLC0415
+
+    project = _write_input_project(tmp_path)
+    integration = LocalRunIntegration()
+    events = []
+    integration.events.subscribe(events.append)
+    runner = Mock()
+
+    with _patch_loop_runner(loop, runner):
+        cli.dispatch(["--outer-loop", loop, "--input", str(project)], integration=integration)
+
+    started = next(event for event in events if event.type is CoreEventType.RUN_STARTED)
+    assert isinstance(started.data, RunStartedData)
+    assert started.data.expected_roles == EXPECTED_AGENT_ROLES[loop]
+    assert started.data.expected_roles

--- a/tests/entrypoints/test_headless.py
+++ b/tests/entrypoints/test_headless.py
@@ -1900,3 +1900,27 @@ def test_dispatch_advertises_expected_roles_on_run_started(loop: str, tmp_path: 
     assert isinstance(started.data, RunStartedData)
     assert started.data.expected_roles == EXPECTED_AGENT_ROLES[loop]
     assert started.data.expected_roles
+
+
+@pytest.mark.parametrize("loop", ["agent", "evolve"])
+def test_dispatch_omits_profiler_role_when_profiler_is_disabled(loop: str, tmp_path: Path) -> None:
+    """A disabled profiler never runs, so its placeholder must not be seeded."""
+    import entrypoints.headless as cli  # noqa: PLC0415
+
+    project = _write_input_project(tmp_path)
+    integration = LocalRunIntegration()
+    events = []
+    integration.events.subscribe(events.append)
+    runner = Mock()
+
+    with _patch_loop_runner(loop, runner):
+        cli.dispatch(
+            ["--outer-loop", loop, "--input", str(project), "--profiler", "none"],
+            integration=integration,
+        )
+
+    started = next(event for event in events if event.type is CoreEventType.RUN_STARTED)
+    assert "profiler" not in started.data.expected_roles
+    assert started.data.expected_roles == tuple(
+        role for role in EXPECTED_AGENT_ROLES[loop] if role != "profiler"
+    )

--- a/tests/server/test_integration.py
+++ b/tests/server/test_integration.py
@@ -233,3 +233,27 @@ def test_close_is_idempotent_and_stops_event_projection(tmp_path):  # noqa: ANN0
     )
 
     assert not any(event.type is EventType.AGENT_OUTPUT_CHUNK for event in parts.journal.read())
+
+
+def test_run_started_expected_roles_round_trip_through_the_wire_bridge() -> None:
+    """The core payload bridges to the wire model with and without the field."""
+    from server.events import RunStartedData  # noqa: PLC0415
+    from server.integration import _EVENT_DATA_ADAPTER  # noqa: PLC0415
+    from vibesys.run.events import RunStartedData as CoreRunStartedData  # noqa: PLC0415
+
+    advertised = CoreRunStartedData(
+        outer_loop="plain",
+        input="objective",
+        max_rounds=3,
+        expected_roles=("implementer", "judge", "perf_eval"),
+    )
+    wire = _EVENT_DATA_ADAPTER.validate_python(advertised.model_dump(mode="python"))
+    assert isinstance(wire, RunStartedData)
+    assert wire.expected_roles == ("implementer", "judge", "perf_eval")
+
+    # A recording that predates the field must still validate, as empty.
+    legacy = _EVENT_DATA_ADAPTER.validate_python(
+        {"kind": "run_started", "outer_loop": "plain", "input": "objective", "max_rounds": 3}
+    )
+    assert isinstance(legacy, RunStartedData)
+    assert legacy.expected_roles == ()

--- a/tests/vibesys/loops/test_roles.py
+++ b/tests/vibesys/loops/test_roles.py
@@ -1,0 +1,58 @@
+"""Tests for ``vibesys.loops.roles`` -- the advertised loop-to-agent-roles contract.
+
+Rather than asserting on the registry's literal contents (which would just
+restate ``roles.py`` and pass unchanged if a call site drifted), these scan
+each loop package's own source for the ``kind="<role>"`` literals its
+``LoopContext.invoke`` call sites actually pass, and check that the
+registry names exactly that set. A call site added or removed without a
+matching registry update fails this test.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import vibesys.loops.agent as agent_package
+import vibesys.loops.evolve as evolve_package
+import vibesys.loops.plain as plain_package
+from vibesys.loops.roles import EXPECTED_AGENT_ROLES
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+# Matches a keyword argument like ``kind="profiler"`` (no surrounding spaces,
+# per this repo's ruff-formatted style for keyword arguments) but not a plain
+# assignment such as ``kind = "migrant"``, which ruff formats with spaces.
+_KIND_KWARG = re.compile(r'\bkind="(\w+)"')
+
+# ``invoke_profiler`` (vibesys.loops.profiler) wraps ``ctx.invoke(kind="profiler", ...)``
+# without spelling the literal out at its call sites, so a call to it implies
+# the "profiler" role.
+_INVOKE_PROFILER_CALL = re.compile(r"\binvoke_profiler\(")
+
+_LOOP_PACKAGES: dict[str, ModuleType] = {
+    "agent": agent_package,
+    "plain": plain_package,
+    "evolve": evolve_package,
+}
+
+
+def _invoked_roles(package: ModuleType) -> set[str]:
+    """Every agent role ``package``'s source actually invokes."""
+    package_dir = Path(inspect.getfile(package)).parent
+    roles: set[str] = set()
+    for source_path in package_dir.rglob("*.py"):
+        text = source_path.read_text()
+        roles.update(_KIND_KWARG.findall(text))
+        if _INVOKE_PROFILER_CALL.search(text):
+            roles.add("profiler")
+    return roles
+
+
+def test_registry_matches_the_invoke_sites_for_every_loop() -> None:
+    """``EXPECTED_AGENT_ROLES`` must name exactly the roles each loop can invoke."""
+    for loop_kind, package in _LOOP_PACKAGES.items():
+        assert _invoked_roles(package) == set(EXPECTED_AGENT_ROLES[loop_kind]), loop_kind


### PR DESCRIPTION
## Problem

Fixes #584. Which agent roles a loop runs per round was a client-side guess: `expectedRoles(outerLoop)` in `clients/core-state/src/run-map.ts` hardcoded the role list for `agent`, `plain`, and `evolve`, and the frontend seeded one pending placeholder per role for each round from that table. The backend, which actually decides which agents run, never advertised the set. The two could silently drift: a loop gaining or losing a role, a renamed role, or a new loop kind would leave the TUI seeding stale placeholders (roles that will never run shown as pending forever) or seeding nothing at all for an unknown loop, with no diagnostic and no way for the backend to correct the display. This inverts the repo's contract direction, where backend event schemas are the frontend contract and frontends consume published semantic data instead of duplicating backend knowledge.

## Solution

The backend now owns and advertises the contract. A new module, `src/vibesys/loops/roles.py`, holds the single authoritative loop-to-roles mapping, ground-truthed from the actual `LoopContext.invoke(kind=...)` call sites in each loop (agent: `orchestrator`, `implementer`, `judge`, plus the conditional `profiler`; plain: `implementer`, `judge`, `perf_eval`; evolve: `implementer`, `judge`, `profiler`; conditional roles are included because a pending placeholder is the right display for a role that may still run). The module is deliberately import-light so `entrypoints.headless` can read it while emitting `run_started`, before any loop package loads, and `expected_agent_roles()` rejects an unknown loop kind loudly. Two safeguards keep the registry honest. A source-scanning drift test derives each loop's roles from the code itself (the `kind="..."` literals at the invoke call sites plus the shared `invoke_profiler` wrapper) and asserts equality with the registry, so an invoke added or removed without updating the registry fails tests. And `dispatch` filters `profiler` out of the advertised tuple when the CLI-resolved profiler kind is `NONE`, since a run started with `--profiler none` never invokes the profiler and would otherwise show a placeholder that can never resolve. Both `RunStartedData` models (`src/vibesys/run/events.py` and `src/server/events.py`) gain `expected_roles: tuple[str, ...] = ()`, defaulting empty so every recording that predates the field still validates, and `headless.dispatch` populates it. The protocol schema and TS bindings are regenerated, never hand-edited. On the client, the fold stores the advertised roles as `RunMapState.expectedRoles` / `CoreState.expectedRoles` and seeds placeholders from them; the old table survives only as `legacyExpectedRoles`, documented as frozen and consulted solely for recordings that predate the contract. For a loop neither side knows, the exported selector `expectedRolesForSeeding` returns null and the round degrades gracefully to exactly the phases its events actually carry, since `ensurePhase` still creates every observed role.

### Architecture

The roles registry is application configuration with one owner: the loops package describes what it runs, `headless` wires that into the `run_started` event, and the frontend consumes the published field. `run-map.ts` keeps ownership of seeding but no longer owns the knowledge of what to seed; `core-state.ts` carries `expectedRoles` through `reduceEventPrefix` with the same keep-newest rule as `outerLoop`, so prefix compaction cannot drop the contract. The wire bridge (`TypeAdapter` in `src/server/integration.py`) round-trips the field between the duplicated core and server event models, covered by a new bridge test in both directions (with the field, and legacy payloads without it).

```mermaid
flowchart TD
    RS[(vibesys/loops/roles.py<br/>EXPECTED_AGENT_ROLES:<br/>one authoritative mapping)] --> H[entrypoints/headless.py dispatch]
    IS[LoopContext.invoke call sites<br/>agent / plain / evolve loops] -. ground truth,<br/>registry test pins coverage .-> RS
    H --> EV[run_started event<br/>expected_roles advertised]
    EV --> W[wire bridge + protocol schema<br/>regenerated TS bindings]
    W --> F[core-state fold:<br/>RunMapState.expectedRoles]
    F --> SEL{expectedRolesForSeeding}
    SEL -->|advertised roles| SEED[seed one pending<br/>placeholder per role per round]
    SEL -->|"null roles (pre-field recording)"| LEG[legacyExpectedRoles:<br/>frozen fallback table]
    SEL -->|unknown loop| DEG[no seeding: round shows<br/>exactly the observed phases]
    LEG --> SEED
```

## Verification

Automated: two new client tests fail against the unfixed fold (a novel loop's advertised roles were ignored, and a known loop could not advertise a role the legacy table lacked); backend tests pin the registry against dispatch's loop set, the emission for all three loops, the wire bridge round trip, and legacy-recording compatibility; the committed-schema parity test passes. The full Python and TS pipelines pass. Manual: a real codex-provider agent-loop run on this branch showed `expected_roles` on the wire and the seeded placeholders in the TUI.

### Correctness properties

- The backend is the single source of truth for per-round roles: `run_started` advertises the same tuple the loop's `invoke` call sites can produce, and a registry test forces the mapping to cover exactly the loop kinds `dispatch` accepts, so adding a loop without declaring its roles fails tests.
- The registry cannot silently drift from the code: a source-scanning test re-derives each loop package's roles from its invoke literals and `invoke_profiler` calls and asserts set equality with `EXPECTED_AGENT_ROLES`.
- A disabled profiler is not advertised: with `--profiler none`, the `run_started` tuple omits `profiler`, so the TUI seeds no placeholder for a role the loop is guaranteed to skip.
- Recordings made before the field exist keep working: the empty default validates through both event models and the wire bridge, and the client falls back to the frozen `legacyExpectedRoles` table for them, preserving today's rendering byte for byte.
- A frontend never invents roles for a loop the backend advertised: advertised roles win over the legacy table whenever present and non-empty.
- Unknown-loop degradation is visible and safe: with no advertised and no legacy roles, nothing is seeded, and every role that actually runs still appears because observed events create their phases.
- `expected_roles` survives prefix compaction (`reduceEventPrefix` keeps the newest non-null value, mirroring `outerLoop`), so a client that folds a snapshot plus a suffix sees the same contract as one that folded every event.

### Testing

- `clients/core-state/src/run-map.test.ts`, new "expected phase seeding" describe block (6 tests): a novel loop `swarm` with novel roles seeds placeholders for each (pre-fix: only the one observed phase existed, `expect` received `[["implementer","active"]]` instead of the three-role expectation); a known loop advertising an extra `benchmark` role seeds it without any client edit (pre-fix: missing); legacy fallback for role-less `run_started`; an empty advertised list treated as absent; unknown loop `mystery` returning null from `expectedRolesForSeeding` with observed-only phases; and roles folding onto state. The first two fail before the fix, all pass after.
- `clients/core-state/src/core-state-prefix.test.ts`: the prefix-merge test now pins `expectedRoles` behavior across `reduceEventPrefix`.
- `tests/entrypoints/test_headless.py::test_expected_role_registry_covers_every_outer_loop` (registry equals dispatch's `_OUTER_LOOPS` and `_LOOP_COMMANDS`, no empty role sets) and `test_dispatch_advertises_expected_roles_on_run_started` parametrized over `agent`, `plain`, and `evolve`.
- `tests/vibesys/loops/test_roles.py` (new): the drift test scans each loop package's source for `kind="..."` invoke literals and `invoke_profiler(` calls and asserts the derived per-loop sets equal the registry exactly (agent: orchestrator/implementer/judge/profiler, plain: implementer/judge/perf_eval, evolve: implementer/judge/profiler).
- `tests/entrypoints/test_headless.py::test_dispatch_omits_profiler_role_when_profiler_is_disabled` (parametrized over `agent` and `evolve`): dispatching with `--profiler none` advertises a tuple without `profiler`; the default-profiler presence case is already pinned by the advertise test above.
- `tests/server/test_integration.py::test_run_started_expected_roles_round_trip_through_the_wire_bridge`: the core payload bridges to the wire model with the field intact, and a legacy payload without the field validates as empty.
- `uv run pytest tests/server/test_protocol_schema.py` (1 passed), `uv run pytest tests/server` (266 passed), `uv run pytest tests/entrypoints tests/vibesys/loops` (862 passed), `uv run ruff check`, `uv run ty check`, `./scripts/check_format.sh`: all clean.
- `pnpm check:ts-architecture` (no dependency violations), `pnpm check:clients`, `pnpm test:clients` (81 core-state, 549 tui, all pass), `pnpm build:clients`: all clean. Generated files were produced only by `pnpm --dir clients/backend-client generate:protocol`.
- Codex-provider harness run (`runtui.sh start 200x50 spsc`, model `gpt-5.6-sol`, agent loop, 1 round): the persisted `run_started` event carried `"expected_roles": ["orchestrator", "implementer", "judge", "profiler"]`, the round view's Agents pane showed the seeded placeholders ("5 agents · 1 active · 1 done · 3 waiting") while only the orchestrator had run, `backend.log` was clean, and teardown on quit was clean. The plain and evolve loops are covered by the parametrized dispatch test rather than separate live runs.

Closes #584.
