### PR TITLE
Loop: stop dropping unreviewed frontier claims from the pareto warning

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -391,7 +391,7 @@ def _pareto_archive_summary(records: list[RoundRecord], space: MetricSpace) -> s
             "have not passed independent review, or because its numbers are the "
             "implementer's own report rather than a framework measurement:"
         )
-        for record in pending[-8:]:
+        for record in pending:
             assert record.commit is not None  # noqa: S101  # tracked: #288
             lines.append(
                 f"- round {record.round_number}, commit {record.commit[:12]}: "

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -168,6 +168,7 @@ _FAILED_HYPOTHESIS_OUTCOMES = (
     }
 ) | {"rejected"}
 _MAX_CONTINUATION_ROUNDS_WITHOUT_DESIGN_REVIEW = 2
+_PARETO_ARCHIVE_PENDING_CLAIM_LIMIT = 8
 
 
 def _persist_agent_run_state(
@@ -385,13 +386,21 @@ def _pareto_archive_summary(records: list[RoundRecord], space: MetricSpace) -> s
         and all(objective.name in record.candidate_metrics for objective in objectives)
     ]
     if pending:
+        pending.sort(key=lambda record: record.round_number)
         lines.append(
             "Measured frontier claims not yet usable as trusted parents (retain the commit, "
             "but do not treat it as a parent). A row lands here because its hard invariants "
             "have not passed independent review, or because its numbers are the "
             "implementer's own report rather than a framework measurement:"
         )
-        for record in pending:
+        omitted = pending[:-_PARETO_ARCHIVE_PENDING_CLAIM_LIMIT]
+        if omitted:
+            lines.append(
+                f"- {len(omitted)} older untrusted claims omitted from this context "
+                f"(rounds {omitted[0].round_number}-{omitted[-1].round_number}); do not "
+                "treat any omitted claim as a trusted parent."
+            )
+        for record in pending[-_PARETO_ARCHIVE_PENDING_CLAIM_LIMIT:]:
             assert record.commit is not None  # noqa: S101  # tracked: #288
             lines.append(
                 f"- round {record.round_number}, commit {record.commit[:12]}: "

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -975,6 +975,35 @@ def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa:
     assert "round 51" in summary
 
 
+def test_pareto_archive_summary_lists_every_pending_claim_without_a_cap():  # noqa: ANN201  # tracked: #288
+    """Ten pending claims all appear, including the earliest two."""
+    pending_records = [
+        RoundRecord(
+            round_number,
+            chr(ord("a") + round_number) * 40,
+            None,
+            None,
+            False,  # noqa: FBT003  # tracked: #288
+            reviewed=False,
+            candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
+            candidate_metrics={
+                "throughput": 6000.0 + round_number,
+                "latency": 3000.0 + round_number,
+            },
+            candidate_evaluation_artifact=f"h{round_number}.json",
+            candidate_operating_point="concurrency=192",
+            candidate_retention_reason="higher-throughput tradeoff",
+        )
+        for round_number in range(1, 11)
+    ]
+
+    summary = _pareto_archive_summary(pending_records, _THROUGHPUT_LATENCY)
+
+    for record in pending_records:
+        assert record.commit is not None
+        assert f"round {record.round_number}, commit {record.commit[:12]}" in summary
+
+
 def _accuracy_row(
     round_number: int,
     accuracy: float,

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -975,8 +975,8 @@ def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa:
     assert "round 51" in summary
 
 
-def test_pareto_archive_summary_lists_every_pending_claim_without_a_cap():  # noqa: ANN201  # tracked: #288
-    """Ten pending claims all appear, including the earliest two."""
+def test_pareto_archive_summary_bounds_pending_claims_with_an_omission_notice():  # noqa: ANN201  # tracked: #288
+    """The newest pending claims remain visible and older ones are disclosed."""
     pending_records = [
         RoundRecord(
             round_number,
@@ -998,10 +998,42 @@ def test_pareto_archive_summary_lists_every_pending_claim_without_a_cap():  # no
     ]
 
     summary = _pareto_archive_summary(pending_records, _THROUGHPUT_LATENCY)
+    assert summary == _pareto_archive_summary(list(reversed(pending_records)), _THROUGHPUT_LATENCY)
+
+    for record in pending_records[-8:]:
+        assert record.commit is not None
+        assert f"round {record.round_number}, commit {record.commit[:12]}" in summary
+    assert "round 1, commit bbbbbbbbbbbb" not in summary
+    assert "round 2, commit cccccccccccc" not in summary
+    assert "2 older untrusted claims omitted from this context (rounds 1-2)" in summary
+    assert "do not treat any omitted claim as a trusted parent" in summary
+
+
+def test_pareto_archive_summary_lists_all_pending_claims_within_the_limit():  # noqa: ANN201  # tracked: #288
+    """A short pending list needs no omission notice."""
+    pending_records = [
+        RoundRecord(
+            round_number,
+            chr(ord("a") + round_number) * 40,
+            None,
+            None,
+            False,  # noqa: FBT003  # tracked: #288
+            reviewed=False,
+            candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
+            candidate_metrics={
+                "throughput": 6000.0 + round_number,
+                "latency": 3000.0 + round_number,
+            },
+        )
+        for round_number in range(1, 9)
+    ]
+
+    summary = _pareto_archive_summary(pending_records, _THROUGHPUT_LATENCY)
 
     for record in pending_records:
         assert record.commit is not None
         assert f"round {record.round_number}, commit {record.commit[:12]}" in summary
+    assert "untrusted claims omitted" not in summary
 
 
 def _accuracy_row(


### PR DESCRIPTION
## Problem

Fixes #547. The Pareto archive warning could silently omit older measured but unreviewed claims after eight entries. Removing the limit entirely would let agent-facing file context grow with the run.

## Solution

Keep a named limit of eight pending claims. The archive sorts pending claims by round, shows the eight newest, and discloses both the count and round range of omitted older claims. The disclosure repeats that omitted claims are untrusted and cannot be adopted as parents.

### Architecture

The change is confined to `_pareto_archive_summary` in the agent loop. It preserves the existing trusted-versus-pending partition and writes a bounded, explicit warning through the existing Pareto archive path.

## Verification

### Correctness properties

- Selection is deterministic: pending claims are ordered by round and the newest eight are rendered.
- When claims are omitted, the archive exposes their count and round range and says they remain untrusted.
- At or below the limit, every qualifying pending claim is rendered and no omission notice appears.

### Testing

- `uv run pytest tests/vibesys/loops/agent/test_orchestrate.py -q --no-cov -k pareto_archive`: 5 passed, 144 deselected, including trusted/pending partitioning and the new limit/disclosure regressions.
- `uv run ruff check src/vibesys/loops/agent/loop.py tests/vibesys/loops/agent/test_orchestrate.py`: passed.
- `uv run ruff format --check src/vibesys/loops/agent/loop.py tests/vibesys/loops/agent/test_orchestrate.py`: passed.
- `git diff --check`: passed. The full orchestrate suite exceeded the local execution window and is not counted as passing.
