### PR TITLE
Agents: pair codex tool calls with results in the driver

### DIFF
--- a/src/vibesys/_agent_cli/codex.py
+++ b/src/vibesys/_agent_cli/codex.py
@@ -1,5 +1,6 @@
+import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from agentshim.codex import CodexGenerationSession
 from agentshim.events import AgentEventHandler
@@ -9,6 +10,55 @@ from .cli_agent import CLICodingAgent
 
 if TYPE_CHECKING:
     from agentshim.executor import CommandExecutor
+
+_COMMAND_TOOL = "execute"
+
+
+class _PairedCodexToolEvents:
+    """Repair the codex adapter's tool-event stream into call/result pairs.
+
+    agentshim through 0.5.1 maps a generic codex item's ``item.started`` and
+    ``item.completed`` both to tool-use, so one ``file_change`` (or
+    ``web_search``, ``mcp_tool_call``, ...) reaches ``on_tool_call`` twice
+    with identical arguments and never reaches ``on_tool_result``. This
+    wrapper treats the second identical call for a still-open item as that
+    item's completion: it swallows the duplicate and emits the missing
+    ``on_tool_result`` instead. Command executions (``execute``) already
+    arrive correctly paired and pass through untouched, as does every other
+    callback. Under an adapter that reports completions as results, no
+    duplicate ever arrives and the wrapper forwards everything unchanged.
+    """
+
+    def __init__(self, inner: AgentEventHandler) -> None:
+        self._inner = inner
+        # One open (args, start time) per tool name: codex items in a turn
+        # are sequential, so a second identical call while the first is open
+        # can only be the same item's completion echo.
+        self._open: dict[str, tuple[Any, float]] = {}
+
+    def __getattr__(self, name: str) -> Any:  # noqa: ANN401  # tracked: #288
+        return getattr(self._inner, name)
+
+    def on_tool_call(self, tool: str, args: Any = None) -> None:  # noqa: ANN401  # tracked: #288
+        """Forward a tool call, folding a completion echo into its result."""
+        if tool != _COMMAND_TOOL:
+            opened = self._open.pop(tool, None)
+            if opened is not None and opened[0] == args:
+                self._inner.on_tool_result(
+                    tool=tool,
+                    stdout="",
+                    exit_code=None,
+                    duration=time.monotonic() - opened[1],
+                )
+                return
+            self._open[tool] = (args, time.monotonic())
+        self._inner.on_tool_call(tool, args)
+
+    def on_tool_result(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401  # tracked: #288
+        """Forward a real result verbatim and close the matching open call."""
+        tool = kwargs.get("tool", args[0] if args else None)
+        self._open.pop(tool, None)
+        self._inner.on_tool_result(*args, **kwargs)
 
 
 def _toml_str(value: str) -> str:
@@ -139,6 +189,11 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
         timeout: int | None = None,
         silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> CodexGenerationSession:
+        # A fresh wrapper per session: open-call state must not leak across
+        # turns.
+        event_handler = (
+            _PairedCodexToolEvents(self.event_handler) if self.event_handler is not None else None
+        )
         return CodexGenerationSession(
             binary_name=self.binary_name,
             env=self.env,
@@ -148,7 +203,7 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
             cwd=cwd,
             timeout=timeout,
             silent=silent,
-            event_handler=self.event_handler,
+            event_handler=event_handler,
             executor=self.executor,
         )
 

--- a/src/vibesys/_agent_cli/codex.py
+++ b/src/vibesys/_agent_cli/codex.py
@@ -1,8 +1,10 @@
+import json
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from agentshim.codex import CodexGenerationSession
+from agentshim.codex.events import CodexEvent, ToolResultEvent, ToolUseEvent
 from agentshim.events import AgentEventHandler
 
 from .base import MCPServerSpec
@@ -14,51 +16,79 @@ if TYPE_CHECKING:
 _COMMAND_TOOL = "execute"
 
 
-class _PairedCodexToolEvents:
-    """Repair the codex adapter's tool-event stream into call/result pairs.
+def _item_lifecycle(line: str) -> tuple[str, str] | None:
+    """Read lifecycle kind and stable item identity before callbacks discard them."""
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict) or data.get("type") not in ("item.started", "item.completed"):
+        return None
+    item = data.get("item")
+    if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+        return None
+    return data["type"], item["id"]
 
-    agentshim through 0.5.1 maps a generic codex item's ``item.started`` and
-    ``item.completed`` both to tool-use, so one ``file_change`` (or
-    ``web_search``, ``mcp_tool_call``, ...) reaches ``on_tool_call`` twice
-    with identical arguments and never reaches ``on_tool_result``. This
-    wrapper treats the second identical call for a still-open item as that
-    item's completion: it swallows the duplicate and emits the missing
-    ``on_tool_result`` instead. Command executions (``execute``) already
-    arrive correctly paired and pass through untouched, as does every other
-    callback. Under an adapter that reports completions as results, no
-    duplicate ever arrives and the wrapper forwards everything unchanged.
+
+def _completion_output(parameters: Any) -> str:  # noqa: ANN401  # tracked: #288
+    """Preserve output and error payloads added when a generic item completes."""
+    if isinstance(parameters, dict):
+        for key in ("aggregated_output", "output", "text", "summary", "result", "error", "message"):
+            value = parameters.get(key)
+            if value:
+                return value if isinstance(value, str) else json.dumps(value)
+    return ""
+
+
+class _PairedCodexSession(CodexGenerationSession):
+    """Repair AgentShim's generic tool lifecycle before item IDs are discarded.
+
+    AgentShim 0.5.x maps generic starts and completions to ToolUseEvent.
+    Completion arguments can change, so use the raw lifecycle kind to convert
+    only completions to ToolResultEvent. The base session then pairs by ID,
+    including when a corrected parser supplies ToolResultEvent itself.
     """
 
-    def __init__(self, inner: AgentEventHandler) -> None:
-        self._inner = inner
-        # One open (args, start time) per tool name: codex items in a turn
-        # are sequential, so a second identical call while the first is open
-        # can only be the same item's completion echo.
-        self._open: dict[str, tuple[Any, float]] = {}
+    def __init__(self, **kwargs: Any) -> None:  # noqa: ANN401  # tracked: #288
+        super().__init__(**kwargs)
+        self._lifecycle: tuple[str, str] | None = None
 
-    def __getattr__(self, name: str) -> Any:  # noqa: ANN401  # tracked: #288
-        return getattr(self._inner, name)
+    def _process_stdout(self, line: str) -> None:
+        self._lifecycle = _item_lifecycle(line)
+        try:
+            super()._process_stdout(line)
+        finally:
+            self._lifecycle = None
 
-    def on_tool_call(self, tool: str, args: Any = None) -> None:  # noqa: ANN401  # tracked: #288
-        """Forward a tool call, folding a completion echo into its result."""
-        if tool != _COMMAND_TOOL:
-            opened = self._open.pop(tool, None)
-            if opened is not None and opened[0] == args:
-                self._inner.on_tool_result(
-                    tool=tool,
-                    stdout="",
-                    exit_code=None,
-                    duration=time.monotonic() - opened[1],
+    def _handle_event(self, event: CodexEvent) -> None:
+        if (
+            isinstance(event, ToolUseEvent)
+            and event.tool_name != _COMMAND_TOOL
+            and self._lifecycle is not None
+            and event.tool_id == self._lifecycle[1]
+        ):
+            if self._lifecycle[0] == "item.started":
+                # AgentShim registers only command executions. Register generic
+                # starts too, using the same clock as its duration calculation.
+                self.tool_map[event.tool_id] = event.tool_name
+                self.tool_start_times[event.tool_id] = time.time()
+                self.tool_args[event.tool_id] = event.parameters
+            else:
+                event = ToolResultEvent(
+                    tool_id=event.tool_id,
+                    tool_name=event.tool_name,
+                    parameters=event.parameters,
+                    output=_completion_output(event.parameters),
                 )
-                return
-            self._open[tool] = (args, time.monotonic())
-        self._inner.on_tool_call(tool, args)
-
-    def on_tool_result(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401  # tracked: #288
-        """Forward a real result verbatim and close the matching open call."""
-        tool = kwargs.get("tool", args[0] if args else None)
-        self._open.pop(tool, None)
-        self._inner.on_tool_result(*args, **kwargs)
+        super()._handle_event(event)
+        if (
+            isinstance(event, ToolResultEvent)
+            and event.tool_id
+            and event.tool_name != _COMMAND_TOOL
+        ):
+            self.tool_map.pop(event.tool_id, None)
+            self.tool_start_times.pop(event.tool_id, None)
+            self.tool_args.pop(event.tool_id, None)
 
 
 def _toml_str(value: str) -> str:
@@ -189,12 +219,7 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
         timeout: int | None = None,
         silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> CodexGenerationSession:
-        # A fresh wrapper per session: open-call state must not leak across
-        # turns.
-        event_handler = (
-            _PairedCodexToolEvents(self.event_handler) if self.event_handler is not None else None
-        )
-        return CodexGenerationSession(
+        return _PairedCodexSession(
             binary_name=self.binary_name,
             env=self.env,
             log_prefix=self._log_prefix,
@@ -203,7 +228,7 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
             cwd=cwd,
             timeout=timeout,
             silent=silent,
-            event_handler=event_handler,
+            event_handler=self.event_handler,
             executor=self.executor,
         )
 

--- a/tests/vibesys/_agent_cli/test_codex.py
+++ b/tests/vibesys/_agent_cli/test_codex.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock
 from vibesys._agent_cli.codex import (
     CodexCodingAgent,
     CodexGenerationSession,
+    _PairedCodexToolEvents,
     _shell_path_config_args,
 )
 from vibesys._agent_cli.gemini import GeminiCodingAgent
@@ -363,6 +364,124 @@ class TestProcessStdout:
         session = _session()
         session._process_stdout("   \n")  # noqa: SLF001  # tracked: #288
         assert session.stdout_lines == []
+
+
+# ---------------------------------------------------------------------------
+# Tool-event pairing
+# ---------------------------------------------------------------------------
+
+
+def _agent_session(handler) -> CodexGenerationSession:  # noqa: ANN001  # tracked: #288
+    """Build a session through the agent, so the pairing wrapper is wired in."""
+    agent = _agent()
+    agent.binary_name = "codex"
+    agent.env = {}
+    agent.logger = MagicMock()
+    agent.executor = None
+    agent.event_handler = handler
+    return agent._create_session(["codex", "exec", "--json", "-"], silent=True)  # noqa: SLF001  # tracked: #288
+
+
+class TestToolEventPairing:
+    def test_generic_item_lifecycle_reaches_handler_as_one_call_and_one_result(self):  # noqa: ANN202  # tracked: #288
+        """One codex ``file_change`` item must surface exactly one tool call
+        and one tool result, whichever agentshim maps its lifecycle events to
+        (agentshim <= 0.5.1 reports ``item.completed`` as a second identical
+        tool call and no result)."""
+        handler = MagicMock()
+        session = _agent_session(handler)
+        for event_type, status in [
+            ("item.started", "in_progress"),
+            ("item.completed", "completed"),
+        ]:
+            session._process_stdout(  # noqa: SLF001  # tracked: #288
+                json.dumps(
+                    {
+                        "type": event_type,
+                        "item": {
+                            "id": "fc1",
+                            "type": "file_change",
+                            "status": status,
+                            "path": "engine.py",
+                            "kind": "update",
+                        },
+                    }
+                )
+            )
+        handler.on_tool_call.assert_called_once_with(
+            "file_change", {"path": "engine.py", "kind": "update"}
+        )
+        handler.on_tool_result.assert_called_once()
+        result = handler.on_tool_result.call_args.kwargs
+        assert result["tool"] == "file_change"
+        assert result.get("stdout", "") == ""
+        assert result["exit_code"] is None
+        assert result["duration"] is not None
+        assert result["duration"] >= 0
+        # The result must follow the call.
+        tool_events = [name for name, *_ in handler.method_calls if name.startswith("on_tool")]
+        assert tool_events == ["on_tool_call", "on_tool_result"]
+
+    def test_create_session_without_handler_adds_no_wrapper(self):  # noqa: ANN202  # tracked: #288
+        session = _agent_session(None)
+        assert not isinstance(session.event_handler, _PairedCodexToolEvents)
+
+    def test_duplicate_call_becomes_the_missing_result(self):  # noqa: ANN202  # tracked: #288
+        inner = MagicMock()
+        paired = _PairedCodexToolEvents(inner)
+        paired.on_tool_call("file_change", {"path": "a.py"})
+        paired.on_tool_call("file_change", {"path": "a.py"})
+        inner.on_tool_call.assert_called_once_with("file_change", {"path": "a.py"})
+        inner.on_tool_result.assert_called_once()
+        assert inner.on_tool_result.call_args.kwargs["tool"] == "file_change"
+        assert inner.on_tool_result.call_args.kwargs["duration"] >= 0
+
+    def test_consecutive_identical_items_each_get_a_call_and_a_result(self):  # noqa: ANN202  # tracked: #288
+        """started/completed, twice over: two items, two calls, two results."""
+        inner = MagicMock()
+        paired = _PairedCodexToolEvents(inner)
+        for _ in range(2):
+            paired.on_tool_call("file_change", {"path": "a.py"})
+            paired.on_tool_call("file_change", {"path": "a.py"})
+        assert inner.on_tool_call.call_count == 2
+        assert inner.on_tool_result.call_count == 2
+
+    def test_execute_calls_are_never_folded(self):  # noqa: ANN202  # tracked: #288
+        """Command executions already pair correctly upstream; repeating an
+        identical command must stay two distinct calls."""
+        inner = MagicMock()
+        paired = _PairedCodexToolEvents(inner)
+        paired.on_tool_call("execute", {"command": "ls"})
+        paired.on_tool_call("execute", {"command": "ls"})
+        assert inner.on_tool_call.call_count == 2
+        inner.on_tool_result.assert_not_called()
+
+    def test_real_result_closes_the_open_call(self):  # noqa: ANN202  # tracked: #288
+        """Under a fixed adapter the completion arrives as a result; the next
+        identical call is then a new item, not an echo to fold."""
+        inner = MagicMock()
+        paired = _PairedCodexToolEvents(inner)
+        paired.on_tool_call("file_change", {"path": "a.py"})
+        paired.on_tool_result(tool="file_change", stdout="", exit_code=None, duration=0.1)
+        paired.on_tool_call("file_change", {"path": "a.py"})
+        assert inner.on_tool_call.call_count == 2
+        inner.on_tool_result.assert_called_once_with(
+            tool="file_change", stdout="", exit_code=None, duration=0.1
+        )
+
+    def test_changed_args_are_a_new_call_not_an_echo(self):  # noqa: ANN202  # tracked: #288
+        inner = MagicMock()
+        paired = _PairedCodexToolEvents(inner)
+        paired.on_tool_call("file_change", {"path": "a.py"})
+        paired.on_tool_call("file_change", {"path": "b.py"})
+        assert inner.on_tool_call.call_count == 2
+        inner.on_tool_result.assert_not_called()
+
+    def test_other_callbacks_delegate_to_the_inner_handler(self):  # noqa: ANN202  # tracked: #288
+        inner = MagicMock()
+        paired = _PairedCodexToolEvents(inner)
+        paired.on_thinking("hello")
+        inner.on_thinking.assert_called_once_with("hello")
 
 
 class TestProcessStderr:

--- a/tests/vibesys/_agent_cli/test_codex.py
+++ b/tests/vibesys/_agent_cli/test_codex.py
@@ -10,20 +10,28 @@ These tests exercise :mod:`vibesys._agent_cli.codex` without spawning the real
 3. ``CodexGenerationSession`` captures cumulative token usage from
    ``turn.completed`` events and forwards a ``reasoning`` item's text through
    the event handler.
+4. ``_PairedCodexSession`` pairs a generic item's ``item.started`` and
+   ``item.completed`` (both mapped to tool-use upstream) by item id into one
+   ``on_tool_call`` / ``on_tool_result`` pair.
 """
 
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
+
+from agentshim.codex.events import ToolResultEvent
 
 from vibesys._agent_cli.codex import (
     CodexCodingAgent,
     CodexGenerationSession,
-    _PairedCodexToolEvents,
     _shell_path_config_args,
 )
 from vibesys._agent_cli.gemini import GeminiCodingAgent
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 def _agent() -> CodexCodingAgent:
@@ -372,7 +380,7 @@ class TestProcessStdout:
 
 
 def _agent_session(handler) -> CodexGenerationSession:  # noqa: ANN001  # tracked: #288
-    """Build a session through the agent, so the pairing wrapper is wired in."""
+    """Build a session through the agent, so the pairing subclass is wired in."""
     agent = _agent()
     agent.binary_name = "codex"
     agent.env = {}
@@ -382,106 +390,305 @@ def _agent_session(handler) -> CodexGenerationSession:  # noqa: ANN001  # tracke
     return agent._create_session(["codex", "exec", "--json", "-"], silent=True)  # noqa: SLF001  # tracked: #288
 
 
+def _item_line(event_type: str, item: Mapping[str, object]) -> str:
+    """Serialize one raw codex item lifecycle line."""
+    return json.dumps({"type": event_type, "item": dict(item)})
+
+
+def _tool_events(handler: MagicMock) -> list[str]:
+    """Ordered names of the tool callbacks the handler received."""
+    return [name for name, *_ in handler.method_calls if name.startswith("on_tool")]
+
+
 class TestToolEventPairing:
-    def test_generic_item_lifecycle_reaches_handler_as_one_call_and_one_result(self):  # noqa: ANN202  # tracked: #288
-        """One codex ``file_change`` item must surface exactly one tool call
-        and one tool result, whichever agentshim maps its lifecycle events to
-        (agentshim <= 0.5.1 reports ``item.completed`` as a second identical
-        tool call and no result)."""
+    """Pairing of generic codex items into call/result pairs by item id.
+
+    agentshim maps a generic item's ``item.started`` and ``item.completed``
+    both to tool-use events, and the completion payload differs from the
+    start (``result`` / ``error`` get populated), so the session must pair
+    the two by the stable item id, not by argument equality.
+    """
+
+    def test_mcp_lifecycle_emits_one_call_and_one_result(self) -> None:
+        """The reviewed defect: completion parameters differ from the start."""
         handler = MagicMock()
         session = _agent_session(handler)
-        for event_type, status in [
-            ("item.started", "in_progress"),
-            ("item.completed", "completed"),
-        ]:
-            session._process_stdout(  # noqa: SLF001  # tracked: #288
-                json.dumps(
-                    {
-                        "type": event_type,
-                        "item": {
-                            "id": "fc1",
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.started",
+                {
+                    "id": "item_5",
+                    "type": "mcp_tool_call",
+                    "server": "docs",
+                    "tool": "search",
+                    "arguments": {"query": "x"},
+                    "result": None,
+                    "error": None,
+                    "status": "in_progress",
+                },
+            )
+        )
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.completed",
+                {
+                    "id": "item_5",
+                    "type": "mcp_tool_call",
+                    "server": "docs",
+                    "tool": "search",
+                    "arguments": {"query": "x"},
+                    "result": {"content": [{"type": "text", "text": "hits"}]},
+                    "error": None,
+                    "status": "completed",
+                },
+            )
+        )
+        handler.on_tool_call.assert_called_once_with(
+            "mcp_tool_call",
+            {
+                "server": "docs",
+                "tool": "search",
+                "arguments": {"query": "x"},
+                "result": None,
+                "error": None,
+            },
+        )
+        handler.on_tool_result.assert_called_once()
+        result = handler.on_tool_result.call_args.kwargs
+        assert result["tool"] == "mcp_tool_call"
+        assert "hits" in result["stdout"]
+        assert result["exit_code"] is None
+        assert result["duration"] is not None
+        assert result["duration"] >= 0
+        assert _tool_events(handler) == ["on_tool_call", "on_tool_result"]
+
+    def test_identical_parameters_with_distinct_ids_stay_two_items(self) -> None:
+        """Byte-identical payloads must pair by id, not by argument equality."""
+        handler = MagicMock()
+        session = _agent_session(handler)
+        for item_id in ("item_a", "item_b"):
+            for event_type, status in (
+                ("item.started", "in_progress"),
+                ("item.completed", "completed"),
+            ):
+                session._process_stdout(  # noqa: SLF001  # tracked: #288
+                    _item_line(
+                        event_type,
+                        {
+                            "id": item_id,
                             "type": "file_change",
                             "status": status,
                             "path": "engine.py",
                             "kind": "update",
                         },
-                    }
+                    )
                 )
+        assert handler.on_tool_call.call_count == 2
+        assert handler.on_tool_result.call_count == 2
+        assert _tool_events(handler) == [
+            "on_tool_call",
+            "on_tool_result",
+            "on_tool_call",
+            "on_tool_result",
+        ]
+        # file_change has no output payload; results carry empty stdout.
+        assert [c.kwargs["stdout"] for c in handler.on_tool_result.call_args_list] == ["", ""]
+
+    def test_interleaved_items_pair_by_id(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        item_a = {"id": "a", "type": "file_change", "path": "a.py"}
+        item_b = {"id": "b", "type": "web_search", "query": "docs"}
+        lines = [
+            ("item.started", {**item_a, "status": "in_progress"}),
+            ("item.started", {**item_b, "status": "in_progress"}),
+            ("item.completed", {**item_b, "status": "completed", "result": "found"}),
+            ("item.completed", {**item_a, "status": "completed"}),
+        ]
+        for event_type, item in lines:
+            session._process_stdout(_item_line(event_type, item))  # noqa: SLF001  # tracked: #288
+        assert [c.args[0] for c in handler.on_tool_call.call_args_list] == [
+            "file_change",
+            "web_search",
+        ]
+        assert [c.kwargs["tool"] for c in handler.on_tool_result.call_args_list] == [
+            "web_search",
+            "file_change",
+        ]
+
+    def test_identical_overlapping_items_keep_both_starts(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        for event_type, item_id in (
+            ("item.started", "a"),
+            ("item.started", "b"),
+            ("item.completed", "b"),
+            ("item.completed", "a"),
+        ):
+            session._process_stdout(  # noqa: SLF001  # tracked: #288
+                _item_line(event_type, {"id": item_id, "type": "file_change", "changes": []})
             )
-        handler.on_tool_call.assert_called_once_with(
-            "file_change", {"path": "engine.py", "kind": "update"}
+        assert _tool_events(handler) == [
+            "on_tool_call",
+            "on_tool_call",
+            "on_tool_result",
+            "on_tool_result",
+        ]
+
+    def test_identical_completion_only_items_each_get_a_pair(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        for item_id in ("a", "b"):
+            session._process_stdout(  # noqa: SLF001  # tracked: #288
+                _item_line("item.completed", {"id": item_id, "type": "file_change", "changes": []})
+            )
+        assert _tool_events(handler) == [
+            "on_tool_call",
+            "on_tool_result",
+            "on_tool_call",
+            "on_tool_result",
+        ]
+
+    def test_completion_without_observed_start_synthesizes_the_call(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.completed",
+                {
+                    "id": "w1",
+                    "type": "web_search",
+                    "status": "completed",
+                    "query": "q",
+                    "result": "r",
+                },
+            )
         )
+        handler.on_tool_call.assert_called_once_with("web_search", {"query": "q", "result": "r"})
         handler.on_tool_result.assert_called_once()
         result = handler.on_tool_result.call_args.kwargs
-        assert result["tool"] == "file_change"
-        assert result.get("stdout", "") == ""
-        assert result["exit_code"] is None
-        assert result["duration"] is not None
-        assert result["duration"] >= 0
-        # The result must follow the call.
-        tool_events = [name for name, *_ in handler.method_calls if name.startswith("on_tool")]
-        assert tool_events == ["on_tool_call", "on_tool_result"]
+        assert result["tool"] == "web_search"
+        assert result["stdout"] == "r"
+        assert result["duration"] is None
+        assert _tool_events(handler) == ["on_tool_call", "on_tool_result"]
 
-    def test_create_session_without_handler_adds_no_wrapper(self):  # noqa: ANN202  # tracked: #288
-        session = _agent_session(None)
-        assert not isinstance(session.event_handler, _PairedCodexToolEvents)
-
-    def test_duplicate_call_becomes_the_missing_result(self):  # noqa: ANN202  # tracked: #288
-        inner = MagicMock()
-        paired = _PairedCodexToolEvents(inner)
-        paired.on_tool_call("file_change", {"path": "a.py"})
-        paired.on_tool_call("file_change", {"path": "a.py"})
-        inner.on_tool_call.assert_called_once_with("file_change", {"path": "a.py"})
-        inner.on_tool_result.assert_called_once()
-        assert inner.on_tool_result.call_args.kwargs["tool"] == "file_change"
-        assert inner.on_tool_result.call_args.kwargs["duration"] >= 0
-
-    def test_consecutive_identical_items_each_get_a_call_and_a_result(self):  # noqa: ANN202  # tracked: #288
-        """started/completed, twice over: two items, two calls, two results."""
-        inner = MagicMock()
-        paired = _PairedCodexToolEvents(inner)
-        for _ in range(2):
-            paired.on_tool_call("file_change", {"path": "a.py"})
-            paired.on_tool_call("file_change", {"path": "a.py"})
-        assert inner.on_tool_call.call_count == 2
-        assert inner.on_tool_result.call_count == 2
-
-    def test_execute_calls_are_never_folded(self):  # noqa: ANN202  # tracked: #288
-        """Command executions already pair correctly upstream; repeating an
-        identical command must stay two distinct calls."""
-        inner = MagicMock()
-        paired = _PairedCodexToolEvents(inner)
-        paired.on_tool_call("execute", {"command": "ls"})
-        paired.on_tool_call("execute", {"command": "ls"})
-        assert inner.on_tool_call.call_count == 2
-        inner.on_tool_result.assert_not_called()
-
-    def test_real_result_closes_the_open_call(self):  # noqa: ANN202  # tracked: #288
-        """Under a fixed adapter the completion arrives as a result; the next
-        identical call is then a new item, not an echo to fold."""
-        inner = MagicMock()
-        paired = _PairedCodexToolEvents(inner)
-        paired.on_tool_call("file_change", {"path": "a.py"})
-        paired.on_tool_result(tool="file_change", stdout="", exit_code=None, duration=0.1)
-        paired.on_tool_call("file_change", {"path": "a.py"})
-        assert inner.on_tool_call.call_count == 2
-        inner.on_tool_result.assert_called_once_with(
-            tool="file_change", stdout="", exit_code=None, duration=0.1
+    def test_command_execution_keeps_base_pairing(self) -> None:
+        """``execute`` items pair upstream; the id pairing must not interfere."""
+        handler = MagicMock()
+        session = _agent_session(handler)
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.started",
+                {
+                    "id": "c1",
+                    "type": "command_execution",
+                    "status": "in_progress",
+                    "command": "ls -la",
+                },
+            )
         )
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.completed",
+                {
+                    "id": "c1",
+                    "type": "command_execution",
+                    "status": "completed",
+                    "command": "ls -la",
+                    "aggregated_output": "file.txt\n",
+                    "exit_code": 0,
+                },
+            )
+        )
+        handler.on_tool_call.assert_called_once_with("execute", {"command": "ls -la"})
+        handler.on_tool_result.assert_called_once()
+        result = handler.on_tool_result.call_args.kwargs
+        assert result["tool"] == "execute"
+        assert result["stdout"] == "file.txt\n"
+        assert result["exit_code"] == 0
+        assert result["duration"] is not None
 
-    def test_changed_args_are_a_new_call_not_an_echo(self):  # noqa: ANN202  # tracked: #288
-        inner = MagicMock()
-        paired = _PairedCodexToolEvents(inner)
-        paired.on_tool_call("file_change", {"path": "a.py"})
-        paired.on_tool_call("file_change", {"path": "b.py"})
-        assert inner.on_tool_call.call_count == 2
-        inner.on_tool_result.assert_not_called()
+    def test_real_result_event_closes_started_item_without_duplicate_call(self) -> None:
+        """A fixed adapter emitting a real ToolResultEvent must resolve cleanly."""
+        handler = MagicMock()
+        session = _agent_session(handler)
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            _item_line(
+                "item.started",
+                {
+                    "id": "m1",
+                    "type": "mcp_tool_call",
+                    "status": "in_progress",
+                    "server": "docs",
+                    "tool": "search",
+                    "arguments": {"query": "x"},
+                },
+            )
+        )
+        session._handle_event(  # noqa: SLF001  # tracked: #288
+            ToolResultEvent(
+                tool_id="m1",
+                output="done",
+                tool_name="mcp_tool_call",
+                parameters={"server": "docs"},
+            )
+        )
+        handler.on_tool_call.assert_called_once()
+        handler.on_tool_result.assert_called_once()
+        result = handler.on_tool_result.call_args.kwargs
+        assert result["tool"] == "mcp_tool_call"
+        assert result["stdout"] == "done"
+        assert result["duration"] is not None
 
-    def test_other_callbacks_delegate_to_the_inner_handler(self):  # noqa: ANN202  # tracked: #288
-        inner = MagicMock()
-        paired = _PairedCodexToolEvents(inner)
-        paired.on_thinking("hello")
-        inner.on_thinking.assert_called_once_with("hello")
+    def test_failed_completion_surfaces_the_error(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        for event_type, extra in (
+            ("item.started", {"result": None, "error": None, "status": "in_progress"}),
+            ("item.completed", {"result": None, "error": {"message": "boom"}, "status": "failed"}),
+        ):
+            session._process_stdout(  # noqa: SLF001  # tracked: #288
+                _item_line(
+                    event_type,
+                    {
+                        "id": "m2",
+                        "type": "mcp_tool_call",
+                        "server": "docs",
+                        "tool": "search",
+                        "arguments": {},
+                        **extra,
+                    },
+                )
+            )
+        handler.on_tool_call.assert_called_once()
+        handler.on_tool_result.assert_called_once()
+        assert "boom" in handler.on_tool_result.call_args.kwargs["stdout"]
+
+    def test_item_updated_and_non_json_lines_emit_no_tool_events(self) -> None:
+        handler = MagicMock()
+        session = _agent_session(handler)
+        item = {"id": "f1", "type": "file_change", "status": "in_progress", "path": "a.py"}
+        session._process_stdout(_item_line("item.started", item))  # noqa: SLF001  # tracked: #288
+        session._process_stdout(_item_line("item.updated", item))  # noqa: SLF001  # tracked: #288
+        session._process_stdout("starting codex 1.2.3\n")  # noqa: SLF001  # tracked: #288
+        assert handler.on_tool_call.call_count == 1
+        handler.on_tool_result.assert_not_called()
+
+    def test_session_without_handler_processes_a_full_lifecycle(self) -> None:
+        session = _agent_session(None)
+        for event_type, status in (
+            ("item.started", "in_progress"),
+            ("item.completed", "completed"),
+        ):
+            session._process_stdout(  # noqa: SLF001  # tracked: #288
+                _item_line(
+                    event_type,
+                    {"id": "f2", "type": "file_change", "status": status, "path": "a.py"},
+                )
+            )
+        assert session.tool_map == {}
+        assert session.tool_start_times == {}
+        assert session.tool_args == {}
 
 
 class TestProcessStderr:


### PR DESCRIPTION
## Problem

Fixes #618. AgentShim 0.5.x reports generic Codex item starts and completions as tool calls, leaving duplicate calls without results in the journal. The original argument-equality workaround also failed when MCP completions populated `result` or `error`, and could confuse distinct items with identical arguments.

## Solution

Pair events inside the existing Codex CLI adapter while raw `item.started` / `item.completed` kinds and stable item IDs are available. `_PairedCodexSession` registers generic starts in AgentShim's existing item maps, converts generic completion echoes into `ToolResultEvent`, and delegates callback emission and duration calculation to the base session. Completed generic entries are removed from the maps.

The original start arguments remain on the call; completion output and errors become result text. Completion-only items receive a synthetic call followed by their result. Command execution and other callbacks retain AgentShim's existing handling. A parser that already supplies `ToolResultEvent` also follows the same registered-ID path.

### Architecture

```mermaid
flowchart TD
    A[Codex JSON item lifecycle and ID] --> B[VibeSys Codex session adapter]
    B --> C[AgentShim ToolUseEvent / ToolResultEvent paired by ID]
    C --> D[Neutral driver events]
    D --> E[Application logger, journal, and clients]
```

The compatibility code stays in `src/vibesys/_agent_cli/codex.py`; installed packages and the wire schema are unchanged. PR #620 includes the identical adapter and tests, so either PR works independently.

## Verification

### Correctness properties

- Changed completion payloads produce one call with the original arguments and one result containing the completion output or error.
- Consecutive identical items, overlapping starts, and completion-only items remain separate by item ID.
- Command executions and native result events retain their existing call/result handling.
- Generic state belongs to one session and is removed after completion.

### Testing

- Before the fix, the MCP changed-result, interleaved-item, and completion-only regressions failed against `1aa055cb` through the installed parser and real `_process_stdout` path.
- `python -m pytest tests/vibesys/_agent_cli/test_codex.py tests/vibesys/agents/drivers/test_agentshim_driver.py tests/vibesys/agents/test_callbacks.py -q --no-cov`: 138 passed, using the existing Python environment with this worktree's source roots on `PYTHONPATH`.
- Changed-file `ruff check`, `ruff format --check`, and `ty check`: passed. `git diff --check`: passed.
- A broader `_agent_cli` plus `agents` run stalled and was interrupted. It is not counted as passing. No new live provider run was performed for this revision.

Closes #618.
