### PR TITLE
fix(sandbox): reject a pre-existing writable evaluator runtime directory

### DIFF
--- a/src/vibesys/sandbox/modal_evaluator.py
+++ b/src/vibesys/sandbox/modal_evaluator.py
@@ -94,9 +94,10 @@ def _ensure_runtime_dir(path: Path) -> None:
 
     Raises ``RuntimeError`` naming the directory and its owning uid when the
     location cannot be used as a private per-user directory, for example a
-    plain file already occupies it or another user owns it, so a hostile or
-    stale runtime-directory entry fails with a clear message instead of a
-    deep ``PermissionError`` surfacing from ``flock`` or ``open``.
+    plain file already occupies it, another user owns it, or it already exists
+    writable by other users, so a hostile or stale runtime-directory entry
+    fails with a clear message instead of a deep ``PermissionError`` surfacing
+    from ``flock`` or ``open``.
     """
     runtime_dir = path.parent
     try:
@@ -110,6 +111,18 @@ def _ensure_runtime_dir(path: Path) -> None:
         raise RuntimeError(  # noqa: TRY003
             f"refusing to use {runtime_dir} as the evaluator runtime directory: "
             f"expected a directory owned by uid {os.getuid()}"
+        )
+    # ``mkdir(exist_ok=True)`` accepts a directory that already existed, and the
+    # ``chmod`` below only closes access from here on: it cannot remove files
+    # another user planted while the directory was writable by them. So reject a
+    # writable directory instead of coercing it. Test the write bits alone, not
+    # all of ``0o077``, because write permission is the planting vector while a
+    # readable ``0o755`` directory is both safe and common.
+    if metadata.st_mode & 0o022:
+        raise RuntimeError(  # noqa: TRY003
+            f"refusing to use {runtime_dir} as the evaluator runtime directory: "
+            "it is group- or world-writable, so another user may already have "
+            "planted files in it"
         )
     runtime_dir.chmod(0o700)
 
@@ -179,7 +192,10 @@ def _compact_rich_output(output: str) -> str:
 def _exclusive_evaluation() -> Generator[None]:
     """Serialize deploy-and-evaluate callers sharing the editor container."""
     _ensure_runtime_dir(_LOCK_PATH)
-    with open(_LOCK_PATH, "w") as lock_file:  # noqa: PTH123  # tracked: #288
+    # ``O_NOFOLLOW`` so a symlink planted at the lock path fails instead of
+    # redirecting this truncating write outside the runtime directory.
+    lock_fd = os.open(_LOCK_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(lock_fd, "w") as lock_file:
         fcntl.flock(lock_file, fcntl.LOCK_EX)
         try:
             yield
@@ -270,7 +286,11 @@ def _healthy_now(base_url: str) -> bool:
 
 def _read_deployment_lease() -> _DeploymentLease | None:
     try:
-        payload = json.loads(_DEPLOYMENT_LEASE_PATH.read_text())
+        # ``O_NOFOLLOW`` so a symlink planted at the lease path is ignored
+        # rather than followed into a file outside the runtime directory.
+        lease_fd = os.open(_DEPLOYMENT_LEASE_PATH, os.O_RDONLY | os.O_NOFOLLOW)
+        with os.fdopen(lease_fd) as lease_file:
+            payload = json.load(lease_file)
         revision = payload["candidate_revision"]
         base_url = payload["base_url"]
     except (OSError, KeyError, TypeError, json.JSONDecodeError):
@@ -296,7 +316,12 @@ def _write_deployment_lease(
     }
     if app_identifier is not None:
         payload["app_identifier"] = app_identifier
-    temporary.write_text(json.dumps(payload))
+    # The rename below replaces a symlink at the lease path rather than
+    # following it, but this staging write would follow one planted at the
+    # sibling ``.tmp`` path, so it needs ``O_NOFOLLOW`` too.
+    staging_fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(staging_fd, "w") as staging_file:
+        json.dump(payload, staging_file)
     temporary.replace(_DEPLOYMENT_LEASE_PATH)
 
 

--- a/tests/vibesys/sandbox/test_modal_evaluator.py
+++ b/tests/vibesys/sandbox/test_modal_evaluator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import errno
 import io
 import json
 import os
@@ -178,6 +179,95 @@ def test_ensure_runtime_dir_rejects_symlink_shadowing_the_directory(tmp_path: Pa
 
     with pytest.raises(RuntimeError, match="expected a directory owned by uid"):
         modal_evaluator._ensure_runtime_dir(shadow / "modal-evaluator.lock")  # noqa: SLF001
+
+
+def test_ensure_runtime_dir_rejects_pre_existing_world_writable_directory(
+    tmp_path: Path,
+) -> None:
+    """A directory others could already have planted files in is rejected, not coerced."""
+    runtime_dir = tmp_path / "rt"
+    runtime_dir.mkdir()
+    runtime_dir.chmod(0o777)
+
+    with pytest.raises(RuntimeError, match="group- or world-writable"):
+        modal_evaluator._ensure_runtime_dir(runtime_dir / "modal-evaluator.lock")  # noqa: SLF001
+
+
+def test_ensure_runtime_dir_accepts_pre_existing_readable_directory(tmp_path: Path) -> None:
+    """0o755 is readable but not a planting vector, so it is tightened rather than rejected."""
+    runtime_dir = tmp_path / "rt"
+    runtime_dir.mkdir()
+    runtime_dir.chmod(0o755)
+
+    modal_evaluator._ensure_runtime_dir(runtime_dir / "modal-evaluator.lock")  # noqa: SLF001
+
+    assert stat.S_IMODE(runtime_dir.stat().st_mode) == 0o700
+
+
+def test_exclusive_evaluation_rejects_symlink_planted_at_the_lock_path(
+    tmp_path: Path,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """A symlink at the lock path fails instead of truncating the file it points at."""
+    runtime_dir = tmp_path / "rt"
+    runtime_dir.mkdir(mode=0o700)
+    outside = tmp_path / "outside"
+    outside.write_text("untouched")
+    lock_path = runtime_dir / "modal-evaluator.lock"
+    lock_path.symlink_to(outside)
+    monkeypatch.setattr(modal_evaluator, "_LOCK_PATH", lock_path)
+
+    with (
+        pytest.raises(OSError, match=r"modal-evaluator\.lock") as raised,
+        modal_evaluator._exclusive_evaluation(),  # noqa: SLF001
+    ):
+        pass
+
+    assert raised.value.errno == errno.ELOOP
+    assert outside.read_text() == "untouched"
+
+
+def test_read_deployment_lease_rejects_symlink_planted_at_the_lease_path(
+    tmp_path: Path,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """A symlink at the lease path yields no lease instead of trusting its target."""
+    runtime_dir = tmp_path / "rt"
+    runtime_dir.mkdir(mode=0o700)
+    outside = tmp_path / "outside.json"
+    outside.write_text(
+        json.dumps({"candidate_revision": "abc123", "base_url": "https://attacker.example"})
+    )
+    lease_path = runtime_dir / "modal-evaluator-deployment.json"
+    lease_path.symlink_to(outside)
+    monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
+
+    assert modal_evaluator._read_deployment_lease() is None  # noqa: SLF001
+
+
+def test_write_deployment_lease_rejects_symlink_planted_at_the_staging_path(
+    tmp_path: Path,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """A symlink at the lease staging path fails instead of clobbering its target."""
+    runtime_dir = tmp_path / "rt"
+    runtime_dir.mkdir(mode=0o700)
+    outside = tmp_path / "outside"
+    outside.write_text("untouched")
+    (runtime_dir / "modal-evaluator-deployment.tmp").symlink_to(outside)
+    monkeypatch.setattr(
+        modal_evaluator,
+        "_DEPLOYMENT_LEASE_PATH",
+        runtime_dir / "modal-evaluator-deployment.json",
+    )
+
+    with pytest.raises(OSError, match=r"modal-evaluator-deployment\.tmp") as raised:
+        modal_evaluator._write_deployment_lease(  # noqa: SLF001
+            "abc123", "https://example.invalid", None
+        )
+
+    assert raised.value.errno == errno.ELOOP
+    assert outside.read_text() == "untouched"
 
 
 def test_extract_modal_web_url_handles_rich_line_wrapping() -> None:


### PR DESCRIPTION
## Problem

#622 namespaced the Modal evaluator's lock and lease per user and rejected a
runtime directory that is a symlink or owned by another uid. Two residual gaps
from #548 survive that, on a shared host where an attacker knows the invoking
uid and can create `vibesys-<uid>` first:

- `_ensure_runtime_dir` calls `mkdir(mode=0o700, exist_ok=True)`, which
  silently accepts a directory that already existed, and only then
  `chmod(0o700)`. A pre-created group- or world-writable directory may already
  hold files another user planted. The chmod closes access going forward but
  removes nothing.
- Neither the lock nor the lease is opened with `O_NOFOLLOW`.

Both are reachable today:

| Vector | Path on `main` | Effect |
| --- | --- | --- |
| Planted lease file | `_read_deployment_lease` does no ownership check | attacker-chosen `base_url` / `app_identifier` reach `_execute_colocated`, sending the candidate payload to their host |
| Symlink at lock path | `open(_LOCK_PATH, "w")` | truncating write to any file the invoking user can write |
| Symlink at lease path | `Path.read_text()` | reads a file outside the runtime directory as a lease |
| Symlink at lease `.tmp` path | `temporary.write_text(...)` | truncating write outside the runtime directory |

`Path.replace` on the lease path itself is `rename`, which replaces a symlink
rather than following it, so only the staging half of the lease write needed
changing.

## Solution

1. Reject a runtime directory whose mode has `st_mode & 0o022`, rather than
   coercing it. Rejecting beats coercing because the damage predates the
   chmod: the permission bits can be fixed, planted files cannot. The mask is
   `0o022` and not `0o077` because write permission is the planting vector,
   while a `0o755` directory is safe (and common under a shared
   `XDG_RUNTIME_DIR`) and its read bits are already closed by the existing
   `chmod(0o700)`, which is kept.
2. Open the lock, the lease read, and the lease staging write with
   `os.open(..., O_NOFOLLOW)` wrapped in `os.fdopen`. A planted symlink now
   fails with `ELOOP` instead of redirecting the read or write.

The directory is deliberately not unlinked and recreated: that would delete a
live lock held by another process of the same user.

### Architecture

No boundary change. Both hunks stay inside `src/vibesys/sandbox/modal_evaluator.py`;
`_ensure_runtime_dir` remains the single validation point that
`_exclusive_evaluation` and `_write_deployment_lease` call before touching the
directory.

## Verification

### Correctness properties

- A runtime directory group- or world-writable is rejected with a `RuntimeError`
  naming the reason, whether or not this process created it.
- A `0o755` runtime directory is still accepted and tightened to `0o700`; the
  fix does not over-reject.
- A symlink at the lock, lease, or lease-staging path raises `OSError` with
  `errno.ELOOP`, and the file it points at is left byte-identical.
- The pre-existing symlink-shadowed-directory and foreign-uid checks from #622
  are unchanged.

### Testing

Five cases added to `tests/vibesys/sandbox/test_modal_evaluator.py`. Four of the
five fail against `main` and pass with this change; the `0o755` case passes on
both by design, as the guard against over-rejecting.

```
# against main (fix reverted, new tests present)
4 failed, 1 passed, 59 deselected

# with the fix
uv run pytest tests/vibesys/sandbox/test_modal_evaluator.py   ->  64 passed
uv run pytest tests/vibesys/sandbox/                          -> 169 passed
uv run ruff check / ruff format --check (changed files)       -> clean
./scripts/check_types.sh                                      -> All checks passed
```

Every external boundary stays mocked with `monkeypatch`; no network and no real
`modal` CLI.

Refs #548. #622 covered the rest of that issue.
