### PR TITLE
fix(agent): disclose omitted pending frontier claims past the cap

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -341,6 +341,13 @@ def _format_metric_row(metrics: dict[str, float], objectives: Sequence[Objective
     )
 
 
+# How many pending frontier claims to render in full. The list can grow
+# unbounded over a long run, so it is still capped, but an omission is always
+# disclosed (see _pareto_archive_summary) instead of silently dropping the
+# oldest, still-unreviewed rows.
+_PENDING_CLAIM_DISPLAY_LIMIT = 8
+
+
 def _pareto_archive_summary(records: list[RoundRecord], space: MetricSpace) -> str:
     """Render trusted frontier parents and any measured points awaiting review."""
     objectives = space.objectives
@@ -391,7 +398,19 @@ def _pareto_archive_summary(records: list[RoundRecord], space: MetricSpace) -> s
             "have not passed independent review, or because its numbers are the "
             "implementer's own report rather than a framework measurement:"
         )
-        for record in pending[-8:]:
+        omitted = pending[:-_PENDING_CLAIM_DISPLAY_LIMIT]
+        if omitted:
+            claim = "claim" if len(omitted) == 1 else "claims"
+            rounds = (
+                f"round {omitted[0].round_number}"
+                if len(omitted) == 1
+                else f"rounds {omitted[0].round_number}-{omitted[-1].round_number}"
+            )
+            lines.append(
+                f"- {len(omitted)} older, still-unreviewed {claim} not shown ({rounds}); "
+                "do not treat them as trusted parents just because they scrolled off."
+            )
+        for record in pending[-_PENDING_CLAIM_DISPLAY_LIMIT:]:
             assert record.commit is not None  # noqa: S101  # tracked: #288
             lines.append(
                 f"- round {record.round_number}, commit {record.commit[:12]}: "

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -975,6 +975,40 @@ def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa:
     assert "round 51" in summary
 
 
+def test_pareto_archive_discloses_pending_claims_omitted_past_the_display_limit():  # noqa: ANN201  # tracked: #288
+    """Regression for #547: the pending list caps at 8 rows, but must say so.
+
+    Ten unreviewed claims accumulate across rounds 101-110. Only the eight
+    most recent are rendered; the two oldest are dropped from the listing but
+    must not vanish silently, since this warning exists to flag untrusted
+    commits to the operator.
+    """
+    pending_rounds = [
+        RoundRecord(
+            round_number,
+            f"{round_number:040d}",
+            None,
+            None,
+            False,  # noqa: FBT003  # tracked: #288
+            reviewed=False,
+            candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
+            candidate_metrics={"throughput": 1000.0 + round_number, "latency": 500.0},
+        )
+        for round_number in range(101, 111)
+    ]
+
+    summary = _pareto_archive_summary(pending_rounds, _THROUGHPUT_LATENCY)
+
+    # The two oldest claims are dropped from the rendered rows...
+    assert "round 101" not in summary
+    assert "round 102" not in summary
+    # ...but the operator can tell they were omitted, not lost.
+    assert "2 older, still-unreviewed claims not shown (rounds 101-102)" in summary
+    # The eight most recent claims still render in full.
+    for round_number in range(103, 111):
+        assert f"round {round_number}" in summary
+
+
 def _accuracy_row(
     round_number: int,
     accuracy: float,


### PR DESCRIPTION
## Problem

`_pareto_archive_summary` renders the block that warns the agent which measured
frontier points have not passed independent review. It sliced `pending[-8:]`
with no signal that anything was dropped, so on a long run the oldest
still-unreviewed claims silently vanished from the agent's context.

The warning exists precisely to stop an unreviewed commit being treated as a
trusted parent. Dropping the oldest rows without saying so defeats it, and the
issue is labeled "Blocks normal use" for that reason.

This output is not display: it goes to `issue_board.write_pareto_archive`, so it
is agent-facing context.

Closes #547.

> **Overlaps #621 by @AyanBinRafaih**, which fixes the same issue by removing the
> cap entirely (`for record in pending`). This PR is an alternative for
> comparison, not a competing claim on the issue. The difference worth deciding:
> #621 is one line and shows every claim; this keeps a bound on an agent-visible
> file that grows with the run, and discloses what the bound hid. If the team
> prefers #621, close this.

## Solution

Keep a display cap, name it `_PENDING_CLAIM_DISPLAY_LIMIT`, and emit a
disclosure line whenever it bites, giving the count of omitted claims and the
round range they span, with an explicit instruction not to treat them as trusted
parents just because they scrolled off.

### Architecture

No ownership change. The rendering stays entirely inside
`_pareto_archive_summary` in `loops/agent/loop.py`; its caller and the issue
board are untouched.

## Verification

### Correctness properties

- Fewer pending claims than the limit produces byte-identical output to before.
- The disclosure line appears only when the cap actually elides rows.
- Singular and plural forms are handled for both the claim count and the round
  range, so a single omitted claim does not read as a range.
- The prompt block stays bounded regardless of run length.

### Testing

`PYTHONPATH=$PWD/src .venv/bin/python -m pytest
tests/vibesys/loops/agent/test_orchestrate.py --no-cov`: 148 passed.

PYTHONPATH is prepended because a worktree's symlinked `.venv` otherwise
resolves the package back to the main checkout and tests the wrong tree.
