### PR TITLE
fix(tui): do nothing on Enter with an empty command box

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1597,6 +1597,33 @@ describe('OpenTUI presentation', () => {
     expect(controller.submissions).toEqual(['/help']);
   });
 
+  it('does nothing when Enter is pressed on an empty command box', async () => {
+    // Reproduces #564: a round with no selected expandable tool result, so no
+    // pane action consumes Enter, and the box has never been typed into.
+    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    const controller = new FakeController(initialSessionState());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    testRenderer.mockInput.pressEnter();
+    await frameAfter(testRenderer);
+    expect(controller.submissions).toEqual([]);
+    expect(controller.state.errorBanner).toBeNull();
+  });
+
+  it('does nothing when Enter is pressed with only whitespace typed', async () => {
+    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    const controller = new FakeController(initialSessionState());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await testRenderer.mockInput.typeText('   ');
+    testRenderer.mockInput.pressEnter();
+    await frameAfter(testRenderer);
+    expect(controller.submissions).toEqual([]);
+    expect(controller.state.errorBanner).toBeNull();
+  });
+
   it('rejects ordinary text from the command input without sending chat', async () => {
     const testRenderer = await createTestRenderer({width: 80, height: 16});
     const controller = new FakeController(initialSessionState());

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -116,6 +116,9 @@ export function createCommandInputPanel(
   };
   const submit = (value: string): void => {
     input.value = '';
+    // Enter on an empty (or whitespace-only) box belongs to whatever pane is
+    // behind it, not to command parsing; see isEmpty() above.
+    if (value.trim() === '') return;
     onSubmit(value);
   };
   input.on(InputRenderableEvents.INPUT, updateDecorations);


### PR DESCRIPTION
## Problem

Pressing Enter on an empty command box shows an error banner. The input submits
an empty string, `parseCommand('')` returns `Enter a slash command. Use /help.`,
and that surfaces as an error banner for a keypress that did nothing wrong.

Repro from #564: open a round with no selected expandable tool result, then
press Enter while the command box is empty.

Enter on an empty box is not a malformed command, it is a no-op. Reporting it as
an error trains the operator to ignore the error banner, which is the surface
that has to stay trustworthy for real failures.

Closes #564.

## Solution

`submit()` in `ui/command-input.ts` forwarded every value to `onSubmit`,
including empty ones. It now returns early when the trimmed value is empty, so
the keypress falls through to whatever pane is behind the box rather than
reaching command parsing at all.

The guard lives in `submit()`, not at the Enter binding, because every path that
submits the box routes through it. Whitespace-only input is treated the same as
empty: `/  ` is not a command either.

### Architecture

No ownership change. `command-input.ts` owns the box's own submit path and is
the single place all of its callers converge on, so the guard is one branch
there instead of one per call site.

## Verification

### Correctness properties

- A non-empty command still reaches `onSubmit` unchanged, so no existing command
  behavior moves.
- A whitespace-only value is treated as empty, matching `isEmpty()` in the same
  file rather than introducing a second notion of blank.
- The error banner is reserved for genuine parse failures.

### Testing

`bun test clients/tui/src/ui/app.test.ts` in the branch worktree: 162 pass, 0
fail. The suite covers the empty-Enter path directly.

## Screenshots

Real terminal captures at 100x30, dark theme, identical keystrokes in both. The
fix removes a symptom, so the before frame is the one that carries the claim.

**Before**, on the parent's `command-input.ts`: a 10-row `Input error` banner
reading `Enter a slash command. Use /help.`, which also squeezes the Agents pane
into overlapping labels.

![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr635-enter-before-0910.png)

**After**: the box shows its placeholder, no banner, round view intact.

![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr635-enter-after-0910.png)

Note on reproducing by hand: the Enter has to reach the command input, which
means being in the round view first (`/open-round --1`, then Enter). A bare
Enter on the landing view is consumed by the Experiments pane. This matches the
issue's own wording, "a round with no selected expandable tool result".

