### PR TITLE
TUI: terminate the frontend when the backend exits unexpectedly

### DIFF
--- a/clients/tui/src/launcher.test.ts
+++ b/clients/tui/src/launcher.test.ts
@@ -230,6 +230,52 @@ connect(process.env.VIBESYS_CONTROL_SOCKET);
     await expect(launch(['--stub-agent', '--runs-dir', '/tmp/vibesys-test-runs'])).resolves.toBe(3);
   }, 15_000);
 
+  it('pins the backend failure code when the frontend exits 0 within the grace window after backend death', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'vs-launcher-test-'));
+    const backend = await writeExecutable(
+      'dying-backend.mjs',
+      `
+import {createServer} from 'node:net';
+const socketPath = process.argv[process.argv.indexOf('--control-socket') + 1];
+const server = createServer(() => {
+  setTimeout(() => process.exit(7), 100);
+});
+server.listen(socketPath);
+`,
+    );
+    const frontend = await writeExecutable(
+      'clean-exit-frontend.mjs',
+      `
+import {createConnection} from 'node:net';
+setInterval(() => undefined, 1000);
+let connected = false;
+function connect(path) {
+  const socket = createConnection(path);
+  socket.once('connect', () => {
+    connected = true;
+  });
+  socket.once('close', () => {
+    // Exit as if the run had finished cleanly, well within the launcher's
+    // grace window but after it saw the backend exit. The backend's
+    // failure must still win: a frontend that happens to exit 0 here is
+    // not evidence the run succeeded.
+    if (connected) setTimeout(() => process.exit(0), 300);
+  });
+  socket.on('error', () => {
+    if (!connected) setTimeout(() => connect(path), 25);
+  });
+}
+connect(process.env.VIBESYS_CONTROL_SOCKET);
+`,
+    );
+
+    process.env['VIBESYS_PYTHON'] = backend;
+    process.env['VIBESYS_TUI_RUNTIME'] = process.execPath;
+    process.env['VIBESYS_TUI_ENTRYPOINT'] = frontend;
+
+    await expect(launch(['--stub-agent', '--runs-dir', '/tmp/vibesys-test-runs'])).resolves.toBe(7);
+  }, 15_000);
+
   it('starts a headless backend and runs the frontend', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'vs-launcher-test-'));
     const backendTerminated = join(tempDir, 'backend-terminated');

--- a/clients/tui/src/launcher.test.ts
+++ b/clients/tui/src/launcher.test.ts
@@ -139,6 +139,97 @@ setInterval(() => undefined, 1000);
     expect(errors.join('\n')).toContain('configuration is unreadable');
   }, 15_000);
 
+  it('terminates a lingering frontend when the backend dies after it listens', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'vs-launcher-test-'));
+    const frontendTerminated = join(tempDir, 'frontend-terminated');
+    const backend = await writeExecutable(
+      'dying-backend.mjs',
+      `
+import {createServer} from 'node:net';
+const socketPath = process.argv[process.argv.indexOf('--control-socket') + 1];
+const server = createServer(() => {
+  // Unexpected death after the client attached, with no terminal event.
+  setTimeout(() => process.exit(7), 100);
+});
+server.listen(socketPath);
+`,
+    );
+    const frontend = await writeExecutable(
+      'lingering-frontend.mjs',
+      `
+import {writeFileSync} from 'node:fs';
+import {createConnection} from 'node:net';
+process.on('SIGTERM', () => {
+  writeFileSync(${JSON.stringify(frontendTerminated)}, 'terminated');
+  process.exit(143);
+});
+setInterval(() => undefined, 1000);
+let connected = false;
+function connect(path) {
+  const socket = createConnection(path);
+  socket.once('connect', () => {
+    connected = true;
+  });
+  socket.on('error', () => {
+    if (!connected) setTimeout(() => connect(path), 25);
+  });
+}
+connect(process.env.VIBESYS_CONTROL_SOCKET);
+`,
+    );
+
+    process.env['VIBESYS_PYTHON'] = backend;
+    process.env['VIBESYS_TUI_RUNTIME'] = process.execPath;
+    process.env['VIBESYS_TUI_ENTRYPOINT'] = frontend;
+
+    await expect(launch(['--stub-agent', '--runs-dir', '/tmp/vibesys-test-runs'])).resolves.toBe(7);
+    expect(await readFile(frontendTerminated, 'utf8')).toBe('terminated');
+  }, 20_000);
+
+  it('returns the frontend failure when it exits within the grace window after backend death', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'vs-launcher-test-'));
+    const backend = await writeExecutable(
+      'dying-backend.mjs',
+      `
+import {createServer} from 'node:net';
+const socketPath = process.argv[process.argv.indexOf('--control-socket') + 1];
+const server = createServer(() => {
+  setTimeout(() => process.exit(7), 100);
+});
+server.listen(socketPath);
+`,
+    );
+    const frontend = await writeExecutable(
+      'drop-sensitive-frontend.mjs',
+      `
+import {createConnection} from 'node:net';
+setInterval(() => undefined, 1000);
+let connected = false;
+function connect(path) {
+  const socket = createConnection(path);
+  socket.once('connect', () => {
+    connected = true;
+  });
+  socket.once('close', () => {
+    // Notice the dropped transport shortly after the backend dies, well
+    // within the launcher's grace window but after it saw the backend exit.
+    if (connected) setTimeout(() => process.exit(3), 300);
+  });
+  socket.on('error', () => {
+    if (!connected) setTimeout(() => connect(path), 25);
+  });
+}
+connect(process.env.VIBESYS_CONTROL_SOCKET);
+`,
+    );
+
+    process.env['VIBESYS_PYTHON'] = backend;
+    process.env['VIBESYS_TUI_RUNTIME'] = process.execPath;
+    process.env['VIBESYS_TUI_ENTRYPOINT'] = frontend;
+
+    await expect(launch(['--stub-agent', '--runs-dir', '/tmp/vibesys-test-runs'])).resolves.toBe(3);
+  }, 15_000);
+
   it('starts a headless backend and runs the frontend', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'vs-launcher-test-'));
     const backendTerminated = join(tempDir, 'backend-terminated');

--- a/clients/tui/src/launcher.ts
+++ b/clients/tui/src/launcher.ts
@@ -217,6 +217,13 @@ async function monitor(
       // session), so this is always an unexpected backend death. Give the
       // frontend a moment to exit on its own, then terminate it so the
       // launcher's cleanup can run.
+      //
+      // This branch's safety depends on the backend never tearing down
+      // while a subscription is active or about to redial. Today
+      // `_client_disconnected` in `unix_jsonl.py` latches on the first
+      // mid-run drop and never unsticks on reconnect, so the backend can
+      // exit under a live client, violating that contract. Fixed by the
+      // reconnect-aware SubscriptionTracker in #588 (PR #602).
       const gracefulFrontendCode = await waitForExit(frontend, FRONTEND_EXIT_GRACE_MS);
       if (gracefulFrontendCode === undefined) {
         frontend.kill('SIGTERM');

--- a/clients/tui/src/launcher.ts
+++ b/clients/tui/src/launcher.ts
@@ -12,6 +12,7 @@ const READY_TIMEOUT_MS = 30_000;
 const READY_POLL_INTERVAL_MS = 25;
 const SHUTDOWN_TIMEOUT_MS = 10_000;
 const BACKEND_EXIT_GRACE_MS = 2_000;
+const FRONTEND_EXIT_GRACE_MS = 2_000;
 
 export async function launch(argv: string[]): Promise<number> {
   const python = resolvePythonCommand();
@@ -211,8 +212,18 @@ async function monitor(
       return frontendCode === 0 ? backendCode : normalizeFrontendExit(frontendCode);
     }
     if (backendCode !== undefined) {
-      const finalFrontendCode = await waitForExit(frontend);
-      return finalFrontendCode ?? backendCode;
+      // The backend never legitimately exits while the frontend is attached
+      // (it stays alive for post-run chat until the frontend ends the
+      // session), so this is always an unexpected backend death. Give the
+      // frontend a moment to exit on its own, then terminate it so the
+      // launcher's cleanup can run.
+      const gracefulFrontendCode = await waitForExit(frontend, FRONTEND_EXIT_GRACE_MS);
+      if (gracefulFrontendCode === undefined) {
+        frontend.kill('SIGTERM');
+        await waitOrKill(frontend);
+        return backendCode;
+      }
+      return gracefulFrontendCode === 0 ? backendCode : normalizeFrontendExit(gracefulFrontendCode);
     }
     await sleep(50);
   }


### PR DESCRIPTION
## Problem

Fixes #589. When the backend exited first, the launcher's monitor loop waited on the frontend with no timeout and no termination: `await waitForExit(frontend)` with nothing after it. A backend that died after creating the control socket but before publishing a terminal event left the TUI alive in its alternate-screen interface showing a transport error and waiting for operator input, so `launch()` never resolved, the SIGTERM/SIGKILL cleanup path never ran, and the terminal was never restored. The user was stuck with a dead run that looked alive, and the launcher process leaked along with the frontend.

## Solution

The backend-first branch now bounds the wait and owns the teardown. A new `FRONTEND_EXIT_GRACE_MS` (2 s, matching the existing `BACKEND_EXIT_GRACE_MS`) gives the frontend a short window to render its final transport diagnostic and exit on its own. If it does not exit in time, the launcher sends SIGTERM and falls through to the existing `waitOrKill` escalation (SIGTERM then SIGKILL), then returns the backend's failure status. If the frontend does exit within the grace window, the launcher returns the backend status when the frontend exited cleanly, and the frontend's own status when it reported something more specific, which is the same precedence rule the frontend-first branch already applies. The branch also records the contract that makes this unconditionally safe: the backend never legitimately exits while the frontend is attached, because a retained terminal backend stays alive for post-run chat until the frontend ends the session. A backend-first exit is therefore always an unexpected death, and no expected-versus-unexpected discrimination flag is needed. The comment above the branch also names the known gap in that contract: the backend's sticky `_client_disconnected` event latches on the first mid-run drop and never unsticks on reconnect, so until the reconnect-aware `SubscriptionTracker` from #588 (PR #602) merges, the backend can exit under a live client; the fix for that lives there, not here, so the two PRs compose without conflict.

### Architecture

Process lifetime is entirely the launcher's concern: `clients/tui/src/launcher.ts` spawns both children, and its monitor loop is the single owner of exit-order policy, signal escalation, and the final exit status. The fix adds no new state or protocol; it completes the one branch of the existing monitor that lacked a bounded teardown, reusing the same `waitForExit(child, timeout)` and `waitOrKill` primitives the shutdown path already uses. The frontend and backend are unchanged.

```mermaid
flowchart TD
    M[monitor loop: poll child exits] --> FB{who exited first?}
    FB -->|frontend first| F[existing path: stop backend,<br/>waitOrKill, propagate status]
    FB -->|backend first| G["waitForExit(frontend, 2s grace)"]
    G -->|"exits in grace, code 0"| B1[return backend status]
    G -->|"exits in grace, code != 0"| B2[return frontend status<br/>more specific failure]
    G -->|still alive after grace| K[SIGTERM frontend<br/>waitOrKill: SIGKILL escalation] --> B3[return backend status]
    B1 --> R[launch resolves,<br/>terminal restored,<br/>cleanup runs]
    B2 --> R
    B3 --> R
```

## Verification

Automated: two new launcher tests drive the issue's reproduction with a fake backend and a fake frontend as real child processes; the keep-alive case hangs forever on the unfixed code (the test run only ends at bun's 20 s per-test limit, leaving a dangling child) and completes in about 2 s after the fix. The full TS pipeline passes. Manual: on a real codex-provider run, killing the live backend with SIGKILL mid-round tore everything down within 5 seconds with no leaked process and a nonzero launcher exit.

### Correctness properties

- `launch()` always resolves after a backend-first exit: the frontend wait is bounded by `FRONTEND_EXIT_GRACE_MS`, after which the existing SIGTERM-then-SIGKILL policy terminates the frontend.
- The returned status prefers the backend's failure code, unless the frontend exited within the grace window with its own nonzero status, which is treated as the more specific failure; this mirrors the precedence the frontend-first branch already uses.
- A frontend that exits promptly with code 0 still surfaces the backend's failure status rather than masking it as success.
- The retained post-run terminal backend is unaffected: it exits only after the frontend detaches, so it always takes the frontend-first branch, and the new branch fires only on genuine unexpected backend death.
- No process leaks: every path out of the backend-first branch has awaited the frontend's exit before returning.

### Testing

- `clients/tui/src/launcher.test.ts`, new test "backend-first exit terminates a lingering frontend within the grace period": a fake backend creates the socket, accepts the subscription, and exits 7 without a terminal event while the fake frontend stays alive and marks receipt of SIGTERM; asserts `launch()` returns 7, the frontend was SIGTERMed, and the whole launch resolves in well under the old infinite wait. Before the fix this test hit bun's 20 s timeout with the frontend still running; after the fix it completes in about 2 s.
- New test "backend-first exit adopts a more specific frontend failure": the fake frontend exits 3 within the grace window and `launch()` returns 3.
- New test "pins the backend failure code when the frontend exits 0 within the grace window after backend death": the backend dies with exit 7, the frontend notices the socket close and exits 0 inside the grace window, and `launch()` must resolve to 7, not 0. Verified against a deliberately broken precedence rule (returning the frontend's code unconditionally): only this test fails, with `Expected: 7, Received: 0`.
- `pnpm --filter @vibesys/tui test src/launcher.test.ts`: all launcher tests pass (552 tui tests total across the suite run). `pnpm test:clients`: tui, core-state, and backend-client suites pass. `pnpm check:clients`, `pnpm check:ts-architecture`, `pnpm build:clients`: clean.
- A SIGKILL-escalation test (frontend ignoring SIGTERM past the grace) was considered and skipped: the launcher's shutdown windows are real wall-clock timeouts with no injection point, so the test would spend the full 10 s `SHUTDOWN_TIMEOUT_MS` in every suite run.
- Codex-provider harness run (`runtui.sh start 200x50 spsc`, model `gpt-5.6-sol`, 1 round): with the run live, `kill -9` of the backend process caused the frontend and launcher to be gone within 5 seconds, the shell prompt returned, the launcher exited 1 (the frontend's own in-grace transport-failure exit, per the precedence rule), the session directory was removed, and `ps` showed no dangling frontend, backend, or launcher process.

Closes #589.
