### PR TITLE
TUI: Distinguish round-one, fail-closed, and self-reported no-delta measurements

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -422,6 +422,18 @@ export type PerfDeltaPct1 = number | null;
 export type PerfMetricName = string | null;
 export type PerfDirection = ("max" | "min") | null;
 export type PerfBaselineValue = number | null;
+export type PerfBaselineRound = number | null;
+export type PerfBaselineCommit = string | null;
+/**
+ * Why a headline measurement carries no causal delta.
+ *
+ * Always re-derived from round evidence (``perf_provenance`` and the
+ * baseline fields), never stored on the round record, so it cannot drift
+ * from them. Absent entirely for records that predate provenance tracking:
+ * a legacy absolute number keeps reading as a deliberate absolute rather
+ * than being relabelled as unresolved.
+ */
+export type PerfDeltaReason = "no_baseline_yet" | "baseline_unresolved" | "not_framework_measured";
 export type Kept = boolean | null;
 export type StrategyDisposition = ("available" | "parked" | "abandoned") | null;
 export type StrategyReason = string | null;
@@ -1018,6 +1030,9 @@ export interface HypothesisEntry {
   perf_metric_name?: PerfMetricName;
   perf_direction?: PerfDirection;
   perf_baseline_value?: PerfBaselineValue;
+  perf_baseline_round?: PerfBaselineRound;
+  perf_baseline_commit?: PerfBaselineCommit;
+  perf_delta_reason?: PerfDeltaReason | null;
   kept?: Kept;
   strategy_disposition?: StrategyDisposition;
   strategy_reason?: StrategyReason;

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -1520,6 +1520,41 @@
           "default": null,
           "title": "Perf Baseline Value"
         },
+        "perf_baseline_round": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Perf Baseline Round"
+        },
+        "perf_baseline_commit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Perf Baseline Commit"
+        },
+        "perf_delta_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PerfDeltaReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "kept": {
           "anyOf": [
             {
@@ -1954,6 +1989,16 @@
       },
       "title": "PauseCommand",
       "type": "object"
+    },
+    "PerfDeltaReason": {
+      "description": "Why a headline measurement carries no causal delta.\n\nAlways re-derived from round evidence (``perf_provenance`` and the\nbaseline fields), never stored on the round record, so it cannot drift\nfrom them. Absent entirely for records that predate provenance tracking:\na legacy absolute number keeps reading as a deliberate absolute rather\nthan being relabelled as unresolved.",
+      "enum": [
+        "no_baseline_yet",
+        "baseline_unresolved",
+        "not_framework_measured"
+      ],
+      "title": "PerfDeltaReason",
+      "type": "string"
     },
     "PerformanceContext": {
       "additionalProperties": false,

--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -89,9 +89,17 @@ When every measured hypothesis shares one objective direction the column
 header carries it as an arrow (`Measured ↑` for maximize, `↓` for minimize),
 so a signed delta reads as good or bad without task knowledge. The hypothesis
 summary spells the measurement out in words: metric name, direction, absolute
-value, baseline, and delta. The framework records a verified metric only when
-its own official evaluation ran, on the sparse cadence or the final round, so
-a hypothesis resolved between evaluations legitimately shows no measurement.
+value, baseline (with the round and commit it came from, when known), and
+delta. The framework records a verified metric only when its own official
+evaluation ran, on the sparse cadence or the final round, so a hypothesis
+resolved between evaluations legitimately shows no measurement.
+
+An absolute value with a leading `?` (`? 55434.2 ops/s`) means a baseline
+should have existed but none was admissible, so the lookup failed closed
+rather than compare against something untrusted; the drill-down spells this
+out as `No trusted baseline resolved`. `self-reported` means the only number
+for that hypothesis is the implementer's own claim, never verified by the
+framework's official evaluation.
 
 The table refetches when an agent phase or a round finishes, so it stays
 current without being reopened. Rows are ordered by first round and never

--- a/clients/tui/src/ui/experiment-log.test.ts
+++ b/clients/tui/src/ui/experiment-log.test.ts
@@ -131,6 +131,43 @@ describe('experiment log rows', () => {
     expect(formatMeasured(entry({perf_delta_pct: -2, perf_unit: 'ops/s'}))).toBe('-2.0%');
   });
 
+  it('renders the three no-delta reasons and a zero delta as four distinct cells', () => {
+    const noBaselineYet = formatMeasured(
+      entry({
+        perf_delta_pct: null,
+        perf_metric: 101,
+        perf_unit: 'ops/s',
+        perf_delta_reason: 'no_baseline_yet',
+      }),
+    );
+    const baselineUnresolved = formatMeasured(
+      entry({
+        perf_delta_pct: null,
+        perf_metric: 102,
+        perf_unit: 'ops/s',
+        perf_delta_reason: 'baseline_unresolved',
+      }),
+    );
+    const selfReported = formatMeasured(
+      entry({perf_delta_pct: null, perf_metric: null, perf_delta_reason: 'not_framework_measured'}),
+    );
+    const zeroDelta = formatMeasured(entry({perf_delta_pct: 0}));
+
+    expect(noBaselineYet).toBe('101 ops/s');
+    expect(baselineUnresolved).toBe('? 102 ops/s');
+    expect(selfReported).toBe('self-reported');
+    expect(zeroDelta).toBe('0.0%');
+    expect(new Set([noBaselineYet, baselineUnresolved, selfReported, zeroDelta]).size).toBe(4);
+  });
+
+  it('renders a legacy entry with no delta_reason as a bare value and leaves a delta unaffected', () => {
+    const legacy = entry({perf_delta_pct: null, perf_metric: 2412.5, perf_unit: 'ops/s'});
+    expect(legacy.perf_delta_reason).toBeUndefined();
+    expect(formatMeasured(legacy)).toBe('2412.5 ops/s');
+
+    expect(formatMeasured(entry({perf_delta_pct: 5.9}))).toBe('+5.9%');
+  });
+
   it('points the header the way improvement goes when the log agrees on one', () => {
     const columns = resolveColumns(WIDE);
 
@@ -183,6 +220,39 @@ describe('experiment log rows', () => {
     expect(metadata).toContain('Measured 2412.5 ops/s');
   });
 
+  it('spells out the baseline identity in the drill-down metadata', () => {
+    const metadata = hypothesisMetadata(
+      entry({
+        perf_metric: 55434.2,
+        perf_baseline_value: 52340.1,
+        perf_baseline_round: 3,
+        perf_baseline_commit: 'abc1234deadbeef',
+        perf_delta_pct: 5.9,
+      }),
+    );
+
+    expect(metadata).toContain('Baseline round 3');
+    expect(metadata).toContain('Baseline commit abc1234');
+  });
+
+  it('spells out each no-delta reason in the drill-down metadata', () => {
+    expect(
+      hypothesisMetadata(entry({perf_delta_pct: null, perf_delta_reason: 'no_baseline_yet'})),
+    ).toContain('No baseline existed yet');
+    expect(
+      hypothesisMetadata(entry({perf_delta_pct: null, perf_delta_reason: 'baseline_unresolved'})),
+    ).toContain('No trusted baseline resolved');
+    expect(
+      hypothesisMetadata(
+        entry({
+          perf_delta_pct: null,
+          perf_metric: null,
+          perf_delta_reason: 'not_framework_measured',
+        }),
+      ),
+    ).toContain('Self-reported, not framework-measured');
+  });
+
   it('renders a record with no hypothesis id as an explicit placeholder', () => {
     const row = entryRow(
       entry({
@@ -210,6 +280,24 @@ describe('experiment log rows', () => {
     expect(row).toContain('m1-preallocat…  41');
     expect(row[roundsStart - 1]).toBe(' ');
     expect(row.slice(roundsStart).startsWith('41')).toBe(true);
+  });
+
+  it('keeps the ? marker readable when a long unit truncates at MEASURED_WIDTH', () => {
+    const columns = resolveColumns(70);
+    expect(columns.measured).toBe(true);
+    const header = headerRow(columns);
+    const measuredStart = header.indexOf('Measured');
+    const row = entryRow(
+      entry({
+        perf_delta_pct: null,
+        perf_metric: 55434.2,
+        perf_unit: 'total_operations_per_second_sustained',
+        perf_delta_reason: 'baseline_unresolved',
+      }),
+      columns,
+    );
+
+    expect(row.slice(measuredStart, measuredStart + 2)).toBe('? ');
   });
 
   it('keeps gutters across the separately colored outcome segments', () => {

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -692,11 +692,21 @@ export function formatRounds(entry: HypothesisEntry): string {
     : `${entry.first_round}-${entry.last_round}`;
 }
 
+/**
+ * Delta wins when present. `not_framework_measured` is checked next, before
+ * the metric fallback, because the entry-level `perf_metric` is null in that
+ * case anyway. A `baseline_unresolved` absolute value gets a `? ` prefix, not
+ * a suffix, so the MEASURED_WIDTH truncation in `fitColumn` can never cut it
+ * off. `no_baseline_yet` and a legacy entry with no reason keep the bare
+ * value: a first measurement is itself a deliberate absolute display.
+ */
 export function formatMeasured(entry: HypothesisEntry): string {
   const delta = entry.perf_delta_pct;
   if (typeof delta === 'number') return formatDelta(delta);
+  if (entry.perf_delta_reason === 'not_framework_measured') return 'self-reported';
   if (typeof entry.perf_metric === 'number') {
-    return `${trimNumber(entry.perf_metric)}${entry.perf_unit ? ` ${entry.perf_unit}` : ''}`;
+    const marker = entry.perf_delta_reason === 'baseline_unresolved' ? '? ' : '';
+    return `${marker}${trimNumber(entry.perf_metric)}${entry.perf_unit ? ` ${entry.perf_unit}` : ''}`;
   }
   return '—';
 }
@@ -759,10 +769,37 @@ function measurementMetadata(entry: HypothesisEntry): string[] {
   if (typeof entry.perf_baseline_value === 'number') {
     parts.push(`Baseline ${trimNumber(entry.perf_baseline_value)}${unit}`);
   }
+  if (typeof entry.perf_baseline_round === 'number') {
+    parts.push(`Baseline round ${entry.perf_baseline_round}`);
+  }
+  if (entry.perf_baseline_commit) {
+    parts.push(`Baseline commit ${entry.perf_baseline_commit.slice(0, 7)}`);
+  }
   if (typeof entry.perf_delta_pct === 'number') {
     parts.push(`Delta ${formatDelta(entry.perf_delta_pct)}`);
   }
+  const reason = deltaReasonLabel(entry.perf_delta_reason);
+  if (reason !== null) parts.push(reason);
   return parts;
+}
+
+/**
+ * Spells out why `perf_delta_pct` is absent. Exhaustive over the wire union
+ * with no default case, so a reason value the client does not yet know how
+ * to word fails the build instead of silently rendering nothing.
+ */
+function deltaReasonLabel(reason: HypothesisEntry['perf_delta_reason']): string | null {
+  switch (reason) {
+    case 'no_baseline_yet':
+      return 'No baseline existed yet';
+    case 'baseline_unresolved':
+      return 'No trusted baseline resolved';
+    case 'not_framework_measured':
+      return 'Self-reported, not framework-measured';
+    case null:
+    case undefined:
+      return null;
+  }
 }
 
 function roundMetadata(roundNumber: number, round: HypothesisRound | undefined): string {

--- a/src/server/api/experiments.py
+++ b/src/server/api/experiments.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 from server.api.protocol import HypothesisEntry, HypothesisRound
+from vibesys.loops.agent.hypotheses import measurement_delta_reason
 from vibesys.loops.agent.model import HypothesisResolution
 from vibesys.schemas import CandidateDisposition, HypothesisOutcome, derive_hypothesis_title
 
@@ -54,6 +55,11 @@ def _entry(hypothesis: Hypothesis, *, active_id: str | None) -> HypothesisEntry:
         perf_metric_name=_text(measurement.metric) if measurement is not None else None,
         perf_direction=measurement.direction if measurement is not None else None,
         perf_baseline_value=measurement.baseline_value if measurement is not None else None,
+        perf_baseline_round=measurement.baseline_round if measurement is not None else None,
+        perf_baseline_commit=(
+            _text(measurement.baseline_commit) if measurement is not None else None
+        ),
+        perf_delta_reason=measurement_delta_reason(hypothesis),
         kept=hypothesis.candidate_retained,
         strategy_disposition=hypothesis.strategy.value,
         strategy_reason=hypothesis.strategy_reason,

--- a/src/server/api/protocol.py
+++ b/src/server/api/protocol.py
@@ -15,7 +15,7 @@ from server.execution import ActiveAgentExecution
 from server.run_lifecycle import RunStatus
 from server.settings import InteractiveSetupDefaults
 from vibesys.loops.agent.model import HypothesisResolution
-from vibesys.schemas import CandidateDisposition, HypothesisOutcome
+from vibesys.schemas import CandidateDisposition, HypothesisOutcome, PerfDeltaReason
 from vs_loop_state import JudgeVerdict
 
 PROTOCOL_VERSION = 1
@@ -291,6 +291,15 @@ class HypothesisEntry(ProtocolModel):
     # The other side of ``perf_delta_pct``, from the same official
     # measurement, so the comparison stays interpretable in absolute terms.
     perf_baseline_value: FiniteFloat | None = None
+    # Causal identity of that baseline, so the comparison is auditable from
+    # the client: which round it was, and which workspace commit it measured.
+    perf_baseline_round: int | None = None
+    perf_baseline_commit: str | None = None
+    # Why ``perf_delta_pct`` is absent, when the server can say. None when a
+    # delta is present, when no official metric was recorded at all, or for
+    # records predating provenance tracking, which keep reading as deliberate
+    # absolute measurements.
+    perf_delta_reason: PerfDeltaReason | None = None
     # Integration, not truth: the framework's explicit retention decision.
     # None means legacy or not yet assessed, never "official evaluation ran".
     kept: bool | None = None

--- a/src/vibesys/loops/agent/hypotheses.py
+++ b/src/vibesys/loops/agent/hypotheses.py
@@ -18,6 +18,7 @@ from vibesys.schemas import (
     HypothesisOutcome,
     HypothesisStrategyUpdate,
     OrchestratorPlan,
+    PerfDeltaReason,
 )
 
 if TYPE_CHECKING:
@@ -153,14 +154,7 @@ def metric_baseline(
     postdate the parent round; comparing against a later measurement would
     invert cause and effect.
     """
-    comparable = [
-        item
-        for item in rounds
-        if item.official_evaluation
-        and item.perf_metric is not None
-        and trusted_perf_provenance(item.perf_provenance)
-        and (item.perf_unit == metric or (metric is not None and metric in item.metrics))
-    ]
+    comparable = baseline_candidates(metric=metric, rounds=rounds)
     if not comparable:
         return None
     if parent_commit is not None:
@@ -183,6 +177,48 @@ def metric_baseline(
         # effect. Fail closed instead.
         return None
     return comparable[-1]
+
+
+def baseline_candidates(
+    *,
+    metric: str | None,
+    rounds: Sequence[RoundRecord],
+) -> list[RoundRecord]:
+    """Return the rounds admissible as a baseline for *metric*, in order.
+
+    The one admissibility rule behind ``metric_baseline``: a trusted official
+    measurement that carries the axis, whether as its headline unit or in its
+    objective row. Whether this set is empty is what separates "no baseline
+    existed yet" from "a baseline existed but could not be resolved".
+    """
+    return [
+        item
+        for item in rounds
+        if item.official_evaluation
+        and item.perf_metric is not None
+        and trusted_perf_provenance(item.perf_provenance)
+        and (item.perf_unit == metric or (metric is not None and metric in item.metrics))
+    ]
+
+
+def measurement_delta_reason(hypothesis: Hypothesis) -> PerfDeltaReason | None:
+    """Why *hypothesis*'s headline number carries no causal delta.
+
+    ``None`` when a delta exists, when no official metric was recorded at
+    all, or when the evidence predates provenance tracking. A hypothesis
+    whose only official headline is the implementer's own report has no
+    measurement to carry the reason, so it is answered from the rounds.
+    """
+    if hypothesis.measurement is not None:
+        return hypothesis.measurement.delta_reason
+    if any(
+        record.official_evaluation
+        and record.perf_metric is not None
+        and not trusted_perf_provenance(record.perf_provenance)
+        for record in hypothesis.rounds
+    ):
+        return PerfDeltaReason.NOT_FRAMEWORK_MEASURED
+    return None
 
 
 def start_hypothesis(
@@ -558,6 +594,20 @@ def _measurement(
         )
     )
     baseline = _baseline(record, prior_rounds)
+    baseline_round = (
+        record.perf_baseline_round
+        if record.perf_baseline_round is not None
+        else baseline.round_number
+        if baseline is not None
+        else None
+    )
+    # The commit of the record actually used as the baseline, which the
+    # fallback makes distinct from the hypothesis's parent commit: with
+    # `official_eval_every > 1` the causal parent is usually a provisional
+    # round, and the baseline is an earlier official one.
+    baseline_commit = record.perf_baseline_commit or (
+        baseline.commit if baseline is not None else None
+    )
     baseline_value = record.perf_baseline_metric
     if baseline_value is None and baseline is not None:
         baseline_value = record_metric_value(baseline, record.perf_unit)
@@ -565,28 +615,32 @@ def _measurement(
     if delta is None and baseline_value not in {None, 0}:
         assert baseline_value is not None  # noqa: S101  # narrowed above
         delta = (record.perf_metric - baseline_value) / abs(baseline_value) * 100
+    delta_reason = None
+    if (
+        delta is None
+        and baseline_round is None
+        and baseline_commit is None
+        and baseline_value is None
+        # A legacy record carries no provenance and keeps reading as a
+        # deliberate absolute; only provenance-era evidence is labelled.
+        and record.perf_provenance is not None
+    ):
+        delta_reason = (
+            PerfDeltaReason.BASELINE_UNRESOLVED
+            if baseline_candidates(metric=record.perf_unit, rounds=prior_rounds)
+            else PerfDeltaReason.NO_BASELINE_YET
+        )
     return HypothesisMeasurement(
         round=record.round_number,
         metric=record.perf_unit,
         value=record.perf_metric,
         unit=record.perf_unit,
         direction=direction,
-        baseline_round=(
-            record.perf_baseline_round
-            if record.perf_baseline_round is not None
-            else baseline.round_number
-            if baseline is not None
-            else None
-        ),
-        # The commit of the record actually used as the baseline, which the
-        # fallback makes distinct from the hypothesis's parent commit: with
-        # `official_eval_every > 1` the causal parent is usually a provisional
-        # round, and the baseline is an earlier official one.
-        baseline_commit=(
-            record.perf_baseline_commit or (baseline.commit if baseline is not None else None)
-        ),
+        baseline_round=baseline_round,
+        baseline_commit=baseline_commit,
         baseline_value=baseline_value,
         delta_pct=delta,
+        delta_reason=delta_reason,
     )
 
 

--- a/src/vibesys/loops/agent/model.py
+++ b/src/vibesys/loops/agent/model.py
@@ -12,6 +12,7 @@ from vibesys.schemas import (
     CandidateDisposition,
     HypothesisOutcome,
     OrchestratorPlan,
+    PerfDeltaReason,
 )
 from vs_loop_state import RoundRecord
 
@@ -62,6 +63,9 @@ class HypothesisMeasurement(BaseModel):
     baseline_commit: str | None = None
     baseline_value: FiniteFloat | None = None
     delta_pct: FiniteFloat | None = None
+    # Why ``delta_pct`` is None, when the evidence can say. None whenever a
+    # baseline was found or the record predates provenance tracking.
+    delta_reason: PerfDeltaReason | None = None
 
 
 class Hypothesis(BaseModel):

--- a/src/vibesys/schemas.py
+++ b/src/vibesys/schemas.py
@@ -73,6 +73,28 @@ class CandidateDisposition(StrEnum):
     PARETO_FRONTIER = "pareto_frontier"
 
 
+class PerfDeltaReason(StrEnum):
+    """Why a headline measurement carries no causal delta.
+
+    Always re-derived from round evidence (``perf_provenance`` and the
+    baseline fields), never stored on the round record, so it cannot drift
+    from them. Absent entirely for records that predate provenance tracking:
+    a legacy absolute number keeps reading as a deliberate absolute rather
+    than being relabelled as unresolved.
+    """
+
+    # No trusted official measurement of the metric existed yet, so there was
+    # legitimately nothing to compare against.
+    NO_BASELINE_YET = "no_baseline_yet"
+    # Trusted measurements existed but none was admissible as this round's
+    # causal baseline: the lookup failed closed rather than inverting cause
+    # and effect.
+    BASELINE_UNRESOLVED = "baseline_unresolved"
+    # The only headline number is the implementer's own report, which the
+    # framework never orders against anything.
+    NOT_FRAMEWORK_MEASURED = "not_framework_measured"
+
+
 HypothesisStrategyDisposition = Literal["parked", "abandoned"]
 
 

--- a/tests/server/test_experiments.py
+++ b/tests/server/test_experiments.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal, TypedDict, Unpack
 from tests.server.support import build_server_parts
 
 from server.api.experiments import build_experiment_log
-from server.api.protocol import ExperimentQuery, PerformanceQuery
+from server.api.protocol import ExperimentQuery, HypothesisEntry, PerformanceQuery
 from vibesys.loops.agent.model import (
     AgentRunState,
     Hypothesis,
@@ -18,8 +18,13 @@ from vibesys.loops.agent.model import (
 )
 from vibesys.loops.agent.state import AgentRunStateStore
 from vibesys.loops.metrics import MetricSpace, Objective
-from vibesys.schemas import CandidateDisposition, HypothesisOutcome, OrchestratorPlan
-from vs_loop_state import MetricComparison, RoundRecord
+from vibesys.schemas import (
+    CandidateDisposition,
+    HypothesisOutcome,
+    OrchestratorPlan,
+    PerfDeltaReason,
+)
+from vs_loop_state import MetricComparison, PerfProvenance, RoundRecord
 from vs_project import AgentRunConfiguration, Project, RunEnvironmentRecord
 
 if TYPE_CHECKING:
@@ -60,6 +65,7 @@ class _RoundFields(TypedDict, total=False):
     perf_baseline_metric: float | None
     perf_delta_pct: float | None
     perf_comparison: MetricComparison | None
+    perf_provenance: PerfProvenance | None
 
 
 class _HypothesisFields(TypedDict, total=False):
@@ -242,6 +248,98 @@ def test_projection_uses_nested_rounds_and_one_official_measurement_tuple() -> N
         "max",
         110.0,
     )
+
+
+def test_projection_carries_baseline_identity_and_the_no_delta_reason() -> None:
+    """Why a number has no delta crosses as a typed value, not as an absence."""
+    state = AgentRunState(
+        hypotheses=[
+            _hypothesis(
+                "H-01",
+                1,
+                measurement=HypothesisMeasurement(
+                    round=1,
+                    metric="throughput",
+                    value=125.0,
+                    unit="ops_s",
+                    baseline_round=1,
+                    baseline_commit="c1",
+                    baseline_value=100.0,
+                    delta_pct=25.0,
+                ),
+            ),
+            _hypothesis(
+                "H-02",
+                2,
+                measurement=HypothesisMeasurement(
+                    round=2,
+                    metric="throughput",
+                    value=130.0,
+                    unit="ops_s",
+                    delta_reason=PerfDeltaReason.NO_BASELINE_YET,
+                ),
+            ),
+            _hypothesis(
+                "H-03",
+                3,
+                measurement=HypothesisMeasurement(
+                    round=3,
+                    metric="throughput",
+                    value=140.0,
+                    unit="ops_s",
+                    delta_reason=PerfDeltaReason.BASELINE_UNRESOLVED,
+                ),
+            ),
+            _hypothesis(
+                "H-04",
+                4,
+                rounds=[
+                    _round(
+                        4,
+                        hypothesis_id="H-04",
+                        perf_metric=150.0,
+                        perf_unit="ops_s",
+                        official_evaluation=True,
+                        perf_provenance="implementer",
+                    )
+                ],
+            ),
+        ]
+    )
+
+    measured, first, unresolved, reported = build_experiment_log(state)
+
+    assert (measured.perf_baseline_round, measured.perf_baseline_commit) == (1, "c1")
+    assert measured.perf_delta_reason is None
+    assert first.perf_delta_reason is PerfDeltaReason.NO_BASELINE_YET
+    assert unresolved.perf_delta_reason is PerfDeltaReason.BASELINE_UNRESOLVED
+    assert (unresolved.perf_baseline_round, unresolved.perf_baseline_commit) == (None, None)
+    # The self-reported number itself stays off the entry-level measurement
+    # tuple; only the reason says a number exists that nobody trusted-measured.
+    assert reported.perf_metric is None
+    assert reported.perf_delta_reason is PerfDeltaReason.NOT_FRAMEWORK_MEASURED
+
+
+def test_hypothesis_entry_round_trips_the_no_delta_reason() -> None:
+    """The new fields survive the wire, and a legacy payload stays valid."""
+    entry = HypothesisEntry(
+        hypothesis_id="H-01",
+        first_round=1,
+        last_round=1,
+        perf_delta_reason=PerfDeltaReason.BASELINE_UNRESOLVED,
+        perf_baseline_round=3,
+        perf_baseline_commit="abc1234deadbeef",
+    )
+
+    decoded = HypothesisEntry.model_validate_json(entry.model_dump_json())
+    assert decoded.perf_delta_reason is PerfDeltaReason.BASELINE_UNRESOLVED
+    assert (decoded.perf_baseline_round, decoded.perf_baseline_commit) == (3, "abc1234deadbeef")
+
+    legacy = HypothesisEntry.model_validate(
+        {"hypothesis_id": "H-02", "first_round": 1, "last_round": 1}
+    )
+    assert legacy.perf_delta_reason is None
+    assert (legacy.perf_baseline_round, legacy.perf_baseline_commit) == (None, None)
 
 
 def test_projection_surfaces_active_hypothesis_before_a_round_finishes() -> None:

--- a/tests/vibesys/loops/agent/test_hypotheses.py
+++ b/tests/vibesys/loops/agent/test_hypotheses.py
@@ -11,6 +11,7 @@ from vibesys.loops.agent.hypotheses import (
     adopt_metric_space,
     append_round,
     apply_strategy_updates,
+    measurement_delta_reason,
     metric_baseline,
     project_round_evidence,
     reproject_run_evidence,
@@ -30,6 +31,7 @@ from vibesys.schemas import (
     HypothesisOutcome,
     HypothesisStrategyUpdate,
     OrchestratorPlan,
+    PerfDeltaReason,
 )
 from vs_loop_state import PerfProvenance, RoundRecord
 
@@ -637,6 +639,70 @@ def _implementer_reported_run() -> AgentRunState:
         ),
         keep_active=False,
     )
+
+
+def test_delta_reason_separates_a_first_reading_from_a_failed_lookup() -> None:
+    """Round one, a fail-closed lookup, and a resolved baseline stay apart."""
+    first = _round(1, 100.0, hypothesis_id="H-1")
+    state = start_hypothesis(AgentRunState(), _plan("H-1"), started_round=1)
+    state = append_round(state, first, keep_active=False)
+    # The parent commit matches no trusted official round and no parent round
+    # bounds the fallback: the exact shape `metric_baseline` fails closed on.
+    state = start_hypothesis(state, _plan("H-2"), started_round=2, parent_commit="f" * 40)
+    state = append_round(
+        state,
+        _round(2, 200.0, hypothesis_id="H-2", parent_commit="f" * 40),
+        keep_active=False,
+    )
+    state = start_hypothesis(
+        state, _plan("H-3"), started_round=3, parent_round=1, parent_commit=first.commit
+    )
+    state = append_round(
+        state,
+        _round(3, 300.0, hypothesis_id="H-3", parent_round=1, parent_commit=first.commit),
+        keep_active=False,
+    )
+
+    round_one = state.by_id("H-1")
+    unresolved = state.by_id("H-2")
+    resolved = state.by_id("H-3")
+    assert round_one is not None
+    assert round_one.measurement is not None
+    assert round_one.measurement.delta_pct is None
+    assert round_one.measurement.delta_reason is PerfDeltaReason.NO_BASELINE_YET
+    assert measurement_delta_reason(round_one) is PerfDeltaReason.NO_BASELINE_YET
+    assert unresolved is not None
+    assert unresolved.measurement is not None
+    assert unresolved.measurement.delta_pct is None
+    assert unresolved.measurement.delta_reason is PerfDeltaReason.BASELINE_UNRESOLVED
+    assert measurement_delta_reason(unresolved) is PerfDeltaReason.BASELINE_UNRESOLVED
+    assert resolved is not None
+    assert resolved.measurement is not None
+    assert resolved.measurement.delta_pct is not None
+    assert resolved.measurement.delta_reason is None
+    assert measurement_delta_reason(resolved) is None
+
+
+def test_a_self_reported_headline_reads_as_not_framework_measured() -> None:
+    """No measurement exists to carry the reason, so the rounds answer it."""
+    hypothesis = _implementer_reported_run().by_id("H-1")
+
+    assert hypothesis is not None
+    assert hypothesis.measurement is None
+    assert measurement_delta_reason(hypothesis) is PerfDeltaReason.NOT_FRAMEWORK_MEASURED
+
+
+def test_a_legacy_absolute_reading_carries_no_delta_reason() -> None:
+    """A record predating provenance keeps reading as a deliberate absolute."""
+    state = start_hypothesis(AgentRunState(), _plan("H-1"), started_round=1)
+    state = append_round(state, _legacy_evidence_round(1, 100.0), keep_active=False)
+
+    hypothesis = state.by_id("H-1")
+    assert hypothesis is not None
+    assert hypothesis.measurement is not None
+    assert hypothesis.measurement.delta_pct is None
+    assert hypothesis.measurement.delta_reason is None
+    assert measurement_delta_reason(hypothesis) is None
 
 
 def test_a_self_reported_improvement_never_resolves_proven() -> None:


### PR DESCRIPTION
## Problem

Fixes #593. Three different "no delta" situations rendered identically in the experiment log's Measured column. A round-one reading (legitimately nothing to compare against), a fail-closed baseline lookup from #536 (candidates existed but the parent commit matched no trusted official round), and an implementer self-reported headline (never ordered against framework numbers per #535) were indistinguishable at a glance. Reproduced on the base commit with a four-hypothesis probe: the round-one and fail-closed hypotheses projected byte-identical bare absolutes, and the self-reported one projected the same em-dash a hypothesis with no measurement at all gets. An operator reading `55434.2 ops/s` could not tell a deliberate first reading from a lookup the framework refused, and a self-reported claim was invisible rather than flagged. Per #465, any fix must not rely on color alone, and records that predate provenance tracking must keep rendering as deliberate absolutes rather than being retroactively relabelled.

## Solution

The evidence to tell the three cases apart already exists in the round records; the fix derives a reason from it at projection time and never stores it. A new `PerfDeltaReason` enum (`no_baseline_yet`, `baseline_unresolved`, `not_framework_measured`) lives in `src/vibesys/schemas.py` next to the other closed vocabularies. `_measurement` in `src/vibesys/loops/agent/hypotheses.py` sets `HypothesisMeasurement.delta_reason` when the delta and all three baseline fields are None and the record carries provenance: `baseline_unresolved` if admissible baseline candidates existed, `no_baseline_yet` if none did. The candidate test is a new `baseline_candidates` helper extracted from `metric_baseline` itself, so the empty-versus-nonempty distinction is by construction the same filter the real lookup applies and cannot drift from it. A second helper, `measurement_delta_reason`, answers `not_framework_measured` for hypotheses whose only official headline is implementer-provenance: those project `measurement=None` under the #535 ordering rule, which is untouched, so the reason has to come from the rounds directly. Records with `perf_provenance=None` predate provenance tracking and get no reason, preserving their legacy rendering.

The server projection (`_entry` in `src/server/api/experiments.py`) copies the reason plus the baseline identity (`perf_baseline_round`, `perf_baseline_commit`) onto `HypothesisEntry`, and the generated protocol schema and TypeScript union were regenerated, not hand-edited. Because the read path reprojects run evidence on every fetch, the reason is recomputed from the rounds each time and can never disagree with the fields it summarizes.

In the TUI, `formatMeasured` renders `self-reported` for a self-reported headline and prefixes a fail-closed absolute with `? ` (a prefix, so it survives the column's end-truncation at any width); a round-one or legacy absolute stays a bare value. The hypothesis drill-down spells everything out: a `Baseline round N` and `Baseline commit abc1234` line when a baseline resolved, and a full-sentence reason (`No baseline existed yet`, `No trusted baseline resolved`, `Self-reported, not framework-measured`) when one did not. The label switch is exhaustive with no default case, so adding a fourth enum member fails the TypeScript build instead of rendering silently. All distinctions are textual, satisfying the #465 constraint. `clients/tui/README.md` documents the two new cell forms.

### Architecture

The reason is derived, flowing one way from round evidence to pixels, with no new stored state at any layer.

```mermaid
flowchart TD
    R["RoundRecord: perf_provenance, official_evaluation, parent linkage (loop-owned, unchanged)"] --> M["_measurement in hypotheses.py: delta resolved? else derive delta_reason via baseline_candidates"]
    M --> H["HypothesisMeasurement.delta_reason (derived, never persisted)"]
    R --> F["measurement_delta_reason: implementer-only headline, no measurement exists"]
    H --> E["_entry in server/api/experiments.py: perf_delta_reason + perf_baseline_round/commit on HypothesisEntry"]
    F --> E
    E --> G["generated protocol.schema.json / protocol.generated.ts: PerfDeltaReason literal union"]
    G --> C["formatMeasured: bare value | '? ' prefix | 'self-reported'"]
    G --> D["drill-down metadata: baseline identity + spelled-out reason via exhaustive deltaReasonLabel"]
```

## Verification

A probe script against the base commit reproduced the issue exactly (round-one and fail-closed hypotheses byte-identical, self-reported indistinguishable from unmeasured); rerun on this branch, the same four hypotheses project `no_baseline_yet`, `baseline_unresolved`, `not_framework_measured`, and a resolved delta carrying its baseline round and commit. New regression tests at the loop, projection, and rendering layers each fail on the base commit and pass here. A live codex-provider run through the real TUI confirmed the end-to-end path.

### Correctness properties

- The reason is never stored: the server reprojects run evidence on every read, so `perf_delta_reason` is recomputed from `perf_provenance` and the baseline fields each time and cannot drift from them.
- `no_baseline_yet` versus `baseline_unresolved` is decided by `baseline_candidates`, the same admissibility filter `metric_baseline` uses for the real lookup, so the label can never contradict what the lookup would have done.
- Legacy records (`perf_provenance is None`) carry no reason and render exactly as before, as deliberate absolutes.
- The #535 ordering rule is untouched: implementer-only hypotheses still project `measurement=None`; the `self-reported` cell replaces an em-dash, never a framework number.
- Entries with a resolved delta are unchanged: `delta_reason` is None whenever any baseline field is set, and the cell renders the delta exactly as before.
- The `? ` marker is a prefix, so it survives `fitColumn` end-truncation at `MEASURED_WIDTH` even when a long unit would swallow a suffix; all three distinctions are text, not color (#465).
- `deltaReasonLabel` switches exhaustively over the generated union with no default, so a new enum member is a compile error in the TUI, not a silently blank label.

### Testing

- `tests/vibesys/loops/agent/test_hypotheses.py`: `test_delta_reason_separates_a_first_reading_from_a_failed_lookup` (round one derives `NO_BASELINE_YET`, an unmatched parent commit derives `BASELINE_UNRESOLVED`, a resolved baseline derives a delta with reason None), `test_a_self_reported_headline_reads_as_not_framework_measured`, `test_a_legacy_absolute_reading_carries_no_delta_reason`.
- `tests/server/test_experiments.py`: `test_projection_carries_baseline_identity_and_the_no_delta_reason` (four hypotheses project four distinct states, and the implementer one keeps `perf_metric=None`), `test_hypothesis_entry_round_trips_the_no_delta_reason` (JSON round-trip preserves the enum and baseline identity; a legacy payload without the new fields still validates with None defaults).
- `clients/tui/src/ui/experiment-log.test.ts`: "renders the three no-delta reasons and a zero delta as four distinct cells", "renders a legacy entry with no delta_reason as a bare value and leaves a delta unaffected", "keeps the ? marker readable when a long unit truncates at MEASURED_WIDTH", "spells out the baseline identity in the drill-down metadata", "spells out each no-delta reason in the drill-down metadata".
- Full Python suites: `uv run pytest tests/server tests/vibesys -q --no-cov` passes (616 tests), targeted run of the two touched files passes (49 tests). `uv run ruff check`, `uv run ty check`, and `./scripts/check_format.sh` are clean.
- TypeScript: `pnpm check:ts-architecture`, `pnpm check:clients`, and `pnpm build:clients` are clean; `pnpm test:clients` passes (25 backend-client, 75 core-state, 554 tui tests, including the five new ones). Regenerated protocol files verified in sync by the schema-parity test.
- Live harness run (codex provider, model `gpt-5.6-sol`, queue-rs spsc task, 1 round, `--profiler none`): round one's Measured cell shows the bare absolute `22554459.26 total_o…` with no marker, and the drill-down metadata line reads `Measured 22554459.26 · No baseline existed yet`; the backend log is clean. A single-round live run can only exercise the `no_baseline_yet` path; the fail-closed and self-reported paths are pinned by the unit tests above.
- Merges cleanly against current `main` (`git merge-tree --write-tree`).

Closes #593.
