### PR TITLE
TUI: render readable tool cards from typed payloads and demote lifecycle chatter

### DIFF
--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -895,6 +895,40 @@ describe('batched transcript folding', () => {
   });
 });
 
+describe('chunk gluing per channel', () => {
+  it('joins consecutive diagnostic chunks with the line breaks they lack', () => {
+    const state = reduceEventBatch(initialCoreState(), [
+      channelEvent(1, 'diagnostic', '[codex thread 01a0 started]'),
+      channelEvent(2, 'diagnostic', '[codex turn started]'),
+      channelEvent(3, 'diagnostic', '[codex turn complete: in=10 out=2]'),
+    ]);
+
+    expect(state.transcript).toHaveLength(1);
+    expect(state.transcript[0]?.content).toBe(
+      '[codex thread 01a0 started]\n[codex turn started]\n[codex turn complete: in=10 out=2]',
+    );
+  });
+
+  it('does not double the separator when a chunk already ends a line', () => {
+    const state = reduceEventBatch(initialCoreState(), [
+      channelEvent(1, 'diagnostic', 'driver: agentshim\n'),
+      channelEvent(2, 'diagnostic', '--- input ---'),
+    ]);
+
+    expect(state.transcript[0]?.content).toBe('driver: agentshim\n--- input ---');
+  });
+
+  it('still concatenates analysis chunks raw, because they are stream fragments', () => {
+    const state = reduceEventBatch(initialCoreState(), [
+      channelEvent(1, 'analysis', 'the ring buffer '),
+      channelEvent(2, 'analysis', 'is the hot path'),
+    ]);
+
+    expect(state.transcript).toHaveLength(1);
+    expect(state.transcript[0]?.content).toBe('the ring buffer is the hot path');
+  });
+});
+
 describe('the carried-forward profile flag', () => {
   it('lands on the round whose round_finished event skipped profiling', () => {
     const state = reduceEvent(initialCoreState(), roundFinishedEvent(1, {profile_skipped: true}));
@@ -1024,6 +1058,19 @@ function chatTitledEvent(sequence: number, threadId: string, title: string): Run
     round_label: 'experiment-chat',
     chat_thread_id: threadId,
     data: {kind: 'chat', answer: 'answer', thread_title: title},
+  };
+}
+
+/** One `agent_output_chunk` on a named channel, all within a single turn. */
+function channelEvent(
+  sequence: number,
+  channel: 'analysis' | 'diagnostic',
+  content: string,
+): RunEvent {
+  return {
+    ...baseEvent(sequence, 'agent_output_chunk'),
+    invocation_id: 'turn',
+    data: {kind: 'agent_output_chunk', channel, content},
   };
 }
 

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -1243,14 +1243,34 @@ function foldTranscriptEntry(
     // must not glue onto a neighbor that is just as complete.
     last.turnId !== undefined &&
     last.turnId === incoming.turnId &&
-    (incoming.kind === 'assistant' || incoming.kind === 'prompt' || incoming.kind === 'analysis')
+    (incoming.kind === 'assistant' ||
+      incoming.kind === 'prompt' ||
+      incoming.kind === 'analysis' ||
+      incoming.kind === 'diagnostic')
   ) {
-    entries[entries.length - 1] = {...last, content: last.content + incoming.content};
+    entries[entries.length - 1] = {...last, content: last.content + glue(last, incoming)};
     return;
   }
   entries.push(incoming);
   index?.record(incoming, entries.length - 1);
   capTranscript(entries, index);
+}
+
+/**
+ * What joins `incoming` onto the entry it glues into.
+ *
+ * Assistant, prompt, and analysis chunks are mid-sentence fragments of a token
+ * stream and must concatenate raw; inserting anything between them would break
+ * words. Diagnostic chunks are whole lines a driver already terminated in
+ * meaning but not in text (`[codex turn started]` carries no newline), so
+ * concatenating them raw produced one squished blob per turn.
+ */
+function glue(last: TranscriptEntry, incoming: TranscriptEntry): string {
+  const separator =
+    incoming.kind === 'diagnostic' && last.content !== '' && !last.content.endsWith('\n')
+      ? '\n'
+      : '';
+  return separator + incoming.content;
 }
 
 const MAX_TRANSCRIPT_ENTRIES = 20_000;

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1701,7 +1701,7 @@ describe('OpenTUI presentation', () => {
     registerCleanup(testRenderer.renderer, app);
 
     const frame = await testRenderer.waitForFrame(value => value.includes('2 passed'));
-    expect(frame).toContain('→ Bash(command="pytest")');
+    expect(frame).toContain('→ Bash pytest');
     expect(frame).toContain('← 2 passed');
     // Header housing, agents pane, transcript frame, and the card's call and
     // result regions: the rail is absent because this fixture has no rounds.
@@ -1748,6 +1748,162 @@ describe('OpenTUI presentation', () => {
     expect(frame).toContain('← 1 failed');
     expect(frame).toContain('stderr:');
     expect(frame).toContain('assertion error');
+  });
+
+  it('unwraps the shell wrapper codex writes around an execute command', async () => {
+    // Wide enough that the unwrapped command is one row, so the assertion is
+    // about the text and not about where the renderer chose to wrap it.
+    const testRenderer = await createTestRenderer({width: 100, height: 16});
+    const controller = new FakeController(
+      toolCallState({
+        toolName: 'execute',
+        toolArguments: {command: `/bin/bash -lc "cargo test -p queue-rs 'ring buffer'"`},
+      }),
+    );
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('→ execute'));
+    expect(frame).toContain(`→ execute cargo test -p queue-rs 'ring buffer'`);
+    expect(frame).not.toContain('/bin/bash');
+    expect(frame).not.toContain('command=');
+  });
+
+  it('summarizes a structured file_change call instead of inlining its JSON', async () => {
+    const testRenderer = await createTestRenderer({width: 130, height: 16});
+    const controller = new FakeController(
+      toolCallState({
+        toolName: 'file_change',
+        toolArguments: {
+          changes: [
+            {path: 'src/lib.rs', kind: 'delete'},
+            {path: 'src/queue.rs', kind: 'modified'},
+            {path: 'src/new.rs', kind: 'added'},
+          ],
+        },
+      }),
+    );
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('→ file_change'));
+    expect(frame).toContain('3 changes: delete src/lib.rs, modify src/queue.rs, +1 more');
+    expect(frame).not.toContain('"path"');
+  });
+
+  it('collapses a long command result to its exit status and output size', async () => {
+    const stdout = `${Array.from({length: 40}, (_, index) => `compiling crate ${index}`).join('\n')}\n`;
+    const testRenderer = await createTestRenderer({width: 80, height: 18});
+    const controller = new FakeController(
+      toolCallState({
+        toolName: 'execute',
+        toolArguments: {command: 'cargo build'},
+        content: stdout,
+        toolResult: {
+          kind: 'tool_result',
+          tool: 'execute',
+          content: stdout,
+          payload: {
+            kind: 'command',
+            stdout,
+            stderr: 'error: could not compile\n',
+            exit_code: 101,
+            duration: 12.5,
+          },
+        },
+      }),
+    );
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const collapsed = await testRenderer.waitForFrame(value => value.includes('exit 101'));
+    expect(collapsed).toContain('← exit 101 · 12.5s · 41 lines');
+    expect(collapsed).not.toContain('compiling crate 0');
+    expect(collapsed).toContain('Show full response');
+  });
+
+  it('collapses a json tool result to its top-level shape', async () => {
+    const value = Object.fromEntries(Array.from({length: 9}, (_, index) => [`k${index}`, index]));
+    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    const controller = new FakeController(
+      toolCallState({
+        toolName: 'Read',
+        toolArguments: {path: 'run-state.json'},
+        content: 'irrelevant',
+        toolResult: {
+          kind: 'tool_result',
+          tool: 'Read',
+          content: 'irrelevant',
+          payload: {kind: 'json', value},
+        },
+      }),
+    );
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value_ => value_.includes('keys:'));
+    expect(frame).toContain('← {keys: k0, k1, k2, k3, +5 more}');
+    expect(frame).not.toContain('"k8"');
+  });
+
+  it('draws provider lifecycle chatter without cards and keeps an error prominent', async () => {
+    const testRenderer = await createTestRenderer({width: 90, height: 26});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      core: {
+        ...initialSessionState().core,
+        transcript: [
+          {
+            id: 'lifecycle',
+            kind: 'diagnostic',
+            label: 'implementer · round 1',
+            content: '[codex thread 01a0 started]\n[codex turn started]',
+          },
+          {
+            id: 'banner',
+            kind: 'diagnostic',
+            label: 'implementer · round 1',
+            content: 'driver: agentshim, provider: codex, model: gpt-5.6',
+          },
+          {
+            id: 'failure',
+            kind: 'diagnostic',
+            label: 'implementer · round 1',
+            content: '[codex error] stream disconnected before completion',
+          },
+        ],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('[codex error]'));
+    expect(frame).toContain('[codex turn started]');
+    expect(frame).toContain('driver: agentshim');
+    // Header housing, agents pane, transcript frame, command bar, and the one
+    // card the error diagnostic still earns. The two quiet diagnostics draw no
+    // border at all, so they add nothing to the count.
+    expect(frame.match(/[╭┏]/g)).toHaveLength(5);
+  });
+
+  it('renders an unanswered tool call once, with no response band', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 16});
+    const controller = new FakeController(
+      toolCallState({
+        toolName: 'file_change',
+        toolArguments: {changes: [{path: 'a.rs', kind: 'delete'}]},
+      }),
+    );
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('→ file_change'));
+    expect(frame.match(/→ file_change/g)).toHaveLength(1);
+    // The response band is the only thing that draws a left arrow followed by
+    // text; the footer's key hint is the glyph pair, not this.
+    expect(frame).not.toContain('← ');
+    // One card: the header, the two panes, the command bar, and this turn.
+    expect(frame.match(/[╭┏]/g)).toHaveLength(5);
   });
 
   it('collapses, prettifies, and expands long JSON tool responses', async () => {
@@ -5178,6 +5334,24 @@ function hugeTranscriptState(entries: number): SessionState {
         kind: 'status' as const,
         content: `event ${index}`,
       })),
+    },
+  };
+}
+
+/** One typed tool turn, the shape `tool_call`/`tool_result` events fold into. */
+function toolCallState(
+  entry: Omit<SessionState['core']['transcript'][number], 'id' | 'kind' | 'label' | 'content'> & {
+    content?: string;
+  },
+): SessionState {
+  const initial = initialSessionState();
+  return {
+    ...initial,
+    core: {
+      ...initial.core,
+      transcript: [
+        {id: 'tool', kind: 'tool' as const, label: 'implementer · round 1', content: '', ...entry},
+      ],
     },
   };
 }

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -12,7 +12,12 @@ import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
 import {visibleConversation} from '../session-model.js';
 import {promptPreview, toolCallPreview, toolResultPreview} from './previews.js';
-import {createMarkdownBlockOptions, entryPalette, type MarkdownBlockOptions} from './styles.js';
+import {
+  conversationRole,
+  createMarkdownBlockOptions,
+  entryPalette,
+  type MarkdownBlockOptions,
+} from './styles.js';
 import type {Theme} from './theme.js';
 
 export interface ConversationViewOptions {
@@ -326,19 +331,27 @@ export class ConversationView {
   #renderEntry(entry: ConversationEntry): BoxRenderable {
     const palette = entryPalette(entry, this.#theme);
     const selected = this.#selectedId === entry.id;
+    const bare = isBareEntry(entry);
     const card = new BoxRenderable(this.renderer, {
       id: `event-${entry.id}`,
       width: '100%',
       flexDirection: 'column',
-      marginTop: 1,
-      paddingLeft: entry.kind === 'status' ? 0 : 1,
+      marginTop: bare && entry.kind !== 'status' ? 0 : 1,
+      paddingLeft: bare ? 0 : 1,
       paddingRight: 1,
-      border: entry.kind !== 'status',
-      borderStyle: 'rounded',
-      // The cursor is the card's border, not a fill: a filled card reads as
-      // selected text, and the transcript already uses fills for roles.
-      borderColor: selected ? this.#theme.borderFocus : palette.border,
       backgroundColor: palette.background,
+      // `border: false` is not enough on its own: OpenTUI turns the border
+      // back on whenever any border styling option is present, so a borderless
+      // entry has to omit `borderStyle` and `borderColor` as well.
+      ...(bare
+        ? {border: false}
+        : {
+            border: true,
+            borderStyle: 'rounded' as const,
+            // The cursor is the card's border, not a fill: a filled card reads
+            // as selected text, and the transcript already uses fills for roles.
+            borderColor: selected ? this.#theme.borderFocus : palette.border,
+          }),
       ...(this.#showsSelection
         ? {
             onMouseUp: () => {
@@ -394,7 +407,16 @@ export class ConversationView {
           ? toolResultPreview(entry.content, entry.toolResult?.payload)
           : null;
       const content = prompt ? prompt.content : (output?.content ?? entry.content);
-      card.add(new TextRenderable(this.renderer, {content, fg: palette.content, width: '100%'}));
+      card.add(
+        new TextRenderable(this.renderer, {
+          content,
+          fg: palette.content,
+          width: '100%',
+          // A command line, a stderr trace, or a banner runs past the card;
+          // truncating it mid-path is worse than a second row.
+          wrapMode: 'word',
+        }),
+      );
       if (output?.collapsible) {
         const hidden =
           output.hiddenLines > 0
@@ -461,6 +483,10 @@ export class ConversationView {
         fg: this.#theme.toolCall.foreground,
         bg: this.#theme.toolCall.background,
         width: '100%',
+        // A shell command is longer than the card is wide more often than not.
+        // Wrapping keeps the whole command readable; clipping it at the border
+        // hides exactly the flags and paths that say what ran.
+        wrapMode: 'word',
       }),
     );
     if (toolResponse) {
@@ -472,6 +498,9 @@ export class ConversationView {
           fg: this.#theme.toolResult.foreground,
           bg: this.#theme.toolResult.background,
           width: '100%',
+          // Expanded output is stdout and stderr verbatim, which is wider than
+          // the card whenever a compiler or a test runner produced it.
+          wrapMode: 'word',
         }),
       );
       if (response.collapsible) {
@@ -491,6 +520,22 @@ export class ConversationView {
       }
     }
   }
+}
+
+/**
+ * Whether an entry is drawn as bare lines instead of a bordered card.
+ *
+ * Provider lifecycle chatter and driver banners arrive on the diagnostic and
+ * subprocess channels a line at a time, and a rounded card turns each of those
+ * lines into five rows of chrome around three words. They read better as a
+ * muted run of text between the cards that carry real turns. A failure is the
+ * exception: whether the backend marked it or the driver's own error marker
+ * did, it keeps the card so it still stops the eye.
+ */
+function isBareEntry(entry: ConversationEntry): boolean {
+  if (entry.kind === 'status') return true;
+  if (entry.kind !== 'diagnostic' && entry.kind !== 'subprocess') return false;
+  return conversationRole(entry) !== 'failure';
 }
 
 function sameEntries(left: ConversationEntry[], right: ConversationEntry[]): boolean {

--- a/clients/tui/src/ui/previews.test.ts
+++ b/clients/tui/src/ui/previews.test.ts
@@ -1,10 +1,12 @@
 import {describe, expect, it} from 'bun:test';
 import {
   elapsedLabel,
+  jsonShapeSummary,
   promptPreview,
   toolCallPreview,
   toolOutputPreview,
   toolResultPreview,
+  unwrapShellCommand,
 } from './previews.js';
 
 describe('conversation previews', () => {
@@ -83,7 +85,8 @@ describe('typed tool result previews', () => {
       duration: 1.5,
     });
 
-    expect(preview.content).toBe('build output\nstderr:\nwarning: deprecated\nexit code: 2');
+    // A blank line before the label so stderr reads as its own section.
+    expect(preview.content).toBe('build output\n\nstderr:\nwarning: deprecated\nexit code: 2');
   });
 
   it('omits the stderr label and exit-code line when they carry nothing', () => {
@@ -126,6 +129,174 @@ describe('typed tool result previews', () => {
     expect(collapsed.collapsible).toBe(true);
     expect(collapsed.hiddenLines).toBeGreaterThan(0);
     expect(expanded.content).toContain('"k19": 19');
+  });
+});
+
+describe('shell tool call previews', () => {
+  it('strips the /bin/bash -lc wrapper the codex CLI writes around a command', () => {
+    expect(unwrapShellCommand('/bin/bash -lc "cargo test --workspace"')).toBe(
+      'cargo test --workspace',
+    );
+    expect(unwrapShellCommand("bash -lc 'cargo build --release'")).toBe('cargo build --release');
+    expect(unwrapShellCommand('sh -c "ls -la"')).toBe('ls -la');
+    expect(unwrapShellCommand('/usr/bin/zsh -lc "pytest -q"')).toBe('pytest -q');
+  });
+
+  it('keeps quotes that belong to the command instead of the wrapper', () => {
+    expect(unwrapShellCommand(`bash -lc 'grep -rn "fn main" src'`)).toBe('grep -rn "fn main" src');
+    // Only one pair comes off, and only when it matches at both ends.
+    expect(unwrapShellCommand('bash -lc "echo \'hi\'"')).toBe("echo 'hi'");
+    expect(unwrapShellCommand('bash -lc "unterminated')).toBe('"unterminated');
+  });
+
+  it('leaves a command that was never wrapped alone', () => {
+    expect(unwrapShellCommand('cargo bench -- --save-baseline main')).toBe(
+      'cargo bench -- --save-baseline main',
+    );
+    // `bashful` is not a shell, and the flag has to be -c or -lc.
+    expect(unwrapShellCommand('bashful -lc "x"')).toBe('bashful -lc "x"');
+    expect(unwrapShellCommand('bash --login -c "x"')).toBe('bash --login -c "x"');
+  });
+
+  it('renders an execute call as the bare command, not a key=value pair', () => {
+    expect(toolCallPreview('execute', {command: '/bin/bash -lc "cargo test -q"'})).toBe(
+      '→ execute cargo test -q\n',
+    );
+    expect(toolCallPreview('shell', {command: 'ls'})).toBe('→ shell ls\n');
+  });
+
+  it("appends claude's Bash description as a shell comment", () => {
+    expect(toolCallPreview('Bash', {command: 'pytest -q', description: 'Run the tests'})).toBe(
+      '→ Bash pytest -q  # Run the tests\n',
+    );
+  });
+
+  it('falls back to the generic rendering when a shell call has no command', () => {
+    expect(toolCallPreview('execute', {argv: ['ls']})).toBe('→ execute(argv=["ls"])\n');
+  });
+});
+
+describe('file-change tool call previews', () => {
+  it('summarizes a single structured change as a verb and a path', () => {
+    expect(toolCallPreview('file_change', {changes: [{path: 'src/lib.rs', kind: 'delete'}]})).toBe(
+      '→ file_change delete src/lib.rs\n',
+    );
+    // The past-participle spelling maps to the same verb.
+    expect(toolCallPreview('apply_patch', {changes: [{path: 'src/lib.rs', kind: 'deleted'}]})).toBe(
+      '→ apply_patch delete src/lib.rs\n',
+    );
+  });
+
+  it('counts the files a multi-file change touches instead of listing them all', () => {
+    const preview = toolCallPreview('file_change', {
+      changes: [
+        {path: 'src/lib.rs', kind: 'deleted'},
+        {path: 'src/queue.rs', kind: 'modified'},
+        {path: 'src/new.rs', kind: 'added'},
+      ],
+    });
+
+    expect(preview).toBe(
+      '→ file_change 3 changes: delete src/lib.rs, modify src/queue.rs, +1 more\n',
+    );
+  });
+
+  it('shows an unrecognized change kind verbatim rather than dropping it', () => {
+    expect(toolCallPreview('file_change', {changes: [{path: 'a.rs', kind: 'chmod'}]})).toBe(
+      '→ file_change chmod a.rs\n',
+    );
+    expect(toolCallPreview('file_change', {changes: [{path: 'a.rs'}]})).toBe(
+      '→ file_change change a.rs\n',
+    );
+  });
+
+  it('falls back to the generic rendering when changes are not an array', () => {
+    expect(toolCallPreview('file_change', {changes: 'src/lib.rs'})).toBe(
+      '→ file_change(changes="src/lib.rs")\n',
+    );
+  });
+});
+
+describe('tool call argument truncation', () => {
+  it('never cuts inside a quoted JSON serialization', () => {
+    const preview = toolCallPreview('Unknown', {
+      spec: {path: 'a'.repeat(120), mode: 'rewrite'},
+    });
+
+    expect(preview).toBe('→ Unknown(spec={keys: path, mode})\n');
+    // Every quote in the rendered line is closed.
+    expect((preview.match(/"/g) ?? []).length % 2).toBe(0);
+  });
+
+  it('closes the quotes it opens around a truncated string argument', () => {
+    const preview = toolCallPreview('Unknown', {text: 'x'.repeat(200)});
+
+    expect(preview).toBe(`→ Unknown(text="${'x'.repeat(80)}...")\n`);
+    expect((preview.match(/"/g) ?? []).length % 2).toBe(0);
+  });
+
+  it('summarizes an over-long array argument by its length', () => {
+    const preview = toolCallPreview('Unknown', {ids: Array.from({length: 40}, (_, i) => i)});
+
+    expect(preview).toBe('→ Unknown(ids=[40 items])\n');
+  });
+});
+
+describe('collapsed typed result summaries', () => {
+  it('reports exit status, wall time, and output size for a long command result', () => {
+    const stdout = `${Array.from({length: 37}, (_, index) => `line ${index}`).join('\n')}\n`;
+    const payload = {kind: 'command', stdout, stderr: '', exit_code: 1, duration: 0.44} as const;
+
+    const collapsed = toolResultPreview('irrelevant', payload);
+
+    expect(collapsed.content).toBe('exit 1 · 0.4s · 37 lines');
+    expect(collapsed.collapsible).toBe(true);
+    expect(collapsed.hiddenLines).toBe(38);
+  });
+
+  it('separates stdout and stderr and names the exit code when expanded', () => {
+    const stdout = `${Array.from({length: 8}, (_, index) => `out ${index}`).join('\n')}\n`;
+    const payload = {
+      kind: 'command',
+      stdout,
+      stderr: 'thread panicked\n',
+      exit_code: 101,
+      duration: 2,
+    } as const;
+
+    const expanded = toolResultPreview('irrelevant', payload, true);
+
+    expect(expanded.content).toStartWith('out 0\n');
+    expect(expanded.content).toContain('out 7\n\nstderr:\nthread panicked\nexit code: 101');
+    expect(expanded.hiddenLines).toBe(0);
+  });
+
+  it('falls back to the first meaningful line when a command reports no status', () => {
+    const stdout = `\n\nfirst real line\n${'tail\n'.repeat(20)}`;
+    const payload = {kind: 'command', stdout, stderr: '', exit_code: null, duration: null} as const;
+
+    expect(toolResultPreview('irrelevant', payload).content).toBe('first real line · 23 lines');
+  });
+
+  it('shows a json result as its top-level shape while collapsed', () => {
+    const value = Object.fromEntries(Array.from({length: 9}, (_, index) => [`k${index}`, index]));
+
+    const collapsed = toolResultPreview('irrelevant', {kind: 'json', value});
+
+    expect(collapsed.content).toBe('{keys: k0, k1, k2, k3, +5 more}');
+    expect(collapsed.collapsible).toBe(true);
+    expect(toolResultPreview('irrelevant', {kind: 'json', value}, true).content).toContain(
+      '"k8": 8',
+    );
+  });
+
+  it('shows an array json result as its length', () => {
+    const value = Array.from({length: 12}, (_, index) => ({index}));
+
+    expect(toolResultPreview('irrelevant', {kind: 'json', value}).content).toBe('[12 items]');
+    expect(jsonShapeSummary([])).toBe('[0 items]');
+    expect(jsonShapeSummary([1])).toBe('[1 item]');
+    expect(jsonShapeSummary({})).toBe('{}');
   });
 });
 

--- a/clients/tui/src/ui/previews.ts
+++ b/clients/tui/src/ui/previews.ts
@@ -12,16 +12,181 @@ export interface CollapsiblePreview {
   collapsible: boolean;
 }
 
-export function toolCallPreview(tool: string, args: Record<string, unknown>): string {
+/**
+ * The `/bin/bash -lc "<command>"` wrapper the codex CLI writes around the
+ * argument of every `execute` call.
+ *
+ * Anchored at both ends and linear: the alternation is over literal shell
+ * names, and the tail is a single greedy `[\s\S]+` with nothing after it, so
+ * there is no nested quantifier for a long command to backtrack through.
+ */
+const SHELL_WRAPPER = /^(?:\S+\/)?(?:bash|zsh|sh|dash|fish)\s+-l?c\s+([\s\S]+)$/;
+
+/** How much of a shell command the call line shows before eliding the rest. */
+const MAX_COMMAND_LENGTH = 160;
+
+/** How much of a first output line a collapsed result summary shows. */
+const MAX_SUMMARY_LINE = 120;
+
+/** How many files a multi-file change summary names before counting the rest. */
+const MAX_LISTED_CHANGES = 2;
+
+/** How many object keys a shape summary names before counting the rest. */
+const MAX_SUMMARY_KEYS = 4;
+
+/**
+ * Formats the arguments of one known tool, or returns null to fall back to the
+ * generic `key=value` rendering when the arguments are not the expected shape.
+ */
+type ToolCallFormatter = (args: Record<string, unknown>) => string | null;
+
+/**
+ * Verbs for the `kind` of a codex `file_change` entry.
+ *
+ * Both the past-participle and the bare-verb spelling appear on the wire
+ * ("deleted" and "delete"), and the set is the provider's, not ours, so it is
+ * a lookup table rather than an enum: an unrecognized kind is shown verbatim
+ * instead of being dropped.
+ */
+const CHANGE_VERBS: Readonly<Record<string, string>> = {
+  add: 'add',
+  added: 'add',
+  create: 'add',
+  created: 'add',
+  delete: 'delete',
+  deleted: 'delete',
+  remove: 'delete',
+  removed: 'delete',
+  modify: 'modify',
+  modified: 'modify',
+  update: 'modify',
+  updated: 'modify',
+  rename: 'rename',
+  renamed: 'rename',
+};
+
+/**
+ * Per-tool call renderers, keyed by lowercased tool name.
+ *
+ * The generic `key="value"` rendering is correct but unreadable for the two
+ * shapes that dominate a transcript: a shell command wrapped in `bash -lc`,
+ * and a patch whose whole argument is an array of file records. Lookup is a
+ * single map hit per entry.
+ */
+const TOOL_CALL_FORMATTERS: ReadonlyMap<string, ToolCallFormatter> = new Map([
+  // codex names it `execute` or `shell`; claude names it `Bash`.
+  ['execute', shellCallSummary],
+  ['shell', shellCallSummary],
+  ['bash', shellCallSummary],
+  ['run_command', shellCallSummary],
+  ['apply_patch', changeCallSummary],
+  ['file_change', changeCallSummary],
+]);
+
+/**
+ * Removes the `bash -lc` wrapper and one matching pair of outer quotes,
+ * leaving the command the agent actually meant to run.
+ *
+ * Exported because it is the whole of acceptance criterion 1 and is tested
+ * directly against the wrapper spellings observed from codex.
+ */
+export function unwrapShellCommand(command: string): string {
+  const match = SHELL_WRAPPER.exec(command.trim());
+  if (match?.[1] === undefined) return command.trim();
+  return stripOuterQuotes(match[1].trim());
+}
+
+function stripOuterQuotes(text: string): string {
+  const quote = text[0];
+  if ((quote === '"' || quote === "'") && text.length > 1 && text.endsWith(quote)) {
+    return text.slice(1, -1);
+  }
+  return text;
+}
+
+/**
+ * Shortens `text` to `limit` characters.
+ *
+ * Truncation happens before any quoting, never inside it: slicing a rendered
+ * `key="value"` pair or a JSON serialization lands mid-string often enough
+ * that the line reads as broken syntax.
+ */
+function truncateText(text: string, limit: number): string {
+  return text.length > limit ? `${text.slice(0, limit)}...` : text;
+}
+
+function shellCallSummary(args: Record<string, unknown>): string | null {
+  const {command} = args;
+  if (typeof command !== 'string' || command === '') return null;
+  const rendered = truncateText(unwrapShellCommand(command), MAX_COMMAND_LENGTH);
+  // claude's Bash tool carries a human summary beside the command; codex's
+  // execute does not, so the comment is appended only when one exists.
+  const {description} = args;
+  return typeof description === 'string' && description !== ''
+    ? `${rendered}  # ${description}`
+    : rendered;
+}
+
+function changeCallSummary(args: Record<string, unknown>): string | null {
+  const {changes} = args;
+  if (!Array.isArray(changes)) return null;
+  const summaries = changes
+    .map(changeEntrySummary)
+    .filter((summary): summary is string => summary !== null);
+  if (summaries.length === 0) return null;
+  if (summaries.length === 1) return summaries[0] ?? null;
+  const listed = summaries.slice(0, MAX_LISTED_CHANGES);
+  const overflow = summaries.length - listed.length;
+  const tail = overflow > 0 ? `, +${overflow} more` : '';
+  return `${summaries.length} changes: ${listed.join(', ')}${tail}`;
+}
+
+function changeEntrySummary(change: unknown): string | null {
+  if (change === null || typeof change !== 'object') return null;
+  const record = change as Record<string, unknown>;
+  const rawPath = record['path'];
+  if (typeof rawPath !== 'string' || rawPath === '') return null;
+  const rawKind = record['kind'];
+  const kind = typeof rawKind === 'string' ? rawKind.toLowerCase() : '';
+  const verb = CHANGE_VERBS[kind] ?? (kind === '' ? 'change' : kind);
+  return `${verb} ${rawPath}`;
+}
+
+/**
+ * A one-line description of a value's shape: its top-level keys, or how many
+ * elements it holds. Used both for a collapsed JSON result and for an argument
+ * whose serialization is too long to show.
+ */
+export function jsonShapeSummary(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.length} item${value.length === 1 ? '' : 's'}]`;
+  }
+  if (value !== null && typeof value === 'object') {
+    const keys = Object.keys(value);
+    if (keys.length === 0) return '{}';
+    const listed = keys.slice(0, MAX_SUMMARY_KEYS);
+    const overflow = keys.length - listed.length;
+    return `{keys: ${listed.join(', ')}${overflow > 0 ? `, +${overflow} more` : ''}}`;
+  }
+  if (typeof value === 'string') return `"${truncateText(value, MAX_TOOL_ARG_LENGTH)}"`;
+  return JSON.stringify(value) ?? String(value);
+}
+
+/** The generic `key="value", key=json` rendering for a tool we know nothing about. */
+function genericCallSummary(args: Record<string, unknown>): string {
   const parts = Object.entries(args).map(([key, value]) => {
-    const stringValue = typeof value === 'string';
-    let rendered = stringValue ? value : (JSON.stringify(value) ?? String(value));
-    if (rendered.length > MAX_TOOL_ARG_LENGTH) {
-      rendered = `${rendered.slice(0, MAX_TOOL_ARG_LENGTH)}...`;
-    }
-    return stringValue ? `${key}="${rendered}"` : `${key}=${rendered}`;
+    if (typeof value === 'string') return `${key}="${truncateText(value, MAX_TOOL_ARG_LENGTH)}"`;
+    const serialized = JSON.stringify(value) ?? String(value);
+    // An over-long serialization is replaced wholesale rather than sliced: a
+    // cut lands inside a quoted key or string and leaves an unclosed quote.
+    return `${key}=${serialized.length > MAX_TOOL_ARG_LENGTH ? jsonShapeSummary(value) : serialized}`;
   });
-  return `→ ${tool}(${parts.join(', ')})\n`;
+  return `(${parts.join(', ')})`;
+}
+
+export function toolCallPreview(tool: string, args: Record<string, unknown>): string {
+  const summary = TOOL_CALL_FORMATTERS.get(tool.toLowerCase())?.(args) ?? null;
+  return summary === null ? `→ ${tool}${genericCallSummary(args)}\n` : `→ ${tool} ${summary}\n`;
 }
 
 export function toolOutputPreview(
@@ -43,24 +208,97 @@ export function toolResultPreview(
   expanded = false,
 ): CollapsiblePreview {
   if (payload == null) return toolOutputPreview(content, expanded);
-  return collapsePreview(
-    formatToolResultPayload(payload, content),
-    expanded,
-    MAX_TOOL_OUTPUT_LINES,
-    MAX_TOOL_OUTPUT_CHARACTERS,
-  );
+  const full = formatToolResultPayload(payload, content);
+  const summary = payloadSummary(payload, full);
+  if (summary === null) {
+    return collapsePreview(full, expanded, MAX_TOOL_OUTPUT_LINES, MAX_TOOL_OUTPUT_CHARACTERS);
+  }
+  return summarizedPreview(full, summary, expanded);
 }
 
+/**
+ * Renders a tool result from its typed payload.
+ *
+ * The expanded form is what the reader gets after asking for the whole thing:
+ * a command lays out stdout, a separated stderr section, and its exit code;
+ * a JSON value is pretty-printed. Both are word-wrapped by the caller.
+ */
 function formatToolResultPayload(payload: ToolResultPayload, fallback: string): string {
-  if (payload.kind === 'json') return JSON.stringify(payload.value, null, 2);
+  if (payload.kind === 'json') return JSON.stringify(payload.value, null, 2) ?? fallback;
   if (payload.kind === 'command') {
     const sections: string[] = [];
     if (payload.stdout !== '') sections.push(payload.stdout.replace(/\n+$/, ''));
-    if (payload.stderr !== '') sections.push(`stderr:\n${payload.stderr.replace(/\n+$/, '')}`);
+    // A blank line before the label so a failure's stderr reads as its own
+    // section rather than as the tail of stdout.
+    if (payload.stderr !== '') {
+      const separated = sections.length > 0 ? '\n' : '';
+      sections.push(`${separated}stderr:\n${payload.stderr.replace(/\n+$/, '')}`);
+    }
     if (payload.exit_code != null) sections.push(`exit code: ${payload.exit_code}`);
     if (sections.length > 0) return sections.join('\n');
   }
   return fallback;
+}
+
+/**
+ * The single line a collapsed typed result shows, or null when the payload
+ * carries nothing better than the generic head-of-output truncation.
+ *
+ * A command reports its status, wall time, and output size; a JSON value
+ * reports its shape. Both answer "did this work, and how much is there" in one
+ * row, which is what the reader scanning a transcript is asking.
+ */
+function payloadSummary(payload: ToolResultPayload, full: string): string | null {
+  if (payload.kind === 'json') return jsonShapeSummary(payload.value);
+  if (payload.kind !== 'command') return null;
+  // An empty command payload fell back to the raw content, which has no shape
+  // to summarize.
+  if (payload.stdout === '' && payload.stderr === '' && payload.exit_code == null) return null;
+  const parts: string[] = [];
+  if (payload.exit_code != null) parts.push(`exit ${payload.exit_code}`);
+  if (payload.duration != null) parts.push(`${payload.duration.toFixed(1)}s`);
+  // Without an exit code or a wall time there is no status to report, and a
+  // bare size says nothing about what happened, so the output speaks for
+  // itself instead.
+  if (parts.length === 0) {
+    const first = firstNonEmptyLine(full);
+    if (first !== '') parts.push(truncateText(first, MAX_SUMMARY_LINE));
+  }
+  const lines = countLines(payload.stdout) + countLines(payload.stderr);
+  if (lines > 0) parts.push(`${lines} line${lines === 1 ? '' : 's'}`);
+  return parts.join(' · ');
+}
+
+function countLines(text: string): number {
+  const trimmed = text.replace(/\n+$/, '');
+  return trimmed === '' ? 0 : trimmed.split('\n').length;
+}
+
+function firstNonEmptyLine(text: string): string {
+  return text.split('\n').find(line => line.trim() !== '') ?? '';
+}
+
+/**
+ * Collapses to `summary` rather than to the head of `full`.
+ *
+ * The hidden counts stay in the units `#renderToolTurn` reports, so the
+ * summary line still advertises the whole payload as available behind Enter.
+ */
+function summarizedPreview(full: string, summary: string, expanded: boolean): CollapsiblePreview {
+  const lines = full.split('\n');
+  if (lines.at(-1) === '') lines.pop();
+  const body = lines.join('\n');
+  const collapsible =
+    lines.length > MAX_TOOL_OUTPUT_LINES || body.length > MAX_TOOL_OUTPUT_CHARACTERS;
+  if (expanded || !collapsible) {
+    return {content: body, hiddenLines: 0, hiddenCharacters: 0, collapsible};
+  }
+  return {
+    content: summary,
+    hiddenLines: lines.length,
+    hiddenCharacters: Math.max(0, body.length - summary.length),
+    collapsible: true,
+  };
 }
 
 function collapsePreview(

--- a/clients/tui/src/ui/styles.test.ts
+++ b/clients/tui/src/ui/styles.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@opentui/core';
 import {createTestRenderer, MockTreeSitterClient} from '@opentui/core/testing';
 import {
+  conversationRole,
   createMarkdownBlockOptions,
   createMarkdownStyle,
   createMarkdownTableOptions,
@@ -164,6 +165,35 @@ const NESTED_FENCES = [
   '```',
   '',
 ].join('\n');
+
+describe('diagnostic entry roles', () => {
+  const diagnostic = (content: string) => conversationRole({id: 'd', kind: 'diagnostic', content});
+
+  it('keeps provider lifecycle chatter in the muted narration role', () => {
+    expect(diagnostic('[codex thread 01a0 started]\n[codex turn started]')).toBe('analysis');
+    expect(diagnostic('[codex stderr] compiling 42 crates')).toBe('analysis');
+    expect(diagnostic('driver: agentshim, provider: codex, model: gpt-5.6')).toBe('analysis');
+  });
+
+  it('promotes a driver error marker to the failure role', () => {
+    expect(diagnostic('[codex error] stream disconnected')).toBe('failure');
+    expect(diagnostic('[claude error] rate limited')).toBe('failure');
+    // A marker anywhere in a glued block still counts.
+    expect(diagnostic('[codex turn started]\n[codex error] boom')).toBe('failure');
+  });
+
+  it('promotes a stderr line whose own text opens with an error token', () => {
+    expect(diagnostic('[codex stderr] ERROR: sandbox denied')).toBe('failure');
+    expect(diagnostic('[codex stderr] Traceback (most recent call last):')).toBe('failure');
+    expect(diagnostic('[codex stderr] panic: index out of range')).toBe('failure');
+  });
+
+  it('lets a backend-marked tone win over the text heuristic', () => {
+    expect(conversationRole({id: 'd', kind: 'diagnostic', content: 'quiet', tone: 'failure'})).toBe(
+      'failure',
+    );
+  });
+});
 
 describe('markdown table options', () => {
   it('sizes columns to content rather than to the pane', () => {

--- a/clients/tui/src/ui/styles.ts
+++ b/clients/tui/src/ui/styles.ts
@@ -212,16 +212,34 @@ export function createMarkdownBlockOptions(
   };
 }
 
+/**
+ * A driver lifecycle line that reports a failure rather than a heartbeat.
+ *
+ * AgentShim drivers stream provider stderr and driver errors through the
+ * diagnostic channel behind a `[<provider> error]` or `[<provider> stderr]`
+ * marker, and nothing in the event distinguishes a crash from a turn
+ * boundary. The marker is the only signal the transcript gets, so the failure
+ * palette is chosen from it: `[codex error] ...` always, and a stderr line
+ * whose own text opens with an error token.
+ */
+const FAILURE_DIAGNOSTIC =
+  /^\[[^\s\]]+ error\]|^\[[^\s\]]+ stderr\] *(?:ERROR|FATAL|error:|fatal:|panic:|Traceback)/m;
+
 export function conversationRole(entry: ConversationEntry): ConversationRole {
   if (entry.tone === 'failure') return 'failure';
   if (entry.tone === 'success') return 'success';
   if (entry.kind === 'assistant') return 'assistant';
   if (entry.kind === 'user') return 'user';
   if (entry.kind === 'prompt') return 'prompt';
+  // A driver's own error markers are the only failure signal on this channel,
+  // so they are promoted out of the muted narration style.
+  if (entry.kind === 'diagnostic') {
+    return FAILURE_DIAGNOSTIC.test(entry.content) ? 'failure' : 'analysis';
+  }
   // An agent narrating its own work is analysis whichever channel carried it:
   // the diagnostic channel is where most backends put that narration, and
   // slate-on-slate buried it. Tool turns keep the neutral surface.
-  if (entry.kind === 'analysis' || entry.kind === 'diagnostic') return 'analysis';
+  if (entry.kind === 'analysis') return 'analysis';
   if (entry.kind === 'tool' || entry.kind === 'subprocess') return 'tool';
   return 'neutral';
 }

--- a/src/vibesys/_agent_cli/codex.py
+++ b/src/vibesys/_agent_cli/codex.py
@@ -1,7 +1,10 @@
+import json
+import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from agentshim.codex import CodexGenerationSession
+from agentshim.codex.events import CodexEvent, ToolResultEvent, ToolUseEvent
 from agentshim.events import AgentEventHandler
 
 from .base import MCPServerSpec
@@ -9,6 +12,83 @@ from .cli_agent import CLICodingAgent
 
 if TYPE_CHECKING:
     from agentshim.executor import CommandExecutor
+
+_COMMAND_TOOL = "execute"
+
+
+def _item_lifecycle(line: str) -> tuple[str, str] | None:
+    """Read lifecycle kind and stable item identity before callbacks discard them."""
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict) or data.get("type") not in ("item.started", "item.completed"):
+        return None
+    item = data.get("item")
+    if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+        return None
+    return data["type"], item["id"]
+
+
+def _completion_output(parameters: Any) -> str:  # noqa: ANN401  # tracked: #288
+    """Preserve output and error payloads added when a generic item completes."""
+    if isinstance(parameters, dict):
+        for key in ("aggregated_output", "output", "text", "summary", "result", "error", "message"):
+            value = parameters.get(key)
+            if value:
+                return value if isinstance(value, str) else json.dumps(value)
+    return ""
+
+
+class _PairedCodexSession(CodexGenerationSession):
+    """Repair AgentShim's generic tool lifecycle before item IDs are discarded.
+
+    AgentShim 0.5.x maps generic starts and completions to ToolUseEvent.
+    Completion arguments can change, so use the raw lifecycle kind to convert
+    only completions to ToolResultEvent. The base session then pairs by ID,
+    including when a corrected parser supplies ToolResultEvent itself.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:  # noqa: ANN401  # tracked: #288
+        super().__init__(**kwargs)
+        self._lifecycle: tuple[str, str] | None = None
+
+    def _process_stdout(self, line: str) -> None:
+        self._lifecycle = _item_lifecycle(line)
+        try:
+            super()._process_stdout(line)
+        finally:
+            self._lifecycle = None
+
+    def _handle_event(self, event: CodexEvent) -> None:
+        if (
+            isinstance(event, ToolUseEvent)
+            and event.tool_name != _COMMAND_TOOL
+            and self._lifecycle is not None
+            and event.tool_id == self._lifecycle[1]
+        ):
+            if self._lifecycle[0] == "item.started":
+                # AgentShim registers only command executions. Register generic
+                # starts too, using the same clock as its duration calculation.
+                self.tool_map[event.tool_id] = event.tool_name
+                self.tool_start_times[event.tool_id] = time.time()
+                self.tool_args[event.tool_id] = event.parameters
+            else:
+                event = ToolResultEvent(
+                    tool_id=event.tool_id,
+                    tool_name=event.tool_name,
+                    parameters=event.parameters,
+                    output=_completion_output(event.parameters),
+                )
+        super()._handle_event(event)
+        if (
+            isinstance(event, ToolResultEvent)
+            and event.tool_id
+            and event.tool_name != _COMMAND_TOOL
+        ):
+            self.tool_map.pop(event.tool_id, None)
+            self.tool_start_times.pop(event.tool_id, None)
+            self.tool_args.pop(event.tool_id, None)
 
 
 def _toml_str(value: str) -> str:
@@ -139,7 +219,7 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
         timeout: int | None = None,
         silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> CodexGenerationSession:
-        return CodexGenerationSession(
+        return _PairedCodexSession(
             binary_name=self.binary_name,
             env=self.env,
             log_prefix=self._log_prefix,

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -1,4 +1,5 @@
 import json  # noqa: D100  # tracked: #288
+import re
 import time
 import traceback
 import uuid
@@ -14,6 +15,22 @@ from vibesys.agents.todos import todos_from_tool_call
 from vibesys.render.format import format_status_prefix
 from vibesys.render.sink import output_sink
 from vibesys.run.events import AgentOutputChannel, AgentStatusData, ToolResultPayload
+
+_DRIVER_LIFECYCLE_RE = re.compile(r"\[[^\s\]]+ (?:stderr|thread|turn|error)[\s\]]")
+"""Matches AgentShim's driver lifecycle marker at the head of a chunk.
+
+Used with ``re.match``, so it is anchored at the start of the text and runs a
+bounded character class before a literal alternation: no backtracking.
+
+AgentShim CLI drivers have no diagnostic hook, so they route their own
+plumbing through ``on_thinking`` tagged with a ``[<provider> <event>]``
+marker: ``[codex thread <id> started]``, ``[codex turn started]``,
+``[codex turn complete: ...]``, ``[codex stderr] <line>``, and
+``[codex error] <message>``. Without this classification the transcript
+presents a provider heartbeat as the agent's own chain of thought, glued
+onto whatever reasoning preceded it. The marker text is published verbatim;
+only the channel changes.
+"""
 
 ContextWindowLookup = Callable[[str | None], int | None]
 """Resolves a model name to its context window size in tokens.
@@ -440,7 +457,10 @@ class AgentLogger(BaseCallbackHandler):
         if not text:
             return
         status = self._status()
-        self._publish(text, "analysis", status=status)
+        channel: AgentOutputChannel = (
+            "diagnostic" if _DRIVER_LIFECYCLE_RE.match(text) else "analysis"
+        )
+        self._publish(text, channel, status=status)
         self._log_line(f"{format_status_prefix(status)}{text}")
 
     def on_tool_call(self, tool: str, args: dict[str, Any] | str | None = None) -> None:  # noqa: D102  # tracked: #288

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 import weakref
@@ -72,6 +73,7 @@ def supported_providers() -> list[str]:
     return sorted(_PROVIDER_CLASSES)
 
 
+_CODEX_PROVIDER = "codex"
 _REASONING_EFFORT_PROVIDERS = frozenset({"codex", "claude"})
 _PYTHON_MCP_COMMANDS = frozenset({"python", "python3"})
 
@@ -127,11 +129,31 @@ def _as_agentshim_mcp(spec: MCPServerSpec, *, in_container: bool) -> AgentShimMC
     )
 
 
+def _call_signature(args: dict[str, Any] | str) -> str:
+    """Render tool arguments as a comparable key, whatever they contain."""
+    try:
+        return json.dumps(args, sort_keys=True, default=repr)
+    except (TypeError, ValueError):
+        return repr(args)
+
+
 class _AgentShimEventHandler:
     """Translate AgentShim callbacks into neutral driver events."""
 
-    def __init__(self) -> None:
+    def __init__(self, provider: str) -> None:
         self.observer: AgentObserver | None = None
+        self._provider = provider
+        # The last tool call no result has closed, as ``(tool, args key)``.
+        #
+        # AgentShim's codex driver turns both ``item.started`` and
+        # ``item.completed`` into the same ``ToolUseEvent`` for every item type
+        # except ``command_execution``, so one ``file_change`` or ``todo_list``
+        # action reaches ``on_tool_call`` twice and opens two transcript turns,
+        # the second of which never receives a result. The callback signature
+        # carries no item id, so the repeat is recognizable only as an
+        # identical call arriving before any result: a later identical call, or
+        # one separated by another tool call, still gets its own turn.
+        self._open_call: tuple[str, str] | None = None
 
     def _emit(self, event: AgentEvent) -> None:
         if self.observer is not None:
@@ -141,10 +163,15 @@ class _AgentShimEventHandler:
         self._emit(AgentEvent(kind=AgentEventKind.THINKING, text=text))
 
     def on_tool_call(self, tool: str, args: dict[str, Any] | str | None = None) -> None:
+        normalized = args if args is not None else {}
+        call = (tool, _call_signature(normalized))
+        if self._provider == _CODEX_PROVIDER and call == self._open_call:
+            return
+        self._open_call = call
         self._emit(
             AgentEvent(
                 kind=AgentEventKind.TOOL_CALL,
-                payload={"tool": tool, "args": args if args is not None else {}},
+                payload={"tool": tool, "args": normalized},
             )
         )
 
@@ -156,6 +183,7 @@ class _AgentShimEventHandler:
         exit_code: int | None = None,
         duration: float | None = None,
     ) -> None:
+        self._open_call = None
         self._emit(
             AgentEvent(
                 kind=AgentEventKind.TOOL_RESULT,
@@ -484,7 +512,7 @@ class AgentShimDriver:
                 "AgentShim execution mode"
             )
 
-        event_handler = _AgentShimEventHandler()
+        event_handler = _AgentShimEventHandler(self._provider)
         if in_container:
             assert self._docker_sandboxes is not None  # noqa: S101  # tracked: #288
             sandbox = self._docker_sandboxes.get(spec.role)

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 import weakref
@@ -73,7 +72,6 @@ def supported_providers() -> list[str]:
     return sorted(_PROVIDER_CLASSES)
 
 
-_CODEX_PROVIDER = "codex"
 _REASONING_EFFORT_PROVIDERS = frozenset({"codex", "claude"})
 _PYTHON_MCP_COMMANDS = frozenset({"python", "python3"})
 
@@ -129,31 +127,11 @@ def _as_agentshim_mcp(spec: MCPServerSpec, *, in_container: bool) -> AgentShimMC
     )
 
 
-def _call_signature(args: dict[str, Any] | str) -> str:
-    """Render tool arguments as a comparable key, whatever they contain."""
-    try:
-        return json.dumps(args, sort_keys=True, default=repr)
-    except (TypeError, ValueError):
-        return repr(args)
-
-
 class _AgentShimEventHandler:
     """Translate AgentShim callbacks into neutral driver events."""
 
-    def __init__(self, provider: str) -> None:
+    def __init__(self) -> None:
         self.observer: AgentObserver | None = None
-        self._provider = provider
-        # The last tool call no result has closed, as ``(tool, args key)``.
-        #
-        # AgentShim's codex driver turns both ``item.started`` and
-        # ``item.completed`` into the same ``ToolUseEvent`` for every item type
-        # except ``command_execution``, so one ``file_change`` or ``todo_list``
-        # action reaches ``on_tool_call`` twice and opens two transcript turns,
-        # the second of which never receives a result. The callback signature
-        # carries no item id, so the repeat is recognizable only as an
-        # identical call arriving before any result: a later identical call, or
-        # one separated by another tool call, still gets its own turn.
-        self._open_call: tuple[str, str] | None = None
 
     def _emit(self, event: AgentEvent) -> None:
         if self.observer is not None:
@@ -163,15 +141,10 @@ class _AgentShimEventHandler:
         self._emit(AgentEvent(kind=AgentEventKind.THINKING, text=text))
 
     def on_tool_call(self, tool: str, args: dict[str, Any] | str | None = None) -> None:
-        normalized = args if args is not None else {}
-        call = (tool, _call_signature(normalized))
-        if self._provider == _CODEX_PROVIDER and call == self._open_call:
-            return
-        self._open_call = call
         self._emit(
             AgentEvent(
                 kind=AgentEventKind.TOOL_CALL,
-                payload={"tool": tool, "args": normalized},
+                payload={"tool": tool, "args": args if args is not None else {}},
             )
         )
 
@@ -183,7 +156,6 @@ class _AgentShimEventHandler:
         exit_code: int | None = None,
         duration: float | None = None,
     ) -> None:
-        self._open_call = None
         self._emit(
             AgentEvent(
                 kind=AgentEventKind.TOOL_RESULT,
@@ -512,7 +484,7 @@ class AgentShimDriver:
                 "AgentShim execution mode"
             )
 
-        event_handler = _AgentShimEventHandler(self._provider)
+        event_handler = _AgentShimEventHandler()
         if in_container:
             assert self._docker_sandboxes is not None  # noqa: S101  # tracked: #288
             sandbox = self._docker_sandboxes.get(spec.role)

--- a/tests/vibesys/_agent_cli/test_codex.py
+++ b/tests/vibesys/_agent_cli/test_codex.py
@@ -10,12 +10,18 @@ These tests exercise :mod:`vibesys._agent_cli.codex` without spawning the real
 3. ``CodexGenerationSession`` captures cumulative token usage from
    ``turn.completed`` events and forwards a ``reasoning`` item's text through
    the event handler.
+4. ``_PairedCodexSession`` pairs a generic item's ``item.started`` and
+   ``item.completed`` (both mapped to tool-use upstream) by item id into one
+   ``on_tool_call`` / ``on_tool_result`` pair.
 """
 
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
+
+from agentshim.codex.events import ToolResultEvent
 
 from vibesys._agent_cli.codex import (
     CodexCodingAgent,
@@ -23,6 +29,9 @@ from vibesys._agent_cli.codex import (
     _shell_path_config_args,
 )
 from vibesys._agent_cli.gemini import GeminiCodingAgent
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 def _agent() -> CodexCodingAgent:
@@ -363,6 +372,323 @@ class TestProcessStdout:
         session = _session()
         session._process_stdout("   \n")  # noqa: SLF001  # tracked: #288
         assert session.stdout_lines == []
+
+
+# ---------------------------------------------------------------------------
+# Tool-event pairing
+# ---------------------------------------------------------------------------
+
+
+def _agent_session(handler) -> CodexGenerationSession:  # noqa: ANN001  # tracked: #288
+    """Build a session through the agent, so the pairing subclass is wired in."""
+    agent = _agent()
+    agent.binary_name = "codex"
+    agent.env = {}
+    agent.logger = MagicMock()
+    agent.executor = None
+    agent.event_handler = handler
+    return agent._create_session(["codex", "exec", "--json", "-"], silent=True)  # noqa: SLF001  # tracked: #288
+
+
+def _item_line(event_type: str, item: Mapping[str, object]) -> str:
+    """Serialize one raw codex item lifecycle line."""
+    return json.dumps({"type": event_type, "item": dict(item)})
+
+
+def _tool_events(handler: MagicMock) -> list[str]:
+    """Ordered names of the tool callbacks the handler received."""
+    return [name for name, *_ in handler.method_calls if name.startswith("on_tool")]
+
+
+class TestToolEventPairing:
+    """Pairing of generic codex items into call/result pairs by item id.
+
+    agentshim maps a generic item's ``item.started`` and ``item.completed``
+    both to tool-use events, and the completion payload differs from the
+    start (``result`` / ``error`` get populated), so the session must pair
+    the two by the stable item id, not by argument equality.
+    """
+
+    def test_mcp_lifecycle_emits_one_call_and_one_result(self) -> None:
+        """The reviewed defect: completion parameters differ from the start."""
+        handler = MagicMock()
+        session = _agent_session(handler)
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.started",
+                {
+                    "id": "item_5",
+                    "type": "mcp_tool_call",
+                    "server": "docs",
+                    "tool": "search",
+                    "arguments": {"query": "x"},
+                    "result": None,
+                    "error": None,
+                    "status": "in_progress",
+                },
+            )
+        )
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.completed",
+                {
+                    "id": "item_5",
+                    "type": "mcp_tool_call",
+                    "server": "docs",
+                    "tool": "search",
+                    "arguments": {"query": "x"},
+                    "result": {"content": [{"type": "text", "text": "hits"}]},
+                    "error": None,
+                    "status": "completed",
+                },
+            )
+        )
+        handler.on_tool_call.assert_called_once_with(
+            "mcp_tool_call",
+            {
+                "server": "docs",
+                "tool": "search",
+                "arguments": {"query": "x"},
+                "result": None,
+                "error": None,
+            },
+        )
+        handler.on_tool_result.assert_called_once()
+        result = handler.on_tool_result.call_args.kwargs
+        assert result["tool"] == "mcp_tool_call"
+        assert "hits" in result["stdout"]
+        assert result["exit_code"] is None
+        assert result["duration"] is not None
+        assert result["duration"] >= 0
+        assert _tool_events(handler) == ["on_tool_call", "on_tool_result"]
+
+    def test_identical_parameters_with_distinct_ids_stay_two_items(self) -> None:
+        """Byte-identical payloads must pair by id, not by argument equality."""
+        handler = MagicMock()
+        session = _agent_session(handler)
+        for item_id in ("item_a", "item_b"):
+            for event_type, status in (
+                ("item.started", "in_progress"),
+                ("item.completed", "completed"),
+            ):
+                session._process_stdout(  # noqa: SLF001  # tracked: #288
+                    _item_line(
+                        event_type,
+                        {
+                            "id": item_id,
+                            "type": "file_change",
+                            "status": status,
+                            "path": "engine.py",
+                            "kind": "update",
+                        },
+                    )
+                )
+        assert handler.on_tool_call.call_count == 2
+        assert handler.on_tool_result.call_count == 2
+        assert _tool_events(handler) == [
+            "on_tool_call",
+            "on_tool_result",
+            "on_tool_call",
+            "on_tool_result",
+        ]
+        # file_change has no output payload; results carry empty stdout.
+        assert [c.kwargs["stdout"] for c in handler.on_tool_result.call_args_list] == ["", ""]
+
+    def test_interleaved_items_pair_by_id(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        item_a = {"id": "a", "type": "file_change", "path": "a.py"}
+        item_b = {"id": "b", "type": "web_search", "query": "docs"}
+        lines = [
+            ("item.started", {**item_a, "status": "in_progress"}),
+            ("item.started", {**item_b, "status": "in_progress"}),
+            ("item.completed", {**item_b, "status": "completed", "result": "found"}),
+            ("item.completed", {**item_a, "status": "completed"}),
+        ]
+        for event_type, item in lines:
+            session._process_stdout(_item_line(event_type, item))  # noqa: SLF001  # tracked: #288
+        assert [c.args[0] for c in handler.on_tool_call.call_args_list] == [
+            "file_change",
+            "web_search",
+        ]
+        assert [c.kwargs["tool"] for c in handler.on_tool_result.call_args_list] == [
+            "web_search",
+            "file_change",
+        ]
+
+    def test_identical_overlapping_items_keep_both_starts(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        for event_type, item_id in (
+            ("item.started", "a"),
+            ("item.started", "b"),
+            ("item.completed", "b"),
+            ("item.completed", "a"),
+        ):
+            session._process_stdout(  # noqa: SLF001  # tracked: #288
+                _item_line(event_type, {"id": item_id, "type": "file_change", "changes": []})
+            )
+        assert _tool_events(handler) == [
+            "on_tool_call",
+            "on_tool_call",
+            "on_tool_result",
+            "on_tool_result",
+        ]
+
+    def test_identical_completion_only_items_each_get_a_pair(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        for item_id in ("a", "b"):
+            session._process_stdout(  # noqa: SLF001  # tracked: #288
+                _item_line("item.completed", {"id": item_id, "type": "file_change", "changes": []})
+            )
+        assert _tool_events(handler) == [
+            "on_tool_call",
+            "on_tool_result",
+            "on_tool_call",
+            "on_tool_result",
+        ]
+
+    def test_completion_without_observed_start_synthesizes_the_call(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.completed",
+                {
+                    "id": "w1",
+                    "type": "web_search",
+                    "status": "completed",
+                    "query": "q",
+                    "result": "r",
+                },
+            )
+        )
+        handler.on_tool_call.assert_called_once_with("web_search", {"query": "q", "result": "r"})
+        handler.on_tool_result.assert_called_once()
+        result = handler.on_tool_result.call_args.kwargs
+        assert result["tool"] == "web_search"
+        assert result["stdout"] == "r"
+        assert result["duration"] is None
+        assert _tool_events(handler) == ["on_tool_call", "on_tool_result"]
+
+    def test_command_execution_keeps_base_pairing(self) -> None:
+        """``execute`` items pair upstream; the id pairing must not interfere."""
+        handler = MagicMock()
+        session = _agent_session(handler)
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.started",
+                {
+                    "id": "c1",
+                    "type": "command_execution",
+                    "status": "in_progress",
+                    "command": "ls -la",
+                },
+            )
+        )
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.completed",
+                {
+                    "id": "c1",
+                    "type": "command_execution",
+                    "status": "completed",
+                    "command": "ls -la",
+                    "aggregated_output": "file.txt\n",
+                    "exit_code": 0,
+                },
+            )
+        )
+        handler.on_tool_call.assert_called_once_with("execute", {"command": "ls -la"})
+        handler.on_tool_result.assert_called_once()
+        result = handler.on_tool_result.call_args.kwargs
+        assert result["tool"] == "execute"
+        assert result["stdout"] == "file.txt\n"
+        assert result["exit_code"] == 0
+        assert result["duration"] is not None
+
+    def test_real_result_event_closes_started_item_without_duplicate_call(self) -> None:
+        """A fixed adapter emitting a real ToolResultEvent must resolve cleanly."""
+        handler = MagicMock()
+        session = _agent_session(handler)
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.started",
+                {
+                    "id": "m1",
+                    "type": "mcp_tool_call",
+                    "status": "in_progress",
+                    "server": "docs",
+                    "tool": "search",
+                    "arguments": {"query": "x"},
+                },
+            )
+        )
+        session._handle_event(  # noqa: SLF001  # tracked: #288
+            ToolResultEvent(
+                tool_id="m1",
+                output="done",
+                tool_name="mcp_tool_call",
+                parameters={"server": "docs"},
+            )
+        )
+        handler.on_tool_call.assert_called_once()
+        handler.on_tool_result.assert_called_once()
+        result = handler.on_tool_result.call_args.kwargs
+        assert result["tool"] == "mcp_tool_call"
+        assert result["stdout"] == "done"
+        assert result["duration"] is not None
+
+    def test_failed_completion_surfaces_the_error(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        for event_type, extra in (
+            ("item.started", {"result": None, "error": None, "status": "in_progress"}),
+            ("item.completed", {"result": None, "error": {"message": "boom"}, "status": "failed"}),
+        ):
+            session._process_stdout(  # noqa: SLF001  # tracked: #288
+                _item_line(
+                    event_type,
+                    {
+                        "id": "m2",
+                        "type": "mcp_tool_call",
+                        "server": "docs",
+                        "tool": "search",
+                        "arguments": {},
+                        **extra,
+                    },
+                )
+            )
+        handler.on_tool_call.assert_called_once()
+        handler.on_tool_result.assert_called_once()
+        assert "boom" in handler.on_tool_result.call_args.kwargs["stdout"]
+
+    def test_item_updated_and_non_json_lines_emit_no_tool_events(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        item = {"id": "f1", "type": "file_change", "status": "in_progress", "path": "a.py"}
+        session._process_stdout(_item_line("item.started", item))  # noqa: SLF001  # tracked: #288
+        session._process_stdout(_item_line("item.updated", item))  # noqa: SLF001  # tracked: #288
+        session._process_stdout("starting codex 1.2.3\n")  # noqa: SLF001  # tracked: #288
+        assert handler.on_tool_call.call_count == 1
+        handler.on_tool_result.assert_not_called()
+
+    def test_session_without_handler_processes_a_full_lifecycle(self) -> None:
+        session = _agent_session(None)
+        for event_type, status in (
+            ("item.started", "in_progress"),
+            ("item.completed", "completed"),
+        ):
+            session._process_stdout(  # noqa: SLF001  # tracked: #288
+                _item_line(
+                    event_type,
+                    {"id": "f2", "type": "file_change", "status": status, "path": "a.py"},
+                )
+            )
+        assert session.tool_map == {}
+        assert session.tool_start_times == {}
+        assert session.tool_args == {}
 
 
 class TestProcessStderr:

--- a/tests/vibesys/agents/drivers/test_agentshim_driver.py
+++ b/tests/vibesys/agents/drivers/test_agentshim_driver.py
@@ -74,6 +74,7 @@ class _FakeAgent:
         self.error: BaseException | None = None
         self.generate_override: _GenerateOverride | None = None
         self.uninstall_override: Callable[[Path, list[Any]], None] | None = None
+        self.tool_call_events: list[tuple[str, dict[str, Any]]] = []
         self.tool_result_events: list[dict[str, Any]] = []
         self._last_session = SimpleNamespace(
             final_usage={"input_tokens": 12, "output_tokens": 3},
@@ -121,6 +122,8 @@ class _FakeAgent:
         assert self.event_handler is not None
         self.generate_calls.append((prompt, cwd, timeout))
         self.event_handler.on_thinking("working")
+        for tool, args in self.tool_call_events:
+            self.event_handler.on_tool_call(tool, args)
         for tool_result in self.tool_result_events:
             self.event_handler.on_tool_result(**tool_result)
         self.event_handler.on_usage({"input_tokens": 12, "output_tokens": 3})
@@ -249,6 +252,102 @@ def test_turn_translates_tool_results_into_typed_command_payloads(
     assert event.payload["stderr"] == "warn"
     assert event.payload["exit_code"] == 3
     assert event.payload["duration"] == 0.7
+
+
+def _self_referential() -> dict[str, Any]:
+    """Arguments ``json.dumps`` refuses even with a fallback serializer."""
+    args: dict[str, Any] = {}
+    args["self"] = args
+    return args
+
+
+def test_codex_item_lifecycle_does_not_open_two_turns_for_one_action(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    """AgentShim reports one codex ``file_change`` item as start *and* complete.
+
+    Both arrive as identical ``on_tool_call`` callbacks with no item id, and
+    neither is followed by a result, so forwarding both left a second tool turn
+    that never closed.
+    """
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+    changes = {"changes": [{"path": "src/lib.rs", "kind": "delete"}]}
+    fake_agent[0].tool_call_events = [("file_change", changes), ("file_change", changes)]
+    observer = _Observer()
+
+    session.run_turn(AgentTurnRequest(message="Do it"), observer)
+
+    calls = [event for event in observer.events if event.kind is subject.AgentEventKind.TOOL_CALL]
+    assert len(calls) == 1
+    assert calls[0].payload == {"tool": "file_change", "args": changes}
+
+
+def test_a_repeat_call_after_a_result_is_its_own_turn() -> None:
+    handler = subject._AgentShimEventHandler("codex")  # noqa: SLF001
+    observer = _Observer()
+    handler.observer = observer
+
+    handler.on_tool_call("execute", {"command": "cargo test"})
+    handler.on_tool_result("execute", stdout="ok", exit_code=0)
+    handler.on_tool_call("execute", {"command": "cargo test"})
+
+    kinds = [event.kind for event in observer.events]
+    assert kinds == [
+        subject.AgentEventKind.TOOL_CALL,
+        subject.AgentEventKind.TOOL_RESULT,
+        subject.AgentEventKind.TOOL_CALL,
+    ]
+
+
+def test_a_repeat_call_behind_another_tool_is_its_own_turn() -> None:
+    handler = subject._AgentShimEventHandler("codex")  # noqa: SLF001
+    observer = _Observer()
+    handler.observer = observer
+
+    handler.on_tool_call("file_change", {"changes": []})
+    handler.on_tool_call("todo_list", {"items": []})
+    handler.on_tool_call("file_change", {"changes": []})
+
+    tools = [
+        event.payload["tool"]
+        for event in observer.events
+        if event.kind is subject.AgentEventKind.TOOL_CALL
+    ]
+    assert tools == ["file_change", "todo_list", "file_change"]
+
+
+def test_providers_without_the_codex_item_defect_forward_every_call() -> None:
+    handler = subject._AgentShimEventHandler("claude")  # noqa: SLF001
+    observer = _Observer()
+    handler.observer = observer
+
+    handler.on_tool_call("Read", {"path": "a.rs"})
+    handler.on_tool_call("Read", {"path": "a.rs"})
+
+    assert len(observer.events) == 2
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param({"cursor": object()}, id="unserializable-value"),
+        pytest.param(_self_referential(), id="circular-structure"),
+    ],
+)
+def test_call_arguments_json_cannot_render_still_compare(
+    fake_agent: list[_FakeAgent], tmp_path: Path, args: dict[str, Any]
+) -> None:
+    """An MCP tool's arguments are arbitrary, so the key must never raise."""
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+    fake_agent[0].tool_call_events = [("mcp_tool_call", args), ("mcp_tool_call", args)]
+    observer = _Observer()
+
+    session.run_turn(AgentTurnRequest(message="Do it"), observer)
+
+    calls = [event for event in observer.events if event.kind is subject.AgentEventKind.TOOL_CALL]
+    assert len(calls) == 1
 
 
 def test_independent_sessions_overlap_and_chat_cleanup_does_not_interrupt_optimizer(

--- a/tests/vibesys/agents/drivers/test_agentshim_driver.py
+++ b/tests/vibesys/agents/drivers/test_agentshim_driver.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import threading
 from dataclasses import dataclass, field
 from datetime import timedelta
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Protocol
+from unittest.mock import MagicMock
 
 import pytest
 
+from vibesys.agents.callbacks import AgentLogger
+from vibesys.agents.client import _LoggerObserver
 from vibesys.agents.contracts import (
     AgentEvent,
     AgentExecutionPolicy,
@@ -17,7 +21,8 @@ from vibesys.agents.contracts import (
     MCPServerSpec,
 )
 from vibesys.agents.drivers import agentshim as subject
-from vibesys.run.events import CommandResultPayload
+from vibesys.render.sink import output_sink
+from vibesys.run.events import CommandResultPayload, CoreEvent, ToolCallData, ToolResultData
 from vs_sandbox import ProjectPathPolicy
 
 if TYPE_CHECKING:
@@ -261,30 +266,102 @@ def _self_referential() -> dict[str, Any]:
     return args
 
 
-def test_codex_item_lifecycle_does_not_open_two_turns_for_one_action(
-    fake_agent: list[_FakeAgent], tmp_path: Path
+@pytest.mark.parametrize("item_count", [1, 2])
+@pytest.mark.parametrize(
+    ("item", "completion"),
+    [
+        pytest.param(
+            {"type": "file_change", "changes": [{"path": "src/lib.rs", "kind": "delete"}]},
+            {},
+            id="file-change",
+        ),
+        pytest.param(
+            {
+                "type": "mcp_tool_call",
+                "server": "docs",
+                "tool": "search",
+                "arguments": {"query": "x"},
+                "result": None,
+                "error": None,
+            },
+            {"result": {"content": [{"type": "text", "text": "hits"}]}},
+            id="mcp-result",
+        ),
+        pytest.param(
+            {"type": "mcp_tool_call", "arguments": {}, "result": None, "error": None},
+            {"error": {"message": "unavailable"}},
+            id="mcp-error",
+        ),
+    ],
+)
+def test_codex_item_lifecycles_reach_the_driver_as_separate_pairs(
+    fake_agent: list[_FakeAgent],
+    tmp_path: Path,
+    item_count: int,
+    item: dict[str, Any],
+    completion: dict[str, Any],
 ) -> None:
-    """AgentShim reports one codex ``file_change`` item as start *and* complete.
-
-    Both arrive as identical ``on_tool_call`` callbacks with no item id, and
-    neither is followed by a result, so forwarding both left a second tool turn
-    that never closed.
-    """
+    """Pair raw lifecycle IDs before the driver publishes identical tool arguments."""
     driver = subject.AgentShimDriver(provider="codex")
     session = driver.create_session(_spec(tmp_path))
-    changes = {"changes": [{"path": "src/lib.rs", "kind": "delete"}]}
-    fake_agent[0].tool_call_events = [("file_change", changes), ("file_change", changes)]
-    observer = _Observer()
+    codex = subject.CodexCodingAgent.__new__(subject.CodexCodingAgent)
+    codex.binary_name = "codex"
+    codex.env = {}
+    codex.logger = MagicMock()
+    codex.executor = None
+    codex.event_handler = fake_agent[0].event_handler
+    parser = codex._create_session(["codex", "exec", "--json"], silent=True)  # noqa: SLF001
 
-    session.run_turn(AgentTurnRequest(message="Do it"), observer)
+    def generate(_prompt: str, *, cwd: str | None, timeout: int | None, silent: bool) -> str:
+        assert cwd == str(tmp_path)
+        assert timeout is None
+        assert silent
+        for index in range(item_count):
+            for kind in ("item.started", "item.completed"):
+                parser._process_stdout(  # noqa: SLF001
+                    json.dumps(
+                        {
+                            "type": kind,
+                            "item": {
+                                "id": f"item_{index}",
+                                **item,
+                                **(completion if kind == "item.completed" else {}),
+                            },
+                        }
+                    )
+                )
+        return "done"
 
-    calls = [event for event in observer.events if event.kind is subject.AgentEventKind.TOOL_CALL]
-    assert len(calls) == 1
-    assert calls[0].payload == {"tool": "file_change", "args": changes}
+    fake_agent[0].generate_override = generate
+    seen: list[CoreEvent] = []
+    unsubscribe = output_sink().subscribe(seen.append)
+    try:
+        session.run_turn(AgentTurnRequest(message="Do it"), _LoggerObserver(AgentLogger()))
+    finally:
+        unsubscribe()
+
+    # Exercise the serialization consumed by the journal and replay clients.
+    wire_events = [CoreEvent.model_validate_json(event.model_dump_json()) for event in seen]
+    calls = [event.data for event in wire_events if isinstance(event.data, ToolCallData)]
+    results = [event.data for event in wire_events if isinstance(event.data, ToolResultData)]
+    assert [type(event.data) for event in wire_events] == [
+        ToolCallData,
+        ToolResultData,
+    ] * item_count
+    assert len({call.call_id for call in calls}) == item_count
+    assert all(call.call_id is not None for call in calls)
+    assert [result.call_id for result in results] == [call.call_id for call in calls]
+    assert [call.args for call in calls] == [
+        {key: value for key, value in item.items() if key != "type"}
+    ] * item_count
+    if completion:
+        assert [json.loads(result.content) for result in results] == [
+            next(iter(completion.values()))
+        ] * item_count
 
 
 def test_a_repeat_call_after_a_result_is_its_own_turn() -> None:
-    handler = subject._AgentShimEventHandler("codex")  # noqa: SLF001
+    handler = subject._AgentShimEventHandler()  # noqa: SLF001
     observer = _Observer()
     handler.observer = observer
 
@@ -301,7 +378,7 @@ def test_a_repeat_call_after_a_result_is_its_own_turn() -> None:
 
 
 def test_a_repeat_call_behind_another_tool_is_its_own_turn() -> None:
-    handler = subject._AgentShimEventHandler("codex")  # noqa: SLF001
+    handler = subject._AgentShimEventHandler()  # noqa: SLF001
     observer = _Observer()
     handler.observer = observer
 
@@ -317,8 +394,8 @@ def test_a_repeat_call_behind_another_tool_is_its_own_turn() -> None:
     assert tools == ["file_change", "todo_list", "file_change"]
 
 
-def test_providers_without_the_codex_item_defect_forward_every_call() -> None:
-    handler = subject._AgentShimEventHandler("claude")  # noqa: SLF001
+def test_repeated_callbacks_without_lifecycle_ids_forward_every_call() -> None:
+    handler = subject._AgentShimEventHandler()  # noqa: SLF001
     observer = _Observer()
     handler.observer = observer
 
@@ -335,10 +412,10 @@ def test_providers_without_the_codex_item_defect_forward_every_call() -> None:
         pytest.param(_self_referential(), id="circular-structure"),
     ],
 )
-def test_call_arguments_json_cannot_render_still_compare(
+def test_call_arguments_json_cannot_render_are_preserved(
     fake_agent: list[_FakeAgent], tmp_path: Path, args: dict[str, Any]
 ) -> None:
-    """An MCP tool's arguments are arbitrary, so the key must never raise."""
+    """The driver preserves arbitrary arguments without serializing or deduplicating."""
     driver = subject.AgentShimDriver(provider="codex")
     session = driver.create_session(_spec(tmp_path))
     fake_agent[0].tool_call_events = [("mcp_tool_call", args), ("mcp_tool_call", args)]
@@ -347,7 +424,8 @@ def test_call_arguments_json_cannot_render_still_compare(
     session.run_turn(AgentTurnRequest(message="Do it"), observer)
 
     calls = [event for event in observer.events if event.kind is subject.AgentEventKind.TOOL_CALL]
-    assert len(calls) == 1
+    assert len(calls) == 2
+    assert all(call.payload["args"] is args for call in calls)
 
 
 def test_independent_sessions_overlap_and_chat_cleanup_does_not_interrupt_optimizer(

--- a/tests/vibesys/agents/test_callbacks.py
+++ b/tests/vibesys/agents/test_callbacks.py
@@ -11,7 +11,7 @@ from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.progress import RoundProgress
 from vibesys.constants import DIM, GREEN, RED, RESET
 from vibesys.render.sink import output_sink
-from vibesys.run.events import ToolCallData, ToolResultData
+from vibesys.run.events import AgentOutputChunkData, ToolCallData, ToolResultData
 
 _ANSI_RE = re.compile(r"\033\[[0-9;]*m")
 
@@ -108,6 +108,58 @@ class TestOnLlmEnd:
         log_text = log.getvalue()
         assert "[thinking]" in log_text
         assert "let me think..." in log_text
+
+
+class TestOnThinkingChannel:
+    """Driver plumbing must not be published as the agent's chain of thought."""
+
+    @staticmethod
+    def _channels(*texts: str) -> list[str]:
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            for text in texts:
+                logger.on_thinking(text)
+        finally:
+            unsubscribe()
+        return [
+            event.data.channel for event in seen if isinstance(event.data, AgentOutputChunkData)
+        ]
+
+    def test_lifecycle_markers_publish_as_diagnostics(self) -> None:
+        assert (
+            self._channels(
+                "[codex thread 01a0 started]",
+                "[codex turn started]",
+                "[codex turn complete: in=10 cached=0 out=2]",
+                "[codex stderr] warning: slow filesystem",
+                "[codex error] stream disconnected",
+                "[copilot error] rate limited",
+            )
+            == ["diagnostic"] * 6
+        )
+
+    def test_reasoning_still_publishes_as_analysis(self) -> None:
+        assert (
+            self._channels(
+                "The ring buffer is the hot path.",
+                "[note] a bracketed aside is not a driver marker",
+                "[codex thread-safety] neither is a hyphenated word",
+            )
+            == ["analysis"] * 3
+        )
+
+    def test_marker_text_is_published_verbatim(self) -> None:
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            AgentLogger().on_thinking("[codex stderr] permission denied")
+        finally:
+            unsubscribe()
+
+        chunk = next(event.data for event in seen if isinstance(event.data, AgentOutputChunkData))
+        assert chunk.content == "[codex stderr] permission denied"
 
 
 class TestOnToolStart:


### PR DESCRIPTION
## Problem

Fixes #516. Round transcripts showed raw tool argument JSON, shell wrappers with confusing nested quoting, and verbose results. Provider lifecycle messages occupied bordered cards and resembled failures. Codex also emitted duplicate, unanswered tool calls: AgentShim 0.5.x maps generic item starts and completions to `ToolUseEvent`.

The original callback-level deduplication lost legitimate actions. Two consecutive `file_change` items with different IDs and identical arguments produced only one journal call. MCP completion payloads also change when results or errors arrive, so argument equality cannot identify an item's lifecycle.

## Solution

Tool previews dispatch by tool and typed result payload. Shell previews remove recognized shell wrappers while preserving command quoting; file changes summarize actions and paths; unknown tools retain the argument fallback with whole-value shape summaries for large structured arguments. Command results show exit status, duration, and size when collapsed, and separated stdout/stderr when expanded. JSON results show a shape summary or formatted contents. The expand/collapse contract and raw-content fallback remain intact.

Non-failure diagnostics and status messages render as bare rows. Failure markers retain prominent cards, with backend tone taking precedence. Tool and output text wrap. The callback emitter classifies driver lifecycle markers as `diagnostic`; core-state joins diagnostic chunks with newlines.

Codex event repair now lives in `src/vibesys/_agent_cli/codex.py`, where raw lifecycle kinds and item IDs remain available. The session registers generic starts in AgentShim's item maps and converts completion echoes into `ToolResultEvent`. Original arguments stay on the call; completion output and errors appear in the result. The neutral driver forwards every callback without argument-signature deduplication. This PR includes the same adapter and adapter tests as #628, so either PR works independently.

### Architecture

```mermaid
flowchart TD
    A[Codex JSON lifecycle and item ID] --> B[Codex session adapter: pair calls and results by ID]
    B --> C[Neutral driver events]
    C --> D[Application logger and journal]
    D --> P[Tool and result previews]
    E[Callback lifecycle classification] --> F[Core-state diagnostic folding]
    F --> G[TUI diagnostic and failure styling]
    P --> V[Conversation rendering and wrapping]
    G --> V
```

The Codex adapter owns provider lifecycle repair, callbacks own channel semantics, core-state owns event folding, and the TUI owns presentation. No wire schema or installed-package changes are required.

## Verification

### Correctness properties

- Shell quoting, typed result summaries, raw-content fallback, and expand/collapse behavior remain supported.
- Lifecycle diagnostics keep their text; failures retain prominent cards.
- Every observed generic item lifecycle produces one call and one result. Consecutive identical items retain distinct calls and matching journal `call_id` values.
- Changed MCP completion payloads preserve original call arguments and carry result/error contents through serialization.
- Command executions and native AgentShim result events retain existing handling. Generic item state is removed on completion.

### Testing

Current revision:

- Replayed two raw `file_change` lifecycles through the installed parser and original `3c360df4` driver: only one `tool_call`, no results. The replacement regression exercises the real parser, driver, application logger, and serialized core events and retains both call/result pairs.
- Six integration cases cover one or two file-change, MCP-result, and MCP-error items. They assert unique call IDs, matching result IDs, original call arguments, and completion contents.
- `python -m pytest tests/vibesys/_agent_cli/test_codex.py tests/vibesys/agents/drivers/test_agentshim_driver.py tests/vibesys/agents/test_callbacks.py -q --no-cov`: 152 passed, using the existing Python environment with this worktree's source roots on `PYTHONPATH`.
- Changed-file `ruff check`, `ruff format --check`, and `ty check`: passed. `git diff --check`: passed. The Codex adapter and its tests are byte-identical to #628.

The preceding UI revision was already validated with preview, rendered-frame, style, core-state, and callback tests; client lint/type/build checks; and a live queue-rs Codex run showing readable commands, collapsed results, and bare lifecycle messages. Those historical checks have not been rerun for this Python-only revision, and the earlier live capture did not exercise consecutive identical generic items. The new serialized-event regression covers that defect directly.

Closes #516.
