### PR TITLE
TUI: emit a terminal tool result when a tool callback fails

### DIFF
--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -288,9 +288,15 @@ class AgentLogger(BaseCallbackHandler):
             # No typed tool_call to close; the diagnostic above is the whole
             # record, and fabricating an orphan tool_result would mislead.
             return
+        pending = self._pending_tool_calls.get(name)
+        if not pending or (call_id is not None and call_id not in pending):
+            # A streamed turn emits no typed tool_call (``on_llm_end`` returns
+            # before the emission), so a failure whose call was never queued
+            # has no lifecycle to close either.
+            return
         self._emit_tool_result(
             name,
-            f"{type(error).__name__}: {error}",
+            f"{type(error).__name__}: {error}" if str(error) else type(error).__name__,
             call_id=call_id,
             is_error=True,
         )

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -100,6 +100,11 @@ class AgentLogger(BaseCallbackHandler):
         self._context_window_lookup = context_window_lookup or _default_context_window_lookup
         self._context_window = self._context_window_lookup(model_name)
         self._pending_tool_calls: dict[str, deque[str]] = defaultdict(deque)
+        # In-flight langchain tool runs keyed by run_id: (tool name,
+        # tool_call_id). Recorded in ``on_tool_start`` solely so
+        # ``on_tool_error`` can attribute a failure to the typed tool_call
+        # already emitted from ``on_llm_end``.
+        self._tool_runs: dict[uuid.UUID, tuple[str | None, str | None]] = {}
         self._agent_kind = agent_kind
         self._round_label = round_label
         self._invocation_id = invocation_id
@@ -237,14 +242,19 @@ class AgentLogger(BaseCallbackHandler):
     def on_tool_start(  # noqa: D102  # tracked: #288
         self,
         serialized: dict[str, Any],
-        input_str: str,
+        input_str: str,  # noqa: ARG002 - protocol parity
         *,
-        inputs: dict[str, Any] | None = None,
+        inputs: dict[str, Any] | None = None,  # noqa: ARG002 - protocol parity
         **kwargs: Any,  # noqa: ANN401  # tracked: #288
     ) -> None:
-        pass  # tool call already logged in on_llm_end
+        # The tool call itself was already emitted from ``on_llm_end``; record
+        # the run only so ``on_tool_error`` can attribute a failure to it.
+        run_id = kwargs.get("run_id")
+        if run_id is not None:
+            self._tool_runs[run_id] = ((serialized or {}).get("name"), kwargs.get("tool_call_id"))
 
-    def on_tool_end(self, output: Any, **kwargs: Any) -> None:  # noqa: ANN401, ARG002, D102  # tracked: #288
+    def on_tool_end(self, output: Any, **kwargs: Any) -> None:  # noqa: ANN401, D102  # tracked: #288
+        self._tool_runs.pop(kwargs.get("run_id"), None)
         content = output.content if hasattr(output, "content") else str(output)
         name = getattr(output, "name", None) or "unknown"
         call_id = getattr(output, "tool_call_id", None)
@@ -254,7 +264,7 @@ class AgentLogger(BaseCallbackHandler):
             call_id=call_id if isinstance(call_id, str) and call_id else None,
         )
 
-    def on_tool_error(self, error: Any, **kwargs: Any) -> None:  # noqa: ANN401, ARG002, D102  # tracked: #288
+    def on_tool_error(self, error: Any, **kwargs: Any) -> None:  # noqa: ANN401, D102  # tracked: #288
         lines = [f"Tool error: {error!r}"]
         if isinstance(error, BaseException):
             tb = traceback.format_exception(type(error), error, error.__traceback__)
@@ -263,6 +273,27 @@ class AgentLogger(BaseCallbackHandler):
         text = "\n".join(lines)
         self._publish(text + "\n", "diagnostic")
         self._log_line(text)
+
+        # Close the typed tool_call emitted from ``on_llm_end`` so consumers
+        # don't show the tool as running forever. Attribution comes from the
+        # run recorded in ``on_tool_start``, else from the provider call id.
+        name, recorded_call_id = self._tool_runs.pop(kwargs.get("run_id"), (None, None))
+        call_id = kwargs.get("tool_call_id") or recorded_call_id
+        if name is None and call_id is not None:
+            name = next(
+                (n for n, pending in self._pending_tool_calls.items() if call_id in pending),
+                None,
+            )
+        if name is None:
+            # No typed tool_call to close; the diagnostic above is the whole
+            # record, and fabricating an orphan tool_result would mislead.
+            return
+        self._emit_tool_result(
+            name,
+            f"{type(error).__name__}: {error}",
+            call_id=call_id,
+            is_error=True,
+        )
 
     # --- Event emission + log formatting ---
 

--- a/tests/vibesys/agents/test_callbacks.py
+++ b/tests/vibesys/agents/test_callbacks.py
@@ -360,6 +360,50 @@ class TestOnToolErrorResult:
         assert results[0].is_error is True
         assert not logger._pending_tool_calls["shell"]  # noqa: SLF001  # tracked: #288
 
+    def test_streamed_turn_error_emits_no_orphan_result(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            # A streamed turn: ``on_llm_end`` returns before emitting typed
+            # tool calls, so the tool run starts with nothing queued.
+            logger.on_llm_new_token("tok")
+            logger.on_llm_end(
+                _make_response(tool_calls=[{"id": "call-1", "name": "shell", "args": {"cmd": "x"}}])
+            )
+            run_id = uuid4()
+            logger.on_tool_start({"name": "shell"}, "", run_id=run_id, tool_call_id="call-1")
+            logger.on_tool_error(RuntimeError("boom"), run_id=run_id, tool_call_id="call-1")
+        finally:
+            unsubscribe()
+
+        calls = [event.data for event in seen if isinstance(event.data, ToolCallData)]
+        results = [event.data for event in seen if isinstance(event.data, ToolResultData)]
+        assert calls == []
+        assert results == []
+        assert "Tool error" in capsys.readouterr().out
+
+    def test_empty_message_error_content_has_no_trailing_colon(self) -> None:
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            logger.on_llm_end(
+                _make_response(tool_calls=[{"id": "call-1", "name": "shell", "args": {"cmd": "x"}}])
+            )
+            run_id = uuid4()
+            logger.on_tool_start({"name": "shell"}, "", run_id=run_id, tool_call_id="call-1")
+            logger.on_tool_error(KeyboardInterrupt(), run_id=run_id, tool_call_id="call-1")
+        finally:
+            unsubscribe()
+
+        results = [event.data for event in seen if isinstance(event.data, ToolResultData)]
+        assert len(results) == 1
+        assert results[0].content == "KeyboardInterrupt"
+        assert results[0].is_error is True
+
     def test_error_without_tool_context_emits_no_result(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/vibesys/agents/test_callbacks.py
+++ b/tests/vibesys/agents/test_callbacks.py
@@ -3,6 +3,9 @@ import re
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
 
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.progress import RoundProgress
@@ -278,6 +281,99 @@ class TestOnToolError:
         logger.on_tool_error(Exception("fail"), run_id=uuid4())
         out = capsys.readouterr().out
         assert DIM not in out
+
+
+class TestOnToolErrorResult:
+    """A tool failure must close the typed tool_call emitted from ``on_llm_end``."""
+
+    def test_error_emits_failure_result_and_clears_pending(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            logger.on_llm_end(
+                _make_response(tool_calls=[{"id": "call-1", "name": "shell", "args": {"cmd": "x"}}])
+            )
+            run_id = uuid4()
+            logger.on_tool_start({"name": "shell"}, "", run_id=run_id, tool_call_id="call-1")
+            logger.on_tool_error(RuntimeError("boom"), run_id=run_id, tool_call_id="call-1")
+        finally:
+            unsubscribe()
+
+        results = [event.data for event in seen if isinstance(event.data, ToolResultData)]
+        assert len(results) == 1
+        result = results[0]
+        assert result.tool == "shell"
+        assert result.call_id == "call-1"
+        assert result.is_error is True
+        assert "RuntimeError" in result.content
+        assert "boom" in result.content
+        assert not logger._pending_tool_calls["shell"]  # noqa: SLF001  # tracked: #288
+        # The free-text diagnostic (with traceback detail) is still published.
+        assert "Tool error" in capsys.readouterr().out
+
+    def test_error_does_not_misattribute_next_same_tool_result(self) -> None:
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            logger.on_llm_end(
+                _make_response(tool_calls=[{"id": "call-1", "name": "shell", "args": {"cmd": "a"}}])
+            )
+            first_run = uuid4()
+            logger.on_tool_start({"name": "shell"}, "", run_id=first_run, tool_call_id="call-1")
+            logger.on_tool_error(RuntimeError("boom"), run_id=first_run, tool_call_id="call-1")
+
+            logger.on_llm_end(
+                _make_response(tool_calls=[{"id": "call-2", "name": "shell", "args": {"cmd": "b"}}])
+            )
+            second_run = uuid4()
+            logger.on_tool_start({"name": "shell"}, "", run_id=second_run, tool_call_id="call-2")
+            # No tool_call_id on the output: correlation falls back to the
+            # FIFO head, which must be call-2 because the failure consumed
+            # call-1.
+            logger.on_tool_end(SimpleNamespace(name="shell", content="ok"), run_id=second_run)
+        finally:
+            unsubscribe()
+
+        results = [event.data for event in seen if isinstance(event.data, ToolResultData)]
+        assert [(r.call_id, r.is_error) for r in results] == [("call-1", True), ("call-2", False)]
+
+    def test_tool_call_id_fallback_resolves_name_without_tool_start(self) -> None:
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            logger.on_llm_end(
+                _make_response(tool_calls=[{"id": "call-1", "name": "shell", "args": {"cmd": "x"}}])
+            )
+            logger.on_tool_error(RuntimeError("boom"), run_id=uuid4(), tool_call_id="call-1")
+        finally:
+            unsubscribe()
+
+        results = [event.data for event in seen if isinstance(event.data, ToolResultData)]
+        assert len(results) == 1
+        assert results[0].tool == "shell"
+        assert results[0].call_id == "call-1"
+        assert results[0].is_error is True
+        assert not logger._pending_tool_calls["shell"]  # noqa: SLF001  # tracked: #288
+
+    def test_error_without_tool_context_emits_no_result(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            logger.on_tool_error(RuntimeError("boom"), run_id=uuid4())
+        finally:
+            unsubscribe()
+
+        results = [event.data for event in seen if isinstance(event.data, ToolResultData)]
+        assert results == []
+        assert "Tool error" in capsys.readouterr().out
 
 
 class TestStateManagement:


### PR DESCRIPTION
## Problem

Fixes #590. `AgentLogger.on_tool_error()` published a diagnostic text chunk and stopped, never emitting the typed `tool_result` that closes the tool lifecycle. The `tool_call` emitted from `on_llm_end` therefore stayed open forever on the failure path: its call id remained queued in `_pending_tool_calls`, the core-state transcript entry never received a `toolResult`, and the TUI rendered the call as still running. Worse than the cosmetic hang, the stale queued call id corrupted later attribution: the next result for the same tool name arriving without an explicit call id was matched FIFO against the dead call, so a subsequent successful invocation's output could be attached to the failed call's card.

## Solution

`on_tool_error` now closes the lifecycle it interrupts, and the fix supplies it the context langchain does not pass to the error callback. `on_tool_start` (previously a no-op, since the typed `tool_call` is already emitted from `on_llm_end`) now records the in-flight run in a `_tool_runs` map keyed by langchain's `run_id`, storing the tool name and provider `tool_call_id`; `on_tool_end` pops the entry on the success path. On error, the handler first publishes the unchanged diagnostic chunk with the full traceback (the issue explicitly keeps it as supplementary detail), then resolves the failed call: the recorded run gives the name and call id, a `tool_call_id` passed directly in the callback kwargs takes precedence, and as a last resort the call id is reverse-looked-up through `_pending_tool_calls` to recover the name. With the call resolved it emits `_emit_tool_result(name, "TypeName: message", call_id=..., is_error=True)`, which removes that specific call id from the pending queue rather than popping FIFO; an exception with an empty message yields just the type name, with no trailing colon. If neither a recorded run nor a matchable call id exists there is no typed `tool_call` to close, so no orphan `tool_result` is fabricated and the diagnostic remains the whole record. The same guard covers streamed turns: under streaming `on_llm_end` emits no typed `tool_call` at all, so a failure whose resolved call was never queued in `_pending_tool_calls` also closes nothing, instead of fabricating a result for a lifecycle that never opened.

### Architecture

The fix lives entirely in the event producer that owns the tool lifecycle: `AgentLogger` in `src/vibesys/agents/callbacks.py`, the langchain callback adapter that translates agent activity into run events. No contract change was needed anywhere downstream: `ToolResultData` already carries `call_id` and `is_error` on the wire, and core-state already folds an `is_error` result into a terminal `toolResult` with failure tone, so the protocol schema, generated TS bindings, and both frontends are untouched. The change is purely that the failure path now exercises the same emission primitive the success path always used.

```mermaid
sequenceDiagram
    participant L as langchain agent
    participant A as AgentLogger
    participant E as event stream
    L->>A: on_llm_end (tool call in message)
    A->>E: tool_call(name, call-1)
    Note over A: call-1 queued in _pending_tool_calls
    L->>A: on_tool_start(run_id, name, tool_call_id)
    Note over A: _tool_runs[run_id] = (name, call-1)
    L->>A: on_tool_error(run_id, error)
    A->>E: agent_output_chunk (diagnostic, traceback)
    Note over A: resolve name + call id from _tool_runs,<br/>kwargs tool_call_id, or pending reverse lookup
    A->>E: tool_result(name, "RuntimeError: boom",<br/>call_id=call-1, is_error=true)
    Note over A: call-1 removed from pending,<br/>next same-name result cannot<br/>FIFO-match the dead call
    E->>E: core-state folds terminal toolResult,<br/>TUI renders failure tone
```

## Verification

Automated: four new unit tests cover the failure attribution paths, three of which fail on the unfixed code, including a misattribution guard proving the pre-fix FIFO corruption; the full agents suite, lint, type check, and format check pass. Manual: a real codex-provider TUI run on this branch streamed live tool activity normally through the touched `on_tool_start`/`on_tool_end` hot path with a clean `backend.log`. Forcing a genuine in-run tool exception is nondeterministic under a live provider, so the error path itself is verified at the unit level, where the issue's reproduction is encoded exactly.

### Correctness properties

- Every typed `tool_call` receives exactly one terminal typed `tool_result`, on the error path as well as the success path, carrying the original tool name, the corresponding `call_id` when known, the error content, and `is_error=True`.
- A failed call's id is removed from `_pending_tool_calls`, so a later result for the same tool name without an explicit call id can no longer FIFO-match a dead call and misattribute output.
- The diagnostic chunk with the full traceback is preserved unchanged and remains supplementary to, not a substitute for, the typed result.
- When no tool context is resolvable (no recorded run, no call id, no pending match), no orphan `tool_result` is emitted; the diagnostic remains the complete record, so the fix cannot fabricate lifecycle events for calls that were never typed. This includes streamed turns, where `on_llm_end` emits no typed `tool_call` and the pending queue is empty.
- The error content is `"TypeName: message"` for exceptions with a message and just `"TypeName"` otherwise, never a dangling `"TypeName: "`.
- The success path is byte-identical in behavior: `on_tool_end` emits exactly what it did before, and `on_tool_start` still emits nothing.

### Testing

- `tests/vibesys/agents/test_callbacks.py::TestOnToolErrorResult`, four new tests: `test_error_emits_failure_result_and_clears_pending` (the issue's reproduction: `tool_call` for `call-1`, then `on_tool_error(RuntimeError("boom"))`, asserting a `tool_result` with `call_id="call-1"`, `is_error=True`, and the diagnostic still present), `test_error_does_not_misattribute_next_same_tool_result` (pre-fix, the next same-name result stole `call-1` FIFO; post-fix it matches its own call), `test_tool_call_id_fallback_resolves_name_without_tool_start` (attribution via the pending reverse lookup when langchain never delivered `on_tool_start`), and `test_error_without_tool_context_emits_no_result`. The first three fail before the fix; all four pass after.
- Two further guards added in review: `test_streamed_turn_error_emits_no_orphan_result` (a streamed turn emits no typed `tool_call`, so a tool failure there must emit no `tool_result` either while keeping the diagnostic) and `test_empty_message_error_content_has_no_trailing_colon` (a message-less exception yields `"KeyboardInterrupt"`, not `"KeyboardInterrupt: "`). Both fail without their guards.
- `uv run pytest tests/vibesys/agents/test_callbacks.py`: 76 passed. `uv run pytest tests/vibesys/agents`: 397 passed.
- `uv run ruff check`, `uv run ty check`, `./scripts/check_format.sh`: clean.
- Codex-provider harness run (`runtui.sh start 200x50 spsc`, model `gpt-5.6-sol`, 1 round): healthy live round with tool calls streaming through the modified callbacks, no tracebacks or protocol errors in `backend.log`, clean teardown on quit.

Closes #590.
