### PR TITLE
fix(tui): dim background with a scrim while a modal is open

### DIFF
--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -48,12 +48,12 @@ export interface OpenTuiApp {
 /** Which of the client's editors currently holds the cursor. */
 type FocusTarget = 'command' | 'chat' | 'modal';
 
-const KEY_HELP = `←→: rounds/agents/transcript · ↑↓: within · [/]: round · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Ctrl+L: live`;
-const SCOPED_KEY_HELP = `←→: rounds/agents/transcript · ↑↓: within · [/]: round · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Esc: back`;
-const LOG_KEY_HELP = `↑↓ or scroll: select · Enter/click: open hypothesis · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
-const LOG_CHAT_KEY_HELP = `↑↓: select · Enter/click: hypothesis · Ctrl+W: chat · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
+const KEY_HELP = `â†â†’: rounds/agents/transcript Â· â†‘â†“: within Â· [/]: round Â· F4: zoom Â· ${COMMAND_NAMES.todos} Â· ${COMMAND_NAMES.prompt} Â· Ctrl+L: live`;
+const SCOPED_KEY_HELP = `â†â†’: rounds/agents/transcript Â· â†‘â†“: within Â· [/]: round Â· F4: zoom Â· ${COMMAND_NAMES.todos} Â· ${COMMAND_NAMES.prompt} Â· Esc: back`;
+const LOG_KEY_HELP = `â†‘â†“ or scroll: select Â· Enter/click: open hypothesis Â· F4: zoom Â· ${COMMAND_NAMES['open-round']} --N`;
+const LOG_CHAT_KEY_HELP = `â†‘â†“: select Â· Enter/click: hypothesis Â· Ctrl+W: chat Â· F4: zoom Â· ${COMMAND_NAMES['open-round']} --N`;
 const HYPOTHESIS_KEY_HELP =
-  '↑↓: select round · Enter/click: trajectory · PgUp/PgDn: scroll · Esc: hypotheses';
+  'â†‘â†“: select round Â· Enter/click: trajectory Â· PgUp/PgDn: scroll Â· Esc: hypotheses';
 /** Bezel, one content row, bezel. See the header frame below. */
 const HEADER_FRAME_HEIGHT = 3;
 
@@ -61,7 +61,7 @@ const HEADER_FRAME_HEIGHT = 3;
 const HEADER_CHROME = 4;
 
 const SPLIT_KEY_HELP =
-  'Ctrl+W: switch pane · F4: zoom focused pane · PgUp/PgDn: scroll · Esc: close pane';
+  'Ctrl+W: switch pane Â· F4: zoom focused pane Â· PgUp/PgDn: scroll Â· Esc: close pane';
 
 const TRANSCRIPT_TITLE = 'Transcript';
 
@@ -71,10 +71,10 @@ const TRANSCRIPT_TITLE = 'Transcript';
  */
 function emptyTranscriptMessage(state: SessionState): string {
   const roundNumber = visibleRoundNumber(state);
-  if (roundNumber === null) return 'Waiting for run events…';
+  if (roundNumber === null) return 'Waiting for run eventsâ€¦';
   const round = stripRounds(state).find(item => item.number === roundNumber);
   if (round?.status === 'planned') return `Round ${roundNumber} has not run yet.`;
-  return 'Waiting for run events…';
+  return 'Waiting for run eventsâ€¦';
 }
 
 export function createOpenTuiApp(
@@ -127,7 +127,7 @@ export function createOpenTuiApp(
   // `flexShrink: 0` because `renderHeader` has already budgeted the line to this
   // width, so a row that still overruns is a bug rather than something to
   // absorb. Shrinking spans put an ellipsis through every one of them at once
-  // (`V...ys·r...ng`) instead of leaving the single cut the budget decided on.
+  // (`V...ysÂ·r...ng`) instead of leaving the single cut the budget decided on.
   const headerLine = new BoxRenderable(renderer, {
     id: 'header',
     width: '100%',
@@ -573,8 +573,8 @@ export function createOpenTuiApp(
     showClipboardStatus: result => {
       transientStatus =
         result === 'copied'
-          ? 'Copied selected text · Ctrl+C exits when no text is selected'
-          : 'Copy unavailable (OSC52) · selection kept · use your terminal copy command';
+          ? 'Copied selected text Â· Ctrl+C exits when no text is selected'
+          : 'Copy unavailable (OSC52) Â· selection kept Â· use your terminal copy command';
       help.content = transientStatus;
     },
   });
@@ -601,5 +601,3 @@ export function createOpenTuiApp(
     },
   };
 }
-
-

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -511,7 +511,7 @@ export function createOpenTuiApp(
     experimentLog.output.visible = showExperimentLog;
     rightPane.render(state, showRightPane, rightWidth);
     overlay.render(state, paneFallback);
-    overlay.renderScrim(state.overlay !== null || state.chatOpen);
+    overlay.renderScrim(state.overlay !== null || state.chatOpen || paneFallback !== null || state.themePicker !== null);
     themePicker.render(state);
     chat.render(state);
     conversationActivityBar.render(state, !showLog);
@@ -596,3 +596,4 @@ export function createOpenTuiApp(
     },
   };
 }
+

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -324,6 +324,7 @@ export function createOpenTuiApp(
   workspace.add(bottom);
   body.add(workspace);
   root.add(body);
+  root.add(overlay.scrim);
   root.add(overlay.output);
   root.add(themePicker.output);
   root.add(chat.output);
@@ -510,6 +511,7 @@ export function createOpenTuiApp(
     experimentLog.output.visible = showExperimentLog;
     rightPane.render(state, showRightPane, rightWidth);
     overlay.render(state, paneFallback);
+    overlay.renderScrim(state.overlay !== null || state.chatOpen);
     themePicker.render(state);
     chat.render(state);
     conversationActivityBar.render(state, !showLog);
@@ -594,3 +596,5 @@ export function createOpenTuiApp(
     },
   };
 }
+
+

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -48,12 +48,12 @@ export interface OpenTuiApp {
 /** Which of the client's editors currently holds the cursor. */
 type FocusTarget = 'command' | 'chat' | 'modal';
 
-const KEY_HELP = `â†â†’: rounds/agents/transcript Â· â†‘â†“: within Â· [/]: round Â· F4: zoom Â· ${COMMAND_NAMES.todos} Â· ${COMMAND_NAMES.prompt} Â· Ctrl+L: live`;
-const SCOPED_KEY_HELP = `â†â†’: rounds/agents/transcript Â· â†‘â†“: within Â· [/]: round Â· F4: zoom Â· ${COMMAND_NAMES.todos} Â· ${COMMAND_NAMES.prompt} Â· Esc: back`;
-const LOG_KEY_HELP = `â†‘â†“ or scroll: select Â· Enter/click: open hypothesis Â· F4: zoom Â· ${COMMAND_NAMES['open-round']} --N`;
-const LOG_CHAT_KEY_HELP = `â†‘â†“: select Â· Enter/click: hypothesis Â· Ctrl+W: chat Â· F4: zoom Â· ${COMMAND_NAMES['open-round']} --N`;
+const KEY_HELP = `Ã¢â€ ÂÃ¢â€ â€™: rounds/agents/transcript Ã‚Â· Ã¢â€ â€˜Ã¢â€ â€œ: within Ã‚Â· [/]: round Ã‚Â· F4: zoom Ã‚Â· ${COMMAND_NAMES.todos} Ã‚Â· ${COMMAND_NAMES.prompt} Ã‚Â· Ctrl+L: live`;
+const SCOPED_KEY_HELP = `Ã¢â€ ÂÃ¢â€ â€™: rounds/agents/transcript Ã‚Â· Ã¢â€ â€˜Ã¢â€ â€œ: within Ã‚Â· [/]: round Ã‚Â· F4: zoom Ã‚Â· ${COMMAND_NAMES.todos} Ã‚Â· ${COMMAND_NAMES.prompt} Ã‚Â· Esc: back`;
+const LOG_KEY_HELP = `Ã¢â€ â€˜Ã¢â€ â€œ or scroll: select Ã‚Â· Enter/click: open hypothesis Ã‚Â· F4: zoom Ã‚Â· ${COMMAND_NAMES['open-round']} --N`;
+const LOG_CHAT_KEY_HELP = `Ã¢â€ â€˜Ã¢â€ â€œ: select Ã‚Â· Enter/click: hypothesis Ã‚Â· Ctrl+W: chat Ã‚Â· F4: zoom Ã‚Â· ${COMMAND_NAMES['open-round']} --N`;
 const HYPOTHESIS_KEY_HELP =
-  'â†‘â†“: select round Â· Enter/click: trajectory Â· PgUp/PgDn: scroll Â· Esc: hypotheses';
+  'Ã¢â€ â€˜Ã¢â€ â€œ: select round Ã‚Â· Enter/click: trajectory Ã‚Â· PgUp/PgDn: scroll Ã‚Â· Esc: hypotheses';
 /** Bezel, one content row, bezel. See the header frame below. */
 const HEADER_FRAME_HEIGHT = 3;
 
@@ -61,7 +61,7 @@ const HEADER_FRAME_HEIGHT = 3;
 const HEADER_CHROME = 4;
 
 const SPLIT_KEY_HELP =
-  'Ctrl+W: switch pane Â· F4: zoom focused pane Â· PgUp/PgDn: scroll Â· Esc: close pane';
+  'Ctrl+W: switch pane Ã‚Â· F4: zoom focused pane Ã‚Â· PgUp/PgDn: scroll Ã‚Â· Esc: close pane';
 
 const TRANSCRIPT_TITLE = 'Transcript';
 
@@ -71,10 +71,10 @@ const TRANSCRIPT_TITLE = 'Transcript';
  */
 function emptyTranscriptMessage(state: SessionState): string {
   const roundNumber = visibleRoundNumber(state);
-  if (roundNumber === null) return 'Waiting for run eventsâ€¦';
+  if (roundNumber === null) return 'Waiting for run eventsÃ¢â‚¬Â¦';
   const round = stripRounds(state).find(item => item.number === roundNumber);
   if (round?.status === 'planned') return `Round ${roundNumber} has not run yet.`;
-  return 'Waiting for run eventsâ€¦';
+  return 'Waiting for run eventsÃ¢â‚¬Â¦';
 }
 
 export function createOpenTuiApp(
@@ -127,7 +127,7 @@ export function createOpenTuiApp(
   // `flexShrink: 0` because `renderHeader` has already budgeted the line to this
   // width, so a row that still overruns is a bug rather than something to
   // absorb. Shrinking spans put an ellipsis through every one of them at once
-  // (`V...ysÂ·r...ng`) instead of leaving the single cut the budget decided on.
+  // (`V...ysÃ‚Â·r...ng`) instead of leaving the single cut the budget decided on.
   const headerLine = new BoxRenderable(renderer, {
     id: 'header',
     width: '100%',
@@ -511,12 +511,7 @@ export function createOpenTuiApp(
     experimentLog.output.visible = showExperimentLog;
     rightPane.render(state, showRightPane, rightWidth);
     overlay.render(state, paneFallback);
-    overlay.renderScrim(
-      state.overlay !== null ||
-        state.chatOpen ||
-        paneFallback !== null ||
-        state.themePicker !== null,
-    );
+    overlay.renderScrim(state.overlay !== null || state.chatOpen || state.themePicker !== null);
     themePicker.render(state);
     chat.render(state);
     conversationActivityBar.render(state, !showLog);
@@ -573,8 +568,8 @@ export function createOpenTuiApp(
     showClipboardStatus: result => {
       transientStatus =
         result === 'copied'
-          ? 'Copied selected text Â· Ctrl+C exits when no text is selected'
-          : 'Copy unavailable (OSC52) Â· selection kept Â· use your terminal copy command';
+          ? 'Copied selected text Ã‚Â· Ctrl+C exits when no text is selected'
+          : 'Copy unavailable (OSC52) Ã‚Â· selection kept Ã‚Â· use your terminal copy command';
       help.content = transientStatus;
     },
   });

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -511,7 +511,12 @@ export function createOpenTuiApp(
     experimentLog.output.visible = showExperimentLog;
     rightPane.render(state, showRightPane, rightWidth);
     overlay.render(state, paneFallback);
-    overlay.renderScrim(state.overlay !== null || state.chatOpen || paneFallback !== null || state.themePicker !== null);
+    overlay.renderScrim(
+      state.overlay !== null ||
+        state.chatOpen ||
+        paneFallback !== null ||
+        state.themePicker !== null,
+    );
     themePicker.render(state);
     chat.render(state);
     conversationActivityBar.render(state, !showLog);
@@ -596,4 +601,5 @@ export function createOpenTuiApp(
     },
   };
 }
+
 

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -596,4 +596,3 @@ export function createOpenTuiApp(
     },
   };
 }
-

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -597,4 +597,3 @@ export function createOpenTuiApp(
   };
 }
 
-

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -48,12 +48,12 @@ export interface OpenTuiApp {
 /** Which of the client's editors currently holds the cursor. */
 type FocusTarget = 'command' | 'chat' | 'modal';
 
-const KEY_HELP = `Ã¢â€ ÂÃ¢â€ â€™: rounds/agents/transcript Ã‚Â· Ã¢â€ â€˜Ã¢â€ â€œ: within Ã‚Â· [/]: round Ã‚Â· F4: zoom Ã‚Â· ${COMMAND_NAMES.todos} Ã‚Â· ${COMMAND_NAMES.prompt} Ã‚Â· Ctrl+L: live`;
-const SCOPED_KEY_HELP = `Ã¢â€ ÂÃ¢â€ â€™: rounds/agents/transcript Ã‚Â· Ã¢â€ â€˜Ã¢â€ â€œ: within Ã‚Â· [/]: round Ã‚Â· F4: zoom Ã‚Â· ${COMMAND_NAMES.todos} Ã‚Â· ${COMMAND_NAMES.prompt} Ã‚Â· Esc: back`;
-const LOG_KEY_HELP = `Ã¢â€ â€˜Ã¢â€ â€œ or scroll: select Ã‚Â· Enter/click: open hypothesis Ã‚Â· F4: zoom Ã‚Â· ${COMMAND_NAMES['open-round']} --N`;
-const LOG_CHAT_KEY_HELP = `Ã¢â€ â€˜Ã¢â€ â€œ: select Ã‚Â· Enter/click: hypothesis Ã‚Â· Ctrl+W: chat Ã‚Â· F4: zoom Ã‚Â· ${COMMAND_NAMES['open-round']} --N`;
+const KEY_HELP = `←→: rounds/agents/transcript · ↑↓: within · [/]: round · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Ctrl+L: live`;
+const SCOPED_KEY_HELP = `←→: rounds/agents/transcript · ↑↓: within · [/]: round · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Esc: back`;
+const LOG_KEY_HELP = `↑↓ or scroll: select · Enter/click: open hypothesis · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
+const LOG_CHAT_KEY_HELP = `↑↓: select · Enter/click: hypothesis · Ctrl+W: chat · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
 const HYPOTHESIS_KEY_HELP =
-  'Ã¢â€ â€˜Ã¢â€ â€œ: select round Ã‚Â· Enter/click: trajectory Ã‚Â· PgUp/PgDn: scroll Ã‚Â· Esc: hypotheses';
+  '↑↓: select round · Enter/click: trajectory · PgUp/PgDn: scroll · Esc: hypotheses';
 /** Bezel, one content row, bezel. See the header frame below. */
 const HEADER_FRAME_HEIGHT = 3;
 
@@ -61,7 +61,7 @@ const HEADER_FRAME_HEIGHT = 3;
 const HEADER_CHROME = 4;
 
 const SPLIT_KEY_HELP =
-  'Ctrl+W: switch pane Ã‚Â· F4: zoom focused pane Ã‚Â· PgUp/PgDn: scroll Ã‚Â· Esc: close pane';
+  'Ctrl+W: switch pane · F4: zoom focused pane · PgUp/PgDn: scroll · Esc: close pane';
 
 const TRANSCRIPT_TITLE = 'Transcript';
 
@@ -71,10 +71,10 @@ const TRANSCRIPT_TITLE = 'Transcript';
  */
 function emptyTranscriptMessage(state: SessionState): string {
   const roundNumber = visibleRoundNumber(state);
-  if (roundNumber === null) return 'Waiting for run eventsÃ¢â‚¬Â¦';
+  if (roundNumber === null) return 'Waiting for run events…';
   const round = stripRounds(state).find(item => item.number === roundNumber);
   if (round?.status === 'planned') return `Round ${roundNumber} has not run yet.`;
-  return 'Waiting for run eventsÃ¢â‚¬Â¦';
+  return 'Waiting for run events…';
 }
 
 export function createOpenTuiApp(
@@ -127,7 +127,7 @@ export function createOpenTuiApp(
   // `flexShrink: 0` because `renderHeader` has already budgeted the line to this
   // width, so a row that still overruns is a bug rather than something to
   // absorb. Shrinking spans put an ellipsis through every one of them at once
-  // (`V...ysÃ‚Â·r...ng`) instead of leaving the single cut the budget decided on.
+  // (`V...ys·r...ng`) instead of leaving the single cut the budget decided on.
   const headerLine = new BoxRenderable(renderer, {
     id: 'header',
     width: '100%',
@@ -568,8 +568,8 @@ export function createOpenTuiApp(
     showClipboardStatus: result => {
       transientStatus =
         result === 'copied'
-          ? 'Copied selected text Ã‚Â· Ctrl+C exits when no text is selected'
-          : 'Copy unavailable (OSC52) Ã‚Â· selection kept Ã‚Â· use your terminal copy command';
+          ? 'Copied selected text · Ctrl+C exits when no text is selected'
+          : 'Copy unavailable (OSC52) · selection kept · use your terminal copy command';
       help.content = transientStatus;
     },
   });

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -200,4 +200,3 @@ export class OverlayView {
   }
 }
 
-

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -199,4 +199,3 @@ export class OverlayView {
     }
   }
 }
-

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -32,6 +32,7 @@ function borderFor(theme: Theme, kind: OverlayKind): string {
 
 export class OverlayView {
   readonly output: BoxRenderable;
+  readonly scrim: BoxRenderable;
   readonly #scroll: ScrollBoxRenderable;
   readonly #hint: TextRenderable;
   #theme: Theme;
@@ -44,6 +45,16 @@ export class OverlayView {
     theme: Theme,
   ) {
     this.#theme = theme;
+    this.scrim = new BoxRenderable(renderer, {
+      id: 'overlay-scrim',
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+      backgroundColor: theme.canvas,
+      opacity: 0.7,
+      zIndex: 19,
+      visible: false,
+    });
     this.output = new BoxRenderable(renderer, {
       id: 'overlay',
       position: 'absolute',
@@ -87,9 +98,14 @@ export class OverlayView {
     this.#scroll.scrollBy(delta, 'viewport');
   }
 
+  renderScrim(visible: boolean): void {
+    this.scrim.visible = visible;
+  }
+
   applyTheme(theme: Theme): void {
     this.#theme = theme;
     this.output.backgroundColor = theme.elevatedSurface;
+    this.scrim.backgroundColor = theme.canvas;
     this.output.borderColor = borderFor(theme, this.#renderedKind ?? 'detail');
     this.#hint.fg = theme.textSubtle;
     this.#renderedKind = null;
@@ -183,3 +199,5 @@ export class OverlayView {
     }
   }
 }
+
+


### PR DESCRIPTION
## Problem

Closes #566

When a modal is open (`/help`, `/design`, or the experiment chat), the background content stays fully visible and legible. The operator has two competing surfaces on screen with no visual indication of which one accepts keystrokes.

## Solution

Add a full-screen scrim `BoxRenderable` at `zIndex: 19` — below the chat modal (20) and the command overlay (25), above everything else. The scrim uses `theme.canvas` at fixed `opacity: 0.7` so the background recedes without moving or reflowing. It is shown whenever `state.overlay !== null || state.chatOpen || state.themePicker !== null` and hidden otherwise.

Closing restores exactly: the scrim is hidden on the same render pass that hides the modal, so nothing about the underlying layout moves.

## Architecture

`OverlayView` owns the scrim alongside the overlay box. `app.ts` mounts `overlay.scrim` on root ahead of `overlay.output` so z-order is respected, and calls `overlay.renderScrim(...)` in the render loop.

The scrim color derives from `theme.canvas`. Note: fixed opacity does not hold WCAG large-text contrast uniformly across all 8 themes — Solarized Dark is the binding case. Per-theme scrim strength computation (as explored in #639) is a follow-up.

`paneFallback` is intentionally excluded from the predicate: it renders a visualization pane through the overlay rather than a true blocking modal, and `paneBorders` only finds the fallback pane in that state — raising the scrim erases the Agents and Transcript frames rather than dimming them. #639 hit the same issue independently. Existing tests assert that background content remains visible in that state.

## Changes

- `ui/overlay.ts` — adds `readonly scrim: BoxRenderable` created once in the constructor; `renderScrim(visible: boolean)` toggles visibility; `applyTheme` updates `scrim.backgroundColor`
- `ui/app.ts` — mounts `overlay.scrim` on root before `overlay.output`; calls `overlay.renderScrim(state.overlay !== null || state.chatOpen || state.themePicker !== null)` in the render loop

## Verification

- All 15 CI checks pass
- `paneFallback` inclusion was attempted but caused 2 existing theming tests to fail; excluded with explanation above and in review comments