### PR TITLE
TUI: make tail bootstrap use one atomic watermark

### DIFF
--- a/src/server/api/service.py
+++ b/src/server/api/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from server.api.design import DesignLog
@@ -56,6 +57,17 @@ if TYPE_CHECKING:
     from server.journal import EventJournal
     from server.settings import InteractiveSetupDefaults
     from vibesys.loops.agent.model import AgentRunState
+
+
+@dataclass(frozen=True)
+class SubscriptionBootstrap:
+    """One journal state captured atomically for a subscription bootstrap."""
+
+    run_id: str
+    floor: int
+    through_sequence: int
+    events: list[RunEvent]
+    active_executions: list[ActiveAgentExecution]
 
 
 class RunApi:
@@ -226,6 +238,29 @@ class RunApi:
                 after_sequence, bootstrap_spine=bootstrap_spine
             )
             return through_sequence, events, self._executions.active_locked()
+
+    def subscription_bootstrap(
+        self, after_sequence: int, tail: int | None
+    ) -> SubscriptionBootstrap:
+        """Capture one atomic bootstrap state for a new or restarted subscription.
+
+        Appends acquire the same condition, so computing the tail floor and
+        reading the checkpoint under one acquisition keeps the replay bounded
+        by ``tail`` no matter how many events land during the bootstrap.
+        """
+        with self._condition:
+            latest = self._journal.latest_sequence_locked()
+            floor = after_sequence if tail is None else max(after_sequence, latest - tail)
+            through_sequence, events = self._journal.checkpoint_locked(
+                floor, bootstrap_spine=tail is not None
+            )
+            return SubscriptionBootstrap(
+                run_id=self._journal.run_id_locked(),
+                floor=floor,
+                through_sequence=through_sequence,
+                events=events,
+                active_executions=self._executions.active_locked(),
+            )
 
     def events(self, after_sequence: int = 0, before_sequence: int | None = None) -> list[RunEvent]:
         """Read journal events within the requested sequence bounds."""

--- a/src/server/transport/unix_jsonl.py
+++ b/src/server/transport/unix_jsonl.py
@@ -25,22 +25,9 @@ from server.api.protocol import (
 from vibesys.unix_socket import validate_socket_path
 
 if TYPE_CHECKING:
-    from server.api.service import RunApi
+    from server.api.service import RunApi, SubscriptionBootstrap
 
 _REQUEST_ADAPTER = TypeAdapter(ProtocolRequest)
-
-
-def _history_floor(request: SubscribeRequest, latest_sequence: int) -> tuple[int, int]:
-    """Return the replay floor, and the floor to report until the next bootstrap.
-
-    Without ``tail`` the reported floor stays 0: the client asked for
-    everything from its own cursor onward, so nothing was withheld and old
-    clients see the field's default.
-    """
-    if request.tail is None:
-        return request.after_sequence, 0
-    floor = max(request.after_sequence, latest_sequence - request.tail)
-    return floor, floor
 
 
 class _RequestHandler(socketserver.StreamRequestHandler):
@@ -77,29 +64,30 @@ class _RequestHandler(socketserver.StreamRequestHandler):
 
     def _stream(self, request: SubscribeRequest) -> None:
         api = self.server.api
-        snapshot = api.snapshot()
+        bootstrap = api.subscription_bootstrap(request.after_sequence, request.tail)
         self._write_message(
             SubscribedMessage(
                 request_id=request.request_id,
-                run_id=snapshot.run_id,
-                latest_sequence=snapshot.sequence,
+                run_id=bootstrap.run_id,
+                latest_sequence=bootstrap.through_sequence,
             )
         )
-        cursor, reported_floor = self._write_bootstrap(api, request, snapshot.sequence)
+        cursor, reported_floor = self._write_bootstrap(request, bootstrap)
         while True:
             if not api.wait_for_change(cursor, timeout=1.0):
                 if self._client_disconnected():
                     return
                 time.sleep(0.05)
                 continue
-            latest_sequence = api.latest_sequence
-            if request.tail is not None and latest_sequence - cursor > request.tail:
+            if request.tail is not None and api.latest_sequence - cursor > request.tail:
                 # The run's durable event store is attached after the client
                 # subscribes, so a subscription that bootstrapped against the
                 # near-empty server store now faces the whole history as if it
                 # were live output. Bootstrap again at a fresh tail rather than
                 # replay a window the tail bound was meant to exclude.
-                cursor, reported_floor = self._write_bootstrap(api, request, latest_sequence)
+                cursor, reported_floor = self._write_bootstrap(
+                    request, api.subscription_bootstrap(request.after_sequence, request.tail)
+                )
                 continue
             # ``wait_for_change`` only tells us that the stream changed. Take
             # one watermark-consistent snapshot before writing so a resumed
@@ -118,24 +106,25 @@ class _RequestHandler(socketserver.StreamRequestHandler):
 
     def _write_bootstrap(
         self,
-        api: RunApi,
         request: SubscribeRequest,
-        latest_sequence: int,
+        bootstrap: SubscriptionBootstrap,
     ) -> tuple[int, int]:
-        """Send one tail-bounded replay batch; return the new cursor and floor."""
-        history_after, reported_floor = _history_floor(request, latest_sequence)
-        through_sequence, replay, active_executions = api.subscription_checkpoint(
-            history_after, bootstrap_spine=request.tail is not None
-        )
+        """Send one tail-bounded replay batch; return the new cursor and floor.
+
+        Without ``tail`` the reported floor stays 0: the client asked for
+        everything from its own cursor onward, so nothing was withheld and old
+        clients see the field's default.
+        """
+        reported_floor = 0 if request.tail is None else bootstrap.floor
         self._write_message(
             EventBatchMessage(
-                events=replay,
-                through_sequence=through_sequence,
-                active_executions=active_executions,
+                events=bootstrap.events,
+                through_sequence=bootstrap.through_sequence,
+                active_executions=bootstrap.active_executions,
                 history_after_sequence=reported_floor,
             )
         )
-        return through_sequence, reported_floor
+        return bootstrap.through_sequence, reported_floor
 
     def _write_stream_error(self, request_id: str, error: Exception) -> None:
         """Report a replay or stream failure without hiding a live connection."""

--- a/src/server/transport/unix_jsonl.py
+++ b/src/server/transport/unix_jsonl.py
@@ -64,7 +64,24 @@ class _RequestHandler(socketserver.StreamRequestHandler):
 
     def _stream(self, request: SubscribeRequest) -> None:
         api = self.server.api
-        bootstrap = api.subscription_bootstrap(request.after_sequence, request.tail)
+        try:
+            bootstrap = api.subscription_bootstrap(request.after_sequence, request.tail)
+        except Exception:
+            # A bootstrap failure must not reject the dial: the client probes
+            # ``tail`` support by dialing and treats a pre-handshake failure
+            # as a server without the field, so it would retry the whole
+            # history against the same fault. Acknowledge the accepted
+            # subscribe first; the failure then reaches the client as a
+            # stream error, exactly as it did when the replay was read after
+            # the handshake.
+            self._write_message(
+                SubscribedMessage(
+                    request_id=request.request_id,
+                    run_id=api.snapshot().run_id,
+                    latest_sequence=api.latest_sequence,
+                )
+            )
+            raise
         self._write_message(
             SubscribedMessage(
                 request_id=request.request_id,

--- a/tests/server/test_api_transport.py
+++ b/tests/server/test_api_transport.py
@@ -141,9 +141,12 @@ def test_subscription_reports_structured_stream_failure(
             stream.write(SubscribeRequest(after_sequence=0).model_dump_json().encode() + b"\n")
             stream.flush()
             subscribed = json.loads(stream.readline())
+            bootstrap = json.loads(stream.readline())
+            parts.journal.record(EventType.CHAT, "hello", status="answered")
             failure = json.loads(stream.readline())
 
     assert subscribed["type"] == "subscribed"
+    assert bootstrap["type"] == "event_batch"
     assert failure["type"] == "protocol_error"
     assert failure["request_id"] == subscribed["request_id"]
     assert failure["code"] == "stream_failed"

--- a/tests/server/test_transport_subscription.py
+++ b/tests/server/test_transport_subscription.py
@@ -2,6 +2,7 @@
 
 import json
 import socket
+import threading
 import uuid
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
@@ -25,6 +26,7 @@ from server.events import (
     RunEvent,
     RunStartedData,
 )
+from server.journal import _BOOTSTRAP_SPINE_TYPES
 from server.transport.unix_jsonl import UnixJsonlServer
 
 _TIMESTAMP = datetime(2026, 1, 1, tzinfo=UTC)
@@ -184,6 +186,98 @@ def test_tail_without_spine_events_delivers_only_suffix(tmp_path):  # noqa: ANN0
     _subscribed, batch = _subscribe(parts.api, SubscribeRequest(after_sequence=0, tail=20))
 
     assert [event["sequence"] for event in batch["events"]] == list(range(latest - 19, latest + 1))
+
+
+def _spine_type_values() -> set[str]:
+    return {event_type.value for event_type in _BOOTSTRAP_SPINE_TYPES}
+
+
+def test_bootstrap_tail_stays_bounded_when_events_land_mid_bootstrap(  # noqa: ANN201
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    tail = 40
+    parts = _attach(tmp_path, _round_log(200))
+    original_snapshot = parts.api.snapshot
+    snapshot_watermarks: list[int] = []
+
+    def stale_snapshot():  # noqa: ANN202
+        # Reproduce the bootstrap race deterministically: a burst of appends
+        # lands after the subscription's snapshot but before its checkpoint.
+        snapshot = original_snapshot()
+        snapshot_watermarks.append(snapshot.sequence)
+        for index in range(3000):
+            parts.journal.publish_output("stdout", f"burst-{index}")
+        return snapshot
+
+    monkeypatch.setattr(parts.api, "snapshot", stale_snapshot)
+
+    subscribed, batch = _subscribe(parts.api, SubscribeRequest(after_sequence=0, tail=tail))
+
+    floor = batch["history_after_sequence"]
+    through = batch["through_sequence"]
+    ordinary = [event for event in batch["events"] if event["sequence"] > floor]
+    context = (
+        f"snapshot watermark {snapshot_watermarks or None}, checkpoint watermark {through}, "
+        f"requested tail {tail}, ordinary bootstrap events {len(ordinary)}"
+    )
+    assert len(ordinary) <= tail, context
+    assert through == parts.api.latest_sequence, context
+    assert floor == through - tail, context
+    assert subscribed["latest_sequence"] == through, context
+    pre_floor = [event for event in batch["events"] if event["sequence"] <= floor]
+    assert all(event["type"] in _spine_type_values() for event in pre_floor), context
+    assert all(event["sequence"] <= through for event in batch["events"]), context
+
+
+def test_subscription_bootstrap_captures_one_atomic_state(tmp_path):  # noqa: ANN001, ANN201
+    parts = _attach(tmp_path, _round_log(200))
+    latest = parts.api.latest_sequence
+
+    bootstrap = parts.api.subscription_bootstrap(0, 40)
+
+    assert bootstrap.run_id == parts.api.snapshot().run_id
+    assert bootstrap.through_sequence == latest
+    assert bootstrap.floor == latest - 40
+    ordinary = [event.sequence for event in bootstrap.events if event.sequence > bootstrap.floor]
+    assert ordinary == list(range(bootstrap.floor + 1, bootstrap.through_sequence + 1))
+    pre_floor = [event for event in bootstrap.events if event.sequence <= bootstrap.floor]
+    assert [event.type for event in pre_floor] == [EventType.RUN_STARTED] + [
+        EventType.ROUND_FINISHED
+    ] * (bootstrap.floor // _ROUND_EVERY)
+    assert bootstrap.active_executions == []
+
+    full = parts.api.subscription_bootstrap(0, None)
+    assert full.floor == 0
+    assert full.through_sequence == latest
+    assert [event.sequence for event in full.events] == list(range(1, latest + 1))
+
+
+def test_bootstrap_tail_stays_bounded_under_concurrent_appends(tmp_path):  # noqa: ANN001, ANN201
+    tail = 10
+    parts = _attach(tmp_path, _round_log(200))
+    stop = threading.Event()
+
+    def append_live_output() -> None:
+        index = 0
+        while not stop.is_set() and index < 20_000:
+            parts.journal.publish_output("stdout", f"live-{index}")
+            index += 1
+
+    writer = threading.Thread(target=append_live_output)
+    writer.start()
+    try:
+        _subscribed, batch = _subscribe(parts.api, SubscribeRequest(after_sequence=0, tail=tail))
+    finally:
+        stop.set()
+        writer.join(timeout=5)
+    assert not writer.is_alive()
+
+    floor = batch["history_after_sequence"]
+    ordinary = [event for event in batch["events"] if event["sequence"] > floor]
+    assert len(ordinary) <= tail
+    pre_floor = [event for event in batch["events"] if event["sequence"] <= floor]
+    assert all(event["type"] in _spine_type_values() for event in pre_floor)
+    assert all(event["sequence"] <= batch["through_sequence"] for event in batch["events"])
 
 
 def test_checkpoint_parses_only_tail_and_spine(tmp_path):  # noqa: ANN001, ANN201

--- a/tests/server/test_transport_subscription.py
+++ b/tests/server/test_transport_subscription.py
@@ -197,19 +197,19 @@ def test_bootstrap_tail_stays_bounded_when_events_land_mid_bootstrap(  # noqa: A
 ):
     tail = 40
     parts = _attach(tmp_path, _round_log(200))
-    original_snapshot = parts.api.snapshot
-    snapshot_watermarks: list[int] = []
+    original_bootstrap = parts.api.subscription_bootstrap
+    pre_burst_watermarks: list[int] = []
 
-    def stale_snapshot():  # noqa: ANN202
+    def bursty_bootstrap(after_sequence: int, tail_bound: int | None):  # noqa: ANN202
         # Reproduce the bootstrap race deterministically: a burst of appends
-        # lands after the subscription's snapshot but before its checkpoint.
-        snapshot = original_snapshot()
-        snapshot_watermarks.append(snapshot.sequence)
+        # lands after the handler commits to bootstrapping but before the
+        # bootstrap's own locked read.
+        pre_burst_watermarks.append(parts.api.latest_sequence)
         for index in range(3000):
             parts.journal.publish_output("stdout", f"burst-{index}")
-        return snapshot
+        return original_bootstrap(after_sequence, tail_bound)
 
-    monkeypatch.setattr(parts.api, "snapshot", stale_snapshot)
+    monkeypatch.setattr(parts.api, "subscription_bootstrap", bursty_bootstrap)
 
     subscribed, batch = _subscribe(parts.api, SubscribeRequest(after_sequence=0, tail=tail))
 
@@ -217,9 +217,11 @@ def test_bootstrap_tail_stays_bounded_when_events_land_mid_bootstrap(  # noqa: A
     through = batch["through_sequence"]
     ordinary = [event for event in batch["events"] if event["sequence"] > floor]
     context = (
-        f"snapshot watermark {snapshot_watermarks or None}, checkpoint watermark {through}, "
+        f"pre-burst watermarks {pre_burst_watermarks or None}, checkpoint watermark {through}, "
         f"requested tail {tail}, ordinary bootstrap events {len(ordinary)}"
     )
+    assert len(pre_burst_watermarks) == 1, context
+    assert through == pre_burst_watermarks[0] + 3000, context
     assert len(ordinary) <= tail, context
     assert through == parts.api.latest_sequence, context
     assert floor == through - tail, context
@@ -227,6 +229,30 @@ def test_bootstrap_tail_stays_bounded_when_events_land_mid_bootstrap(  # noqa: A
     pre_floor = [event for event in batch["events"] if event["sequence"] <= floor]
     assert all(event["type"] in _spine_type_values() for event in pre_floor), context
     assert all(event["sequence"] <= through for event in batch["events"]), context
+
+
+def test_bootstrap_failure_surfaces_after_the_handshake(  # noqa: ANN201
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    parts = _attach(tmp_path, _round_log(50))
+    latest = parts.api.latest_sequence
+
+    def failing_bootstrap(_after_sequence: int, _tail: int | None):  # noqa: ANN202
+        raise RuntimeError
+
+    monkeypatch.setattr(parts.api, "subscription_bootstrap", failing_bootstrap)
+
+    with _live_subscription(parts.api, SubscribeRequest(after_sequence=0, tail=40)) as read:
+        subscribed = read()
+        failure = read()
+
+    # The dial itself must succeed: the client probes tail support by dialing
+    # and treats a pre-handshake failure as a server without the field, so a
+    # transient replay fault would otherwise trigger a full-history retry.
+    assert subscribed["type"] == "subscribed"
+    assert subscribed["latest_sequence"] == latest
+    assert failure["type"] == "protocol_error"
+    assert failure["code"] == "stream_failed"
 
 
 def test_subscription_bootstrap_captures_one_atomic_state(tmp_path):  # noqa: ANN001, ANN201


### PR DESCRIPTION
## Problem

Fixes #587. A tail subscription's bootstrap was assembled from two different journal states. The transport handler called `api.snapshot()` to get a sequence watermark, computed the history floor as `latest_sequence - tail` from that watermark, and only then called `subscription_checkpoint()` against the current store. Any events appended between those two reads made the computed floor stale: a request for the newest 1,000 events could receive the entire history. That defeats the bounded-startup contract introduced by #468, and on a long run it reintroduces exactly what that PR removed: a large server-side parse, a huge JSON batch on the wire, a large frontend fold, and delayed first paint. The same racy sequence was duplicated in the in-loop rebootstrap path that re-tails when the durable store attaches mid-subscription.

## Solution

The bootstrap read is moved behind the API boundary into one method that captures everything under a single lock acquisition. `RunApi.subscription_bootstrap(after_sequence, tail)` takes `self._condition` once and, while holding it, reads the latest sequence, computes the floor (`after_sequence` when `tail` is `None`, else `max(after_sequence, latest - tail)`), takes the checkpoint at that floor with the documented pre-floor run-level spine, and reads the run id and active executions. It returns a frozen `SubscriptionBootstrap` dataclass carrying `run_id`, `floor`, `through_sequence`, `events`, and `active_executions`, all describing one journal state. Appends acquire the same condition, so no event can land between the floor computation and the checkpoint. The transport handler (`_stream` in `unix_jsonl.py`) now calls this method for both the initial bootstrap and the in-loop rebootstrap, and no longer calls the racy `snapshot()` at all; the `subscribed` message's `latest_sequence` comes from the same captured watermark. The module-level `_history_floor` helper is deleted, and the one piece of it that was presentation policy rather than journal state (report floor 0 to the client when no tail was requested, because nothing was withheld) moves into `_write_bootstrap` with its rationale.

Moving the bootstrap ahead of the `subscribed` handshake changed one failure ordering: a bootstrap exception used to surface after the handshake (the replay was read later) but would now surface before it, and the client probes `tail` support by dialing and treating a pre-handshake failure as a server without the field, which would send it into a full-history retry against the same fault. The handler therefore acknowledges the accepted subscribe first when the bootstrap raises (run id and watermark from the API) and then lets the failure propagate as the usual `stream_failed` protocol error, preserving the wire ordering the client's fallback logic assumes.

### Architecture

The watermark arithmetic now lives where the lock lives: `RunApi` in `src/server/api/service.py` owns the journal's condition variable, so it is the only layer that can promise atomicity across the floor computation and the checkpoint. The transport layer (`src/server/transport/unix_jsonl.py`) is reduced to framing: it asks the API for one `SubscriptionBootstrap` and serializes it, keeping only the reported-floor presentation rule. No protocol message shape changes, so the frontend is untouched.

```mermaid
sequenceDiagram
    participant C as TUI client
    participant T as transport _stream
    participant A as RunApi.subscription_bootstrap
    participant J as journal (under condition)
    C->>T: subscribe(after_sequence, tail)
    T->>A: subscription_bootstrap(after, tail)
    activate A
    Note over A,J: one condition acquisition,<br/>appends blocked
    A->>J: latest_sequence_locked()
    A->>A: floor = max(after, latest - tail)
    A->>J: checkpoint_locked(floor, bootstrap_spine)
    A->>J: run_id_locked(), active_locked()
    deactivate A
    A-->>T: SubscriptionBootstrap(run_id, floor,<br/>through_sequence, events, active)
    T-->>C: subscribed(latest_sequence=through)
    T-->>C: event batch, at most tail ordinary events + spine
    Note over T: same atomic call reused by the<br/>in-loop rebootstrap when the durable<br/>store attaches mid-subscription
```

## Verification

Automated: a deterministic regression test reproduces the exact pre-fix interleaving (3,000 events landing between the old snapshot read and the checkpoint) and fails on the unfixed code with `3040 <= 40`, recording the snapshot watermark, checkpoint watermark, requested tail, and ordinary bootstrap count that the issue asked for; a unit test pins the atomic method's contract; a stress test races a live writer thread against a real socket subscription. Full server suite, lint, type check, and format check pass. Manual: a real codex-provider TUI run on this branch landed and streamed live events normally with a clean `backend.log`.

### Correctness properties

- The floor, through-sequence watermark, event window, pre-floor spine, run id, and active-execution checkpoint of a bootstrap all describe one journal state, captured under a single acquisition of the same condition that appends take.
- A bootstrap with `tail=N` contains at most `N` ordinary events (sequence above the floor) regardless of concurrent append volume; everything at or below the floor is a documented spine record type.
- `floor == through_sequence - tail` when the journal is longer than the tail, and the `subscribed` message's `latest_sequence` equals the batch's `through_sequence`, so the client's cursor and the replay window cannot disagree.
- Events appended after the captured watermark arrive only in later live batches, never folded into the bootstrap.
- Without `tail`, the client receives everything after its own cursor and the reported floor stays 0, preserving the wire behavior old clients expect.
- A bootstrap failure reaches the client only after the `subscribed` handshake, as a `stream_failed` protocol error, so the client's tail-support probe cannot misread a transient replay fault as an old server and retry the full history.

### Testing

- `tests/server/test_transport_subscription.py::test_bootstrap_tail_stays_bounded_when_events_land_mid_bootstrap`: wraps `subscription_bootstrap` to append a 3,000-event burst after the handler commits to bootstrapping but before the locked read; the bootstrap stays bounded at 40 ordinary events with the correct floor, through-sequence, and spine-only pre-floor records. (On the pre-fix code the equivalent race was injected through the then-live `snapshot()` hook and failed with `assert 3040 <= 40`.)
- `tests/server/test_transport_subscription.py::test_bootstrap_failure_surfaces_after_the_handshake`: monkeypatches `subscription_bootstrap` to raise and asserts the wire carries `subscribed` first and then a `protocol_error` with code `stream_failed`; without the handshake-first guard the failure arrives before the handshake and the test fails.
- `tests/server/test_transport_subscription.py::test_subscription_bootstrap_captures_one_atomic_state`: pins the returned `SubscriptionBootstrap` for both `tail=40` (bounded window, exact spine sequence) and `tail=None` (floor 0, full replay).
- `tests/server/test_transport_subscription.py::test_bootstrap_tail_stays_bounded_under_concurrent_appends`: a writer thread appends up to 20,000 live events while a real socket client subscribes with `tail=10`; the batch never exceeds 10 ordinary events.
- `tests/server/test_api_transport.py`: the stream-failure test now triggers its fault through a live append instead of the removed bootstrap-time `snapshot()` call, keeping the stream-error path covered.
- `uv run pytest tests/server`: 269 passed. `uv run ruff check`, `uv run ty check`, `./scripts/check_format.sh`: clean.
- Codex-provider harness run (`runtui.sh start 200x50 spsc`, model `gpt-5.6-sol`, 1 round): healthy landing, live streaming through the new bootstrap path, no tracebacks or protocol errors in `backend.log`.

Closes #587.
