### PR TITLE
TUI: close out dead rounds and keep the agent graph stable across kill and resume

### DIFF
--- a/clients/core-state/src/core-state-prefix.test.ts
+++ b/clients/core-state/src/core-state-prefix.test.ts
@@ -101,6 +101,171 @@ describe('prefix backfill equivalence', () => {
 });
 
 describe('prefix merges across the chunk boundary', () => {
+  it('replays a resumed lifetime when backfill follows the server spine', () => {
+    const events = [
+      runStartedEvent(1),
+      executionStartedEvent(2, 'old-attempt'),
+      chunkEvent(3, 'old attempt started'),
+      chunkEvent(4, 'old attempt still running'),
+      chunkEvent(5, 'old attempt still running'),
+      chunkEvent(6, 'old attempt last output'),
+      {...runStartedEvent(7), timestamp: timestamp(7)},
+      executionStartedEvent(8, 'resumed-attempt'),
+      chunkEvent(9, 'tail after resume'),
+    ];
+    const floor = 8;
+    const spine = events.filter(
+      event =>
+        event.sequence !== undefined && event.sequence <= floor && event.type === 'run_started',
+    );
+    const tail = [
+      ...spine,
+      ...events.filter(event => event.sequence !== undefined && event.sequence > floor),
+    ];
+
+    const full = reduceEventBatch(initialCoreState(), events);
+    const bootstrapped = reduceEventBatch(initialCoreState(), tail, undefined, undefined, floor);
+    // This mirrors two event-history requests. The first carries the last
+    // pre-resume output and resumed start, while the old start arrives only in
+    // the later request. Both run boundaries are omitted as spine duplicates.
+    const afterFirstBackfill = reduceEventPrefix(
+      bootstrapped,
+      events.filter(
+        event =>
+          event.sequence === 4 ||
+          event.sequence === 5 ||
+          event.sequence === 6 ||
+          event.sequence === 8,
+      ),
+      3,
+    );
+    const merged = reduceEventPrefix(
+      afterFirstBackfill,
+      events.filter(event => event.sequence === 2 || event.sequence === 3),
+      0,
+    );
+
+    // `activeExecutions` is a checkpoint projection, intentionally owned by
+    // the server rather than event history. Every replay-derived field agrees.
+    expect({...merged, activeExecutions: {}}).toEqual({...full, activeExecutions: {}});
+    expect(merged.phases.filter(phase => phase.kind === 'implementer')).toMatchObject([
+      {executionId: 'old-attempt', status: 'interrupted'},
+      {executionId: 'resumed-attempt', status: 'active'},
+    ]);
+    expect(merged.phases.find(phase => phase.executionId === 'old-attempt')?.finishedAt).toBe(
+      timestamp(6),
+    );
+    expect(reduceEventPrefix(merged, [], 0)).toEqual(merged);
+  });
+
+  it('preserves each inferred endpoint across multi-resume backfill chunkings', () => {
+    const events = [
+      runStartedEvent(1),
+      executionStartedEvent(2, 'first-attempt'),
+      chunkEvent(3, 'first attempt last output'),
+      runStartedEvent(4),
+      executionStartedEvent(5, 'middle-attempt'),
+      chunkEvent(6, 'middle attempt last output'),
+      runStartedEvent(7),
+      executionStartedEvent(8, 'latest-attempt'),
+      chunkEvent(9, 'latest attempt output'),
+    ];
+    const full = reduceEventBatch(initialCoreState(), events);
+
+    for (const chunks of [
+      [
+        {sequences: [5, 6, 8], floor: 4},
+        {sequences: [2, 3], floor: 0},
+      ],
+      [
+        {sequences: [8], floor: 6},
+        {sequences: [5, 6], floor: 4},
+        {sequences: [2, 3], floor: 0},
+      ],
+    ]) {
+      const merged = foldWithSpineBackfill(events, 8, chunks);
+
+      expect({...merged, activeExecutions: {}}).toEqual({...full, activeExecutions: {}});
+      expect(merged.rounds).toMatchObject([
+        {
+          status: 'failed',
+          finishedAt: timestamp(3),
+          agentIntervals: [
+            {startedAt: timestamp(2), finishedAt: timestamp(3)},
+            {startedAt: timestamp(5), finishedAt: timestamp(6)},
+          ],
+          activeAgentStarts: {'implementer:latest-attempt': timestamp(8)},
+        },
+      ]);
+    }
+  });
+
+  it('lets an explicit round finish supersede an inferred resume endpoint', () => {
+    const events = [
+      runStartedEvent(1),
+      executionStartedEvent(2, 'first-attempt'),
+      chunkEvent(3, 'first attempt last output'),
+      runStartedEvent(4),
+      executionStartedEvent(5, 'latest-attempt'),
+      chunkEvent(6, 'latest attempt output'),
+      roundFinishedEvent(7),
+    ];
+    const full = reduceEventBatch(initialCoreState(), events);
+    const merged = foldWithSpineBackfill(events, 4, [
+      {sequences: [2, 3], floor: 0},
+      {sequences: [], floor: 0},
+    ]);
+
+    expect({...merged, activeExecutions: {}}).toEqual({...full, activeExecutions: {}});
+    expect(merged.rounds).toMatchObject([
+      {status: 'completed', finishedAt: timestamp(7), closedByRoundFinished: true},
+    ]);
+  });
+
+  for (const [terminal, expectedStatus] of [
+    ['run_failed', 'failed'],
+    ['run_interrupted', 'interrupted'],
+    ['run_finished', 'interrupted'],
+  ] as const) {
+    it(`retains ${terminal} before the resumed start`, () => {
+      const events: RunEvent[] = [
+        runStartedEvent(1),
+        executionStartedEvent(2, 'old-attempt'),
+        chunkEvent(3, 'old attempt last output'),
+        {sequence: 4, timestamp: timestamp(4), type: terminal},
+        runStartedEvent(5),
+        executionStartedEvent(6, 'resumed-attempt'),
+        chunkEvent(7, 'tail after resume'),
+      ];
+      const floor = 6;
+      const spine = events.filter(
+        event =>
+          event.sequence !== undefined &&
+          event.sequence <= floor &&
+          ['run_started', 'run_finished', 'run_failed', 'run_interrupted'].includes(event.type),
+      );
+      const tail = [
+        ...spine,
+        ...events.filter(event => event.sequence !== undefined && event.sequence > floor),
+      ];
+      const full = reduceEventBatch(initialCoreState(), events);
+      const bootstrapped = reduceEventBatch(initialCoreState(), tail, undefined, undefined, floor);
+      const merged = reduceEventPrefix(
+        bootstrapped,
+        events.filter(
+          event => event.sequence === 2 || event.sequence === 3 || event.sequence === 6,
+        ),
+        0,
+      );
+
+      expect({...merged, activeExecutions: {}}).toEqual({...full, activeExecutions: {}});
+      expect(merged.phases.find(phase => phase.executionId === 'old-attempt')).toMatchObject({
+        status: expectedStatus,
+        finishedAt: timestamp(4),
+      });
+    });
+  }
+
   it('lands a tail tool result on a tool call from the chunk', () => {
     const events = [
       toolCallEvent(1, 'call-a'),
@@ -194,6 +359,7 @@ describe('prefix merges across the chunk boundary', () => {
         status: 'completed',
         startedAt: timestamp(1),
         finishedAt: timestamp(2),
+        closedByRoundFinished: true,
         agentIntervals: [],
         activeAgentStarts: {},
       },
@@ -346,6 +512,39 @@ function backfillAt(events: readonly RunEvent[], boundaries: readonly number[]):
 
 function foldAsPrefix(events: readonly RunEvent[], boundary: number): CoreState {
   return backfillAt(events, [boundary]);
+}
+
+function foldWithSpineBackfill(
+  events: readonly RunEvent[],
+  floor: number,
+  chunks: readonly {sequences: readonly number[]; floor: number}[],
+): CoreState {
+  const spine = events.filter(
+    event =>
+      event.sequence !== undefined &&
+      event.sequence <= floor &&
+      (event.type === 'run_started' ||
+        event.type === 'run_finished' ||
+        event.type === 'run_failed' ||
+        event.type === 'run_interrupted'),
+  );
+  let state = reduceEventBatch(
+    initialCoreState(),
+    [...spine, ...events.filter(event => event.sequence !== undefined && event.sequence > floor)],
+    undefined,
+    undefined,
+    floor,
+  );
+  for (const chunk of chunks) {
+    state = reduceEventPrefix(
+      state,
+      events.filter(
+        event => event.sequence !== undefined && chunk.sequences.includes(event.sequence),
+      ),
+      chunk.floor,
+    );
+  }
+  return state;
 }
 
 function sequenceAt(events: readonly RunEvent[], index: number): number {

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -151,6 +151,11 @@ export interface CoreState {
   maxRounds: number | null;
   rounds: RoundState[];
   phases: AgentPhase[];
+  /**
+   * Timestamp of the newest event the run map folded, or null before the first
+   * one. The run map owns the field and its meaning; see `RunMapState`.
+   */
+  lastEventTimestamp: string | null;
   activeExecutions: Record<string, ActiveAgentExecution>;
   transcript: TranscriptEntry[];
   /** The default thread's transcript; equals `chatTranscripts[DEFAULT_CHAT_THREAD_ID]`. */
@@ -189,6 +194,7 @@ export function initialCoreState(): CoreState {
     maxRounds: null,
     rounds: [],
     phases: [],
+    lastEventTimestamp: null,
     activeExecutions: {},
     transcript: [],
     chatTranscript: [],
@@ -371,6 +377,8 @@ export function reduceEventPrefix(
     maxRounds: state.maxRounds ?? older.maxRounds,
     rounds: mergeRoundLists(older.rounds, state.rounds),
     phases: mergePhaseLists(older.phases, state.phases),
+    // The newer batch folded the newer events, so it saw the run more recently.
+    lastEventTimestamp: state.lastEventTimestamp ?? older.lastEventTimestamp,
     // Liveness comes from the backend checkpoint, never from replayed history.
     activeExecutions: state.activeExecutions,
     transcript: mergeTranscriptPrefix(older.transcript, state.transcript),
@@ -562,6 +570,7 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
   next.expectedRoles = runMap.expectedRoles;
   next.rounds = runMap.rounds;
   next.phases = runMap.phases;
+  next.lastEventTimestamp = runMap.lastEventTimestamp;
 
   const data = event.data;
   // The run map owns a round's status and timing; the carried-forward flag is

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -128,6 +128,24 @@ export interface CoreDiagnostic {
   sequence: number;
 }
 
+export interface RunLifetimeBoundary {
+  event: RunEvent;
+  /** Last event observed before a resumed run_started boundary, if known. */
+  closeout: {sequence: number; timestamp: string} | null;
+}
+
+function isRunLifetimeBoundary(event: RunEvent): boolean {
+  switch (event.type) {
+    case 'run_started':
+    case 'run_finished':
+    case 'run_failed':
+    case 'run_interrupted':
+      return true;
+    default:
+      return false;
+  }
+}
+
 /**
  * Run status as core state carries it: every status the backend reports, plus
  * the client-only `connecting` that precedes the first snapshot or event.
@@ -156,6 +174,10 @@ export interface CoreState {
    * one. The run map owns the field and its meaning; see `RunMapState`.
    */
   lastEventTimestamp: string | null;
+  /** Sequence of the latest non-chat event folded through the run map. */
+  lastRunMapSequence: number;
+  /** Run lifetime boundaries retained from the replayed event stream. */
+  runLifetimeBoundaries: readonly RunLifetimeBoundary[];
   activeExecutions: Record<string, ActiveAgentExecution>;
   transcript: TranscriptEntry[];
   /** The default thread's transcript; equals `chatTranscripts[DEFAULT_CHAT_THREAD_ID]`. */
@@ -195,6 +217,8 @@ export function initialCoreState(): CoreState {
     rounds: [],
     phases: [],
     lastEventTimestamp: null,
+    lastRunMapSequence: 0,
+    runLifetimeBoundaries: [],
     activeExecutions: {},
     transcript: [],
     chatTranscript: [],
@@ -364,7 +388,39 @@ export function reduceEventPrefix(
   events: readonly RunEvent[],
   historyAfterSequence: number,
 ): CoreState {
-  const older = reduceEventBatch(initialCoreState(), events);
+  const sequences = new Set(
+    events.map(event => event.sequence).filter(sequence => sequence !== undefined),
+  );
+  const boundaries = state.runLifetimeBoundaries.filter(
+    boundary => boundary.event.sequence !== undefined && !sequences.has(boundary.event.sequence),
+  );
+  // Fold ordinary prefix data once. Run-level spine events may carry terminal
+  // transcript and diagnostic facts that the tail already has, so replaying
+  // them through this fold would duplicate those facts during the merge.
+  const olderData = reduceEventBatch(initialCoreState(), events);
+  // Rebuild just the run-map projection with every retained lifetime boundary.
+  // This keeps a narrow older chunk in the same run configuration as a full
+  // replay, and re-applies terminal/resume boundaries without duplicating
+  // their non-map projections.
+  const runMapReplay = reduceEventBatch(
+    {...initialCoreState(), runLifetimeBoundaries: state.runLifetimeBoundaries},
+    [...events, ...boundaries.map(boundary => boundary.event)].sort(
+      (left, right) => (left.sequence ?? 0) - (right.sequence ?? 0),
+    ),
+  );
+  const older: CoreState = {
+    ...olderData,
+    outerLoop: runMapReplay.outerLoop,
+    expectedRoles: runMapReplay.expectedRoles,
+    rounds: runMapReplay.rounds,
+    phases: runMapReplay.phases,
+    lastEventTimestamp: runMapReplay.lastEventTimestamp,
+    lastRunMapSequence: runMapReplay.lastRunMapSequence,
+    runLifetimeBoundaries: mergeRunLifetimeBoundaries(
+      runMapReplay.runLifetimeBoundaries,
+      state.runLifetimeBoundaries,
+    ),
+  };
   const chatTranscripts = mergeChatTranscriptsPrefix(older.chatTranscripts, state.chatTranscripts);
   return {
     sequence: state.sequence,
@@ -379,6 +435,12 @@ export function reduceEventPrefix(
     phases: mergePhaseLists(older.phases, state.phases),
     // The newer batch folded the newer events, so it saw the run more recently.
     lastEventTimestamp: state.lastEventTimestamp ?? older.lastEventTimestamp,
+    lastRunMapSequence:
+      state.lastRunMapSequence > 0 ? state.lastRunMapSequence : older.lastRunMapSequence,
+    runLifetimeBoundaries: mergeRunLifetimeBoundaries(
+      older.runLifetimeBoundaries,
+      state.runLifetimeBoundaries,
+    ),
     // Liveness comes from the backend checkpoint, never from replayed history.
     activeExecutions: state.activeExecutions,
     transcript: mergeTranscriptPrefix(older.transcript, state.transcript),
@@ -552,6 +614,53 @@ function mergeTypedToolFlags(
   return merged;
 }
 
+/** Retain each boundary and its closest known predecessor. */
+function mergeRunLifetimeBoundaries(
+  older: readonly RunLifetimeBoundary[],
+  newer: readonly RunLifetimeBoundary[],
+): readonly RunLifetimeBoundary[] {
+  const merged = new Map<number, RunLifetimeBoundary>();
+  for (const boundary of [...older, ...newer]) {
+    const sequence = boundary.event.sequence;
+    if (sequence === undefined) continue;
+    const existing = merged.get(sequence);
+    if (
+      existing === undefined ||
+      (boundary.closeout?.sequence ?? -1) > (existing.closeout?.sequence ?? -1)
+    ) {
+      merged.set(sequence, boundary);
+    }
+  }
+  return [...merged.values()].sort(
+    (left, right) => (left.event.sequence ?? 0) - (right.event.sequence ?? 0),
+  );
+}
+
+function boundaryFor(
+  boundaries: readonly RunLifetimeBoundary[],
+  event: RunEvent,
+  state: CoreState,
+): RunLifetimeBoundary {
+  const sequence = event.sequence;
+  if (sequence === undefined) return {event, closeout: null};
+  const known = boundaries.find(boundary => boundary.event.sequence === sequence);
+  // Chat events return before the run map fold, so the map's last timestamp
+  // and sequence, rather than the core cursor, identify the closeout point.
+  const observed =
+    state.lastRunMapSequence > 0 &&
+    state.lastRunMapSequence < sequence &&
+    state.lastEventTimestamp !== null
+      ? {sequence: state.lastRunMapSequence, timestamp: state.lastEventTimestamp}
+      : null;
+  return {
+    event,
+    closeout:
+      observed !== null && observed.sequence > (known?.closeout?.sequence ?? -1)
+        ? observed
+        : (known?.closeout ?? null),
+  };
+}
+
 export function reduceEvent(state: CoreState, event: RunEvent): CoreState {
   return foldEvent(state, event, null);
 }
@@ -565,12 +674,32 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
   if (event.agent_kind === 'chat') return applyChatEvent(next, event, folder);
   if (event.agent_kind) next.agentKind = event.agent_kind;
   if (event.round_label) next.roundLabel = event.round_label;
-  const runMap = applyRunMapEvent(next, event);
+  const boundary =
+    event.type === 'run_started' && event.sequence !== undefined
+      ? boundaryFor(state.runLifetimeBoundaries, event, state)
+      : isRunLifetimeBoundary(event)
+        ? {event, closeout: null}
+        : null;
+  const runMap = applyRunMapEvent(
+    {
+      outerLoop: next.outerLoop,
+      expectedRoles: next.expectedRoles,
+      rounds: next.rounds,
+      phases: next.phases,
+      lastEventTimestamp: next.lastEventTimestamp,
+    },
+    event,
+    boundary?.closeout?.timestamp ?? null,
+  );
   next.outerLoop = runMap.outerLoop;
   next.expectedRoles = runMap.expectedRoles;
   next.rounds = runMap.rounds;
   next.phases = runMap.phases;
   next.lastEventTimestamp = runMap.lastEventTimestamp;
+  next.lastRunMapSequence = sequence;
+  if (boundary !== null) {
+    next.runLifetimeBoundaries = mergeRunLifetimeBoundaries(next.runLifetimeBoundaries, [boundary]);
+  }
 
   const data = event.data;
   // The run map owns a round's status and timing; the carried-forward flag is

--- a/clients/core-state/src/run-map.test.ts
+++ b/clients/core-state/src/run-map.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from 'bun:test';
 import type {RunEvent} from '@vibesys/backend-client';
+import {hasActiveAgentTiming} from './round-timing.js';
 import {
   applyRunMapEvent,
   expectedRolesForSeeding,
@@ -72,16 +73,120 @@ describe('run map projection', () => {
     ]);
   });
 
-  it('closes active timing when a run is interrupted', () => {
+  it('closes active timing when a run is interrupted, with no agent scope on the event', () => {
+    // The three backends that emit this event (`runtime.py` on SIGTERM,
+    // `controller.py`, `headless.py`) all describe the run, not an agent, so
+    // the event carries no `agent_kind` and no `round_label`. A fold that reads
+    // the scope first drops it and the round's clock never stops.
     let state = applyRunMapEvent(emptyRunMap(), execution(1, 'agent_execution_started', 'a'));
-    state = applyRunMapEvent(state, {
-      ...execution(4, 'run_interrupted', 'a'),
-      data: {kind: 'run_interrupted', reason: 'operator', signal: 'SIGINT'},
-    });
+    state = applyRunMapEvent(state, runInterrupted(4));
 
     const round = requiredRound(state);
     expect(round.status).toBe('failed');
+    expect(hasActiveAgentTiming(round)).toBe(false);
+    // Frozen where the run died: the same value ten seconds later.
     expect(roundAgentElapsedMs(round, new Date('2026-01-01T00:00:10Z'))).toBe(3000);
+    expect(roundAgentElapsedMs(round, new Date('2026-01-01T00:10:00Z'))).toBe(3000);
+  });
+});
+
+describe('run-level closeout', () => {
+  it('closes every round and phase on interrupt, not just the labelled one', () => {
+    let state = applyRunMapEvent(initialRunMap(), runStarted('agent'));
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_started', 'a'));
+    state = applyRunMapEvent(state, execution(3, 'agent_execution_finished', 'a'));
+    state = applyRunMapEvent(state, roundFinished(4, 1));
+    state = applyRunMapEvent(state, execution(5, 'agent_execution_started', 'b', 2));
+    state = applyRunMapEvent(state, runInterrupted(6));
+
+    expect(state.phases.map(phase => [phase.roundNumber, phase.kind, phase.status])).toEqual([
+      [1, 'orchestrator', 'cancelled'],
+      [1, 'implementer', 'completed'],
+      [1, 'judge', 'cancelled'],
+      [1, 'profiler', 'cancelled'],
+      [2, 'orchestrator', 'cancelled'],
+      [2, 'implementer', 'interrupted'],
+      [2, 'judge', 'cancelled'],
+      [2, 'profiler', 'cancelled'],
+    ]);
+    // Round one closed on its own event and keeps that status; round two was
+    // still open, so the run-level event is what ends it.
+    expect(state.rounds.map(round => [round.number, round.status])).toEqual([
+      [1, 'completed'],
+      [2, 'failed'],
+    ]);
+    expect(state.rounds.every(round => !hasActiveAgentTiming(round))).toBe(true);
+  });
+
+  it('fails the running agents and cancels the unstarted ones when a run fails', () => {
+    let state = applyRunMapEvent(initialRunMap(), runStarted('agent'));
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_started', 'a'));
+    state = applyRunMapEvent(state, runFailed(3));
+
+    expect(state.phases.map(phase => [phase.kind, phase.status])).toEqual([
+      ['orchestrator', 'cancelled'],
+      ['implementer', 'failed'],
+      ['judge', 'cancelled'],
+      ['profiler', 'cancelled'],
+    ]);
+    expect(requiredRound(state).status).toBe('failed');
+  });
+
+  it('never overwrites a phase that already reached a terminal status', () => {
+    // The graceful teardown emits per-execution `phase_finished(interrupted)`
+    // before the run-scoped event, so the sweep runs over phases it has already
+    // settled and must leave both their status and their end alone.
+    let state = applyRunMapEvent(emptyRunMap(), execution(1, 'agent_execution_started', 'a'));
+    state = applyRunMapEvent(state, {
+      ...execution(2, 'phase_finished', 'a'),
+      status: 'interrupted',
+    });
+    state = applyRunMapEvent(state, execution(3, 'agent_execution_started', 'b'));
+    state = applyRunMapEvent(state, execution(4, 'agent_execution_finished', 'b'));
+    state = applyRunMapEvent(state, runInterrupted(5));
+
+    expect(state.phases.map(phase => [phase.kind, phase.status, phase.finishedAt])).toEqual([
+      // Never started, so it is not run rather than ended, and has no end.
+      ['orchestrator', 'cancelled', undefined],
+      ['implementer', 'interrupted', '2026-01-01T00:00:02Z'],
+      ['judge', 'cancelled', undefined],
+      ['profiler', 'cancelled', undefined],
+      ['implementer', 'completed', '2026-01-01T00:00:04Z'],
+    ]);
+  });
+
+  it('closes the state a killed run left open when a resumed run starts', () => {
+    // Repro step six: SIGKILL, so no terminal event is ever written. The next
+    // thing the journal carries is the resumed process's `run_started`.
+    let state = applyRunMapEvent(initialRunMap(), runStarted('agent'));
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_started', 'a'));
+    state = applyRunMapEvent(state, streamedChunk(5));
+    state = applyRunMapEvent(state, {
+      ...runStarted('agent'),
+      sequence: 6,
+      timestamp: '2026-01-01T01:00:00Z',
+    });
+
+    expect(state.phases.map(phase => [phase.kind, phase.status])).toEqual([
+      ['orchestrator', 'cancelled'],
+      ['implementer', 'interrupted'],
+      ['judge', 'cancelled'],
+      ['profiler', 'cancelled'],
+    ]);
+    const round = requiredRound(state);
+    expect(round.status).toBe('failed');
+    expect(hasActiveAgentTiming(round)).toBe(false);
+    // Closed at the last event the dead process wrote (00:00:05), not at the
+    // resume an hour later: the downtime is not the round's elapsed time.
+    expect(roundAgentElapsedMs(round, new Date('2026-01-01T02:00:00Z'))).toBe(3000);
+  });
+
+  it('leaves a first run_started alone, having nothing open to close', () => {
+    const state = applyRunMapEvent(initialRunMap(), runStarted('agent'));
+
+    expect(state.rounds).toEqual([]);
+    expect(state.phases).toEqual([]);
+    expect(state.outerLoop).toBe('agent');
   });
 });
 
@@ -151,7 +256,36 @@ describe('expected phase seeding', () => {
 });
 
 function initialRunMap(): RunMapState {
-  return {outerLoop: null, expectedRoles: null, rounds: [], phases: []};
+  return {outerLoop: null, expectedRoles: null, rounds: [], phases: [], lastEventTimestamp: null};
+}
+
+/** A timestamped event with no agent scope, the shape run-scoped events have. */
+function runScoped(sequence: number, type: RunEvent['type']): RunEvent {
+  return {sequence, timestamp: `2026-01-01T00:00:0${sequence}Z`, type};
+}
+
+function runInterrupted(sequence: number): RunEvent {
+  return {
+    ...runScoped(sequence, 'run_interrupted'),
+    data: {kind: 'run_interrupted', reason: 'operator', signal: 'SIGTERM'},
+  };
+}
+
+function runFailed(sequence: number): RunEvent {
+  return runScoped(sequence, 'run_failed');
+}
+
+/** An output chunk: folded for its timestamp alone, which no phase records. */
+function streamedChunk(sequence: number): RunEvent {
+  return runScoped(sequence, 'agent_output_chunk');
+}
+
+function roundFinished(sequence: number, roundNumber: number): RunEvent {
+  return {
+    ...runScoped(sequence, 'round_finished'),
+    status: 'completed',
+    round_label: `round-${roundNumber}`,
+  };
 }
 
 function runStarted(outerLoop: string, expectedRoles?: string[]): RunEvent {
@@ -171,7 +305,13 @@ function runStarted(outerLoop: string, expectedRoles?: string[]): RunEvent {
 }
 
 function emptyRunMap(): RunMapState {
-  return {outerLoop: 'agent', expectedRoles: null, rounds: [], phases: []};
+  return {
+    outerLoop: 'agent',
+    expectedRoles: null,
+    rounds: [],
+    phases: [],
+    lastEventTimestamp: null,
+  };
 }
 
 function requiredRound(state: RunMapState): RunMapState['rounds'][number] {
@@ -180,7 +320,12 @@ function requiredRound(state: RunMapState): RunMapState['rounds'][number] {
   return round;
 }
 
-function execution(sequence: number, type: RunEvent['type'], executionId: string): RunEvent {
+function execution(
+  sequence: number,
+  type: RunEvent['type'],
+  executionId: string,
+  roundNumber = 1,
+): RunEvent {
   const started = type === 'agent_execution_started';
   return {
     sequence,
@@ -189,7 +334,7 @@ function execution(sequence: number, type: RunEvent['type'], executionId: string
     execution_id: executionId,
     invocation_id: executionId,
     agent_kind: 'implementer',
-    round_label: 'round-1-implementer',
+    round_label: `round-${roundNumber}-implementer`,
     ...(started
       ? {
           data: {

--- a/clients/core-state/src/run-map.ts
+++ b/clients/core-state/src/run-map.ts
@@ -3,6 +3,7 @@ import {
   activeTimingElapsedMs,
   closeActiveAgentTimings,
   finishAgentTiming,
+  hasActiveAgentTiming,
   type RoundTimingState,
   startAgentTiming,
 } from './round-timing.js';
@@ -46,19 +47,120 @@ export interface RunMapState {
   expectedRoles: readonly string[] | null;
   rounds: RoundSummary[];
   phases: AgentPhase[];
+  /**
+   * Timestamp of the newest event this state has folded, or null before the
+   * first one.
+   *
+   * A run that is killed hard emits no terminal event, so the moment it stopped
+   * is not recoverable from any later event: the next thing the journal carries
+   * is the resumed process's `run_started`, minutes or hours afterwards.
+   * Recording when the run was last seen alive is what lets the closeout stop
+   * the clocks there rather than charging the downtime to the round.
+   */
+  lastEventTimestamp: string | null;
 }
 
 export function applyRunMapEvent(state: RunMapState, event: RunEvent): RunMapState {
+  const seen: RunMapState = {...state, lastEventTimestamp: event.timestamp};
+  // Run-scoped terminal events say the run ended, not which agent ended it, so
+  // they carry no `agent_kind` and no `round_label`. Every projection below is
+  // keyed by that scope and would drop them, which is why the closeout runs
+  // first and returns: one owner for "the run ended", sweeping the whole map
+  // rather than the one round a label happened to name.
+  if (event.type === 'run_failed') return closeOpenRunState(seen, 'failed', event.timestamp);
+  if (event.type === 'run_interrupted') {
+    return closeOpenRunState(seen, 'interrupted', event.timestamp);
+  }
+  const base =
+    event.type === 'run_started'
+      ? closeAbandonedRunState(seen, state.lastEventTimestamp ?? event.timestamp)
+      : seen;
   const started =
     event.type === 'run_started' && event.data?.kind === 'run_started' ? event.data : null;
-  const outerLoop = started === null ? state.outerLoop : started.outer_loop;
+  const outerLoop = started === null ? base.outerLoop : started.outer_loop;
   const expectedRoles =
     started?.expected_roles !== undefined && started.expected_roles.length > 0
       ? started.expected_roles
-      : state.expectedRoles;
-  const rounds = applyRoundEvent(state.rounds, state.phases, event);
-  const phases = applyPhaseEvent({...state, outerLoop, expectedRoles, rounds}, event);
-  return {outerLoop, expectedRoles, rounds, phases};
+      : base.expectedRoles;
+  const rounds = applyRoundEvent(base.rounds, base.phases, event);
+  const phases = applyPhaseEvent({...base, outerLoop, expectedRoles, rounds}, event);
+  return {outerLoop, expectedRoles, rounds, phases, lastEventTimestamp: event.timestamp};
+}
+
+/**
+ * Closes every phase and round the run left open, at `timestamp`.
+ *
+ * `activeStatus` is what an agent that was running becomes: `interrupted` when
+ * an operator or a signal stopped the run, `failed` when the run itself did. A
+ * phase that never started becomes `cancelled`: it is not a failure, it is work
+ * that will never be attempted. Phases that already reached a terminal status
+ * keep it, so this is idempotent over the per-execution `phase_finished` events
+ * a graceful teardown emits before its run-scoped event.
+ *
+ * Timings close on every round, not just one: an open `activeAgentStarts` entry
+ * is what the elapsed selectors treat as "still running", so a round that keeps
+ * one ticks forever after the process it was measuring is gone.
+ */
+function closeOpenRunState(
+  state: RunMapState,
+  activeStatus: Extract<AgentPhaseStatus, 'failed' | 'interrupted'>,
+  timestamp: string,
+): RunMapState {
+  return {
+    ...state,
+    rounds: state.rounds.map(round => closeRound(round, timestamp)),
+    phases: state.phases.map(phase => closePhase(phase, activeStatus, timestamp)),
+  };
+}
+
+/**
+ * Closes state a previous life of the same run left behind.
+ *
+ * A resumed process appends to the journal of a run that may have died without
+ * a terminal event, because a hard kill gets no chance to emit one. Its open
+ * phases and rounds belong to a process that no longer exists: nothing will
+ * finish them, and their open timings would keep the round clocks running. The
+ * new `run_started` is where the fold learns a new life began, so it is where
+ * the old one ends, dated to when that life was last seen rather than to the
+ * resume, so the downtime in between is not charged to the round. The first
+ * `run_started` of a run has nothing open and leaves the state untouched.
+ */
+function closeAbandonedRunState(state: RunMapState, timestamp: string): RunMapState {
+  if (!hasOpenRunState(state)) return state;
+  return closeOpenRunState(state, 'interrupted', timestamp);
+}
+
+function hasOpenRunState(state: RunMapState): boolean {
+  return (
+    state.phases.some(phase => phase.status === 'active' || phase.status === 'pending') ||
+    state.rounds.some(round => !isRoundClosed(round.status) || hasActiveAgentTiming(round))
+  );
+}
+
+/** Whether a round has reached a status the run map never moves it off. */
+function isRoundClosed(status: RoundStatus): boolean {
+  return status === 'completed' || status === 'failed';
+}
+
+function closeRound(round: RoundSummary, timestamp: string): RoundSummary {
+  const closed = isRoundClosed(round.status)
+    ? round
+    : {...round, status: 'failed' as const, finishedAt: round.finishedAt ?? timestamp};
+  return hasActiveAgentTiming(closed) ? closeActiveAgentTimings(closed, timestamp) : closed;
+}
+
+function closePhase(
+  phase: AgentPhase,
+  activeStatus: Extract<AgentPhaseStatus, 'failed' | 'interrupted'>,
+  timestamp: string,
+): AgentPhase {
+  if (phase.status === 'active') {
+    return {...phase, status: activeStatus, finishedAt: phase.finishedAt ?? timestamp};
+  }
+  // A phase that never started has no end to record, so it takes the status and
+  // no `finishedAt`: an agent that never ran did not run until `timestamp`.
+  if (phase.status === 'pending') return {...phase, status: 'cancelled'};
+  return phase;
 }
 
 export function roundNumberFromLabel(label: string | null | undefined): number | null {
@@ -177,13 +279,6 @@ function applyPhaseEvent(state: RunMapState, event: RunEvent): AgentPhase[] {
   if (roundNumber !== null && roles !== null) {
     phases = seedExpectedPhases(roles, phases, roundNumber);
   }
-  if (event.type === 'run_failed' || event.type === 'run_interrupted') {
-    return phases.map(phase =>
-      phase.roundNumber === roundNumber && phase.status === 'active'
-        ? {...phase, status: 'failed', finishedAt: event.timestamp}
-        : phase,
-    );
-  }
   const started = event.type === 'agent_execution_started' || event.type === 'phase_started';
   const finished = event.type === 'agent_execution_finished' || event.type === 'phase_finished';
   if (!started && !finished) return ensurePhase(phases, kind, roundNumber);
@@ -219,17 +314,17 @@ function applyRoundEvent(
   const number = roundNumberFromLabel(event.round_label);
   if (number === null || event.type === 'run_finished') return rounds;
   const existing = rounds.find(round => round.number === number);
-  const terminalFailure = event.type === 'run_failed' || event.type === 'run_interrupted';
-  const status = terminalFailure
-    ? 'failed'
-    : event.type === 'round_finished'
+  // Run-scoped terminal events never reach here: `applyRunMapEvent` closes every
+  // round for them, because the round a label names is not the only one open.
+  const status =
+    event.type === 'round_finished'
       ? event.status === 'failed'
         ? 'failed'
         : 'completed'
       : existing?.status === 'completed' || existing?.status === 'failed'
         ? existing.status
         : 'active';
-  const terminal = terminalFailure || event.type === 'round_finished';
+  const terminal = event.type === 'round_finished';
   const patch: RoundSummary = {
     number,
     status,
@@ -362,13 +457,7 @@ function updateRoundAgentElapsed(
   const started = event.type === 'agent_execution_started' || event.type === 'phase_started';
   const finished = event.type === 'agent_execution_finished' || event.type === 'phase_finished';
   if (!started && !finished) {
-    if (
-      event.type !== 'round_finished' &&
-      event.type !== 'run_failed' &&
-      event.type !== 'run_interrupted'
-    ) {
-      return round;
-    }
+    if (event.type !== 'round_finished') return round;
     return closeActiveAgentTimings(round, event.timestamp);
   }
   if (event.type === 'phase_started' || event.type === 'phase_finished') {

--- a/clients/core-state/src/run-map.ts
+++ b/clients/core-state/src/run-map.ts
@@ -22,6 +22,10 @@ export interface RoundSummary extends RoundTimingState {
   status: RoundStatus;
   startedAt?: string;
   finishedAt?: string;
+  /** Internal provenance for a terminal endpoint inferred at a run boundary. */
+  closedByRunBoundary?: true;
+  /** An explicit round_finished event may supersede a prior inferred endpoint. */
+  closedByRoundFinished?: true;
 }
 
 export interface AgentPhase {
@@ -60,7 +64,11 @@ export interface RunMapState {
   lastEventTimestamp: string | null;
 }
 
-export function applyRunMapEvent(state: RunMapState, event: RunEvent): RunMapState {
+export function applyRunMapEvent(
+  state: RunMapState,
+  event: RunEvent,
+  abandonedAt: string | null = null,
+): RunMapState {
   const seen: RunMapState = {...state, lastEventTimestamp: event.timestamp};
   // Run-scoped terminal events say the run ended, not which agent ended it, so
   // they carry no `agent_kind` and no `round_label`. Every projection below is
@@ -73,7 +81,7 @@ export function applyRunMapEvent(state: RunMapState, event: RunEvent): RunMapSta
   }
   const base =
     event.type === 'run_started'
-      ? closeAbandonedRunState(seen, state.lastEventTimestamp ?? event.timestamp)
+      ? closeAbandonedRunState(seen, abandonedAt ?? state.lastEventTimestamp ?? event.timestamp)
       : seen;
   const started =
     event.type === 'run_started' && event.data?.kind === 'run_started' ? event.data : null;
@@ -145,7 +153,12 @@ function isRoundClosed(status: RoundStatus): boolean {
 function closeRound(round: RoundSummary, timestamp: string): RoundSummary {
   const closed = isRoundClosed(round.status)
     ? round
-    : {...round, status: 'failed' as const, finishedAt: round.finishedAt ?? timestamp};
+    : {
+        ...round,
+        status: 'failed' as const,
+        finishedAt: round.finishedAt ?? timestamp,
+        closedByRunBoundary: true as const,
+      };
   return hasActiveAgentTiming(closed) ? closeActiveAgentTimings(closed, timestamp) : closed;
 }
 
@@ -241,8 +254,22 @@ function mergeRoundPrefix(older: RoundSummary, newer: RoundSummary): RoundSummar
     older.activeAgentStarts === undefined && newer.activeAgentStarts === undefined
       ? undefined
       : {...older.activeAgentStarts, ...newer.activeAgentStarts};
+  const preserveRunBoundary =
+    older.closedByRunBoundary === true && newer.closedByRoundFinished !== true;
   return {
     ...round,
+    // A resume keeps the interrupted round closed even once its next attempt
+    // starts. This matches `applyRoundEvent`, which never reopens a terminal
+    // round during a chronological replay.
+    ...(preserveRunBoundary
+      ? {
+          status: older.status,
+          ...(older.finishedAt === undefined ? {} : {finishedAt: older.finishedAt}),
+          closedByRunBoundary: true as const,
+        }
+      : isRoundClosed(older.status) && !isRoundClosed(newer.status)
+        ? {status: older.status}
+        : {}),
     ...(agentIntervals === undefined ? {} : {agentIntervals}),
     ...(activeAgentStarts === undefined ? {} : {activeAgentStarts}),
   };
@@ -328,7 +355,9 @@ function applyRoundEvent(
   const patch: RoundSummary = {
     number,
     status,
-    ...(terminal ? {finishedAt: event.timestamp} : {startedAt: event.timestamp}),
+    ...(terminal
+      ? {finishedAt: event.timestamp, closedByRoundFinished: true as const}
+      : {startedAt: event.timestamp}),
   };
   const round = existing ? mergeRound(existing, patch) : patch;
   return replaceRound(rounds, updateRoundAgentElapsed(round, phases, event));

--- a/clients/tui/src/ui/agent-graph.ts
+++ b/clients/tui/src/ui/agent-graph.ts
@@ -83,6 +83,46 @@ export function stageKinds(phases: AgentPhase[]): string[] {
   return kinds;
 }
 
+export interface GraphWindow {
+  phases: AgentPhase[];
+  /** Agents the rows could not hold; 0 when the whole round is on screen. */
+  hidden: number;
+}
+
+/**
+ * The phases that fit in `rows`, and the count of those that do not.
+ *
+ * A stage stacks: an interrupted attempt and the attempt that replaced it are
+ * two agents in one column, so a round can be taller than the pane. The layout
+ * itself is unbounded, so something has to decide what is on screen, and a
+ * graph that silently ran off the bottom is what this replaces. Each column
+ * keeps its newest agents, because the live attempt is the one an operator is
+ * watching, and the count says what was left behind. One row is reserved for
+ * that count when there is one, so the indicator never sits on a node.
+ */
+export function graphWindow(phases: AgentPhase[], rows: number): GraphWindow {
+  const full = fitColumns(phases, rows);
+  if (full.hidden === 0) return full;
+  return fitColumns(phases, rows - 1);
+}
+
+/** Agents a column can stack in `rows` rows, 0 when not even one fits. */
+function columnCapacity(rows: number): number {
+  return Math.max(0, Math.floor((rows + ROW_GAP) / (NODE_HEIGHT + ROW_GAP)));
+}
+
+function fitColumns(phases: AgentPhase[], rows: number): GraphWindow {
+  const capacity = columnCapacity(rows);
+  const dropped = new Set<AgentPhase>();
+  for (const kind of stageKinds(phases)) {
+    const column = phases.filter(phase => phase.kind === kind);
+    for (const phase of column.slice(0, Math.max(0, column.length - capacity))) {
+      dropped.add(phase);
+    }
+  }
+  return {phases: phases.filter(phase => !dropped.has(phase)), hidden: dropped.size};
+}
+
 export function layoutAgentGraph(phases: AgentPhase[], availableWidth: number): AgentGraph {
   const kinds = stageKinds(phases);
   const columns = kinds.map(kind => phases.filter(phase => phase.kind === kind));

--- a/clients/tui/src/ui/agent-map.test.ts
+++ b/clients/tui/src/ui/agent-map.test.ts
@@ -1,6 +1,11 @@
-import {describe, expect, test} from 'bun:test';
-import {agentPaneWidth, STACKED_WIDTH, TRANSCRIPT_MIN} from './agent-map.js';
+import {afterEach, describe, expect, test} from 'bun:test';
+import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
+import type {AgentPhase} from '@vibesys/core-state';
+import type {SessionController} from '../session-controller.js';
+import {initialSessionState, type SessionState} from '../session-model.js';
+import {AgentMapView, agentPaneWidth, STACKED_WIDTH, TRANSCRIPT_MIN} from './agent-map.js';
 import {RAIL_COMPACT_WIDTH, roundRailWidth} from './round-rail.js';
+import {resolveTheme} from './theme.js';
 
 /**
  * The round view lays out rail -> agents -> transcript. app.ts sizes the agent
@@ -50,5 +55,89 @@ describe('agentPaneWidth transcript floor beside the rail', () => {
         TRANSCRIPT_MIN,
       );
     }
+  });
+});
+
+/**
+ * A killed attempt and the attempt that resumed it are two agents in one stage,
+ * so a round can be taller than the pane. The symptom is stated in rows, so it
+ * is reproduced through the real renderable tree at a fixed terminal size: the
+ * frame is what says whether a node was drawn past the bottom border.
+ */
+describe('agent graph row budget', () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const destroy of cleanup.splice(0).reverse()) destroy();
+  });
+
+  const ROWS = 20;
+
+  /** One round whose implementer stage stacks `attempts` agents. */
+  function stackedState(attempts: number): SessionState {
+    const base = initialSessionState();
+    const phases: AgentPhase[] = [
+      {kind: 'orchestrator', status: 'completed', roundNumber: 1, roundLabel: 'round-1'},
+      ...Array.from({length: attempts}, (_, index) => ({
+        kind: 'implementer',
+        status: (index === attempts - 1 ? 'active' : 'interrupted') as AgentPhase['status'],
+        roundNumber: 1,
+        roundLabel: `round-1-retry-${index + 1}-implementer`,
+        executionId: `e${index}`,
+      })),
+      {kind: 'judge', status: 'pending', roundNumber: 1, roundLabel: null},
+    ];
+    return {
+      ...base,
+      experimentLog: null,
+      selectedRound: 1,
+      core: {...base.core, rounds: [{number: 1, status: 'active'}], phases},
+    };
+  }
+
+  async function renderGraph(attempts: number): Promise<{frame: string; nodes: number}> {
+    const testRenderer: TestRendererSetup = await createTestRenderer({width: 120, height: ROWS});
+    const view = new AgentMapView(
+      testRenderer.renderer,
+      {} as unknown as SessionController,
+      resolveTheme(null),
+    );
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.destroy();
+      view.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    });
+    view.render(stackedState(attempts), 120, 0, ROWS);
+    await testRenderer.renderOnce();
+    const frame = testRenderer.captureCharFrame();
+    // Every node draws its kind on its first row, so the markers count nodes.
+    const nodes = (frame.match(/[●!] implementer/g) ?? []).length;
+    return {frame, nodes};
+  }
+
+  test('keeps a stacked round inside the pane and says what it left out', async () => {
+    const {frame, nodes} = await renderGraph(6);
+    const rows = frame.trimEnd().split('\n');
+
+    // The pane's bottom border is the boundary: a node drawn past the rows on
+    // hand lands on it, or off screen entirely.
+    expect(rows).toHaveLength(ROWS);
+    expect(rows[ROWS - 1]).toMatch(/^╰[─╯]*$/);
+    // 20 rows minus two border rows minus the heading minus the count leaves 16,
+    // which holds two five-row nodes and the two-row gap between them.
+    expect(nodes).toBe(2);
+    expect(frame).toContain('↑ 4');
+    // The stage is still on screen, so selecting it still has something to
+    // select: a column never loses its last node.
+    expect(frame).toContain('orchestrator');
+    expect(frame).toContain('judge');
+  });
+
+  test('draws a round that fits whole, with no count', async () => {
+    const {frame, nodes} = await renderGraph(1);
+
+    expect(nodes).toBe(1);
+    expect(frame).not.toContain('↑');
   });
 });

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -18,6 +18,7 @@ import {
   type AgentGraph,
   type EdgeTone,
   graphPaneBounds,
+  graphWindow,
   layoutAgentGraph,
   NODE_HEIGHT,
   stageKinds,
@@ -38,6 +39,10 @@ const STATUS_MARKER: Record<AgentPhase['status'], string> = {
 
 /** Width the stacked fallback uses, and the width this pane had before. */
 export const STACKED_WIDTH = 30;
+/** Border top and bottom; the title rides the top border. */
+const PANE_VCHROME = 2;
+/** The heading row above the graph, which is drawn whenever phases exist. */
+const HEADING_ROWS = 1;
 /** Columns the transcript needs to stay worth reading beside the graph. */
 export const TRANSCRIPT_MIN = 42;
 /** Share of the terminal the graph takes when there is room for it. */
@@ -82,6 +87,7 @@ export class AgentMapView {
   #theme: Theme;
   #renderedState: SessionState | null = null;
   #renderedWidth = 0;
+  #renderedRows = 0;
   #renderedFocus = false;
   #elapsedTimer: ReturnType<typeof setInterval> | null = null;
   #runningRound: {round: RoundSummary; text: TextRenderable} | null = null;
@@ -119,8 +125,18 @@ export class AgentMapView {
    * screen. It sizes this pane against what is left, so the transcript keeps
    * its floor beside a rail rather than being squeezed by it, and it says
    * whether the rail is a surface the round keys can be on.
+   *
+   * `rows` is the pane's height including its border, the same budget the rail
+   * draws from. A round whose stages stack taller than that is windowed rather
+   * than drawn off the bottom of the pane; callers that manage their own height
+   * (tests driving the view directly) can omit it and get the unclamped graph.
    */
-  render(state: SessionState, widthOverride?: number, railWidth = 0): void {
+  render(
+    state: SessionState,
+    widthOverride?: number,
+    railWidth = 0,
+    rows = Number.POSITIVE_INFINITY,
+  ): void {
     const phases = visiblePhases(state);
     // The pane's width follows the terminal, so a resize has to redraw even
     // when the state is unchanged.
@@ -137,6 +153,7 @@ export class AgentMapView {
     if (
       state === this.#renderedState &&
       paneWidth === this.#renderedWidth &&
+      rows === this.#renderedRows &&
       focused === this.#renderedFocus
     ) {
       return;
@@ -145,6 +162,7 @@ export class AgentMapView {
     // reason to redraw even when the phases are identical.
     this.#renderedState = state;
     this.#renderedWidth = paneWidth;
+    this.#renderedRows = rows;
     this.#renderedFocus = focused;
     this.output.width = paneWidth;
     // The pane that owns the arrow keys says so, the way every other focusable
@@ -209,7 +227,14 @@ export class AgentMapView {
     // ticks for exactly as long as one is.
     if (round !== null && hasActiveAgentTiming(round)) this.#runningRound = {round, text: heading};
     if (width === null) this.#renderStacked(phases, state.selectedAgentKind);
-    else this.#renderGraph(phases, state.selectedAgentKind, width);
+    else {
+      this.#renderGraph(
+        phases,
+        state.selectedAgentKind,
+        width,
+        Math.max(0, rows - PANE_VCHROME - HEADING_ROWS),
+      );
+    }
     this.#syncElapsedTimer();
   }
 
@@ -222,8 +247,29 @@ export class AgentMapView {
    * column, laid out by `agent-graph.ts` and positioned absolutely: a graph has
    * no row-and-column structure for flex to follow.
    */
-  #renderGraph(phases: AgentPhase[], selectedKind: string | null, paneWidth: number): void {
-    const graph = layoutAgentGraph(phases, paneWidth - 4);
+  #renderGraph(
+    phases: AgentPhase[],
+    selectedKind: string | null,
+    paneWidth: number,
+    graphRows: number,
+  ): void {
+    // A round whose stages stack (an interrupted attempt beside the one that
+    // replaced it) is taller than the pane, and the layout is unbounded, so the
+    // rows on hand decide what is drawn. Without this the extra nodes were laid
+    // out past the bottom border and simply never seen.
+    const fitted = graphWindow(phases, graphRows);
+    if (fitted.hidden > 0) {
+      this.output.add(
+        new TextRenderable(this.renderer, {
+          // The oldest attempts are the ones dropped, so the count points up at
+          // them the way the rounds rail points at the rounds above its window.
+          content: `↑ ${fitted.hidden}`,
+          fg: this.#theme.textSubtle,
+          width: '100%',
+        }),
+      );
+    }
+    const graph = layoutAgentGraph(fitted.phases, paneWidth - 4);
     // The graph sits in the middle of the pane rather than hugging the heading:
     // a chain is a few rows tall and a pane is not. `area` centres, `canvas`
     // gives the absolutely positioned cells their origin.

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -434,10 +434,28 @@ export function createOpenTuiApp(
     roundRail.output.visible = railWidth > 0;
     todoStrip.output.visible = !showLog && zoomedPane === null;
     if (!showLog) {
+      // The row budget the main area draws from, shared by the rail and the
+      // agents pane because they are columns of the same row. It comes from the
+      // strip height the state implies, not from `todoStrip.output.height`: the
+      // box height reflects the last committed layout, so reading it back in the
+      // same paint that expanded or collapsed the strip bills the panes the
+      // previous frame's height and leaves them a row long or short (clipping
+      // the selected late round, the overflow indicator, or a graph node) until
+      // the next paint.
+      const mainRows = Math.max(
+        0,
+        renderer.terminalHeight -
+          headerFrame.height -
+          errorHeight -
+          todoStripHeight(state) -
+          help.height -
+          commandInput.box.height,
+      );
       agentMap.render(
         state,
         zoomedPane === 'agents' ? renderer.terminalWidth : undefined,
         railWidth,
+        mainRows,
       );
       // The todo box sits under the agent pane and stops where it stops: the
       // todos belong to an agent, so running them under the transcript would
@@ -448,20 +466,7 @@ export function createOpenTuiApp(
         state,
         typeof agentWidth === 'number' ? todoStripWidth(agentWidth, renderer.terminalWidth) : null,
       );
-      // The rail's row budget comes from the strip height the state implies, not
-      // from `todoStrip.output.height`: the box height reflects the last
-      // committed layout, so reading it back in the same paint that expanded or
-      // collapsed the strip bills the rail the previous frame's height and leaves
-      // it a row long or short (clipping the selected late round or the overflow
-      // indicator) until the next paint.
-      const railRows =
-        renderer.terminalHeight -
-        headerFrame.height -
-        errorHeight -
-        todoStripHeight(state) -
-        help.height -
-        commandInput.box.height;
-      if (railWidth > 0) roundRail.render(state, railWidth, Math.max(0, railRows));
+      if (railWidth > 0) roundRail.render(state, railWidth, mainRows);
       conversation.render(state);
     }
     // The agent map is the first thing to give up room: it is a summary the

--- a/clients/tui/src/ui/header.test.ts
+++ b/clients/tui/src/ui/header.test.ts
@@ -211,7 +211,7 @@ describe('header', () => {
     // the measurement phase put `selected perf_eval` on the curated header:
     // the backend identifier this header exists to remove.
     const seeded = applyRunMapEvent(
-      {outerLoop: 'plain', expectedRoles: null, rounds: [], phases: []},
+      {outerLoop: 'plain', expectedRoles: null, rounds: [], phases: [], lastEventTimestamp: null},
       perfEvalStart(),
     );
     const kinds = seeded.phases.map(phase => phase.kind);

--- a/src/vibesys/loops/agent/issue_board.py
+++ b/src/vibesys/loops/agent/issue_board.py
@@ -102,6 +102,19 @@ def write_plan_artifact(progress_path: Path, round_number: int, plan: Orchestrat
     return _write_json_atomic(path, plan.model_dump(mode="json"))
 
 
+#: Name tail of a completed implementer attempt artifact.
+_IMPLEMENTER_ARTIFACT_SUFFIX = "-implementer.json"
+#: Name tail of an attempt's start marker. The completed-artifact glob requires
+#: the exact ``-implementer.json`` tail, so a marker never reads back as a
+#: completed attempt.
+_IMPLEMENTER_START_MARKER_SUFFIX = "-implementer.started.json"
+
+
+def _implementer_evidence_root(progress_path: Path) -> Path:
+    """Return the framework-owned directory of per-attempt implementer evidence."""
+    return _structured_artifact_root(progress_path) / "evidence"
+
+
 def write_implementer_artifact(
     progress_path: Path,
     round_number: int,
@@ -109,12 +122,18 @@ def write_implementer_artifact(
     response: ImplementerResponse,
 ) -> Path:
     """Persist parsed implementer claims as untrusted data for Judge audit."""
-    path = (
-        _structured_artifact_root(progress_path)
-        / "evidence"
-        / f"round-{round_number:04d}-attempt-{retry:02d}-implementer.json"
+    path = _implementer_evidence_root(progress_path) / (
+        f"round-{round_number:04d}-attempt-{retry:02d}{_IMPLEMENTER_ARTIFACT_SUFFIX}"
     )
     return _write_json_atomic(path, response.model_dump(mode="json"))
+
+
+def write_implementer_start_marker(progress_path: Path, round_number: int, retry: int) -> Path:
+    """Record that one implementer attempt began, before its turn runs."""
+    path = _implementer_evidence_root(progress_path) / (
+        f"round-{round_number:04d}-attempt-{retry:02d}{_IMPLEMENTER_START_MARKER_SUFFIX}"
+    )
+    return _write_json_atomic(path, {"round": round_number, "attempt": retry})
 
 
 def validation_artifact_root(progress_path: Path) -> Path:
@@ -166,20 +185,31 @@ def validation_result_artifact_paths(progress_path: Path) -> list[Path]:
 
 def implementer_artifact_paths(progress_path: Path, round_number: int) -> list[Path]:
     """Return persisted implementer attempts for one round in attempt order."""
-    evidence_root = _structured_artifact_root(progress_path) / "evidence"
-    pattern = f"round-{round_number:04d}-attempt-*-implementer.json"
-    return sorted(evidence_root.glob(pattern))
+    pattern = f"round-{round_number:04d}-attempt-*{_IMPLEMENTER_ARTIFACT_SUFFIX}"
+    return sorted(_implementer_evidence_root(progress_path).glob(pattern))
+
+
+def _implementer_attempt_numbers(progress_path: Path, round_number: int, suffix: str) -> list[int]:
+    """Return the attempt numbers named by one round's *suffix* evidence files."""
+    prefix = f"round-{round_number:04d}-attempt-"
+    names = _implementer_evidence_root(progress_path).glob(f"{prefix}*{suffix}")
+    attempts = (path.name.removeprefix(prefix).removesuffix(suffix) for path in names)
+    return [int(attempt) for attempt in attempts if attempt.isdigit()]
 
 
 def next_implementer_attempt(progress_path: Path, round_number: int) -> int:
-    """Return the next durable attempt number for an interrupted round."""
-    attempts: list[int] = []
-    prefix = f"round-{round_number:04d}-attempt-"
-    suffix = "-implementer.json"
-    for path in implementer_artifact_paths(progress_path, round_number):
-        attempt_text = path.name.removeprefix(prefix).removesuffix(suffix)
-        if attempt_text.isdigit():
-            attempts.append(int(attempt_text))
+    """Return the next durable attempt number for an interrupted round.
+
+    Start markers count alongside completed artifacts, which makes the attempt
+    number durable at attempt start rather than only once the turn returns. A
+    process killed mid-invoke therefore resumes on a fresh attempt instead of
+    replaying the killed attempt's round label.
+    """
+    attempts = [
+        attempt
+        for suffix in (_IMPLEMENTER_ARTIFACT_SUFFIX, _IMPLEMENTER_START_MARKER_SUFFIX)
+        for attempt in _implementer_attempt_numbers(progress_path, round_number, suffix)
+    ]
     return max(attempts, default=0) + 1
 
 

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -1283,6 +1283,11 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
         recommended_skills=resolved_skills,
         prior_attempt_artifact_locations=prior_attempt_artifact_locations,
     )
+    # Make this attempt number durable before the turn starts. A process killed
+    # mid-invoke writes no completed artifact, so a resume that counted only
+    # those would reuse this attempt number and replay the round label below
+    # over paid work.
+    issue_board.write_implementer_start_marker(progress_path, round_number, retry)
     fallback = ResponseFallback(_missing_implementer_response)
     timed_out = False
     try:

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -1393,6 +1393,34 @@ def test_persisted_implementer_attempts_define_resume_boundary(tmp_path):  # noq
     assert issue_board.next_implementer_attempt(progress, 9) == 1
 
 
+def test_implementer_start_marker_advances_the_resume_boundary(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    progress = tmp_path / "progress"
+    implementation = ImplementerResponse(
+        summary="Recorded after the marker.",
+        expected_behavior="A killed attempt must not be replayed under its label.",
+    )
+    marker = issue_board.write_implementer_start_marker(progress, 8, 1)
+
+    assert marker == (
+        tmp_path / "progress" / "evidence" / "round-0008-attempt-01-implementer.started.json"
+    )
+    # An attempt killed mid-invoke leaves the marker and no completed artifact,
+    # yet the round must resume on attempt 2.
+    assert issue_board.implementer_artifact_paths(progress, 8) == []
+    assert issue_board.next_implementer_attempt(progress, 8) == 2
+
+    completed = issue_board.write_implementer_artifact(progress, 8, 1, implementation)
+
+    # The marker and its own completed artifact name one attempt, not two.
+    assert issue_board.implementer_artifact_paths(progress, 8) == [completed]
+    assert issue_board.next_implementer_attempt(progress, 8) == 2
+
+    issue_board.write_implementer_start_marker(progress, 9, 1)
+
+    assert issue_board.next_implementer_attempt(progress, 8) == 2
+    assert issue_board.next_implementer_attempt(progress, 9) == 2
+
+
 def test_agent_memory_paths_distinguish_files_from_directories(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "workspace"
     directory = workspace / "progress"
@@ -2652,6 +2680,43 @@ def test_timed_out_implementer_persists_fail_closed_attempt_and_retries(
         if call.kwargs.get("response_cls") is ImplementerResponse
     ]
     assert "round-0001-attempt-01-implementer.json" in implementer_calls[1].kwargs["system_prompt"]
+
+
+def test_implementer_start_marker_precedes_the_invocation(
+    tmp_path: Path,
+    ref_file: str,
+) -> None:
+    """A process killed mid-invoke must not resume under the killed label."""
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                task="Build server",
+                pass_criteria="tests pass",  # noqa: S106  # tracked: #288
+                reasoning="cold start",
+            ),
+        ],
+        implementer_outcomes=[HypothesisOutcome.NOMINATED],
+    )
+    delegate = runner.invoke.side_effect
+
+    def invoke_killed_mid_implementer(**kwargs):  # noqa: ANN003, ANN202  # tracked: #288
+        if kwargs["kind"] == "implementer":
+            raise RuntimeError("killed mid-invoke")  # noqa: TRY003  # tracked: #288
+        return delegate(**kwargs)
+
+    runner.invoke.side_effect = invoke_killed_mid_implementer
+
+    # The loop does not catch this, so the attempt ends exactly where an
+    # external kill would end it: after the marker, before any artifact.
+    with pytest.raises(RuntimeError, match="killed mid-invoke"):
+        _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1, max_retries_per_round=2)
+
+    project = _created_project(tmp_path)
+    markers = list(project.rglob("round-0001-attempt-01-implementer.started.json"))
+    assert len(markers) == 1
+    assert not list(project.rglob("round-0001-attempt-01-implementer.json"))
+    workspace = runner.invoke.call_args_list[0].kwargs["workspace"]
+    assert issue_board.next_implementer_attempt(workspace / "progress.md", 1) == 2
 
 
 def test_unparseable_implementer_responses_commit_fail_closed_once_exhausted(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288


### PR DESCRIPTION
## Problem

Fixes #514. A killed run left open phases and timings in the TUI, and a resumed implementer could reuse the killed attempt's label. The initial fix closes run-scoped terminal events and handles a hard-kill when the next `run_started` arrives.

Tail subscriptions exposed a remaining case: the server sends run-level spine events before the history floor but omits ordinary execution starts. During later backfill, a fresh prefix fold did not see the resume or terminal boundary, so it could merge an old active execution into the resumed execution. Multi-chunk backfill could also close the old attempt at an earlier chunk's timestamp instead of the actual last pre-resume event.

## Solution

`core-state` retains the run-lifetime spine events (`run_started`, `run_finished`, `run_failed`, and `run_interrupted`) and the closest non-chat predecessor for each resumed-start boundary. Prefix reduction folds the history chunk and separately reconstructs its run-map projection with retained boundaries interleaved by sequence. Only the run-map fields from that reconstruction enter the merge. This preserves the old attempt's closeout status, phase identity, interval, and timestamp without duplicating terminal transcript or diagnostic facts already delivered in the tail.

Prefix round merging retains a run-boundary endpoint across later resumed attempts, while an explicit `round_finished` event remains authoritative.

The existing loop marker and TUI graph changes remain scoped as before: an implementer start marker makes resumed attempt labels distinct, and the graph respects its row budget.

### Architecture

```mermaid
flowchart LR
  S[server tail: spine + suffix] --> C[core-state tail fold]
  C --> B[retained lifetime boundaries]
  H[history backfill] --> P[prefix data fold]
  B --> R[run-map replay in sequence]
  P --> M[prefix merge]
  R --> M
  M --> U[TUI phases, rounds, timings]
```

The backend remains the source of event semantics and execution liveness. `core-state` owns replay and prefix merge behavior; the TUI consumes the resulting semantic state.

## Verification

### Correctness properties

- Run-scoped terminal events close every open phase, round, and active timing with their semantic status.
- A hard-killed lifetime closes at its last non-chat event when a later `run_started` is folded, so downtime is excluded.
- Full replay and actual spine-bootstrap plus multi-chunk backfill agree for every replay-derived field, including distinct old/resumed canonical execution IDs, phase status, round intervals, and inferred closeout timestamps. `activeExecutions` remains intentionally checkpoint-owned.
- Retained `run_failed`, `run_interrupted`, and `run_finished` boundaries are replayed during backfill without duplicating their transcript or diagnostics.
- A later explicit `round_finished` can supersede an inferred run-boundary endpoint; resumed attempts alone cannot move that endpoint.

### Testing

- `pnpm exec biome check clients/core-state/src/core-state.ts clients/core-state/src/run-map.ts clients/core-state/src/core-state-prefix.test.ts`: passed.
- `pnpm --dir clients/core-state check`: passed.
- `pnpm --dir clients/tui check`: passed.
- `/tmp/vibesys-bun/bin/bun test --max-concurrency 1 clients/core-state/src/core-state.test.ts clients/core-state/src/run-map.test.ts clients/core-state/src/core-state-prefix.test.ts` (95 passing)

The new prefix regressions cover a floor after the resumed execution starts, split backfill across the old attempt's final output, repeated prefix application, explicit failed/interrupted/successful terminal boundaries, multiple resumed lifetimes across varied chunk sizes, and an explicit round-finish override.

An independent second review also checked 32 resume/backfill variants. `git diff --check` passed. No new live-provider run was performed for this revision.
