### PR TITLE
TUI: mark the selected row and agent node with a caret glyph

### DIFF
--- a/clients/tui/src/ui/agent-map-selection.test.ts
+++ b/clients/tui/src/ui/agent-map-selection.test.ts
@@ -1,0 +1,74 @@
+import {afterEach, describe, expect, it} from 'bun:test';
+import {createTestRenderer} from '@opentui/core/testing';
+import type {AgentPhase} from '@vibesys/core-state';
+import type {SessionController} from '../session-controller.js';
+import {initialSessionState, type SessionState} from '../session-model.js';
+import {AgentMapView, nodeLabel} from './agent-map.js';
+import {resolveTheme} from './theme.js';
+
+// Kept apart from agent-map.test.ts (layout/width tests) so unrelated changes
+// to that suite do not textually conflict with these selection-glyph tests.
+
+/**
+ * Before this, a selected node's only signal was border, background, and text
+ * color: `STATUS_MARKER` encodes run status, never selection. `nodeLabel`
+ * prefixes the selection caret independent of that marker, following the '›'
+ * precedent in theme-picker.ts and the hypothesis drill-down.
+ */
+describe('nodeLabel', () => {
+  function phase(status: AgentPhase['status']): AgentPhase {
+    return {kind: 'implementer', status, roundNumber: null, roundLabel: null};
+  }
+
+  it('prefixes a caret only when selected, independent of the status marker', () => {
+    expect(nodeLabel(phase('active'), false)).toBe('● implementer');
+    expect(nodeLabel(phase('active'), true)).toBe('› ● implementer');
+    expect(nodeLabel(phase('pending'), false)).toBe('○ implementer');
+    expect(nodeLabel(phase('pending'), true)).toBe('› ○ implementer');
+    expect(nodeLabel(phase('completed'), true)).toBe('› ✓ implementer');
+    expect(nodeLabel(phase('failed'), true)).toBe('› × implementer');
+  });
+});
+
+describe('agent node rendered selection glyph', () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const destroy of cleanup.splice(0).reverse()) destroy();
+  });
+
+  /** Never fires in a render-only test; onMouseUp is never simulated. */
+  const controller = {
+    focusRound: () => {},
+    selectAgent: () => {},
+  } as unknown as SessionController;
+
+  function stateWith(phases: AgentPhase[], selectedAgentKind: string | null): SessionState {
+    const base = initialSessionState();
+    return {...base, core: {...base.core, phases}, selectedAgentKind};
+  }
+
+  it('prefixes only the selected node with the caret, leaving the status marker alone', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const view = new AgentMapView(testRenderer.renderer, controller, resolveTheme(null));
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.destroy();
+      view.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    });
+    const phases: AgentPhase[] = [
+      {kind: 'implementer', status: 'active', roundNumber: null, roundLabel: null},
+      {kind: 'judge', status: 'pending', roundNumber: null, roundLabel: null},
+    ];
+    // A wide, explicit pane width keeps the graph layout (not the stacked
+    // fallback) and gives each node room for its full label.
+    view.render(stateWith(phases, 'implementer'), 60);
+    await testRenderer.renderOnce();
+    const frame = testRenderer.captureCharFrame();
+
+    expect(frame).toContain('› ● implementer');
+    expect(frame).toContain('○ judge');
+    expect(frame).not.toContain('› ○ judge');
+  });
+});

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -51,6 +51,18 @@ function statusColor(theme: Theme, status: AgentPhase['status']): string {
   return theme.textSubtle;
 }
 
+/**
+ * The status marker and agent kind, with a selection caret prefixed when this
+ * is the selected node. The caret is independent of `STATUS_MARKER`, which
+ * encodes run status, not selection; before this, selecting a node changed
+ * only border, background, and text color, invisible on a low-contrast
+ * terminal. Follows the '›' precedent in theme-picker.ts and the hypothesis
+ * drill-down (`experiment-log.ts#renderDetail`).
+ */
+export function nodeLabel(phase: AgentPhase, selected: boolean): string {
+  return `${selected ? '› ' : ''}${STATUS_MARKER[phase.status]} ${phase.kind}`;
+}
+
 function edgeColor(theme: Theme, tone: EdgeTone): string {
   if (tone === 'failed') return theme.error;
   if (tone === 'live') return theme.accent;
@@ -292,7 +304,7 @@ export class AgentMapView {
     const inner = node.width - 2;
     box.add(
       new TextRenderable(this.renderer, {
-        content: truncate(`${STATUS_MARKER[phase.status]} ${phase.kind}`, inner),
+        content: truncate(nodeLabel(phase, selected), inner),
         fg: selected ? this.#theme.textStrong : color,
         width: '100%',
       }),
@@ -355,7 +367,7 @@ export class AgentMapView {
     const color = statusColor(this.#theme, phase.status);
     row.add(
       new TextRenderable(this.renderer, {
-        content: `${STATUS_MARKER[phase.status]} ${phase.kind}`,
+        content: nodeLabel(phase, selected),
         fg: selected ? this.#theme.textStrong : color,
         width: '100%',
       }),

--- a/clients/tui/src/ui/experiment-log.test.ts
+++ b/clients/tui/src/ui/experiment-log.test.ts
@@ -1,5 +1,7 @@
-import {describe, expect, it} from 'bun:test';
+import {afterEach, describe, expect, it} from 'bun:test';
+import {createTestRenderer} from '@opentui/core/testing';
 import type {HypothesisEntry} from '@vibesys/backend-client';
+import type {SessionController} from '../session-controller.js';
 import {
   entryKey,
   initialSessionState,
@@ -9,7 +11,9 @@ import {
   setExperiments,
 } from '../session-model.js';
 import {
+  ExperimentLogView,
   entryCells,
+  entryLeadingMarker,
   entryRow,
   formatMeasured,
   formatRounds,
@@ -19,6 +23,7 @@ import {
   outcomeColor,
   outcomeLabel,
   resolveColumns,
+  selectionCaret,
   sentenceCase,
 } from './experiment-log.js';
 import {resolveTheme, THEME_NAMES} from './theme.js';
@@ -114,7 +119,11 @@ describe('experiment log rows', () => {
       resolveColumns(WIDE),
     );
 
-    expect(row.startsWith('▸')).toBe(true);
+    // The leading column reserves a selection caret ahead of the active
+    // marker; unselected, that slot is a blank rather than absent, so the
+    // active marker lands in the same place whether or not the row is
+    // selected.
+    expect(row.startsWith(' ▸')).toBe(true);
     expect(row).toContain('Active');
   });
 
@@ -196,7 +205,9 @@ describe('experiment log rows', () => {
       resolveColumns(WIDE),
     );
 
-    expect(row).toContain('(unidentified)');
+    // The two-character selection-caret slot leaves one fewer column for the
+    // id itself, so a 15-character placeholder now truncates one char sooner.
+    expect(row).toContain('(unidentifie…');
     expect(row).toContain('—');
     expect(row).not.toContain('Active');
   });
@@ -207,7 +218,7 @@ describe('experiment log rows', () => {
     const row = entryRow(entry({hypothesis_id: 'm1-preallocated-spsc-ring'}), columns);
     const roundsStart = header.indexOf('Rounds');
 
-    expect(row).toContain('m1-preallocat…  41');
+    expect(row).toContain('m1-prealloca…  41');
     expect(row[roundsStart - 1]).toBe(' ');
     expect(row.slice(roundsStart).startsWith('41')).toBe(true);
   });
@@ -245,6 +256,42 @@ describe('experiment log rows', () => {
       resolveColumns(WIDE),
     );
     expect(withActionOnly.leading).toContain('Batch prefill');
+  });
+});
+
+describe('selectionCaret', () => {
+  it('renders a caret for the selected row and a matching blank otherwise', () => {
+    expect(selectionCaret(true)).toBe('›');
+    expect(selectionCaret(false)).toBe(' ');
+  });
+});
+
+describe('entryLeadingMarker', () => {
+  it('carries the selection caret and the active marker as independent signals', () => {
+    expect(entryLeadingMarker(entry({active: false}), false)).toBe('  ');
+    expect(entryLeadingMarker(entry({active: false}), true)).toBe('› ');
+    expect(entryLeadingMarker(entry({active: true}), false)).toBe(' ▸');
+    expect(entryLeadingMarker(entry({active: true}), true)).toBe('›▸');
+  });
+});
+
+describe('entryCells and entryRow with selection', () => {
+  it('shows the caret only on the selected row, at the same column as an unselected row', () => {
+    const columns = resolveColumns(WIDE);
+    const selected = entryRow(entry({hypothesis_id: 'H-01'}), columns, true);
+    const unselected = entryRow(entry({hypothesis_id: 'H-01'}), columns, false);
+
+    expect(selected.startsWith('›')).toBe(true);
+    expect(unselected.startsWith(' ')).toBe(true);
+    // Everything past the reserved caret column is identical: selection never
+    // reflows the row's other columns.
+    expect(selected.slice(1)).toBe(unselected.slice(1));
+  });
+
+  it('defaults to unselected when the caller does not pass a selection flag', () => {
+    const columns = resolveColumns(WIDE);
+    expect(entryRow(entry(), columns)).toBe(entryRow(entry(), columns, false));
+    expect(entryCells(entry(), columns)).toEqual(entryCells(entry(), columns, false));
   });
 });
 
@@ -343,5 +390,103 @@ describe('experiment log selection', () => {
     ]);
 
     expect(replaced.experimentLog?.selectedId).toBe('H-99');
+  });
+});
+
+/**
+ * The pure helpers above prove the caret occupies a reserved column; these
+ * tests reproduce the symptom the issue reported (selection legible only by a
+ * background swap) through the real OpenTUI test renderer, per
+ * coding-best-practices.md's rule that a terminal-geometry symptom needs the
+ * renderer, not just a formatter test.
+ */
+describe('experiment log rendered selection glyph', () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const destroy of cleanup.splice(0).reverse()) destroy();
+  });
+
+  /** None of these fire in a render-only test; onMouseUp is never simulated. */
+  const controller = {
+    focusPane: () => {},
+    openHypothesisDetail: () => {},
+    moveExperimentSelection: () => {},
+    selectExperimentActivity: () => {},
+    openRound: () => {},
+  } as unknown as SessionController;
+
+  async function renderLog(state: SessionState): Promise<string> {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const view = new ExperimentLogView(testRenderer.renderer, controller, resolveTheme(null));
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.destroy();
+      view.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    });
+    view.render(state);
+    await testRenderer.renderOnce();
+    return testRenderer.captureCharFrame();
+  }
+
+  it('puts the caret at the same column on the selected row as the blank it replaces elsewhere', async () => {
+    const initial = logState([
+      entry({hypothesis_id: 'H-01', first_round: 1, last_round: 1}),
+      entry({hypothesis_id: 'H-02', first_round: 2, last_round: 2}),
+    ]);
+    expect(initial.experimentLog?.selectedId).toBe('H-01');
+
+    const h01Selected = (await renderLog(initial)).split('\n');
+    const rowH01Selected = h01Selected.findIndex(line => line.includes('H-01'));
+    const rowH02Unselected = h01Selected.findIndex(line => line.includes('H-02'));
+    const colH01 = h01Selected[rowH01Selected]?.indexOf('H-01') ?? -1;
+    const colH02 = h01Selected[rowH02Unselected]?.indexOf('H-02') ?? -1;
+    expect(colH01).toBeGreaterThan(0);
+    expect(colH01).toBe(colH02);
+    // The active marker sits directly before the id; the caret is one column
+    // further left again, so it never displaces the marker or the id.
+    expect(h01Selected[rowH01Selected]?.[colH01 - 2]).toBe('›');
+    expect(h01Selected[rowH02Unselected]?.[colH02 - 2]).toBe(' ');
+
+    const moved = moveExperimentSelection(initial, 1);
+    expect(moved.experimentLog?.selectedId).toBe('H-02');
+    const h02Selected = (await renderLog(moved)).split('\n');
+    const rowH01AfterMove = h02Selected.findIndex(line => line.includes('H-01'));
+    const rowH02AfterMove = h02Selected.findIndex(line => line.includes('H-02'));
+
+    // Moving the selection off H-01 does not reflow its row: the id lands in
+    // exactly the column it held while selected.
+    expect(h02Selected[rowH01AfterMove]?.indexOf('H-01')).toBe(colH01);
+    expect(h02Selected[rowH02AfterMove]?.indexOf('H-02')).toBe(colH02);
+    expect(h02Selected[rowH01AfterMove]?.[colH01 - 2]).toBe(' ');
+    expect(h02Selected[rowH02AfterMove]?.[colH02 - 2]).toBe('›');
+  });
+
+  it('marks the selected unowned round row with the same caret, in its own reserved column', async () => {
+    const withActivity = setExperiments(
+      openExperimentLog({
+        ...initialSessionState(),
+        core: {
+          ...initialSessionState().core,
+          rounds: [
+            {number: 3, status: 'completed'},
+            {number: 4, status: 'completed'},
+          ],
+        },
+      }),
+      [],
+    );
+    const frame = (await renderLog(withActivity)).split('\n');
+    const rowSelected = frame.findIndex(line => line.includes('Round 3'));
+    const rowUnselected = frame.findIndex(line => line.includes('Round 4'));
+    const colSelected = frame[rowSelected]?.indexOf('Round 3') ?? -1;
+    const colUnselected = frame[rowUnselected]?.indexOf('Round 4') ?? -1;
+    expect(colSelected).toBeGreaterThan(0);
+    expect(colSelected).toBe(colUnselected);
+    // The caret sits two columns before "Round": one column for itself, one
+    // for the space that always follows it.
+    expect(frame[rowSelected]?.[colSelected - 2]).toBe('›');
+    expect(frame[rowUnselected]?.[colUnselected - 2]).toBe(' ');
   });
 });

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -382,7 +382,7 @@ export class ExperimentLogView {
     isSelected: boolean,
     index: number,
   ): void {
-    const cells = entryCells(entry, columns);
+    const cells = entryCells(entry, columns, isSelected);
     // The active hypothesis is called out on its own, so it stays visible
     // whether or not it happens to be the selected row.
     const base = entry.active === true ? this.#theme.warning : this.#theme.textPrimary;
@@ -422,7 +422,7 @@ export class ExperimentLogView {
     });
     row.add(
       this.#cell(
-        ` Round ${roundNumber} · recorded agent turns · no hypothesis`,
+        `${selectionCaret(isSelected)} Round ${roundNumber} · recorded agent turns · no hypothesis`,
         this.#theme.textPrimary,
         isSelected,
       ),
@@ -478,8 +478,9 @@ export class ExperimentLogView {
         this.controller.selectExperimentActivity();
       },
     });
+    const prefixed = `${selectionCaret(selected)} ${content}`;
     const text = new TextRenderable(this.renderer, {
-      content,
+      content: prefixed,
       fg: this.#theme.warning,
       width: '100%',
       ...(selected ? {bg: this.#theme.selectedSurface} : {}),
@@ -490,7 +491,7 @@ export class ExperimentLogView {
     this.#rows.add(row);
     if (activity.startedAt === undefined || !Number.isFinite(Date.parse(activity.startedAt)))
       return;
-    this.#activeActivityLine = {text, content, startedAt: activity.startedAt};
+    this.#activeActivityLine = {text, content: prefixed, startedAt: activity.startedAt};
     this.#refreshElapsedActivity();
     this.#syncElapsedTimer();
   }
@@ -607,6 +608,29 @@ export function headerRow(columns: Columns, direction: 'max' | 'min' | null = nu
 }
 
 /**
+ * The selection caret shared by every selectable row in the log: `'›'` for the
+ * selected row, a matching blank otherwise, so a row's other columns land in
+ * the same place whether or not it is selected. Independent of any
+ * status/active glyph the row also carries, following the precedent in
+ * theme-picker.ts and the hypothesis drill-down (`#renderDetail`), where the
+ * background swap alone was not enough to read selection on a low-contrast
+ * terminal.
+ */
+export function selectionCaret(isSelected: boolean): string {
+  return isSelected ? '›' : ' ';
+}
+
+/**
+ * The two-character leading marker on a hypothesis row: the selection caret,
+ * then the active-hypothesis marker. The two are independent signals, so both
+ * render in the same row without either overwriting the other.
+ */
+export function entryLeadingMarker(entry: HypothesisEntry, isSelected: boolean): string {
+  const active = entry.active === true ? '▸' : ' ';
+  return `${selectionCaret(isSelected)}${active}`;
+}
+
+/**
  * The row split into the segments the view colors independently. Widths are
  * baked in so the segments still line up as separate renderables.
  */
@@ -616,10 +640,14 @@ export interface EntryCells {
   trailing: string;
 }
 
-export function entryCells(entry: HypothesisEntry, columns: Columns): EntryCells {
-  const marker = entry.active === true ? '▸' : ' ';
+export function entryCells(
+  entry: HypothesisEntry,
+  columns: Columns,
+  isSelected = false,
+): EntryCells {
+  const marker = entryLeadingMarker(entry, isSelected);
   const leading = [
-    fitColumn(`${marker}${truncate(entry.hypothesis_id, ID_WIDTH - 1)}`, ID_WIDTH),
+    fitColumn(`${marker}${truncate(entry.hypothesis_id, ID_WIDTH - marker.length)}`, ID_WIDTH),
     fitColumn(formatRounds(entry), ROUNDS_WIDTH),
   ];
   if (columns.claim) {
@@ -650,8 +678,8 @@ function fitColumn(value: string, width: number): string {
   return truncate(value, width).padEnd(width);
 }
 
-export function entryRow(entry: HypothesisEntry, columns: Columns): string {
-  const cells = entryCells(entry, columns);
+export function entryRow(entry: HypothesisEntry, columns: Columns, isSelected = false): string {
+  const cells = entryCells(entry, columns, isSelected);
   return `${cells.leading}${cells.outcome}${cells.trailing}`;
 }
 


### PR DESCRIPTION
## Problem

Fixes #553. In the experiment log, a selected-but-inactive hypothesis row and every unowned round row differed from their neighbors only by a background-color swap: the leading `▸` marker in `clients/tui/src/ui/experiment-log.ts` encodes whether the entry is active, never whether it is selected, and the selection style is a `selectedSurface` background never run through a contrast guard. In the agent graph, selecting a node changed only border, background, and text color; its only glyph (`STATUS_MARKER`) encodes run status. On a low-contrast or color-dropping terminal the operator cannot tell which row or node Enter will act on, even though the rounds rail and the theme picker already solve exactly this with a textual caret.

## Solution

Selection now carries a caret glyph independent of the active/status accent, and the background swap stays. In `experiment-log.ts` two pure module-scope helpers own the geometry: `selectionCaret(isSelected)` returns `›` or a space, and `entryLeadingMarker(entry, isSelected)` composes it with the existing active `▸` into a reserved two-character leading slot, so the caret has its own column and can never collide with or be mistaken for the active marker. Hypothesis rows (`entryCells`/`entryRow`, which now take the selection flag and truncate the id by the marker's real length instead of a hardcoded 1), unowned round rows, and the live activity line all render through it. The activity line's memo stores the prefixed content rather than the raw text, so the 1-second elapsed-timer refresh rewrites the row with the caret intact instead of dropping it on the first tick. In `agent-map.ts`, a pure `nodeLabel(phase, selected)` helper prefixes `› ` on the selected node's label in both the graph and stacked render paths; `STATUS_MARKER`, borders, and background behavior are untouched. The helpers are exported at module scope, following the `agent-runtime-label` precedent of directly unit-testable label builders, and the whole change is additive: no selection semantics, key handling, or theme values moved.

The new agent-graph tests live in their own file, `clients/tui/src/ui/agent-map-selection.test.ts`, rather than inside the existing layout suite, so sibling changes to `agent-map.test.ts` (the row-budget work for #514 is in flight in this batch) do not conflict with this branch.

### Architecture

The change is confined to the `@vibesys/tui` package's two row/label builders; selection state itself stays in the session model, core-state and the backend are untouched, and the helpers are pure functions of (entry, selected).

```mermaid
flowchart TD
    S["session model: selected hypothesis / round / agent node"] --> E["experiment-log.ts: entryLeadingMarker = selectionCaret + active marker, reserved 2-char slot"]
    S --> A["agent-map.ts: nodeLabel(phase, selected) prefixes the caret on graph and stacked nodes"]
    E --> R["hypothesis rows, unowned round rows, activity line (caret stored in the timer memo)"]
    A --> N["selected node legible without color; STATUS_MARKER still encodes status"]
    R --> B["selectedSurface background swap unchanged, caret purely additive"]
    N --> B
```

## Verification

Pure-function tests pin the caret builders and rendered-frame tests pin the on-screen result in both surfaces; with the source reverted the new suites fail at load (the exports do not exist on the unfixed code), and all pass on this branch. The full TS check suite passes at the current `main` tip, and a live codex-provider run shows the caret tracking selection in both surfaces.

### Correctness properties

- Selection is legible without color: every selectable experiment-log row and agent node shows `›` exactly when selected, in a reserved column that exists whether or not anything is selected, so columns never shift as the selection moves.
- The caret is orthogonal to the active/status accent: `▸` still means active and `STATUS_MARKER` still means run status; all four combinations of selected and active render distinctly.
- The elapsed-timer refresh of the live activity line preserves the caret: the memo the tick rewrites stores the prefixed content, so no timer tick can un-mark the selected line.
- The background selection styling and all selection semantics (which keys move it, what Enter does) are byte-for-byte unchanged; the change is presentation-only and additive.
- Fixed-width truncation stays aligned: rows truncate by the marker slot's real length, so reserving the caret column shifts every row uniformly by one character instead of misaligning columns.

### Testing

- `clients/tui/src/ui/experiment-log.test.ts`: new pure-function suites for `selectionCaret`, `entryLeadingMarker`, and `entryCells`/`entryRow` with selection, plus two rendered-frame tests (caret column stability across selection moves on hypothesis rows; the unowned round row's caret in its reserved column). Three pre-existing assertions are updated for the one-character truncation shift the reserved column causes (for example `m1-preallocat…` becomes `m1-prealloca…`), an inherent consequence of reserving the column.
- `clients/tui/src/ui/agent-map-selection.test.ts` (new file): `nodeLabel` across every status and selection combination, and a rendered-frame test asserting `› ● implementer` for the selected node while `○ judge` renders without a caret. `agent-map.test.ts` itself is byte-identical to `main`.
- Fail-before/pass-after (sources reverted via `git checkout --` on the two source files, tests kept; reapplied from a saved patch verified byte-identical): before, both new suites fail at module load with `Export named 'entryLeadingMarker'/'nodeLabel' not found`, an unambiguous signal the surface did not exist; after, all new and updated tests pass.
- `pnpm check:ts` (Checked 86 files), `pnpm check:ts-architecture` (no dependency violations), `pnpm check:clients`, `pnpm build:clients`: all pass at the current `main` tip (12e807a). `pnpm test:clients`: 692 pass, 0 fail on a clean run; one intermittent `EBUSY` in `dev/harness.test.ts` on the first run is the environmental NFS teardown race tracked as #617 (reproduces with this change absent) and cleared on immediate re-run.
- Live harness run (codex provider, model `gpt-5.6-sol`, queue-rs spsc, `--profiler none`) at 200x50: the selected active hypothesis row renders `›▸spsc_preallo…`, the caret and the active marker composed in the reserved two-character slot; on the kickoff screen the selected live activity line shows `› ● Decide whether profiling is needed · 14s` and keeps its caret across elapsed-timer ticks (16s in the next capture), the exact refresh path that dropped it before the memo fix; in the round view Tab moves the caret between agent kinds, `› ✓ orchestrator` then `› ● implementer`, while unselected nodes keep bare status markers (`○ judge`). The single-hypothesis run offered no second row to arrow between, so row-to-row caret movement is pinned by the rendered-frame unit tests. `backend.log` showed no tracebacks or protocol errors.
- Merges cleanly against current `main` (`git merge-tree --write-tree`).

Closes #553.
