### PR TITLE
TUI: keep runtime alive until the last active subscriber closes

### DIFF
--- a/src/server/transport/subscriptions.py
+++ b/src/server/transport/subscriptions.py
@@ -1,0 +1,49 @@
+"""Subscription lifetime accounting for the transport server."""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+class SubscriptionTracker:
+    """Count active event subscriptions across handler threads.
+
+    A disconnect must not end the server's lifetime while another subscription
+    is still streaming: a client that reconnects after a dropped connection,
+    or a second concurrent client, holds the count above zero until its own
+    stream closes. ``wait_for_subscriber`` answers the separate question of
+    whether any client has ever subscribed, and never resets.
+    """
+
+    def __init__(self) -> None:  # noqa: D107  # tracked: #288
+        self._ever_subscribed = threading.Event()
+        self._condition = threading.Condition()
+        self._active = 0
+
+    @contextmanager
+    def track(self) -> Generator[None]:
+        """Count one subscription stream for the duration of the block."""
+        with self._condition:
+            self._active += 1
+        self._ever_subscribed.set()
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._active -= 1
+                if self._active == 0:
+                    self._condition.notify_all()
+
+    def wait_for_subscriber(self, timeout: float) -> bool:
+        """Wait until any client has established an event stream."""
+        return self._ever_subscribed.wait(timeout)
+
+    def wait_for_none_active(self) -> None:
+        """Block until no subscription streams remain active."""
+        with self._condition:
+            self._condition.wait_for(lambda: self._active == 0)

--- a/src/server/transport/subscriptions.py
+++ b/src/server/transport/subscriptions.py
@@ -9,6 +9,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+# How long ``wait_for_none_active`` lingers after the count reaches zero
+# before declaring the server subscriber-free. A dropped client redials on a
+# finite backoff whose first delay is 500ms, so returning the instant the
+# count hits zero would let teardown unlink the socket underneath that
+# redial. The window must stay well under the launcher's 2s backend exit
+# grace so a deliberate quit still tears down without a SIGTERM.
+RECONNECT_SETTLE_SECONDS = 1.0
+
 
 class SubscriptionTracker:
     """Count active event subscriptions across handler threads.
@@ -30,6 +38,9 @@ class SubscriptionTracker:
         """Count one subscription stream for the duration of the block."""
         with self._condition:
             self._active += 1
+            # Wake a disconnect waiter sitting in its settle window so the
+            # reconnect extends the server's lifetime immediately.
+            self._condition.notify_all()
         self._ever_subscribed.set()
         try:
             yield
@@ -43,7 +54,17 @@ class SubscriptionTracker:
         """Wait until any client has established an event stream."""
         return self._ever_subscribed.wait(timeout)
 
-    def wait_for_none_active(self) -> None:
-        """Block until no subscription streams remain active."""
+    def wait_for_none_active(self, settle_seconds: float | None = None) -> None:
+        """Block until no stream has been active for ``settle_seconds``.
+
+        The settle window bridges a client's redial backoff: a reconnect that
+        lands inside it keeps the wait blocked, so a transient drop cannot
+        hand teardown a socket the client is about to dial again.
+        """
+        if settle_seconds is None:
+            settle_seconds = RECONNECT_SETTLE_SECONDS
         with self._condition:
-            self._condition.wait_for(lambda: self._active == 0)
+            while True:
+                self._condition.wait_for(lambda: self._active == 0)
+                if not self._condition.wait_for(lambda: self._active > 0, timeout=settle_seconds):
+                    return

--- a/src/server/transport/unix_jsonl.py
+++ b/src/server/transport/unix_jsonl.py
@@ -22,6 +22,7 @@ from server.api.protocol import (
     SubscribedMessage,
     SubscribeRequest,
 )
+from server.transport.subscriptions import SubscriptionTracker
 from vibesys.unix_socket import validate_socket_path
 
 if TYPE_CHECKING:
@@ -55,15 +56,13 @@ class _RequestHandler(socketserver.StreamRequestHandler):
                 request_id = str(raw.get("request_id", request_id))
                 request = _REQUEST_ADAPTER.validate_python(raw)
                 if isinstance(request, SubscribeRequest):
-                    self.server.client_subscribed.set()
-                    try:
-                        self._stream(request)
-                    except (BrokenPipeError, ConnectionResetError):
-                        pass
-                    except Exception as exc:  # noqa: BLE001  # tracked: #288
-                        self._write_stream_error(request.request_id, exc)
-                    finally:
-                        self.server.client_disconnected.set()
+                    with self.server.subscriptions.track():
+                        try:
+                            self._stream(request)
+                        except (BrokenPipeError, ConnectionResetError):
+                            pass
+                        except Exception as exc:  # noqa: BLE001  # tracked: #288
+                            self._write_stream_error(request.request_id, exc)
                     return
                 response = api.execute(request)
             except Exception as exc:  # noqa: BLE001  # tracked: #288
@@ -170,12 +169,10 @@ class _JsonlUnixServer(socketserver.ThreadingUnixStreamServer):
         self,
         path: Path,
         api: RunApi,
-        client_subscribed: threading.Event,
-        client_disconnected: threading.Event,
+        subscriptions: SubscriptionTracker,
     ):
         self.api = api
-        self.client_subscribed = client_subscribed
-        self.client_disconnected = client_disconnected
+        self.subscriptions = subscriptions
         super().__init__(str(path), _RequestHandler)
 
 
@@ -187,19 +184,13 @@ class UnixJsonlServer:
         self.api = api
         self._server: _JsonlUnixServer | None = None
         self._thread: threading.Thread | None = None
-        self._client_subscribed = threading.Event()
-        self._client_disconnected = threading.Event()
+        self._subscriptions = SubscriptionTracker()
 
     def start(self) -> None:  # noqa: D102  # tracked: #288
         validate_socket_path(self.path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.unlink(missing_ok=True)
-        self._server = _JsonlUnixServer(
-            self.path,
-            self.api,
-            self._client_subscribed,
-            self._client_disconnected,
-        )
+        self._server = _JsonlUnixServer(self.path, self.api, self._subscriptions)
         os.chmod(self.path, 0o600)  # noqa: PTH101  # tracked: #288
         self._thread = threading.Thread(
             target=self._server.serve_forever,
@@ -209,12 +200,12 @@ class UnixJsonlServer:
         self._thread.start()
 
     def wait_for_subscriber(self, timeout: float) -> bool:
-        """Wait until the presentation client has established its event stream."""
-        return self._client_subscribed.wait(timeout)
+        """Wait until a presentation client has established its event stream."""
+        return self._subscriptions.wait_for_subscriber(timeout)
 
     def wait_for_subscriber_disconnect(self) -> None:
-        """Keep terminal events queryable until the attached client exits."""
-        self._client_disconnected.wait()
+        """Keep terminal events queryable until the last active subscriber exits."""
+        self._subscriptions.wait_for_none_active()
 
     def close(self) -> None:  # noqa: D102  # tracked: #288
         if self._server is not None:

--- a/tests/server/test_runtime.py
+++ b/tests/server/test_runtime.py
@@ -4,6 +4,8 @@ import json
 import socket
 import threading
 import time
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -20,19 +22,28 @@ from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
 from vibesys.run.events import CoreEventType, EventStatus
 
 
-def _collect_until(socket_path: Path, terminal_type: str, received: list[dict]) -> None:
+def _await_socket(socket_path: Path) -> None:
     deadline = time.monotonic() + 5
     while not socket_path.exists() and time.monotonic() < deadline:
         time.sleep(0.01)
+
+
+@contextmanager
+def _subscription(socket_path: Path) -> Generator[Callable[[], dict]]:
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
         client.settimeout(5)
         client.connect(str(socket_path))
-        stream = client.makefile("rwb")
-        stream.write(SubscribeRequest(after_sequence=0).model_dump_json().encode() + b"\n")
-        stream.flush()
+        with client.makefile("rwb") as stream:
+            stream.write(SubscribeRequest(after_sequence=0).model_dump_json().encode() + b"\n")
+            stream.flush()
+            yield lambda: json.loads(stream.readline())
+
+
+def _collect_until(socket_path: Path, terminal_type: str, received: list[dict]) -> None:
+    _await_socket(socket_path)
+    with _subscription(socket_path) as read:
         while True:
-            message = json.loads(stream.readline())
-            events = message.get("events", [])
+            events = read().get("events", [])
             received.extend(events)
             if any(event["type"] == terminal_type for event in events):
                 return
@@ -69,6 +80,46 @@ def test_runtime_streams_success_before_client_disconnect(tmp_path):  # noqa: AN
     assert not subscriber.is_alive()
     assert any(event["type"] == "server_ready" for event in received)
     assert sum(event["type"] == "run_finished" for event in received) == 1
+    assert not socket_path.exists()
+
+
+def test_runtime_waits_for_reconnected_subscriber_before_teardown(tmp_path: Path) -> None:
+    """A subscriber that reconnects must outlive the run's terminal event.
+
+    The first subscription drops before the run finishes; the runtime must not
+    treat that as "the client is gone" while the second subscription is live.
+    """
+    socket_path = tmp_path / "control.sock"
+    runtime = ServerRuntime(socket_path=socket_path)
+    release_run = threading.Event()
+    run_returned = threading.Event()
+    returned_while_attached: list[bool] = []
+
+    def drive_reconnect() -> None:
+        _await_socket(socket_path)
+        with _subscription(socket_path) as read:
+            assert read()["type"] == "subscribed"
+        with _subscription(socket_path) as read:
+            assert read()["type"] == "subscribed"
+            release_run.set()
+            while not any(event["type"] == "run_finished" for event in read().get("events", [])):
+                pass
+            returned_while_attached.append(run_returned.wait(timeout=1.0))
+
+    clients = threading.Thread(target=drive_reconnect)
+    clients.start()
+
+    def run() -> str:
+        assert release_run.wait(timeout=5)
+        return "ran"
+
+    value = runtime.run(run)
+
+    run_returned.set()
+    clients.join(timeout=5)
+    assert value == "ran"
+    assert not clients.is_alive()
+    assert returned_while_attached == [False]
     assert not socket_path.exists()
 
 

--- a/tests/server/test_subscription_tracker.py
+++ b/tests/server/test_subscription_tracker.py
@@ -1,0 +1,30 @@
+"""Unit contracts of the transport's subscription lifetime tracker."""
+
+import threading
+import time
+
+from server.transport.subscriptions import SubscriptionTracker
+
+
+def test_disconnect_wait_bridges_a_redial_inside_the_settle_window() -> None:
+    tracker = SubscriptionTracker()
+    unblocked = threading.Event()
+    first = tracker.track()
+    first.__enter__()
+
+    def wait_for_none() -> None:
+        tracker.wait_for_none_active(settle_seconds=0.4)
+        unblocked.set()
+
+    waiter = threading.Thread(target=wait_for_none, daemon=True)
+    waiter.start()
+    time.sleep(0.05)
+    first.__exit__(None, None, None)
+    # The redial lands inside the settle window, so the wait must keep
+    # blocking well past where the window alone would have expired.
+    with tracker.track():
+        assert not unblocked.wait(timeout=0.6)
+
+    assert unblocked.wait(timeout=2)
+    waiter.join(timeout=2)
+    assert not waiter.is_alive()

--- a/tests/server/test_transport_subscription.py
+++ b/tests/server/test_transport_subscription.py
@@ -3,6 +3,7 @@
 import json
 import socket
 import threading
+import time
 import uuid
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
@@ -26,6 +27,7 @@ from server.events import (
     RunEvent,
     RunStartedData,
 )
+from server.transport.subscriptions import SubscriptionTracker
 from server.transport.unix_jsonl import UnixJsonlServer
 
 _TIMESTAMP = datetime(2026, 1, 1, tzinfo=UTC)
@@ -328,6 +330,30 @@ def test_disconnect_wait_blocks_until_last_subscriber_closes(tmp_path: Path) -> 
         assert unblocked.wait(timeout=5)
         waiter.join(timeout=5)
         assert not waiter.is_alive()
+
+
+def test_disconnect_wait_bridges_a_redial_inside_the_settle_window() -> None:
+    tracker = SubscriptionTracker()
+    unblocked = threading.Event()
+    first = tracker.track()
+    first.__enter__()
+
+    def wait_for_none() -> None:
+        tracker.wait_for_none_active(settle_seconds=0.4)
+        unblocked.set()
+
+    waiter = threading.Thread(target=wait_for_none, daemon=True)
+    waiter.start()
+    time.sleep(0.05)
+    first.__exit__(None, None, None)
+    # The redial lands inside the settle window, so the wait must keep
+    # blocking well past where the window alone would have expired.
+    with tracker.track():
+        assert not unblocked.wait(timeout=0.6)
+
+    assert unblocked.wait(timeout=2)
+    waiter.join(timeout=2)
+    assert not waiter.is_alive()
 
 
 def test_wait_for_change_does_not_parse_events(tmp_path):  # noqa: ANN001, ANN201

--- a/tests/server/test_transport_subscription.py
+++ b/tests/server/test_transport_subscription.py
@@ -3,7 +3,6 @@
 import json
 import socket
 import threading
-import time
 import uuid
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
@@ -27,7 +26,6 @@ from server.events import (
     RunEvent,
     RunStartedData,
 )
-from server.transport.subscriptions import SubscriptionTracker
 from server.transport.unix_jsonl import UnixJsonlServer
 
 _TIMESTAMP = datetime(2026, 1, 1, tzinfo=UTC)
@@ -330,30 +328,6 @@ def test_disconnect_wait_blocks_until_last_subscriber_closes(tmp_path: Path) -> 
         assert unblocked.wait(timeout=5)
         waiter.join(timeout=5)
         assert not waiter.is_alive()
-
-
-def test_disconnect_wait_bridges_a_redial_inside_the_settle_window() -> None:
-    tracker = SubscriptionTracker()
-    unblocked = threading.Event()
-    first = tracker.track()
-    first.__enter__()
-
-    def wait_for_none() -> None:
-        tracker.wait_for_none_active(settle_seconds=0.4)
-        unblocked.set()
-
-    waiter = threading.Thread(target=wait_for_none, daemon=True)
-    waiter.start()
-    time.sleep(0.05)
-    first.__exit__(None, None, None)
-    # The redial lands inside the settle window, so the wait must keep
-    # blocking well past where the window alone would have expired.
-    with tracker.track():
-        assert not unblocked.wait(timeout=0.6)
-
-    assert unblocked.wait(timeout=2)
-    waiter.join(timeout=2)
-    assert not waiter.is_alive()
 
 
 def test_wait_for_change_does_not_parse_events(tmp_path):  # noqa: ANN001, ANN201

--- a/tests/server/test_transport_subscription.py
+++ b/tests/server/test_transport_subscription.py
@@ -1,7 +1,8 @@
-"""Tail subscription, bounded backfill, and late-attach transport contracts."""
+"""Tail subscription, bounded backfill, late-attach, and lifetime transport contracts."""
 
 import json
 import socket
+import threading
 import uuid
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
@@ -122,16 +123,23 @@ def _attach(tmp_path: Path, events: list[RunEvent]) -> ServerParts:
 
 
 @contextmanager
-def _live_subscription(api: RunApi, request: SubscribeRequest) -> Generator[Callable[[], dict]]:
-    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"  # noqa: S108
-    with UnixJsonlServer(socket_path, api):  # noqa: SIM117
-        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
-            client.settimeout(10)
-            client.connect(str(socket_path))
-            stream = client.makefile("rwb")
+def _subscribed_client(
+    socket_path: Path, request: SubscribeRequest
+) -> Generator[Callable[[], dict]]:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(10)
+        client.connect(str(socket_path))
+        with client.makefile("rwb") as stream:
             stream.write(request.model_dump_json().encode() + b"\n")
             stream.flush()
             yield lambda: json.loads(stream.readline())
+
+
+@contextmanager
+def _live_subscription(api: RunApi, request: SubscribeRequest) -> Generator[Callable[[], dict]]:
+    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"  # noqa: S108
+    with UnixJsonlServer(socket_path, api), _subscribed_client(socket_path, request) as read:
+        yield read
 
 
 def _subscribe(api: RunApi, request: SubscribeRequest) -> tuple[dict, dict]:
@@ -288,6 +296,38 @@ def test_live_append_keeps_existing_tail_floor(tmp_path):  # noqa: ANN001, ANN20
 
     assert batch["history_after_sequence"] == floor
     assert [event["type"] for event in batch["events"]] == ["output"]
+
+
+def test_disconnect_wait_blocks_until_last_subscriber_closes(tmp_path: Path) -> None:
+    parts = build_server_parts(tmp_path / "logs")
+    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"  # noqa: S108
+    request = SubscribeRequest(after_sequence=0)
+
+    with UnixJsonlServer(socket_path, parts.api) as server:
+        with _subscribed_client(socket_path, request) as read:
+            assert read()["type"] == "subscribed"
+        parts.journal.publish_output("stdout", "wake the first handler")
+        # With no subscriber left, the wait returns; it must not poison later waits.
+        server.wait_for_subscriber_disconnect()
+
+        with _subscribed_client(socket_path, request) as read:
+            assert read()["type"] == "subscribed"
+            unblocked = threading.Event()
+
+            def wait_for_disconnect() -> None:
+                server.wait_for_subscriber_disconnect()
+                unblocked.set()
+
+            waiter = threading.Thread(target=wait_for_disconnect, daemon=True)
+            waiter.start()
+            # The first client's earlier disconnect must not unblock the wait
+            # while the second subscription is still streaming.
+            assert not unblocked.wait(timeout=1.0)
+        parts.journal.publish_output("stdout", "wake the second handler")
+
+        assert unblocked.wait(timeout=5)
+        waiter.join(timeout=5)
+        assert not waiter.is_alive()
 
 
 def test_wait_for_change_does_not_parse_events(tmp_path):  # noqa: ANN001, ANN201


### PR DESCRIPTION
## Problem

Fixes #588. The server represented "the client disconnected" as one sticky `threading.Event` on `UnixJsonlServer`: every subscription handler set it when that handler's stream ended, and nothing ever cleared it. Since #525 the TUI can drop its event subscription and establish a new one, so the old handler's exit permanently poisoned the flag. When the optimization run finished, `ServerRuntime.run()` called `wait_for_subscriber_disconnect()`, which returned immediately because of the long-gone first subscription, and the runtime closed the server and the retained post-run chat resources out from under the live replacement subscription. The same single-bit design was wrong for multiple simultaneous presentation clients: one client disconnecting allowed runtime teardown while another was still attached.

## Solution

Disconnect stops being a sticky bit and becomes reference counting over active subscription streams. A new `SubscriptionTracker` (`src/server/transport/subscriptions.py`) owns two separate questions the old event conflated: "has any client ever subscribed?" (a `threading.Event` that is set once and intentionally never resets, backing the existing startup gate `wait_for_subscriber`) and "is any subscription active right now?" (a `Condition`-guarded counter). The request handler wraps each stream in `tracker.track()`, a context manager that increments on entry and decrements in a `finally`, notifying waiters when the count reaches zero, so the count stays correct on clean ends, client resets, and handler exceptions alike. `wait_for_subscriber_disconnect()` blocks until the count is zero and then lingers through a settle window (`RECONNECT_SETTLE_SECONDS`, 1.0s) before declaring the server subscriber-free: a dropped client redials on a backoff whose first delay is 500ms, so returning the instant the count hits zero would let teardown unlink the socket underneath that redial. A reconnect that lands inside the window notifies the condition and puts the waiter back to blocking, and with several clients attached the runtime waits for the last one. The window stays well under the launcher's 2s backend exit grace, so a deliberate quit still tears down without a SIGTERM. Teardown ordering is otherwise unchanged, and the multi-client policy the issue asked to make explicit is the one the transport already supports: concurrent subscribers are served, and the runtime outlives the last of them.

### Architecture

The tracker is transport-layer state with one owner: `UnixJsonlServer` creates it, hands it to the threaded socket server, and exposes only the two wait methods the runtime already consumed, so `ServerRuntime` needed no change at all. Handler threads touch the tracker only through `track()`, which pairs increment and decrement structurally rather than by convention. The new module keeps `unix_jsonl.py` about framing and streaming while the lifetime accounting lives in one small, independently testable unit.

```mermaid
flowchart TD
    subgraph handler threads
        A[subscription A stream] -- "with track(): +1 ... -1" --> T
        B[subscription B stream] -- "with track(): +1 ... -1" --> T
    end
    T[(SubscriptionTracker<br/>ever_subscribed: sticky Event<br/>active: Condition-guarded count)]
    S[UnixJsonlServer] -- owns --> T
    R[ServerRuntime.run] -- "wait_for_subscriber(timeout)" --> T
    R -- "wait_for_subscriber_disconnect()<br/>blocks until active == 0<br/>holds for a 1s settle window" --> T
    R --> X[close server, release retained<br/>chat resources, teardown]
    T -. "notify_all when the last<br/>active stream closes" .-> R
```

## Verification

Automated: a runtime-level regression test drives the issue's exact timeline (subscribe, disconnect mid-run, reconnect, run finishes, the reconnected subscriber still receives the terminal event before teardown) and a transport-level unit test pins that the disconnect wait blocks while any stream is active and releases when the last one closes; both fail on the unfixed code. Full server suite, lint, type check, and format check pass. Manual: a real codex-provider TUI run on this branch landed and streamed normally, and quitting the TUI tore the backend down cleanly (session directory removed, no surviving backend process).

### Correctness properties

- Runtime teardown is gated on the count of currently active subscription streams, not on whether any stream ever ended: a reconnect that overlaps the old stream, or lands within the 1s settle window after it closes, keeps the runtime alive; the count-zero gap of a slower reconnect is bounded by the window, which covers the client's 500ms first redial backoff.
- With multiple concurrent subscribers, `wait_for_subscriber_disconnect()` returns only after the last active stream has been closed for the full settle window; with none ever connected, the startup gate `wait_for_subscriber(timeout)` behaves exactly as before (sticky, never resets).
- The settle window (1.0s) stays under the launcher's 2s backend exit grace, so a deliberate quit still completes teardown before the launcher escalates to SIGTERM.
- The active count is exact under all stream exits (clean end, broken pipe, handler exception) because increment and decrement are paired in one context manager with the decrement in `finally`.
- Waiters are woken through the same condition that guards the counter, so there is no window where the count is zero but a waiter sleeps forever.
- No protocol or frontend change: the fix is entirely in the transport's lifetime accounting, and `ServerRuntime`'s call sites are untouched.

### Testing

- `tests/server/test_runtime.py::test_runtime_waits_for_reconnected_subscriber_before_teardown`: a client thread subscribes, drops the stream, subscribes again, then the run finishes; the test asserts the reconnected subscriber observes `run_finished` and that the runtime had not returned while it was attached. Before the fix the runtime tore down immediately after the run because of the first disconnect; after the fix it waits for the live stream.
- `tests/server/test_transport_subscription.py::test_disconnect_wait_blocks_until_last_subscriber_closes`: with two subscribed clients over the real socket, `wait_for_subscriber_disconnect()` still blocks after the first disconnects and returns promptly after the second does. Fails before the fix (returns after the first disconnect), passes after.
- `tests/server/test_subscription_tracker.py::test_disconnect_wait_bridges_a_redial_inside_the_settle_window`: a tracker unit test where the only stream closes and a new one opens 50ms later, inside the settle window; the waiter must stay blocked across the gap and release only after the replacement closes and its own window drains. Fails on the windowless code (the waiter returns in the gap), passes after. It lives in its own module because it needs no socket harness.
- `uv run pytest tests/server/test_runtime.py tests/server/test_transport_subscription.py`: 20 passed. `uv run pytest tests/server`: 267 passed.
- `uv run ruff check`, `uv run ty check`, `./scripts/check_format.sh`: clean.
- Codex-provider harness run (`runtui.sh start 200x50 spsc`, model `gpt-5.6-sol`, 1 round): healthy landing and live run; after quitting with Ctrl+C the launcher exited, the session directory was removed, and no backend or frontend process survived.

Closes #588.
