### PR TITLE
opencode driver: session resume, stale-session recovery, error events, drop stale PWD

### DIFF
--- a/src/vibesys/_agent_cli/opencode.py
+++ b/src/vibesys/_agent_cli/opencode.py
@@ -12,6 +12,39 @@ if TYPE_CHECKING:
 
 OPENCODE_DEFAULT_MODEL = "google-vertex/gemini-3-pro-preview"
 
+# How many of opencode's ``{"type":"error",...}`` stdout events to keep for the
+# failure message; the last ones name the actual provider/API failure.
+_ERROR_EVENTS_TO_KEEP = 5
+
+
+class _ErrorCapturingOpencodeSession(OpencodeGenerationSession):
+    """Keep opencode's ``error`` events so a failed run says why it failed.
+
+    agentshim's parser handles text, step-finish and tool events; opencode
+    reports API and provider failures as ``{"type":"error",...}`` events on
+    stdout, which otherwise vanish and leave a bare "exited with code 1".
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401  # tracked: #288
+        super().__init__(*args, **kwargs)
+        self.raw_error_lines: list[str] = []
+
+    def _process_stdout(self, line: str) -> None:
+        if '"type":"error"' in line:
+            self.raw_error_lines.append(line.rstrip("\n"))
+            del self.raw_error_lines[:-_ERROR_EVENTS_TO_KEEP]
+        super()._process_stdout(line)
+
+    def run(self, prompt: str) -> str:
+        """Run the generation; append captured error events to a failure."""
+        try:
+            return super().run(prompt)
+        except RuntimeError as exc:
+            if not self.raw_error_lines:
+                raise
+            detail = "\n".join(self.raw_error_lines)
+            raise RuntimeError(f"{exc}\nopencode error events:\n{detail}") from exc  # noqa: TRY003  # tracked: #288
+
 
 class OpencodeCodingAgent(CLICodingAgent[OpencodeGenerationSession]):
     """Coding agent implementation using the Opencode CLI tool."""
@@ -44,16 +77,31 @@ class OpencodeCodingAgent(CLICodingAgent[OpencodeGenerationSession]):
         """Return the log prefix for this agent."""
         return "[Opencode]"
 
-    def _get_command(self, prompt: str) -> list[str]:
-        cmd = [self.binary_path, "run", f'"{prompt}"']
-
+    def _base_command(self) -> list[str]:
+        # The prompt reaches opencode on stdin (``CLIGenerationSession.run``
+        # writes it there). Passing it as a positional as well would send it
+        # twice and, for long orchestrator prompts, exceed the OS argv limit.
+        cmd = [self.binary_path, "run"]
         if self.model:
             cmd.extend(["--model", self.model])
-
-        # Output in json format
-        cmd.extend(["--format=json"])
-
+        cmd.append("--format=json")
         return cmd
+
+    def _get_command(self, prompt: str) -> list[str]:  # noqa: ARG002  # tracked: #288
+        return self._base_command()
+
+    def _get_resume_command(self, prompt: str, session_id: str) -> list[str]:  # noqa: ARG002  # tracked: #288
+        # Continue the SAME opencode session so follow-ups (retry feedback, a
+        # missing-response nudge) keep the conversation context. Without this
+        # every follow-up lands in a fresh, empty session.
+        cmd = self._base_command()
+        cmd[2:2] = ["--session", session_id]
+        return cmd
+
+    def _extract_session_id(self, session: OpencodeGenerationSession) -> str | None:
+        # ``OpencodeGenerationSession`` captures ``sessionID`` from the JSON
+        # event stream while parsing stdout.
+        return session.session_id
 
     def _create_session(
         self,
@@ -62,7 +110,7 @@ class OpencodeCodingAgent(CLICodingAgent[OpencodeGenerationSession]):
         timeout: int | None = None,
         silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> OpencodeGenerationSession:
-        return OpencodeGenerationSession(
+        return _ErrorCapturingOpencodeSession(
             binary_name=self.binary_name,
             env=self.env,
             log_prefix=self._log_prefix,

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -89,6 +89,12 @@ def _is_missing_codex_rollout(exc: RuntimeError) -> bool:
     return "thread/resume failed" in message and "no rollout found" in message
 
 
+def _is_missing_opencode_session(exc: RuntimeError) -> bool:
+    # ``opencode run --session <id>`` prints ``Error: Session not found`` when
+    # its session store no longer has the session (rebuilt or cleaned up).
+    return "session not found" in str(exc).lower()
+
+
 def _heavy_codex_turn_reason(agent: CodingAgent) -> str | None:
     session = getattr(agent, "_last_session", None)
     usage = getattr(session, "final_usage", None) or {}
@@ -418,6 +424,8 @@ class AgentShimSession:
         if self._provider == "codex":
             # Codex names the cause: the rollout the thread ID points at is gone.
             return _is_missing_codex_rollout(exc)
+        if self._provider == "opencode":
+            return _is_missing_opencode_session(exc)
         # Claude Code reports a rejected ``--resume`` as a plain nonzero exit
         # with no distinguishing message, and a session it will not resume is
         # unrecoverable, so any failed resumed turn is retried once from a
@@ -501,6 +509,10 @@ class AgentShimDriver:
             agent = self._provider_cls(model=spec.model, event_handler=event_handler)
         if spec.environment:
             agent.env = {**agent.env, **dict(spec.environment)}
+        # A subprocess cwd does not rewrite $PWD, and bun-based CLIs (opencode)
+        # trust $PWD over the real cwd for workspace config discovery: a stale
+        # value makes them miss <workspace>/opencode.json. Let the cwd win.
+        agent.env = {key: value for key, value in agent.env.items() if key != "PWD"}
 
         if not in_container:
             resources = declare_agent_host_resources(

--- a/tests/vibesys/_agent_cli/test_opencode.py
+++ b/tests/vibesys/_agent_cli/test_opencode.py
@@ -1,0 +1,113 @@
+"""Unit tests for the Opencode provider's command construction and error capture.
+
+These tests exercise :mod:`vibesys._agent_cli.opencode` without spawning the
+real ``opencode`` binary:
+
+1. ``_get_command`` carries no prompt positional (the prompt goes to stdin, as
+   for every provider; a positional would send it twice and hit the argv limit
+   on long orchestrator prompts).
+2. ``_get_resume_command`` continues the same session with ``--session``, and
+   ``_extract_session_id`` reads the id the JSON stream reported.
+3. ``{"type":"error"}`` stdout events are kept and appended to the failure
+   message when a run exits non-zero.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vibesys._agent_cli.opencode import OpencodeCodingAgent, _ErrorCapturingOpencodeSession
+
+
+def _agent(model: str | None = "openrouter/some-model") -> OpencodeCodingAgent:
+    """Build an OpencodeCodingAgent without running binary detection."""
+    agent = OpencodeCodingAgent.__new__(OpencodeCodingAgent)
+    agent.binary_path = "/usr/local/bin/opencode"
+    agent.model = model
+    return agent
+
+
+def _session() -> _ErrorCapturingOpencodeSession:
+    return _ErrorCapturingOpencodeSession(
+        binary_name="opencode",
+        env={},
+        log_prefix="[Opencode]",
+        cmd=["opencode", "run", "--format=json"],
+        logger=MagicMock(),
+        silent=True,
+        event_handler=None,
+    )
+
+
+class TestGetCommand:
+    def test_initial_command_has_no_prompt_positional(self) -> None:  # tracked: #288
+        cmd = _agent()._get_command("a very long prompt")  # noqa: SLF001  # tracked: #288
+        assert cmd == [
+            "/usr/local/bin/opencode",
+            "run",
+            "--model",
+            "openrouter/some-model",
+            "--format=json",
+        ]
+        assert "a very long prompt" not in " ".join(cmd)
+
+    def test_initial_command_omits_model_when_unset(self) -> None:  # tracked: #288
+        cmd = _agent(model=None)._get_command("prompt")  # noqa: SLF001  # tracked: #288
+        assert cmd == ["/usr/local/bin/opencode", "run", "--format=json"]
+
+    def test_resume_command_continues_the_session(self) -> None:  # tracked: #288
+        cmd = _agent()._get_resume_command("prompt", "ses_123")  # noqa: SLF001  # tracked: #288
+        assert cmd == [
+            "/usr/local/bin/opencode",
+            "run",
+            "--session",
+            "ses_123",
+            "--model",
+            "openrouter/some-model",
+            "--format=json",
+        ]
+
+    def test_extract_session_id_reads_the_stream_id(self) -> None:  # tracked: #288
+        session = _session()
+        assert _agent()._extract_session_id(session) is None  # noqa: SLF001  # tracked: #288
+        session._process_stdout('{"type":"text","sessionID":"ses_abc","part":{"text":"hi"}}\n')  # noqa: SLF001  # tracked: #288
+        assert _agent()._extract_session_id(session) == "ses_abc"  # noqa: SLF001  # tracked: #288
+
+
+class TestErrorCapture:
+    def test_error_events_are_appended_to_the_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = _session()
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
+            '{"type":"error","error":{"name":"ProviderError","data":{"message":"rate limited"}}}\n'
+        )  # tracked: #288
+
+        def failing_run(self: object, prompt: str) -> str:  # noqa: ARG001
+            raise RuntimeError("opencode exited with code 1: ")  # noqa: TRY003  # tracked: #288
+
+        monkeypatch.setattr(
+            "agentshim.cli_agent.CLIGenerationSession.run", failing_run, raising=True
+        )
+        with pytest.raises(RuntimeError) as info:
+            session.run("prompt")
+        message = str(info.value)
+        assert message.startswith("opencode exited with code 1")
+        assert "opencode error events:" in message
+        assert "rate limited" in message
+
+    def test_failure_without_error_events_is_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = _session()
+
+        def failing_run(self: object, prompt: str) -> str:  # noqa: ARG001
+            raise RuntimeError("opencode exited with code 1: boom")  # noqa: TRY003  # tracked: #288
+
+        monkeypatch.setattr(
+            "agentshim.cli_agent.CLIGenerationSession.run", failing_run, raising=True
+        )
+        with pytest.raises(RuntimeError, match=r"^opencode exited with code 1: boom$"):
+            session.run("prompt")

--- a/tests/vibesys/agents/drivers/test_agentshim_driver.py
+++ b/tests/vibesys/agents/drivers/test_agentshim_driver.py
@@ -545,3 +545,77 @@ def test_a_fresh_claude_turn_that_fails_is_not_retried(
     with pytest.raises(RuntimeError):
         session.run_turn(AgentTurnRequest(message="one"))
     assert attempts == [None]
+
+
+@pytest.fixture
+def fake_opencode_agent(monkeypatch: pytest.MonkeyPatch) -> list[_FakeAgent]:
+    built: list[_FakeAgent] = []
+
+    def factory(
+        model: str | None = None,
+        event_handler: Any | None = None,  # noqa: ANN401  # tracked: #288
+        *,
+        executor: Any | None = None,  # noqa: ANN401  # tracked: #288
+    ) -> _FakeAgent:
+        agent = _FakeAgent(model, event_handler, executor=executor)
+        built.append(agent)
+        return agent
+
+    monkeypatch.setitem(subject._PROVIDER_CLASSES, "opencode", factory)  # noqa: SLF001
+    monkeypatch.setattr(subject, "declare_agent_host_resources", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(subject, "build_host_sandbox", lambda *_args, **_kwargs: "sandbox")
+    return built
+
+
+def test_opencode_missing_session_retries_once_with_a_fresh_session(
+    fake_opencode_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="opencode")
+    session = driver.create_session(_spec(tmp_path, provider="opencode"))
+    agent = fake_opencode_agent[0]
+    seen: list[str | None] = []
+
+    def generate(prompt: str, /, *, cwd: str | None, timeout: int | None, silent: bool) -> str:  # noqa: ARG001
+        seen.append(agent.session_id)
+        if agent.session_id is not None:
+            raise RuntimeError("opencode exited with code 1: Error: Session not found")  # noqa: TRY003  # tracked: #288
+        return "fresh"
+
+    agent.generate_override = generate
+
+    result = session.run_turn(AgentTurnRequest(message="again"), _Observer())
+
+    assert result.text == "fresh"
+    assert result.disposition is subject.SessionDisposition.RESET_REQUIRED
+    assert seen == ["session-1", None]
+
+
+def test_opencode_other_failures_are_not_retried(
+    fake_opencode_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="opencode")
+    session = driver.create_session(_spec(tmp_path, provider="opencode"))
+    agent = fake_opencode_agent[0]
+    calls = 0
+
+    def generate(prompt: str, /, *, cwd: str | None, timeout: int | None, silent: bool) -> str:  # noqa: ARG001
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("opencode exited with code 1: provider error")  # noqa: TRY003  # tracked: #288
+
+    agent.generate_override = generate
+
+    with pytest.raises(RuntimeError, match="provider error"):
+        session.run_turn(AgentTurnRequest(message="again"), _Observer())
+    assert calls == 1
+    assert agent.session_id == "session-1"
+
+
+def test_session_environment_drops_the_inherited_pwd(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="codex")
+    driver.create_session(_spec(tmp_path, environment=(("PWD", "/somewhere/stale"), ("GPU", "1"))))
+
+    assert "PWD" not in fake_agent[0].env
+    assert fake_agent[0].env["GPU"] == "1"


### PR DESCRIPTION
## Summary

Brings the opencode provider to parity with codex and claude so multi-turn agent sessions work with `--cli-provider opencode`:

- `_agent_cli/opencode.py`: implement `_get_resume_command` (`opencode run --session <id>`) and `_extract_session_id` (the `sessionID` the JSON event stream reports). Without them every follow-up turn (retry feedback, a structured-reply nudge) started a blank conversation. The prompt is no longer also passed as a positional: `CLIGenerationSession.run` already writes it to stdin, so the positional sent it twice and long orchestrator prompts exceeded the OS argv limit. opencode reports provider/API failures as `{"type":"error"}` stdout events; the last few are kept and appended to the `RuntimeError` so a failed turn says why instead of a bare "exited with code 1".
- `agents/drivers/agentshim.py`: treat opencode's `Error: Session not found` as a failed resume (retry once from a fresh conversation, like a dead codex rollout), and drop the inherited `PWD` from the agent environment: bun-based CLIs trust `$PWD` over the real cwd for config discovery, so a stale value made opencode miss `<workspace>/opencode.json`.

Seen on real campaigns driven by opencode (Kimi K3 / GLM 5.2 through OpenRouter) over several weeks.

## Test plan

- [x] `tests/vibesys/_agent_cli/test_opencode.py` (new): command shape, resume command, session id extraction, error-event capture
- [x] three driver tests in `tests/vibesys/agents/drivers/test_agentshim_driver.py`: stale-session retry, non-resume failures not retried, PWD dropped
- [x] `uv run pytest tests/vibesys/_agent_cli tests/vibesys/agents`: 524 passed; ruff clean