### PR TITLE
TUI: wait for mock server exit before removing dev-harness scratch dirs

### DIFF
--- a/clients/tui/dev/harness.test.ts
+++ b/clients/tui/dev/harness.test.ts
@@ -17,7 +17,7 @@
  */
 
 import {afterEach, expect, test} from 'bun:test';
-import {spawn, spawnSync} from 'node:child_process';
+import {type ChildProcess, spawn, spawnSync} from 'node:child_process';
 import {chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {createConnection, type Socket} from 'node:net';
 import {tmpdir} from 'node:os';
@@ -52,16 +52,57 @@ const WAIT_TIMEOUT_MS = 15_000;
  */
 const MID_EXECUTION_BOOTSTRAP = 40;
 
-const cleanups: (() => void)[] = [];
+const cleanups: (() => void | Promise<void>)[] = [];
 
-afterEach(() => {
-  while (cleanups.length > 0) cleanups.pop()?.();
+afterEach(async () => {
+  while (cleanups.length > 0) await cleanups.pop()?.();
 });
 
 function scratchDirectory(prefix: string): string {
   const directory = mkdtempSync(join(tmpdir(), prefix));
-  cleanups.push(() => rmSync(directory, {recursive: true, force: true}));
+  cleanups.push(() => removeScratchDirectory(directory));
   return directory;
+}
+
+/**
+ * Removes a scratch directory, retrying while the filesystem still counts a
+ * dying process's open files against it. Unlinking an open file succeeds on a
+ * local filesystem, but an NFS client silly-renames it to `.nfsXXXX` instead,
+ * so until the holder has exited and the client has reaped the rename, the
+ * rename refuses to unlink (EBUSY) and the directory stays non-empty
+ * (ENOTEMPTY). Both clear on their own once the process is gone; anything else
+ * is a real bug and is rethrown immediately.
+ */
+async function removeScratchDirectory(directory: string): Promise<void> {
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  while (true) {
+    try {
+      rmSync(directory, {recursive: true, force: true});
+      return;
+    } catch (error) {
+      const code = (error as {code?: unknown}).code;
+      if ((code !== 'EBUSY' && code !== 'ENOTEMPTY') || Date.now() >= deadline) throw error;
+      await delay(25);
+    }
+  }
+}
+
+/**
+ * SIGKILLs `child` and resolves once the process has actually exited. The kill
+ * alone is not enough for teardown: signal delivery is asynchronous, so at the
+ * moment `kill` returns the process can still hold its files in the scratch
+ * directory open, which is exactly what the removal that follows in LIFO order
+ * must not race.
+ */
+function killAndAwaitExit(child: ChildProcess): Promise<void> {
+  return new Promise(resolve => {
+    if (child.pid === undefined || child.exitCode !== null || child.signalCode !== null) {
+      resolve();
+      return;
+    }
+    child.once('exit', () => resolve());
+    child.kill('SIGKILL');
+  });
 }
 
 function delay(ms: number): Promise<void> {
@@ -96,7 +137,7 @@ function connect(socketPath: string): Promise<Socket> {
   return new Promise((resolve, reject) => {
     const socket = createConnection(socketPath);
     socket.on('connect', () => {
-      cleanups.push(() => socket.destroy());
+      cleanups.push(() => void socket.destroy());
       resolve(socket);
     });
     socket.on('error', reject);
@@ -135,7 +176,7 @@ async function startMockServer(socketPath: string, args: string[]): Promise<void
     [MOCK_SERVER, '--socket', socketPath, '--owner-pid', String(process.pid), ...args],
     {stdio: 'ignore'},
   );
-  cleanups.push(() => server.kill('SIGKILL'));
+  cleanups.push(() => killAndAwaitExit(server));
   await waitFor('the mock server to bind', () => isListening(socketPath));
 }
 
@@ -290,6 +331,50 @@ test(
     expect(countByType(all, 'agent_execution_finished')).toBe(3);
     expect(countByType(all, 'invocation_started')).toBe(0);
     expect(countByType(all, 'invocation_finished')).toBe(0);
+  },
+  TEST_TIMEOUT_MS,
+);
+
+test(
+  'kill cleanup resolves only after the mock server has exited',
+  async () => {
+    const directory = scratchDirectory('vs-mock-exit-');
+    const socketPath = join(directory, 'mock.sock');
+    const server = spawn(
+      'bun',
+      [MOCK_SERVER, '--socket', socketPath, '--owner-pid', String(process.pid), '--paused'],
+      {stdio: 'ignore'},
+    );
+    cleanups.push(() => killAndAwaitExit(server));
+    await waitFor('the mock server to bind', () => isListening(socketPath));
+
+    await killAndAwaitExit(server);
+    // What LIFO teardown relies on: by the time the kill cleanup resolves, the
+    // process is gone, so the removal that follows cannot race its open files.
+    expect(server.exitCode !== null || server.signalCode !== null).toBe(true);
+    // And it is idempotent, because afterEach runs the pushed cleanup again.
+    await killAndAwaitExit(server);
+  },
+  TEST_TIMEOUT_MS,
+);
+
+test(
+  'scratch removal outwaits a straggler that still holds a file open',
+  async () => {
+    const directory = scratchDirectory('vs-mock-straggler-');
+    const heldPath = join(directory, 'held.log');
+    const holder = spawn('bash', ['-c', 'exec 3>"$1"; sleep 0.4', 'bash', heldPath], {
+      stdio: 'ignore',
+    });
+    cleanups.push(() => killAndAwaitExit(holder));
+    await waitFor('the straggler to open its file', async () => existsSync(heldPath));
+
+    // On a silly-renaming tmpdir this is the exact shape the suite used to die
+    // on: the open file cannot be unlinked until the holder exits, so the first
+    // attempts fail and the removal has to retry. On a local filesystem the
+    // first attempt simply succeeds; either way the directory must end up gone.
+    await removeScratchDirectory(directory);
+    expect(existsSync(directory)).toBe(false);
   },
   TEST_TIMEOUT_MS,
 );


### PR DESCRIPTION
## Problem

Fixes #617. The dev-harness suite `clients/tui/dev/harness.test.ts` tears down each test by running a `cleanups` stack LIFO: the mock server's cleanup (`server.kill('SIGKILL')`) runs before the scratch directory's cleanup (`rmSync(directory, {recursive: true, force: true})`), but the kill is fire-and-forget: nothing waits for the process to exit, so the `rmSync` executes while the mock server can still hold its socket and stdio files open inside the directory. On a local tmpfs, unlinking an open file succeeds and the race is invisible. On an NFS-backed `/tmp`, the client silly-renames open files to `.nfsXXXX` instead of unlinking them, the directory stays non-empty, and the removal fails with `EBUSY`. On the NFS host from the issue, 27 of 40 dedicated runs of this file failed that way (in both mock-server-spawning tests), and every failure left an undeletable `/tmp/vs-mock-*` directory behind; they accumulate across runs.

## Solution

Teardown now waits for the process to be gone before touching its files, and the removal tolerates the one lag that remains after that. The `cleanups` stack accepts async cleanups and `afterEach` awaits each pop, so ordering guarantees extend across process exits. `startMockServer` pushes `killAndAwaitExit`, which sends SIGKILL and resolves only on the child's `exit` event (resolving immediately if the process already exited or never spawned, so the cleanup is idempotent and cannot hang on a broken spawn). `scratchDirectory` pushes `removeScratchDirectory`, which retries the `rmSync` every 25ms while it fails with `EBUSY` or `ENOTEMPTY`, up to the suite's existing `WAIT_TIMEOUT_MS`; any other error, or the deadline, rethrows immediately so real failures still fail the test. The retry exists because awaiting the exit removes the race but not the epilogue: the NFS client reaps its silly-renamed `.nfsXXXX` files asynchronously after the holder's file descriptors close, so the directory can stay briefly non-empty even once the process is gone. Both clear on their own, which is exactly what a bounded retry expresses. The first test's server (spawned by `mock-ui.sh` rather than `startMockServer`) already waits for the socket to stop listening before teardown and now gets the removal retry as well.

The fix stays in the test file because the race is the test file's own teardown protocol; no production code, no fixture, and no script changes.

### Architecture

The change is confined to the dev mock harness's process-lifetime handling; the mock server, the wire protocol, and every assertion the suite makes are untouched.

```mermaid
flowchart TD
    T["afterEach: await cleanups LIFO"] --> S["socket cleanups: destroy"]
    S --> K["killAndAwaitExit: SIGKILL, resolve on the child's exit event"]
    K --> R["removeScratchDirectory: rmSync, retry EBUSY/ENOTEMPTY while the NFS client reaps .nfsXXXX renames, bounded by WAIT_TIMEOUT_MS"]
    R --> G["scratch directory gone on every filesystem; anything else rethrows and fails the test"]
```

## Verification

The flake reproduces deterministically enough on the reporting host (NFS-backed `/tmp`) to measure: 40 runs of the file before and after the fix, plus two new process-level tests that pin the teardown contract, plus the full client check suites.

### Correctness properties

- By the time the kill cleanup resolves, the mock server has exited (`exit` observed, or it was already dead), so the removal that follows it in LIFO order cannot race the process's open files.
- The removal retry is selective and bounded: only `EBUSY` and `ENOTEMPTY` are retried, both of which clear on their own once a dead process's files are reaped, and only until `WAIT_TIMEOUT_MS`; every other error and the deadline rethrow, so a real bug still fails loudly.
- `killAndAwaitExit` is idempotent (the test calls it, then `afterEach` runs the pushed copy again) and safe when the child never spawned (`pid` undefined) or already exited, so teardown cannot hang.
- The suite leaves no `/tmp/vs-mock-*` directory behind, on silly-renaming and local filesystems alike.
- Everything the tests assert is unchanged: the fix touches only teardown, and the async `afterEach` preserves the existing LIFO cleanup order.

### Testing

- Before, on the NFS `/tmp` host: 40 dedicated runs of `dev/harness.test.ts` produced 27 failing runs (34 `EBUSY: resource busy or locked, rm '/tmp/vs-mock-...'` failures across the snapshot and legacy-replay tests), each leaving an undeletable scratch directory. After: 40 of 40 runs pass, zero `EBUSY`, zero leftover directories.
- New test "kill cleanup resolves only after the mock server has exited": spawns a real mock server, runs the kill cleanup, and asserts the process is observably dead (`exitCode`/`signalCode` set) the moment it resolves, then re-runs it to pin idempotence.
- New test "scratch removal outwaits a straggler that still holds a file open": a child process holds a file open inside the scratch directory for 400ms while the removal runs. On this NFS host that is the exact silly-rename shape the suite used to die on, so the first attempts fail and the retry loop is exercised for real; on a local filesystem the first attempt succeeds trivially. Either way the directory must end up gone.
- `bun test dev/harness.test.ts`: 6 pass, 0 fail. `pnpm test:clients` at the current `main` tip (12e807a): 25 pass (backend-client), 84 pass (core-state), 686 pass (tui, including the two new harness tests), 0 fail. `pnpm check:ts`, `pnpm check:ts-architecture`, `pnpm check:clients`, `pnpm build:clients`: all pass.
- Merges cleanly (`git merge-tree --write-tree`) against current `main` and against all nine open sibling branches (#606, #619 to #626).

Closes #617.
