### PR TITLE
Sandbox: namespace the Modal evaluator lock and deployment lease per user

### DIFF
--- a/src/vibesys/sandbox/modal_evaluator.py
+++ b/src/vibesys/sandbox/modal_evaluator.py
@@ -32,6 +32,7 @@ import shlex
 import subprocess
 import sys
 import tarfile
+import tempfile
 import threading
 import time
 import urllib.error
@@ -47,8 +48,6 @@ _MODAL_DEPLOYMENT = re.compile(
     r"https://modal\.com/apps/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/deployed/"
     r"([a-zA-Z0-9_.-]+)"
 )
-_LOCK_PATH = "/tmp/vibesys-modal-evaluator.lock"  # noqa: S108  # tracked: #288
-_DEPLOYMENT_LEASE_PATH = Path("/tmp/vibesys-modal-evaluator-deployment.json")  # noqa: S108  # tracked: #288
 _CANDIDATE_REVISION_ENV = "VIBESYS_CANDIDATE_REVISION"
 _RELEASE_DEPLOYMENT_ENV = "VIBESYS_RELEASE_MODAL_DEPLOYMENT"
 _MAX_DIAGNOSTIC_CHARS = 20_000
@@ -69,6 +68,50 @@ _MAX_ENCODED_SETUP_COMMAND_CHARS = 60_000
 _MAX_STAGE_ARCHIVE_BYTES = 8 * 1024 * 1024
 _CONTAINER_DISCOVERY_TIMEOUT_SECONDS = 90.0
 _KEEPWARM_INTERVAL_SECONDS = 30.0
+
+
+def _runtime_dir() -> Path:
+    """Return this process's private per-user runtime directory.
+
+    Prefers ``XDG_RUNTIME_DIR``, which is already private per user by POSIX
+    convention; otherwise falls back to a uid-suffixed directory under the
+    system temp directory so unrelated users sharing a host cannot collide
+    on the evaluator's lock or lease files.
+    """
+    xdg_runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg_runtime_dir:
+        return Path(xdg_runtime_dir) / "vibesys"
+    return Path(tempfile.gettempdir()) / f"vibesys-{os.getuid()}"
+
+
+_LOCK_PATH = _runtime_dir() / "modal-evaluator.lock"
+_DEPLOYMENT_LEASE_PATH = _runtime_dir() / "modal-evaluator-deployment.json"
+
+
+def _ensure_runtime_dir(path: Path) -> None:
+    """Create and validate the private per-user runtime directory for ``path``.
+
+    Raises ``RuntimeError`` naming the directory and its owning uid when the
+    location cannot be used as a private per-user directory, for example a
+    plain file already occupies it or another user owns it, so a hostile or
+    stale runtime-directory entry fails with a clear message instead of a
+    deep ``PermissionError`` surfacing from ``flock`` or ``open``.
+    """
+    runtime_dir = path.parent
+    try:
+        runtime_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        owner_uid = runtime_dir.stat().st_uid
+        is_directory = runtime_dir.is_dir()
+    except OSError as exc:
+        raise RuntimeError(  # noqa: TRY003
+            f"cannot use {runtime_dir} as the evaluator runtime directory: {exc}"
+        ) from exc
+    if not is_directory or owner_uid != os.getuid():
+        raise RuntimeError(  # noqa: TRY003
+            f"refusing to use {runtime_dir} as the evaluator runtime directory: "
+            f"expected a directory owned by uid {os.getuid()}"
+        )
+    runtime_dir.chmod(0o700)
 
 
 @dataclass(frozen=True)
@@ -135,6 +178,7 @@ def _compact_rich_output(output: str) -> str:
 @contextmanager
 def _exclusive_evaluation() -> Generator[None]:
     """Serialize deploy-and-evaluate callers sharing the editor container."""
+    _ensure_runtime_dir(_LOCK_PATH)
     with open(_LOCK_PATH, "w") as lock_file:  # noqa: PTH123  # tracked: #288
         fcntl.flock(lock_file, fcntl.LOCK_EX)
         try:
@@ -244,6 +288,7 @@ def _write_deployment_lease(
     base_url: str,
     app_identifier: str | None,
 ) -> None:
+    _ensure_runtime_dir(_DEPLOYMENT_LEASE_PATH)
     temporary = _DEPLOYMENT_LEASE_PATH.with_suffix(".tmp")
     payload = {
         "candidate_revision": candidate_revision,

--- a/src/vibesys/sandbox/modal_evaluator.py
+++ b/src/vibesys/sandbox/modal_evaluator.py
@@ -29,6 +29,7 @@ import json
 import os
 import re
 import shlex
+import stat
 import subprocess
 import sys
 import tarfile
@@ -100,13 +101,12 @@ def _ensure_runtime_dir(path: Path) -> None:
     runtime_dir = path.parent
     try:
         runtime_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-        owner_uid = runtime_dir.stat().st_uid
-        is_directory = runtime_dir.is_dir()
+        metadata = runtime_dir.lstat()
     except OSError as exc:
         raise RuntimeError(  # noqa: TRY003
             f"cannot use {runtime_dir} as the evaluator runtime directory: {exc}"
         ) from exc
-    if not is_directory or owner_uid != os.getuid():
+    if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.getuid():
         raise RuntimeError(  # noqa: TRY003
             f"refusing to use {runtime_dir} as the evaluator runtime directory: "
             f"expected a directory owned by uid {os.getuid()}"

--- a/tests/vibesys/sandbox/test_modal_evaluator.py
+++ b/tests/vibesys/sandbox/test_modal_evaluator.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import shlex
+import stat
 import subprocess
 import tarfile
 from types import SimpleNamespace
@@ -88,6 +89,53 @@ def test_deployment_path_rejects_missing_directory_and_escape(tmp_path: Path) ->
         modal_evaluator._deployment_path(str(workspace), "deploy")  # noqa: SLF001
     with pytest.raises(ValueError, match="escapes the project"):
         modal_evaluator._deployment_path(str(workspace), "escape.py")  # noqa: SLF001
+
+
+def test_runtime_dir_is_per_user_without_xdg_runtime_dir(monkeypatch) -> None:  # noqa: ANN001
+    """Falls back to a uid-suffixed temp directory when XDG_RUNTIME_DIR is unset."""
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.setattr(modal_evaluator.os, "getuid", lambda: 1001)
+    first = modal_evaluator._runtime_dir()  # noqa: SLF001
+    monkeypatch.setattr(modal_evaluator.os, "getuid", lambda: 1002)
+    second = modal_evaluator._runtime_dir()  # noqa: SLF001
+
+    assert first != second
+    assert first.name == "vibesys-1001"
+    assert second.name == "vibesys-1002"
+
+
+def test_runtime_dir_prefers_xdg_runtime_dir(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """Uses XDG_RUNTIME_DIR when set instead of the uid-suffixed temp fallback."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+
+    assert modal_evaluator._runtime_dir() == tmp_path / "vibesys"  # noqa: SLF001
+
+
+def test_exclusive_evaluation_creates_private_runtime_dir_and_lock_file(
+    tmp_path: Path,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """The lock's runtime directory is created mode 0o700 before flock is taken."""
+    lock_path = tmp_path / "rt" / "modal-evaluator.lock"
+    monkeypatch.setattr(modal_evaluator, "_LOCK_PATH", lock_path)
+
+    with modal_evaluator._exclusive_evaluation():  # noqa: SLF001
+        pass
+
+    runtime_dir = lock_path.parent
+    assert runtime_dir.is_dir()
+    assert stat.S_IMODE(runtime_dir.stat().st_mode) == 0o700
+    assert lock_path.exists()
+
+
+def test_ensure_runtime_dir_rejects_file_shadowing_the_directory(tmp_path: Path) -> None:
+    """A plain file occupying the runtime-dir path raises a clear RuntimeError."""
+    blocked = tmp_path / "rt"
+    blocked.write_text("not a directory")
+    target = blocked / "modal-evaluator.lock"
+
+    with pytest.raises(RuntimeError, match="cannot use"):
+        modal_evaluator._ensure_runtime_dir(target)  # noqa: SLF001
 
 
 def test_extract_modal_web_url_handles_rich_line_wrapping() -> None:

--- a/tests/vibesys/sandbox/test_modal_evaluator.py
+++ b/tests/vibesys/sandbox/test_modal_evaluator.py
@@ -7,7 +7,9 @@ import os
 import shlex
 import stat
 import subprocess
+import sys
 import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, call
@@ -111,6 +113,35 @@ def test_runtime_dir_prefers_xdg_runtime_dir(tmp_path: Path, monkeypatch) -> Non
     assert modal_evaluator._runtime_dir() == tmp_path / "vibesys"  # noqa: SLF001
 
 
+def test_import_does_not_validate_or_create_the_runtime_directory(
+    tmp_path: Path,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """Importing only builds runtime paths, even when XDG points at a symlink."""
+    target = tmp_path / "target"
+    target.mkdir()
+    hostile_runtime_dir = tmp_path / "runtime"
+    hostile_runtime_dir.symlink_to(target, target_is_directory=True)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(hostile_runtime_dir))
+    calls: list[str] = []
+
+    def record_call(*_args: object, **_kwargs: object) -> None:
+        calls.append("filesystem")
+
+    for method in ("mkdir", "chmod", "lstat"):
+        monkeypatch.setattr(modal_evaluator.Path, method, record_call)
+    module_name = "vibesys.sandbox._modal_evaluator_import_probe"
+    spec = spec_from_file_location(module_name, modal_evaluator.__file__)
+    if spec is None or spec.loader is None:
+        raise AssertionError
+    imported = module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, imported)
+    spec.loader.exec_module(imported)
+
+    assert calls == []
+    assert hostile_runtime_dir / "vibesys" / "modal-evaluator.lock" == imported._LOCK_PATH  # noqa: SLF001
+
+
 def test_exclusive_evaluation_creates_private_runtime_dir_and_lock_file(
     tmp_path: Path,
     monkeypatch,  # noqa: ANN001
@@ -136,6 +167,17 @@ def test_ensure_runtime_dir_rejects_file_shadowing_the_directory(tmp_path: Path)
 
     with pytest.raises(RuntimeError, match="cannot use"):
         modal_evaluator._ensure_runtime_dir(target)  # noqa: SLF001
+
+
+def test_ensure_runtime_dir_rejects_symlink_shadowing_the_directory(tmp_path: Path) -> None:
+    """A symlink at the runtime-dir path is rejected instead of followed."""
+    target_directory = tmp_path / "target"
+    target_directory.mkdir()
+    shadow = tmp_path / "rt"
+    shadow.symlink_to(target_directory, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="expected a directory owned by uid"):
+        modal_evaluator._ensure_runtime_dir(shadow / "modal-evaluator.lock")  # noqa: SLF001
 
 
 def test_extract_modal_web_url_handles_rich_line_wrapping() -> None:


### PR DESCRIPTION
## Problem

Fixes #548. A shared host-wide Modal lock and deployment lease let one user's files block another user's evaluations or expose a lease for a deployment the second account cannot access. The runtime directory guard also followed symlinks, allowing a pre-created symlink to pass ownership checks through its target.

## Solution

Store both coordination files under `$XDG_RUNTIME_DIR/vibesys`, falling back to `gettempdir()/vibesys-<uid>`. Before opening the lock or writing a lease, create the runtime directory with mode `0700` and inspect its entry with `lstat`. Reject symlinks, non-directories, and directories owned by another uid.

Path construction remains pure at import time. Directory creation and validation happen only at the existing lock and lease write sites. A new import regression verifies this already-present behavior, addressing the second review concern without adding import-time work.

### Architecture

The sandbox evaluator owns the runtime paths and their validation. Existing exclusive locking, cleanup, and atomic lease replacement remain unchanged. No protocol or frontend changes are involved.

## Verification

### Correctness properties

- Lock and lease paths are namespaced per user.
- The runtime directory entry must be an actual directory owned by the current uid; a symlink to an owned directory is rejected.
- Importing the module neither creates nor validates the runtime directory.
- Per-user lock serialization and atomic lease writes retain their existing behavior.

### Testing

- `uv run pytest tests/vibesys/sandbox/test_modal_evaluator.py -q --no-cov`: 59 passed, including symlink rejection and an import probe tracking filesystem operations.
- `uv run ruff check src/vibesys/sandbox/modal_evaluator.py tests/vibesys/sandbox/test_modal_evaluator.py`: passed.
- `uv run ruff format --check src/vibesys/sandbox/modal_evaluator.py tests/vibesys/sandbox/test_modal_evaluator.py`: passed.
- `git diff --check`: passed. No live Modal deployment was performed for this revision.

Closes #548.
