### PR TITLE
agent_runner: recover typed replies behind inline braces and raw newlines

### DIFF
--- a/src/vibesys/agent_runner.py
+++ b/src/vibesys/agent_runner.py
@@ -216,22 +216,71 @@ def parse_typed_response_text(text: str, response_cls: type[T]) -> T | None:
     fenced_matches = re.findall(r"```(?:json)?\s*(\{.*?\})\s*```", text, flags=re.DOTALL)
     candidates.extend(match.strip() for match in fenced_matches if match.strip())
 
-    start = text.find("{")
-    end = text.rfind("}")
-    if start != -1 and end != -1 and end > start:
-        candidates.append(text[start : end + 1].strip())
+    # Every balanced top-level ``{...}`` object, in order. Narrative text often
+    # carries inline braces (``{"cudagraph_mode": "FULL"}``) before the real
+    # reply, so a single first-``{``-to-last-``}`` slice would fail to parse.
+    candidates.extend(_balanced_objects(text))
 
     seen: set[str] = set()
     for candidate in candidates:
         if not candidate or candidate in seen:
             continue
         seen.add(candidate)
-        try:
-            payload = json.loads(candidate)
-            return response_cls.model_validate(payload)
-        except (json.JSONDecodeError, ValidationError, TypeError):
-            continue
+        for attempt in (candidate, _escape_control_chars_in_strings(candidate)):
+            try:
+                payload = json.loads(attempt)
+                return response_cls.model_validate(payload)
+            except (json.JSONDecodeError, ValidationError, TypeError):
+                continue
     return None
+
+
+def _balanced_objects(text: str) -> list[str]:
+    """Return each balanced top-level ``{...}`` span of *text*, in order."""
+    spans: list[str] = []
+    depth = 0
+    start = -1
+    for index, char in enumerate(text):
+        if char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}" and depth > 0:
+            depth -= 1
+            if depth == 0:
+                spans.append(text[start : index + 1].strip())
+    return spans
+
+
+def _escape_control_chars_in_strings(candidate: str) -> str:
+    r"""Escape raw newlines, tabs and carriage returns inside JSON string values.
+
+    Some models (Kimi K3 through OpenRouter, for one) emit literal newlines
+    inside string values instead of the ``\\n`` escape JSON requires, which
+    makes ``json.loads`` fail with "Unterminated string". Everything outside
+    string values is left untouched.
+    """
+    out: list[str] = []
+    in_string = False
+    escaped = False
+    for char in candidate:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            elif char in _CONTROL_ESCAPES:
+                out.append(_CONTROL_ESCAPES[char])
+                continue
+        elif char == '"':
+            in_string = True
+        out.append(char)
+    return "".join(out)
+
+
+_CONTROL_ESCAPES = {"\n": "\\n", "\t": "\\t", "\r": "\\r"}
 
 
 def _coerce_typed_response(payload: Any, response_cls: type[T]) -> T | None:  # noqa: ANN401  # tracked: #288

--- a/tests/vibesys/test_agent_runner_parse.py
+++ b/tests/vibesys/test_agent_runner_parse.py
@@ -1,0 +1,50 @@
+"""Recovery of a typed reply from raw model text (``parse_typed_response_text``).
+
+Two failure shapes seen in real runs: narrative text with inline JSON-looking
+braces before the reply object, and string values containing raw newlines
+instead of ``\\n`` escapes (Kimi K3 through OpenRouter emits both).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from vibesys.agent_runner import parse_typed_response_text
+
+
+class Reply(BaseModel):
+    analysis: str
+    verdict: str
+
+
+def test_plain_and_fenced_objects_still_parse() -> None:
+    plain = '{"analysis": "ok", "verdict": "pass"}'
+    fenced = "Here you go:\n```json\n" + plain + "\n```"
+    assert parse_typed_response_text(plain, Reply) == Reply(analysis="ok", verdict="pass")
+    assert parse_typed_response_text(fenced, Reply) == Reply(analysis="ok", verdict="pass")
+
+
+def test_reply_after_inline_braces_in_narrative_is_found() -> None:
+    text = (
+        'I set {"cudagraph_mode": "FULL_DECODE_ONLY"} in serve.sh, which crashed on '
+        'a shape {1, 2}. Final answer:\n{"analysis": "knob flipped", "verdict": "pass"}'
+    )
+    assert parse_typed_response_text(text, Reply) == Reply(analysis="knob flipped", verdict="pass")
+
+
+def test_raw_newlines_inside_string_values_are_repaired() -> None:
+    text = '{"analysis": "line one\nline two\twith tab", "verdict": "fail"}'
+    assert parse_typed_response_text(text, Reply) == Reply(
+        analysis="line one\nline two\twith tab", verdict="fail"
+    )
+
+
+def test_escaped_quotes_and_backslashes_survive_the_repair() -> None:
+    text = '{"analysis": "said \\"hi\\"\nthen C:\\\\path", "verdict": "pass"}'
+    parsed = parse_typed_response_text(text, Reply)
+    assert parsed == Reply(analysis='said "hi"\nthen C:\\path', verdict="pass")
+
+
+def test_nothing_parseable_returns_none() -> None:
+    assert parse_typed_response_text("no json here {unbalanced", Reply) is None
+    assert parse_typed_response_text("", Reply) is None


### PR DESCRIPTION
## Summary

`parse_typed_response_text` sliced the model text from the first `{` to the last `}`, so a reply preceded by narrative that itself contains braces (a knob value like `{"cudagraph_mode": "FULL_DECODE_ONLY"}` is common in implementer output) never parsed and the round fell back to the failure reply. It now tries every balanced top-level object in order.

Models that emit literal newlines or tabs inside JSON string values (Kimi K3 through OpenRouter does) failed with "Unterminated string"; each candidate is retried with those control characters escaped, leaving everything outside string values untouched.

Both shapes were seen repeatedly on real campaigns.

## Test plan

- [x] `tests/vibesys/test_agent_runner_parse.py` (new): plain/fenced still parse, reply behind inline braces, raw newline repair, escaped quotes and backslashes survive, nothing parseable returns None
- [x] `uv run pytest tests/vibesys/test_agent_runner_parse.py tests/vibesys/agents/test_agent_runners.py`: 83 passed; ruff clean