### PR TITLE
TUI: unwind the modal chat and the visualization one Escape at a time

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1204,7 +1204,7 @@ describe('OpenTUI presentation', () => {
     expect(frame).toMatch(/▸r9\s+·\s+plan/);
   });
 
-  it('closes a visualization and the chat together on one Escape', async () => {
+  it('unwinds the modal chat over a visualization one Escape at a time', async () => {
     const testRenderer = await createTestRenderer({width: 130, height: 22});
     const controller = new FakeController({
       ...initialSessionState(),
@@ -1223,14 +1223,71 @@ describe('OpenTUI presentation', () => {
     registerCleanup(testRenderer.renderer, app);
     await controller.openPane('perf');
     controller.publish({...controller.state, chatOpen: true});
+    let frame = await frameAfter(testRenderer);
+    expect(frame).toContain('1200');
+
+    // The modal chat is the innermost layer: the first Escape closes only it,
+    // and the visualization behind it stays exactly where it was.
+    testRenderer.mockInput.pressKey('ESCAPE');
+    frame = await frameAfterEscape(testRenderer);
+    expect(controller.state.chatOpen).toBe(false);
+    expect(controller.state.layout.right).not.toBeNull();
+    expect(controller.state.layout.focus).toBe('right');
+    expect(controller.state.hypothesisScope).not.toBeNull();
+    expect(frame).toContain('1200');
+
+    // The second Escape is the pane's own: it closes now, leaving the round
+    // trajectory that was always behind both of them.
+    testRenderer.mockInput.pressKey('ESCAPE');
+    frame = await frameAfterEscape(testRenderer);
+    expect(controller.state.layout.right).toBeNull();
+    expect(controller.state.layout.focus).toBe('left');
+    expect(controller.state.hypothesisScope).not.toBeNull();
+    expect(frame).not.toContain('1200');
+  });
+
+  it('closes the chat alone on Escape when no pane is behind it', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController({...initialSessionState(), chatOpen: true});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
     await frameAfter(testRenderer);
 
     testRenderer.mockInput.pressKey('ESCAPE');
     await frameAfterEscape(testRenderer);
 
-    // Back on the round in one press, not part way with the chat still over it.
     expect(controller.state.chatOpen).toBe(false);
     expect(controller.state.layout.right).toBeNull();
+    expect(controller.state.layout.focus).toBe('left');
+  });
+
+  it('closes the pane alone on Escape when no chat is open', async () => {
+    const testRenderer = await createTestRenderer({width: 130, height: 22});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      hypothesisScope: {id: 'H-01', label: 'H-01 · r1', title: 'H-01', rounds: [1]},
+      selectedRound: 1,
+      core: {
+        ...initialSessionState().core,
+        rounds: [{number: 1, status: 'active'}],
+        phases: [{kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1-judge'}],
+        transcript: [
+          {id: 'e1', kind: 'assistant', label: 'judge', content: 'weighing it', roundNumber: 1},
+        ],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openPane('perf');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.focus).toBe('right');
+
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+
+    expect(controller.state.layout.right).toBeNull();
+    expect(controller.state.chatOpen).toBe(false);
+    expect(controller.state.layout.focus).toBe('left');
     expect(controller.state.hypothesisScope).not.toBeNull();
   });
 

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1291,6 +1291,41 @@ describe('OpenTUI presentation', () => {
     expect(controller.state.hypothesisScope).not.toBeNull();
   });
 
+  it('closes Help over a visualization before closing the visualization', async () => {
+    const testRenderer = await createTestRenderer({width: 130, height: 22});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      hypothesisScope: {id: 'H-01', label: 'H-01 · r1', title: 'H-01', rounds: [1]},
+      selectedRound: 1,
+      core: {
+        ...initialSessionState().core,
+        rounds: [{number: 1, status: 'active'}],
+        phases: [{kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1-judge'}],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openPane('perf');
+    controller.publish({
+      ...controller.state,
+      overlay: {kind: 'help', content: 'Available commands'},
+    });
+    await testRenderer.waitForFrame(value => value.includes('Available commands'));
+
+    // Help is foreground. Escape dismisses it without closing the Performance pane.
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await testRenderer.waitForFrame(value => !value.includes('Available commands'));
+    expect(controller.state.overlay).toBeNull();
+    expect(controller.state.layout.right).not.toBeNull();
+    expect(controller.state.layout.focus).toBe('right');
+
+    // Once Help is gone, the next Escape closes the pane.
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+    expect(controller.state.layout.right).toBeNull();
+    expect(controller.state.layout.focus).toBe('left');
+  });
+
   it('hands the keys back when the pane holding them closes', async () => {
     const testRenderer = await createTestRenderer({width: 130, height: 22});
     const controller = new FakeController({

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -112,15 +112,15 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
-    // The focused pane takes the scroll keys. Everything else the chat or the
-    // transcript would normally handle is left alone.
+    // The focused pane takes the scroll keys. Escape belongs to the modal/pane
+    // ladder below, so a right pane's own Escape waits until any modal chat in
+    // front of it has already closed.
     if (
       controller.state.layout.focus === 'right' &&
       controller.state.layout.right !== null &&
-      (key.name === 'pageup' || key.name === 'pagedown' || key.name === 'escape')
+      (key.name === 'pageup' || key.name === 'pagedown')
     ) {
-      if (key.name === 'escape') controller.closeOverlays();
-      else actions.scrollRightPane(key.name === 'pageup' ? -1 : 1);
+      actions.scrollRightPane(key.name === 'pageup' ? -1 : 1);
       key.preventDefault();
       return;
     }
@@ -143,8 +143,10 @@ export function bindKeybindings(
     }
     if (controller.state.chatOpen) {
       if (key.name === 'escape') {
-        if (controller.state.layout.right !== null) controller.closeOverlays();
-        else actions.closeChat();
+        // The modal chat is the innermost layer: Escape closes only it,
+        // regardless of whatever pane sits behind it. A pane open behind the
+        // chat unwinds on its own Escape, once the chat is gone.
+        actions.closeChat();
         key.preventDefault();
         return;
       }
@@ -157,6 +159,18 @@ export function bindKeybindings(
         if (actions.completeChatInput()) key.preventDefault();
         return;
       }
+      return;
+    }
+    // With the chat closed (or never open), Escape's next layer is the
+    // visualization pane: one press folds it away on its own, leaving
+    // whatever is behind it (a hypothesis trajectory, the round view) intact.
+    if (
+      key.name === 'escape' &&
+      controller.state.layout.focus === 'right' &&
+      controller.state.layout.right !== null
+    ) {
+      controller.closePane();
+      key.preventDefault();
       return;
     }
     if (controller.state.overlay !== null) {

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -124,8 +124,8 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
-    // Modal state is authoritative: the theme picker, the modal chat, and any
-    // overlay must contain input before the focused docked chat runs. Otherwise
+    // Modal state is authoritative: the theme picker, command overlay, and
+    // modal chat must contain input before the focused docked chat runs. Otherwise
     // a modal opened while the docked chat has focus would leak printable keys
     // into the hidden composer, let Up/Down drive chat suggestions, and route
     // Escape to the left pane instead of closing the modal.
@@ -138,6 +138,20 @@ export function bindKeybindings(
       else if (key.name === 'return' || key.name === 'enter') controller.applySelectedTheme();
       // The picker is modal: keys it does not use are swallowed here so they
       // cannot move panes or type into the still-focused input behind it.
+      key.preventDefault();
+      return;
+    }
+    if (controller.state.overlay !== null) {
+      if (key.name === 'escape') {
+        controller.live();
+        viewport.scrollTo(viewport.scrollHeight);
+      } else if (key.name === 'pageup' || key.name === 'pagedown') {
+        // Content taller than the box scrolls here rather than falling through
+        // to the transcript behind it.
+        actions.scrollOverlay(key.name === 'pageup' ? -1 : 1);
+      }
+      // The overlay is modal: everything it does not handle is swallowed so
+      // keys cannot reach the panes or the hidden command input behind it.
       key.preventDefault();
       return;
     }
@@ -170,20 +184,6 @@ export function bindKeybindings(
       controller.state.layout.right !== null
     ) {
       controller.closePane();
-      key.preventDefault();
-      return;
-    }
-    if (controller.state.overlay !== null) {
-      if (key.name === 'escape') {
-        controller.live();
-        viewport.scrollTo(viewport.scrollHeight);
-      } else if (key.name === 'pageup' || key.name === 'pagedown') {
-        // Content taller than the box scrolls here rather than falling through
-        // to the transcript behind it.
-        actions.scrollOverlay(key.name === 'pageup' ? -1 : 1);
-      }
-      // The overlay is modal: everything it does not handle is swallowed so
-      // keys cannot reach the panes or the hidden command input behind it.
       key.preventDefault();
       return;
     }


### PR DESCRIPTION
## Problem

Fixes #555. Escape could close both a modal chat and the visualization behind it. The first fix separated those operations but still let a focused visualization consume Escape before a foreground command overlay: `/perf`, then `/help`, then Escape closed the Performance pane while Help remained open.

## Solution

Handle command overlays before modal chat and visualization key routes. Escape dismisses the foreground overlay while retaining the pane and its focus; the next Escape can close the pane. Modal chat continues to close independently of the pane behind it. Existing single-surface close operations are reused.

### Architecture

The TUI keybinding handler owns input priority. The session model retains ownership of closing each surface. No backend or protocol changes are required.

```mermaid
flowchart TD
    K[Escape after theme-picker handling] --> O{Command overlay open?}
    O -- yes --> H[Dismiss overlay]
    O -- no --> C{Modal chat open?}
    C -- yes --> M[Close chat]
    C -- no --> P{Visualization focused?}
    P -- yes --> V[Close visualization]
    P -- no --> R[Existing navigation handling]
```

## Verification

### Correctness properties

- Help over Performance closes first; Performance remains available for the next Escape.
- Modal chat and visualization close one layer per Escape.
- Overlay input remains contained while the overlay is open.
- Single-surface close behavior and visualization scrolling remain supported.

### Testing

- From `clients/tui`, `/home/ayanbrafaih/.bun/bin/bun test --max-concurrency 1 src/ui/app.test.ts`: 163 passed, including the stacked Help/Performance regression.
- `pnpm --dir clients/tui check`: passed.
- `pnpm exec biome check clients/tui/src/ui/keybindings.ts clients/tui/src/ui/app.test.ts`: passed.
- `git diff --check`: passed.
- A broader package-script run encountered environment and fixture failures in other suites. It is not counted as passing. No new live-provider run was performed for this revision.

Closes #555.
