### PR TITLE
TUI: derive the right-pane minimum width from the chart plot width

### DIFF
--- a/clients/tui/src/performance-chart.test.ts
+++ b/clients/tui/src/performance-chart.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'bun:test';
 import type {ProtocolResponse, RunEvent} from '@vibesys/backend-client';
-import {renderPerformanceCurve} from './performance-chart.js';
+import {PLOT_WIDTH, renderPerformanceCurve} from './performance-chart.js';
 
 describe('renderPerformanceCurve', () => {
   it('plots persisted performance records by round', () => {
@@ -115,6 +115,66 @@ describe('renderPerformanceCurve', () => {
     expect(chart).toContain('Measures  Ops per second.');
     expect(chart.endsWith('No performance data yet.')).toBe(true);
     expect(chart).not.toContain('●');
+  });
+});
+
+describe('chart geometry', () => {
+  // The axis rows, bottom border row, and bottom round-label row are drawn
+  // to look like one fixed-width grid. Unlike the free-text summary and
+  // context lines (which the right pane word-wraps on purpose), these rows
+  // must never exceed PLOT_WIDTH + 10 (8-char axis gutter + ' ┤' = 10, plus
+  // the PLOT_WIDTH plot columns) or they wrap and break the grid.
+  function structuralRows(chart: string): {
+    axisRows: string[];
+    borderRow: string;
+    labelRow: string;
+  } {
+    const lines = chart.split('\n');
+    const axisRows = lines.filter(line => line.includes('┤'));
+    const borderIndex = lines.findIndex(line => line.includes('└'));
+    const borderRow = lines[borderIndex] ?? '';
+    const labelRow = lines[borderIndex + 1] ?? '';
+    return {axisRows, borderRow, labelRow};
+  }
+
+  it('keeps every structural row within PLOT_WIDTH + 10 columns for single-digit rounds', () => {
+    const chart = renderPerformanceCurve([
+      performance(1, 1000),
+      performance(2, 2000),
+      performance(9, 1500),
+    ]);
+    const {axisRows, borderRow, labelRow} = structuralRows(chart);
+    expect(axisRows.length).toBeGreaterThan(0);
+    for (const row of [...axisRows, borderRow, labelRow]) {
+      expect(row.length).toBeLessThanOrEqual(PLOT_WIDTH + 10);
+    }
+  });
+
+  it('keeps every structural row within PLOT_WIDTH + 10 columns for double-digit rounds', () => {
+    // Before the fix, the label row hardcoded its right-hand pad width
+    // assuming a 2-character left label ('r' + a single digit), so a
+    // double-digit minRound pushed the row past PLOT_WIDTH + 10.
+    const chart = renderPerformanceCurve([
+      performance(10, 1000),
+      performance(11, 2000),
+      performance(99, 1500),
+    ]);
+    const {axisRows, borderRow, labelRow} = structuralRows(chart);
+    expect(axisRows.length).toBeGreaterThan(0);
+    for (const row of [...axisRows, borderRow, labelRow]) {
+      expect(row.length).toBeLessThanOrEqual(PLOT_WIDTH + 10);
+    }
+  });
+
+  it('aligns the left round label under the plot area, in the same column the border row draws └ before', () => {
+    const chart = renderPerformanceCurve([
+      performance(10, 1000),
+      performance(11, 2000),
+      performance(99, 1500),
+    ]);
+    const {borderRow, labelRow} = structuralRows(chart);
+    const plotStartColumn = borderRow.indexOf('└') + 1;
+    expect(labelRow.indexOf('r10')).toBe(plotStartColumn);
   });
 });
 

--- a/clients/tui/src/performance-chart.ts
+++ b/clients/tui/src/performance-chart.ts
@@ -11,7 +11,11 @@ interface PerfPoint {
 type PerformanceContext = NonNullable<ProtocolResponse['performance_context']>;
 
 const PLOT_HEIGHT = 8;
-const PLOT_WIDTH = 48;
+/**
+ * Plot columns, excluding the axis gutter. `right-pane.ts` derives the pane's
+ * minimum width from this so the two cannot drift apart.
+ */
+export const PLOT_WIDTH = 48;
 const CONTEXT_LABEL_WIDTH = 10;
 
 export function renderPerformanceCurve(
@@ -51,7 +55,14 @@ export function renderPerformanceCurve(
     lines.push(`${formatAxis(value).padStart(8)} ┤${(grid[row] ?? []).join('')}`);
   }
   lines.push(`         └${'─'.repeat(PLOT_WIDTH)}`);
-  lines.push(`${''.padStart(11)}r${minRound}${String(`r${maxRound}`).padStart(PLOT_WIDTH - 2)}`);
+  // The row must total the same 10 + PLOT_WIDTH columns as the axis and
+  // border rows above, with the left label starting under the plot's first
+  // column (right after the border row's '└'). Padding the right label to a
+  // fixed PLOT_WIDTH - 2 assumed a single-digit minRound; pad relative to the
+  // actual left-label length instead so double-digit rounds still align.
+  const minLabel = `r${minRound}`;
+  const maxLabel = `r${maxRound}`;
+  lines.push(`${''.padStart(10)}${minLabel}${maxLabel.padStart(PLOT_WIDTH - minLabel.length)}`);
 
   const best = visible.reduce((current, point) => (point.value > current.value ? point : current));
   const latest = visible.at(-1);

--- a/clients/tui/src/ui/right-pane.test.ts
+++ b/clients/tui/src/ui/right-pane.test.ts
@@ -1,5 +1,9 @@
 import {describe, expect, it} from 'bun:test';
+import {PLOT_WIDTH} from '../performance-chart.js';
 import {MIN_SPLIT_WIDTH, rightPaneWidth, splitFits} from './right-pane.js';
+
+/** Border (1) and padding (1) columns on each side of the pane. */
+const PANE_BORDER_AND_PADDING = 4;
 
 describe('split thresholds', () => {
   it('splits only once both panes would be readable', () => {
@@ -28,6 +32,16 @@ describe('pane sizing', () => {
     // The performance chart is 48 plot columns plus an 8-column axis gutter;
     // below that the visualization is the thing that breaks.
     expect(rightPaneWidth(MIN_SPLIT_WIDTH)).toBeGreaterThanOrEqual(56);
+  });
+
+  it('gives the chart its full structural width at the narrowest split, derived from PLOT_WIDTH', () => {
+    // The pane's content area (its width minus border and padding) must fit
+    // the chart's widest structural row: the 10-column axis/label gutter
+    // plus PLOT_WIDTH plot columns. This ties the two together through
+    // PLOT_WIDTH itself, so they cannot drift apart the way the old
+    // hand-copied RIGHT_PANE_MIN literal could.
+    const contentWidth = rightPaneWidth(MIN_SPLIT_WIDTH) - PANE_BORDER_AND_PADDING;
+    expect(contentWidth).toBeGreaterThanOrEqual(PLOT_WIDTH + 10);
   });
 
   it('stops widening the pane on very wide terminals', () => {

--- a/clients/tui/src/ui/right-pane.ts
+++ b/clients/tui/src/ui/right-pane.ts
@@ -1,4 +1,5 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
+import {PLOT_WIDTH} from '../performance-chart.js';
 import {focusedPane, type RightPane, type SessionState} from '../session-model.js';
 import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import type {Theme} from './theme.js';
@@ -12,8 +13,18 @@ import type {Theme} from './theme.js';
  */
 export const MIN_SPLIT_WIDTH = 100;
 
-/** Chart plot width plus axis gutter, border, and padding. */
-const RIGHT_PANE_MIN = 62;
+/**
+ * Columns around the plot that aren't plot columns: an 8-char axis value
+ * gutter plus 2 for the ' ┤' separator (10 columns of chart gutter), plus 1
+ * column of border and 1 column of padding on each side of the pane (4
+ * columns).
+ */
+const RIGHT_PANE_CHROME = 10 + 4;
+/**
+ * Chart plot width plus its gutter, border, and padding. Derived from the
+ * chart's own PLOT_WIDTH so the two cannot drift apart.
+ */
+const RIGHT_PANE_MIN = PLOT_WIDTH + RIGHT_PANE_CHROME;
 const RIGHT_PANE_MAX = 84;
 const RIGHT_PANE_SHARE = 0.45;
 /** Columns the transcript needs to stay worth reading beside the pane. */


### PR DESCRIPTION
## Problem

Fixes #550. The right pane's minimum width was the literal `62` in `clients/tui/src/ui/right-pane.ts`, documented by its own comment as "chart plot width plus axis gutter, border, and padding", while the actual plot width was a separate unexported literal `48` in `clients/tui/src/performance-chart.ts`. Nothing linked the two, so changing the chart's plot width would silently leave the pane minimum stale and let the pane be sized narrower than the curve it must hold. Pinning the invariant with a test also exposed that the chart's bottom round-label row already violated it: the row used a hardcoded 11-column left indent and padded the right label to a fixed `PLOT_WIDTH - 2`, which assumes a single-digit minimum round, so the row was 59 columns against the 58 every other structural row occupies (60 once runs reach double-digit rounds), one to two columns wider than the minimum-width pane can render without truncation.

## Solution

`performance-chart.ts` now exports `PLOT_WIDTH` with a comment stating that `right-pane.ts` derives its minimum from it, and `right-pane.ts` computes `RIGHT_PANE_MIN = PLOT_WIDTH + RIGHT_PANE_CHROME` with the chrome itemized in a named constant (`10 + 4`: an 8-column axis value gutter plus 2 for the `' ┤'` separator, then 1 border and 1 padding column per pane side). The derived value is still 62, so no breakpoint, split share, or fallback behavior changes at any current size; the change is exactly the coupling the ticket asks for. The import direction is legal: both modules live in `@vibesys/tui`, and `pnpm check:ts-architecture` stays green.

The label row is rebuilt so the derived minimum is actually sufficient: the left indent is 10 columns (placing `r<minRound>` under the plot's first column, immediately after the border row's `└`), and the right label is padded relative to the actual left label's length instead of a fixed `PLOT_WIDTH - 2`. Every structural row of the chart now totals exactly `10 + PLOT_WIDTH` columns regardless of how many digits the round numbers have, which is the width contract `RIGHT_PANE_CHROME` encodes.

### Architecture

Both touched modules are in the `@vibesys/tui` package; the fix introduces one intra-package import in the enforced dependency direction and no core-state, backend-client, protocol, or Python surface is involved.

```mermaid
flowchart TD
    P["performance-chart.ts: export PLOT_WIDTH = 48"] --> C["renderPerformanceCurve: axis rows, border row, and label row all exactly 10 + PLOT_WIDTH columns"]
    P --> R["right-pane.ts: RIGHT_PANE_CHROME = 10 + 4 (axis gutter + ' ┤', border + padding per side)"]
    R --> M["RIGHT_PANE_MIN = PLOT_WIDTH + RIGHT_PANE_CHROME = 62"]
    M --> L["split/modal layout sizing: pane never narrower than the chart's structural width"]
    C --> L
```

## Verification

Four regression tests pin the invariant; all fail on the unfixed code and pass on this branch. The TS check suite passes at the current `main` tip, and a live codex-provider run renders the full curve at the `/perf` split and the narrowest fallback width.

### Correctness properties

- `RIGHT_PANE_MIN` is derived from the chart's exported `PLOT_WIDTH` plus a named, itemized chrome constant; the two constants can no longer drift, and any future `PLOT_WIDTH` change moves the pane minimum automatically.
- Every structural row the chart renders (axis value rows, the `└` border row, the round-label row) totals exactly `10 + PLOT_WIDTH` columns for single- and double-digit round numbers alike, so the minimum-width pane holds the whole curve without truncation or wrapping.
- The left round label starts in the same column the border row draws its first `─`, directly under the plot area.
- The derived minimum still evaluates to 62, so `MIN_SPLIT_WIDTH`, `RIGHT_PANE_MAX`, the split share, and the modal fallback behave byte-for-byte as before at every existing terminal size.

### Testing

- New regression tests: `clients/tui/src/performance-chart.test.ts` "keeps every structural row within PLOT_WIDTH + 10 columns for single-digit rounds", "keeps every structural row within PLOT_WIDTH + 10 columns for double-digit rounds", "aligns the left round label under the plot area, in the same column the border row draws └ before", and `clients/tui/src/ui/right-pane.test.ts` "gives the chart its full structural width at the narrowest split, derived from PLOT_WIDTH". Before the fix: the right-pane test fails at import (`PLOT_WIDTH` not exported), and with only the export added the chart tests fail with `Expected: <= 58, Received: 59` (60 for double-digit rounds) and the alignment test with `Expected: 10, Received: 11`. After: all pass (19 tests across the two files).
- `pnpm check:ts`, `pnpm check:ts-architecture`, `pnpm check:clients`, `pnpm build:clients`: pass at the current `main` tip (12e807a).
- `pnpm test:clients`: 687 pass, 1 fail in `clients/tui/dev/harness.test.ts` ("replays a legacy capture"), an environmental `EBUSY` removing the test's own temp directory on this shared host; it reproduces without this change and the same suite is green in CI on `main` at 12e807a.
- Live harness run (codex provider, model `gpt-5.6-sol`, queue-rs spsc, 1 round, `--profiler none`): after the round completed, `/perf` at 100x40 rendered the split pane with the full plot, intact borders, and the label row aligned under the plot area (`r1` at the plot origin, the max label at the right edge); after `size 88x40` (below the split threshold) the floating-overlay fallback rendered the same complete chart. The overlay's scrollbar occupying the last interior column is pre-existing overlay behavior, unchanged by this diff. `backend.log` showed no tracebacks or protocol errors.
- Merges cleanly against current `main` (`git merge-tree --write-tree`).

Closes #550.
