### PR TITLE
fix(tui): keep the round rail's elapsed refresh in the current width mode

### DIFF
--- a/clients/tui/src/ui/round-rail.test.ts
+++ b/clients/tui/src/ui/round-rail.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, test} from 'bun:test';
+import {afterEach, describe, expect, jest, test} from 'bun:test';
 import {rgbToHex, type TextRenderable} from '@opentui/core';
 import {createTestRenderer} from '@opentui/core/testing';
 import type {HypothesisRound} from '@vibesys/backend-client';
@@ -406,5 +406,54 @@ describe('RoundRailView judge verdict', () => {
     // RAIL_FULL_WIDTH (28) minus the border (2) and the 1-column padding on
     // each side (2) leaves 24 usable columns.
     expect(row?.text.length).toBeLessThanOrEqual(RAIL_FULL_WIDTH - 4);
+  });
+});
+
+describe('RoundRailView elapsed refresh', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** A run whose one round is still active, so the elapsed timer starts. */
+  function runningRailState(): SessionState {
+    const running: RoundSummary = {
+      number: 1,
+      status: 'active',
+      activeAgentStarts: {'agent:1': new Date().toISOString()},
+    };
+    const base = initialSessionState();
+    return {...base, experimentLog: null, core: {...base.core, rounds: [running]}};
+  }
+
+  function labelFor(view: RoundRailView, roundNumber: number): string | undefined {
+    return view.output
+      .getChildren()
+      .map(child => {
+        const content = (child as {content?: {chunks?: {text?: string}[]}}).content;
+        return (content?.chunks ?? []).map(chunk => chunk.text ?? '').join('');
+      })
+      .find(line => line.includes(`r${roundNumber}`));
+  }
+
+  test('redraws the running round in compact form after the 1s elapsed refresh', async () => {
+    const {renderer} = await createTestRenderer({width: 120, height: 40});
+    const view = new RoundRailView(
+      renderer,
+      {} as unknown as SessionController,
+      resolveTheme(null),
+    );
+
+    jest.useFakeTimers();
+    view.render(runningRailState(), RAIL_COMPACT_WIDTH, 10);
+    const before = labelFor(view, 1);
+    jest.advanceTimersByTime(1000);
+    const after = labelFor(view, 1);
+    view.destroy();
+
+    // Compact form is "<marker>r<number><glyph>", no spaces. The full form the
+    // timer used to hardcode joins marker, glyph, status word, and metric with
+    // spaces, so a space anywhere in `after` is the regression signal.
+    expect(before).toMatch(/^[ ▸]r1⟳$/);
+    expect(after).toMatch(/^[ ▸]r1⟳$/);
   });
 });

--- a/clients/tui/src/ui/round-rail.ts
+++ b/clients/tui/src/ui/round-rail.ts
@@ -329,7 +329,7 @@ export class RoundRailView {
         round,
         state,
         round.number === visibleRoundNumber(state),
-        false,
+        this.#renderedWidth <= RAIL_COMPACT_WIDTH,
       );
     }, 1000);
   }


### PR DESCRIPTION
> **Rebased onto #645, and now position 4/4 of stack #650.** Both PRs edit
> `RoundRailView` and both add a `describe` block to `round-rail.test.ts` at the
> same point, which conflicts textually even though the two suites are
> independent. Resolving it once here, in order, is cheaper than leaving it for
> whichever of the two merges second. The resolution keeps both suites verbatim;
> nothing in either was rewritten.
>
> The frames below were shot when this branch sat on `main`, so their baseline
> predates #645's verdict glyph. They still show this PR's delta, the compact
> row surviving the 1s refresh, which #645 does not touch.
>
> It now also sits downstream of #652, which collapses the palette to one
> background, so the rail in the frames below renders on that single surface
> rather than the old elevated one.


## Problem

The round rail's 1s elapsed-time refresh redrew the running round's label with a
hardcoded `false` for the `compact` argument. A rail drawn in its compact
13-column form was therefore re-rendered in full width once per second, so the
row overflowed or wrapped and the fixed one-row-per-round layout broke for the
rest of the live run.

Repro from #551: `runtui.sh start 92x40 spsc`, let a round go active, and watch
the row re-expand every second. It bites between 85 and 99 columns, where the
rail is compact but the terminal is wide enough to make the full-width label
overflow rather than truncate.

Closes #551.

> **Overlaps #624 by @AyanBinRafaih**, which fixes the same issue by storing the
> `compact` flag on `#runningRound` at render time. This PR is an alternative for
> comparison, not a competing claim. #624's approach is arguably the more
> faithful one, since it replays exactly the flag the row was drawn with; this
> one recomputes from the stored width and threads no new field. Either fixes
> the bug. If the team prefers #624, close this.

### Before / after

The compact rail 2.6s after render, 90x40, dark, so the 1s elapsed refresh has
fired. Base is #645. Compact form needs 85 <= cols < 100, hence 90 columns.

| Before (this PR's base) | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr637-rail-before.png) | ![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr637-rail-after.png) |

## Solution

Derive `compact` from the already-stored `#renderedWidth` at refresh time rather
than passing a literal, so the timer redraws in whatever mode the rail is
currently in.

### Architecture

No ownership change and no new state on `RoundRailView`. The one-line change is
in the `#syncElapsedTimer` callback in `ui/round-rail.ts`.

## Verification

### Correctness properties

- The compact form stays `<marker>r<number><glyph>` with no spaces after a
  refresh, which is what the regression test pins.
- A full-width rail is unaffected, since the derived flag matches what the
  initial render passed.
- No new field is threaded through the timer callback, so there is no second
  copy of the width to keep in sync.

### Testing

`bun test clients/tui/src/ui/round-rail.test.ts`: 26 pass, 0 fail.

Confirmed the test catches the regression rather than passing vacuously:
reverting `round-rail.ts` to main's version gives 25 pass, 1 fail, and restoring
the fix returns it to 26 pass.

This branch was rebased onto current main; the conflict was additive on both
sides in `round-rail.test.ts` (main's profile-skipped tests and this branch's
elapsed-refresh tests) and both blocks are kept.

## Screenshots

Real terminal captures at 92x40, dark theme, same fixture and same keystrokes.
Both frames sat ~3.4s in the running state, so at least three 1-second refreshes
fired before capture. The frames are otherwise pixel-identical; only the rail
differs.

**Before**, on the parent's `round-rail.ts`: the rail wraps across three rows,
`▸r1 ⟳` / `run 192h` / `12m`, spilling out of its 13-column form.

**After**: `▸r1⟳`, one row.

Two notes on the capture. The bundled fixture ends with the run completed, so no
round is active and the elapsed timer never starts; these frames replay a prefix
of `clients/tui/dev/fixtures/bad-cpp-round1.jsonl` cut at the judge's
`invocation_started`, so `activeAgentStarts` is non-empty and `#runningRound` is
set. It is a real prefix of the bundled fixture, not a hand-made file. The
elapsed reads `192h 12m` because the harness measures against the real clock
while replaying a run recorded on 1 September.



