### PR TITLE
TUI: redraw the running round in its rendered width inside the compact rail

### DIFF
--- a/clients/tui/src/ui/round-rail.test.ts
+++ b/clients/tui/src/ui/round-rail.test.ts
@@ -234,6 +234,64 @@ describe('RoundRailView row budget', () => {
   });
 });
 
+describe('RoundRailView elapsed timer refresh', () => {
+  /** A single active round with a live agent, so the rail arms the elapsed timer. */
+  function activeRoundState(): SessionState {
+    const base = railState(1);
+    return {
+      ...base,
+      selectedRound: 1,
+      core: {
+        ...base.core,
+        rounds: [
+          {
+            number: 1,
+            status: 'active',
+            startedAt: new Date().toISOString(),
+            activeAgentStarts: {worker: new Date().toISOString()},
+          },
+        ],
+      },
+    };
+  }
+
+  function textOf(text: TextRenderable): string {
+    const content = (text.content as {chunks?: {text?: string}[]} | undefined)?.chunks ?? [];
+    return content.map(chunk => chunk.text ?? '').join('');
+  }
+
+  test('keeps the compact label after the elapsed timer refreshes at a compact width', async () => {
+    const {renderer} = await createTestRenderer({width: 120, height: 40});
+    const view = new RoundRailView(
+      renderer,
+      {} as unknown as SessionController,
+      resolveTheme(null),
+    );
+    view.render(activeRoundState(), RAIL_COMPACT_WIDTH, 10);
+    // The elapsed timer ticks on a real one-second interval; wait past a tick so the
+    // refresh runs, then read the row it rewrote.
+    await new Promise(resolve => setTimeout(resolve, 1100));
+    const text = textOf(view.output.getChildren()[0] as TextRenderable);
+    view.destroy();
+    expect(text).not.toContain(' run ');
+    expect(text.length).toBeLessThanOrEqual(RAIL_COMPACT_WIDTH);
+  });
+
+  test('keeps the elapsed suffix after the timer refreshes at full width', async () => {
+    const {renderer} = await createTestRenderer({width: 120, height: 40});
+    const view = new RoundRailView(
+      renderer,
+      {} as unknown as SessionController,
+      resolveTheme(null),
+    );
+    view.render(activeRoundState(), RAIL_FULL_WIDTH, 10);
+    await new Promise(resolve => setTimeout(resolve, 1100));
+    const text = textOf(view.output.getChildren()[0] as TextRenderable);
+    view.destroy();
+    expect(text).toContain(' run ');
+  });
+});
+
 describe('RoundRailView profile-skipped rounds', () => {
   test('marks a completed profile-skipped round hollow and dim', async () => {
     const base = railState(3);

--- a/clients/tui/src/ui/round-rail.ts
+++ b/clients/tui/src/ui/round-rail.ts
@@ -142,7 +142,12 @@ export class RoundRailView {
   #renderedWidth = 0;
   #renderedRows = 0;
   #elapsedTimer: ReturnType<typeof setInterval> | null = null;
-  #runningRound: {round: RoundState; state: SessionState; text: TextRenderable} | null = null;
+  #runningRound: {
+    round: RoundState;
+    state: SessionState;
+    text: TextRenderable;
+    compact: boolean;
+  } | null = null;
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -271,7 +276,9 @@ export class RoundRailView {
         this.controller.selectRound(round.number);
       },
     });
-    if (isRunning && hasActiveAgentTiming(round)) this.#runningRound = {round, state, text};
+    if (isRunning && hasActiveAgentTiming(round)) {
+      this.#runningRound = {round, state, text, compact};
+    }
     return text;
   }
 
@@ -315,12 +322,12 @@ export class RoundRailView {
     if (this.#runningRound === null || this.#elapsedTimer !== null) return;
     this.#elapsedTimer = setInterval(() => {
       if (this.#runningRound === null) return;
-      const {round, state, text} = this.#runningRound;
+      const {round, state, text, compact} = this.#runningRound;
       text.content = this.#roundLabel(
         round,
         state,
         round.number === visibleRoundNumber(state),
-        false,
+        compact,
       );
     }, 1000);
   }


### PR DESCRIPTION
## Problem

Fixes #551. On a mid-width terminal (85 to 99 columns) the rounds rail renders in its compact 13-column form, but the per-second elapsed-time refresh redrew the active round's row at full width: the `setInterval` callback in `RoundRailView#syncElapsedTimer` (`clients/tui/src/ui/round-rail.ts`) called `#roundLabel(round, state, ..., false)` with the compact argument hardcoded to `false`, while the initial render at line 256 passed the rail's real mode. The regenerated row (for example `▸r7 ⟳ run 1m 5s`) carries no truncation, so once per second it overflowed or wrapped the compact column, corrupting the fixed one-row-per-round layout the rail's overflow counters depend on.

## Solution

The timer now redraws in the same width mode the row was rendered in. `#runningRound`, the memo the timer reads (round, state, and the `TextRenderable` it rewrites), gains a `compact` field captured at render time in `#roundLabelText`, and the interval callback passes that captured flag to `#roundLabel` instead of the literal `false`. This is the root-cause shape of the fix: the refresh path had access to everything about the running round except the mode it was drawn in, so the mode joins the memo rather than being re-derived or plumbed through a side channel. A rail re-render on resize rebuilds `#runningRound` with the new mode, so the timer always agrees with the layout that is actually on screen, in both directions of a width change.

### Architecture

The change is confined to the `@vibesys/tui` package's rail widget; no core-state, backend-client, protocol, or Python surface is involved, and the fold that produces `activeAgentStarts` is untouched.

```mermaid
flowchart TD
    S["SessionState fold (core-state): activeAgentStarts on the running round"] --> R["RoundRailView.render(state, width, rows)"]
    R --> L["#roundLabelText: draws the row, captures {round, state, text, compact} in #runningRound"]
    L --> T["#syncElapsedTimer: 1s interval rewrites text.content"]
    T --> C["#roundLabel(round, state, visible, compact) with the captured mode (was hardcoded false)"]
    C --> V["compact rail stays 13 columns; full rail keeps its elapsed suffix"]
```

## Verification

Two regression tests pin the refresh behavior in both width modes; the compact one fails on the unfixed code and passes on this branch. The full TS check suite passes at the current `main` tip, and a live codex-provider run at 92x40 holds the compact rail stable across elapsed ticks.

### Correctness properties

- The elapsed-time refresh is idempotent with respect to layout: rewriting the running round's row never changes its width mode, so a compact rail stays within its 13-column budget on every tick and the one-row-per-round invariant behind the overflow counters holds.
- The full-width rail keeps its elapsed suffix (`run Ns`) across ticks; the fix does not dim or truncate the wide form.
- The mode the timer uses is exactly the mode of the last real render: a resize that flips the rail between compact and full rebuilds the memo, so the timer can never redraw in a stale mode in either direction.
- Timer lifecycle (armed only while a running round has an active agent timing, cleared on destroy) is unchanged; only the label call inside the tick changed.

### Testing

- New regression tests in `clients/tui/src/ui/round-rail.test.ts`: "keeps the compact label after the elapsed timer refreshes at a compact width" and "keeps the elapsed suffix after the timer refreshes at full width". They render a live round through a real `createTestRenderer`, wait past a 1-second tick, and read back the rewritten row. Before the fix (source reverted via a saved patch, never `git stash`): 1 failed with `Expected to not contain: " run " / Received: "▸r1 ⟳ run 1s"` (26 pass, 1 fail). After: 27 pass, 0 fail.
- `pnpm check:ts` (Checked 85 files), `pnpm check:ts-architecture` (no dependency violations, 90 modules), `pnpm check:clients`, `pnpm build:clients`: all pass at the current `main` tip (12e807a).
- `pnpm test:clients`: clean run, 686 pass, 0 fail. An intermittent `EBUSY: resource busy or locked, rm '/tmp/vs-mock-*'` in `clients/tui/dev/harness.test.ts` reproduces on this NFS-backed host with the change fully reverted and is tracked separately as #617; it is environmental, not from this change.
- Live harness run (codex provider, model `gpt-5.6-sol`, queue-rs spsc, `--profiler none`) at 92x40: with a round active in the round view, three captures two seconds apart (the pane's elapsed chip advances 7m 15s to 7m 18s, so timer ticks landed between frames) all show the compact rail row as `▸r1⟳` inside its intact 13-column box, never re-expanded to the full `run Ns` form.
- Merges cleanly against current `main` (`git merge-tree --write-tree`).

Closes #551.
