### PR TITLE
TUI: preserve valid unterminated event records across append and reopen

### DIFF
--- a/src/server/events.py
+++ b/src/server/events.py
@@ -477,6 +477,11 @@ class EventStore:
             self._records = _records_from_events(_repair_legacy_sequences(events))
         else:
             self._records, self._malformed_tail_offset = scanned
+        # A valid final record whose line was never terminated must gain its
+        # newline before ``append`` writes anything after it.
+        self._missing_tail_newline = self._malformed_tail_offset is None and _ends_without_newline(
+            self.path
+        )
         self._sequences = [record.header.sequence for record in self._records]
         self._next_sequence = self._sequences[-1] + 1 if self._sequences else 1
 
@@ -486,6 +491,12 @@ class EventStore:
                 with self.path.open("r+b") as stream:
                     stream.truncate(self._malformed_tail_offset)
                 self._malformed_tail_offset = None
+            if self._missing_tail_newline:
+                # Terminate the valid final record so the new record starts
+                # its own line instead of concatenating onto it.
+                with self.path.open("a", encoding="utf-8") as stream:
+                    stream.write("\n")
+                self._missing_tail_newline = False
             event = event.model_copy(
                 update={"sequence": self._next_sequence, "run_id": self.run_id}
             )
@@ -658,7 +669,10 @@ class EventStore:
             offset += len(line)
             header_fields = _scan_header_fields(line)
             if header_fields is None:
-                if index != len(lines) - 1:
+                # A complete final record the header scan cannot classify must
+                # be judged by full validation, so it also falls to the eager
+                # path; only a torn (non-JSON) tail is set aside for repair.
+                if index != len(lines) - 1 or _is_complete_json(line):
                     return None
                 # Preserve access to earlier audit history if a process was
                 # interrupted during its final append.
@@ -680,28 +694,26 @@ class EventStore:
                     raw_sequence=raw_sequence,
                 )
             )
-        tail_offset = self._parse_eager_tail(raw, records, malformed_tail_offset)
-        return records, tail_offset
+        self._parse_eager_tail(raw, records, malformed_tail_offset)
+        return records, malformed_tail_offset
 
     def _parse_eager_tail(
         self, raw: bytes, records: list[_StoredRecord], malformed_tail_offset: int | None
-    ) -> int | None:
-        """Validate the trailing window, reproducing today's tail semantics.
+    ) -> None:
+        """Validate the trailing window, raising on any record that fails.
 
-        A final record that scans as JSON but fails validation is still an
-        interrupted append; anything earlier is still a hard failure.
+        Every record here scanned as complete JSON, which a torn append can
+        never leave behind, so a validation failure on the final record is
+        corruption to surface, not an interrupted write to set aside.
         """
         for position in range(max(0, len(records) - _EAGER_TAIL_RECORDS), len(records)):
             record = records[position]
             try:
                 self._parse_record(record, raw[record.offset : record.offset + record.length])
-            except ValidationError:
+            except ValidationError as error:
                 if position != len(records) - 1 or malformed_tail_offset is not None:
                     raise
-                offset = record.offset
-                del records[position]
-                return offset
-        return malformed_tail_offset
+                raise _complete_invalid_tail_error(self.path, record.offset) from error
 
     def _read_unlocked(self) -> tuple[list[RunEvent], int | None]:
         if not self.path.exists():
@@ -716,12 +728,14 @@ class EventStore:
                 self._parsed_records += 1
                 event = RunEvent.model_validate_json(line)
                 events.append(event)
-            except ValidationError:
+            except ValidationError as error:
+                if index != len(lines) - 1:
+                    raise
+                if _is_complete_json(line):
+                    raise _complete_invalid_tail_error(self.path, record_offset) from error
                 # Preserve access to earlier audit history if a process was
                 # interrupted during its final append.
-                if index == len(lines) - 1:
-                    return events, record_offset
-                raise
+                return events, record_offset
         return events, None
 
 
@@ -759,6 +773,41 @@ def _scan_header_fields(line: bytes) -> tuple[int, EventType, str | None, str | 
 
 def _is_optional_str(value: Any) -> bool:  # noqa: ANN401  # scanning untyped JSON
     return value is None or isinstance(value, str)
+
+
+def _is_complete_json(line: bytes) -> bool:
+    """Whether the bytes parse as one complete JSON value.
+
+    A torn append leaves a strict prefix of the record plus its newline, and
+    no strict prefix of a serialized object is complete JSON, so this
+    discriminates an interrupted write from a fully written record.
+    """
+    try:
+        json.loads(line)
+    except ValueError:
+        return False
+    return True
+
+
+def _ends_without_newline(path: Path) -> bool:
+    """Whether the file's final byte leaves its last record unterminated."""
+    if not path.exists():
+        return False
+    size = path.stat().st_size
+    if size == 0:
+        return False
+    with path.open("rb") as stream:
+        stream.seek(size - 1)
+        return stream.read(1) != b"\n"
+
+
+def _complete_invalid_tail_error(path: Path, offset: int) -> ValueError:
+    """Corruption error for a fully written final record that fails validation.
+
+    Unlike a torn append, the record is complete, so silently truncating it
+    would erase a durable fact; the operator must inspect the file instead.
+    """
+    return ValueError(f"complete final record at byte offset {offset} in {path} failed validation")
 
 
 def _header_from_event(event: RunEvent, sequence: int) -> EventHeader:

--- a/src/server/events.py
+++ b/src/server/events.py
@@ -493,9 +493,13 @@ class EventStore:
                 self._malformed_tail_offset = None
             if self._missing_tail_newline:
                 # Terminate the valid final record so the new record starts
-                # its own line instead of concatenating onto it.
-                with self.path.open("a", encoding="utf-8") as stream:
-                    stream.write("\n")
+                # its own line instead of concatenating onto it. The flag is a
+                # construction-time observation, so recheck the file itself: if
+                # it was removed or replaced since, a blind "\n" would corrupt
+                # the fresh file's first record.
+                if _ends_without_newline(self.path):
+                    with self.path.open("a", encoding="utf-8") as stream:
+                        stream.write("\n")
                 self._missing_tail_newline = False
             event = event.model_copy(
                 update={"sequence": self._next_sequence, "run_id": self.run_id}
@@ -669,10 +673,11 @@ class EventStore:
             offset += len(line)
             header_fields = _scan_header_fields(line)
             if header_fields is None:
-                # A complete final record the header scan cannot classify must
-                # be judged by full validation, so it also falls to the eager
-                # path; only a torn (non-JSON) tail is set aside for repair.
-                if index != len(lines) - 1 or _is_complete_json(line):
+                # A final line holding complete JSON the header scan cannot
+                # classify must be judged by full validation, so it falls to
+                # the eager path; only a tail with no complete JSON prefix (a
+                # torn append) is set aside for repair.
+                if index != len(lines) - 1 or _starts_with_complete_json(line):
                     return None
                 # Preserve access to earlier audit history if a process was
                 # interrupted during its final append.
@@ -731,7 +736,7 @@ class EventStore:
             except ValidationError as error:
                 if index != len(lines) - 1:
                     raise
-                if _is_complete_json(line):
+                if _starts_with_complete_json(line):
                     raise _complete_invalid_tail_error(self.path, record_offset) from error
                 # Preserve access to earlier audit history if a process was
                 # interrupted during its final append.
@@ -775,15 +780,22 @@ def _is_optional_str(value: Any) -> bool:  # noqa: ANN401  # scanning untyped JS
     return value is None or isinstance(value, str)
 
 
-def _is_complete_json(line: bytes) -> bool:
-    """Whether the bytes parse as one complete JSON value.
+def _starts_with_complete_json(line: bytes) -> bool:
+    """Whether the bytes begin with one complete JSON value.
 
     A torn append leaves a strict prefix of the record plus its newline, and
-    no strict prefix of a serialized object is complete JSON, so this
-    discriminates an interrupted write from a fully written record.
+    no strict prefix of a serialized object contains a complete JSON value, so
+    this discriminates an interrupted write from fully written bytes: a lone
+    record, or complete records concatenated onto one line by a writer that
+    never terminated it. Truncating the latter would erase durable facts, so
+    it must be surfaced as corruption, not repaired as a torn tail.
     """
     try:
-        json.loads(line)
+        text = line.decode()
+    except UnicodeDecodeError:
+        return False
+    try:
+        json.JSONDecoder().raw_decode(text)
     except ValueError:
         return False
     return True

--- a/tests/server/test_event_store.py
+++ b/tests/server/test_event_store.py
@@ -1,5 +1,6 @@
 """Persistence and cursor tests for the run-event store."""
 
+import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
@@ -167,6 +168,68 @@ class TestEventStore:
             (1, "complete"),
             (2, "after repair"),
         ]
+
+    def test_append_preserves_a_valid_unterminated_final_record(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        path = tmp_path / "events.jsonl"
+        path.write_text(_persisted_event(1, "unterminated").model_dump_json())
+        store = EventStore(path, run_id="active-run")
+        assert [event.text for event in store.read()] == ["unterminated"]
+
+        store.append(make_event(EventType.OUTPUT, "appended"))
+
+        assert [event.text for event in store.read()] == ["unterminated", "appended"]
+        reopened = EventStore(path, run_id="reopened-run")
+        assert [(event.sequence, event.text) for event in reopened.read()] == [
+            (1, "unterminated"),
+            (2, "appended"),
+        ]
+        raw = path.read_text()
+        assert raw.endswith("\n")
+        assert [json.loads(line)["text"] for line in raw.splitlines()] == [
+            "unterminated",
+            "appended",
+        ]
+
+    def test_append_writes_no_repair_newline_after_a_terminated_tail(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        path = tmp_path / "events.jsonl"
+        _write_events(path, [_persisted_event(1, "one")])
+        original = path.read_bytes()
+        store = EventStore(path, run_id="active-run")
+
+        appended = store.append(make_event(EventType.OUTPUT, "two"))
+
+        assert path.read_bytes() == original + (appended.model_dump_json() + "\n").encode()
+
+    def test_a_missing_final_newline_is_repaired_exactly_once(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        path = tmp_path / "events.jsonl"
+        path.write_text(_persisted_event(1, "unterminated").model_dump_json())
+        store = EventStore(path, run_id="active-run")
+
+        store.append(make_event(EventType.OUTPUT, "second"))
+        store.append(make_event(EventType.OUTPUT, "third"))
+
+        raw = path.read_text()
+        assert "\n\n" not in raw
+        assert len(raw.splitlines()) == 3
+        assert [event.text for event in EventStore(path, run_id="reopened-run").read()] == [
+            "unterminated",
+            "second",
+            "third",
+        ]
+
+    def test_a_complete_but_invalid_final_record_raises_instead_of_truncating(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        path = tmp_path / "events.jsonl"
+        valid = _persisted_event(1, "complete").model_dump_json()
+        record = json.loads(_persisted_event(2, "terminal").model_dump_json())
+        record["data"] = {"kind": "output", "stream": "stdout", "content": 5}
+        path.write_text(valid + "\n" + json.dumps(record) + "\n")
+        original = path.read_bytes()
+
+        with pytest.raises(ValueError, match=f"byte offset {len(valid) + 1} ") as excinfo:
+            EventStore(path, run_id="active-run")
+
+        assert str(path) in str(excinfo.value)
+        assert path.read_bytes() == original
 
     def test_rejects_a_malformed_record_before_the_tail(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "events.jsonl"

--- a/tests/server/test_event_store.py
+++ b/tests/server/test_event_store.py
@@ -217,6 +217,30 @@ class TestEventStore:
             "third",
         ]
 
+    def test_append_after_external_removal_starts_the_new_file_cleanly(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        path = tmp_path / "events.jsonl"
+        path.write_text(_persisted_event(1, "unterminated").model_dump_json())
+        store = EventStore(path, run_id="active-run")
+        path.unlink()
+
+        appended = store.append(make_event(EventType.OUTPUT, "fresh"))
+
+        assert path.read_bytes() == (appended.model_dump_json() + "\n").encode()
+        assert [event.text for event in EventStore(path, run_id="reopened-run").read()] == ["fresh"]
+
+    def test_concatenated_final_records_raise_instead_of_truncating(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        path = tmp_path / "events.jsonl"
+        first = _persisted_event(1, "first").model_dump_json()
+        second = _persisted_event(2, "second").model_dump_json()
+        third = _persisted_event(3, "third").model_dump_json()
+        path.write_text(first + "\n" + second + third + "\n")
+        original = path.read_bytes()
+
+        with pytest.raises(ValueError, match=f"byte offset {len(first) + 1} "):
+            EventStore(path, run_id="active-run")
+
+        assert path.read_bytes() == original
+
     def test_a_complete_but_invalid_final_record_raises_instead_of_truncating(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "events.jsonl"
         valid = _persisted_event(1, "complete").model_dump_json()

--- a/tests/server/test_lazy_event_store.py
+++ b/tests/server/test_lazy_event_store.py
@@ -305,6 +305,21 @@ def test_lazy_store_matches_eager_store_for_a_complete_invalid_tail(tmp_path):  
     assert path.read_bytes() == original
 
 
+def test_lazy_store_matches_eager_store_for_a_concatenated_tail(tmp_path):  # noqa: ANN001, ANN201
+    path = tmp_path / "events.jsonl"
+    serialized = [event.model_dump_json() for event in _generated_events(seed=53, count=12)]
+    path.write_text("\n".join(serialized[:-2]) + "\n" + serialized[-2] + serialized[-1] + "\n")
+    original = path.read_bytes()
+
+    with pytest.raises(ValueError, match="complete final record") as lazy_error:
+        EventStore(path, run_id="active-run")
+    with pytest.raises(ValueError, match="complete final record") as eager_error:
+        _EagerEventStore(path, run_id="reference")
+
+    assert str(lazy_error.value) == str(eager_error.value)
+    assert path.read_bytes() == original
+
+
 def test_a_bounded_read_only_parses_the_records_it_returns(tmp_path):  # noqa: ANN001, ANN201
     path = tmp_path / "events.jsonl"
     count = 6 * _EAGER_TAIL_RECORDS

--- a/tests/server/test_lazy_event_store.py
+++ b/tests/server/test_lazy_event_store.py
@@ -260,6 +260,51 @@ def test_a_corrupt_final_record_is_ignored_and_repaired_by_append(tmp_path):  # 
     assert len(reopened.read()) == len(events) + 1
 
 
+def test_lazy_store_matches_eager_store_for_a_valid_unterminated_tail(tmp_path):  # noqa: ANN001, ANN201
+    serialized = "".join(
+        event.model_dump_json() + "\n" for event in _generated_events(seed=43, count=12)
+    )
+    path = tmp_path / "events.jsonl"
+    path.write_text(serialized.rstrip("\n"))
+
+    _assert_matches_eager_store(path)
+
+    lazy_path = tmp_path / "lazy.jsonl"
+    eager_path = tmp_path / "eager.jsonl"
+    lazy_path.write_text(serialized.rstrip("\n"))
+    eager_path.write_text(serialized.rstrip("\n"))
+    appended = make_event(EventType.OUTPUT, "after repair")
+    EventStore(lazy_path, run_id="reference").append(appended)
+    _EagerEventStore(eager_path, run_id="reference").append(appended)
+
+    assert lazy_path.read_bytes() == eager_path.read_bytes()
+    # The repair terminates the final record instead of concatenating onto it.
+    assert lazy_path.read_bytes().startswith(serialized.encode())
+
+
+def test_lazy_store_matches_eager_store_for_a_complete_invalid_tail(tmp_path):  # noqa: ANN001, ANN201
+    path = tmp_path / "events.jsonl"
+    invalid = (
+        '{"protocol_version":1,"sequence":99,"run_id":"persisted-run",'
+        '"timestamp":"2026-01-01T00:00:00+00:00","type":"output",'
+        '"data":{"kind":"output","stream":"stdout","content":5}}'
+    )
+    path.write_text(
+        "".join(event.model_dump_json() + "\n" for event in _generated_events(seed=47, count=12))
+        + invalid
+        + "\n"
+    )
+    original = path.read_bytes()
+
+    with pytest.raises(ValueError, match="complete final record") as lazy_error:
+        EventStore(path, run_id="active-run")
+    with pytest.raises(ValueError, match="complete final record") as eager_error:
+        _EagerEventStore(path, run_id="reference")
+
+    assert str(lazy_error.value) == str(eager_error.value)
+    assert path.read_bytes() == original
+
+
 def test_a_bounded_read_only_parses_the_records_it_returns(tmp_path):  # noqa: ANN001, ANN201
     path = tmp_path / "events.jsonl"
     count = 6 * _EAGER_TAIL_RECORDS


### PR DESCRIPTION
## Problem

Fixes #586. The run journal (`EventStore` in `src/server/events.py`) could destroy valid history in two ways. First, a syntactically valid final record whose line was never terminated with a newline was accepted at construction, but the next `append()` wrote the new record directly after the existing bytes, producing `{old event}{new event}` on one line. On the next reopen that concatenation no longer parses, the combined line is treated as a malformed tail, and previously valid, durable history silently disappears from the replayed journal. Second, a final record that is complete JSON with a valid header but fails full `RunEvent` validation was treated exactly like an interrupted partial write: silently dropped from the index and physically truncated by the next append. That path erases a fully written record (potentially a terminal or diagnostic event) without ever surfacing that the journal is corrupt.

## Solution

The fix separates the two situations the old code conflated, using a property that makes them mechanically distinguishable: a torn append leaves a strict prefix of a serialized record, and no strict prefix of a JSON object is itself complete JSON. A new `_starts_with_complete_json` helper applies that test to the final line with `json.JSONDecoder.raw_decode`, so a line that merely begins with one complete JSON value (for example two concatenated records) also counts as complete and surfaces as corruption instead of being repaired away as a torn tail. A physically incomplete tail keeps today's recovery semantics (set aside at construction, truncated by the next append). A complete final record that fails validation now raises a `ValueError` naming the byte offset and file (`_complete_invalid_tail_error`), in both the lazy header-scan path and the eager full-parse path, and the file is left untouched for inspection. Separately, the constructor now records whether the file's last byte is a newline (`_ends_without_newline`), and `append()` writes the missing `"\n"` before the first new record so a valid unterminated final record is terminated in place instead of being concatenated onto. Because that observation is made at construction time, `append()` rechecks the file's current tail under the lock before writing the repair newline, so a file removed or replaced since construction is not corrupted by a stale repair. The repair happens exactly once, only when needed, and only under the append lock, so a terminated tail is never touched.

### Architecture

The change is confined to the journal layer that owns durability: `EventStore` in `src/server/events.py`, which both the lazy header-scan reader and the eager full-validation reader go through. No event model, protocol schema, transport, or frontend code changes; consumers see either the same replayed events as before or an explicit corruption error where data was previously destroyed silently. The lazy scan path defers any complete-JSON final line it cannot classify to the eager path, so both paths converge on identical semantics and identical error text, which the new parity tests assert byte for byte.

```mermaid
flowchart TD
    F[run-events.jsonl on disk] --> C[EventStore construction]
    C --> S{final line state}
    S -->|"complete JSON, valid"| OK[indexed normally<br/>missing newline noted]
    S -->|"complete JSON, invalid"| ERR[ValueError: complete final record<br/>at byte offset N failed validation<br/>file left untouched]
    S -->|"incomplete JSON (torn append)"| REC[set aside for repair<br/>earlier history preserved]
    OK --> A[append event]
    REC --> A
    A --> N{tail repair needed?}
    N -->|"missing newline"| W1[write newline first]
    N -->|"torn tail"| W2[truncate at torn offset]
    N -->|no| W3[no repair]
    W1 --> APP[write new record line]
    W2 --> APP
    W3 --> APP
    APP --> R[reopen replays every valid record]
```

## Verification

Automated: five new regression tests, all failing on the unfixed code, cover both failure modes across both store implementations, plus the full server suite, lint, type check, and format check. Manual: a real codex-provider TUI run through the `tui-issue-solver` harness (queue-rs, `spsc`, 1 round) confirmed a healthy run end to end on this branch, with a clean `backend.log` and an on-disk `run-events.jsonl` whose records all parse and whose final record is newline-terminated.

### Correctness properties

- A syntactically valid final JSON record remains valid and replayable after any number of subsequent appends, whether or not the file originally ended with a newline.
- The missing-newline repair is applied exactly once, only under the append lock, and never to a file whose tail is already terminated (asserted byte for byte).
- Only a physically incomplete tail (a strict prefix left by an interrupted write, which can never be complete JSON) is recovered by silent truncation; a complete final record that fails validation, including a line holding concatenated complete records, raises a `ValueError` naming the byte offset and path, and the file is not modified.
- The append-time newline repair is judged against the file's bytes at append time, not against the construction-time observation, so an external removal or replacement of the file between construction and append cannot receive a stray leading newline.
- The lazy header-scan store and the eager full-parse store produce byte-identical files after repair and identical error messages on corruption, so the two read paths cannot diverge on tail semantics.
- Records earlier than the final line keep today's behavior: any validation failure there remains a hard error.

### Testing

- `tests/server/test_event_store.py`: `test_append_preserves_a_valid_unterminated_final_record` (the issue's exact reproduction: write a record without a trailing newline, append, reopen, both records replay), `test_append_writes_no_repair_newline_after_a_terminated_tail`, `test_a_missing_final_newline_is_repaired_exactly_once`, and `test_a_complete_but_invalid_final_record_raises_instead_of_truncating`. Before the fix the reproduction test failed with the second event unreadable and the corruption test failed because the invalid record was silently truncated; after the fix all pass.
- `tests/server/test_event_store.py`: `test_append_after_external_removal_starts_the_new_file_cleanly` (unlink the file after construction, append, the fresh file holds exactly the new record with no stray leading newline) and `test_concatenated_final_records_raise_instead_of_truncating` (a final line holding two complete records raises the byte-offset `ValueError` and the file is untouched).
- `tests/server/test_lazy_event_store.py`: `test_lazy_store_matches_eager_store_for_a_valid_unterminated_tail`, `test_lazy_store_matches_eager_store_for_a_complete_invalid_tail`, and `test_lazy_store_matches_eager_store_for_a_concatenated_tail` assert lazy/eager parity, including identical error text and that the repaired file still starts with the original serialized bytes while a corrupt file is left byte-identical.
- `uv run pytest tests/server`: 274 passed.
- `uv run ruff check src/server/events.py tests/server/test_event_store.py tests/server/test_lazy_event_store.py`, `uv run ty check`, and `./scripts/check_format.sh`: clean.
- Codex-provider harness run (`runtui.sh start 200x50 spsc`, model `gpt-5.6-sol`, 1 round): healthy landing and live round, no tracebacks or protocol errors in `backend.log`, and the session's `run-events.jsonl` contained only valid newline-terminated records.

Closes #586.
