### PR TITLE
fix(tui): dim the background behind a modal

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -170,7 +170,11 @@ modal they used before panes existed. That modal is the same surface as the
 pane, so it keeps the pane's title and its focus marker rather than reading as a
 generic dialog. The layout re-flows on resize in either direction.
 
-`/help`, `/theme`, and errors stay modal.
+`/help`, `/theme`, and errors stay modal. While any of them is open, a scrim
+dims the entire screen behind it, so the modal is the only surface left at full
+contrast and the operator can tell where a keystroke will land. The scrim is a
+translucent paint applied over the finished frame rather than a layout node: the
+background keeps every character where it was, and closing restores it exactly.
 
 ### Experiment chat
 
@@ -270,6 +274,11 @@ the Markdown palette are derived from that core, and each derived foreground is
 pushed toward the nearest extreme until it clears the theme's `minContrast`
 against the surface it actually sits on. The `dark` theme additionally pins its
 derived values to the original literals so the baseline is byte-identical.
+The modal scrim is derived the same way: it pulls the background toward the
+theme's own `canvas`, and its strength is solved per theme so body text lands on
+WCAG's large-text floor whatever it started from. One fixed blend cannot do
+that, because a blend deep enough to recede Solarized Dark's 5.6:1 body text
+leaves High Contrast Dark's 21:1 fully readable.
 Status meaning never depends on color: agent phases carry a marker glyph and
 the spelled-out status, todos carry a per-status marker, and only the running
 round shows elapsed time.

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -2,6 +2,7 @@ import {afterEach, describe, expect, it} from 'bun:test';
 import {
   CliRenderEvents,
   InputRenderable,
+  type Renderable,
   rgbToHex,
   ScrollBoxRenderable,
   TextareaRenderable,
@@ -69,7 +70,15 @@ import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 import {renderDesignSummary} from './design-log.js';
 import {paneTitle} from './focus.js';
 import {headerBackground} from './header.js';
-import {contrastRatio, listThemes, resolveTheme, THEME_NAMES, type ThemeName} from './theme.js';
+import {
+  contrastRatio,
+  listThemes,
+  mix,
+  resolveTheme,
+  scrim,
+  THEME_NAMES,
+  type ThemeName,
+} from './theme.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -5205,6 +5214,199 @@ function clipboardReturning(
       return result;
     },
   };
+}
+
+describe('modal scrim', () => {
+  const helpOverlay = {kind: 'help' as const, content: 'Available commands'};
+
+  function behindTheModal(themeName: ThemeName): SessionState {
+    const initial = initialSessionState(themeName);
+    return {
+      ...initial,
+      core: {
+        ...initial.core,
+        status: 'running',
+        transcript: [
+          {id: 'behind', kind: 'assistant', label: 'implementer', content: 'transcript behind it'},
+        ],
+      },
+    };
+  }
+
+  it.each(
+    THEME_NAMES.map(name => [name] as const),
+  )('%s dims every cell around the modal and leaves the modal at full contrast', async (themeName: ThemeName) => {
+    const theme = resolveTheme(themeName);
+    const {color, strength} = scrim(theme);
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(behindTheModal(themeName));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('transcript behind it'));
+    await testRenderer.waitForVisualIdle();
+    const closed = frameCells(testRenderer);
+    const headerBefore = requireSpanColors(testRenderer, 'VibeSys');
+
+    controller.publish({...controller.state, overlay: helpOverlay});
+    await testRenderer.waitForFrame(value => value.includes('Available commands'));
+    await testRenderer.waitForVisualIdle();
+    const open = frameCells(testRenderer);
+
+    const box = boxOf(testRenderer, 'overlay');
+    // Every band around the modal, so a scrim confined to the box region
+    // fails here rather than passing on the rows it happens to cover.
+    const dimmed = {above: 0, below: 0, left: 0, right: 0};
+    const moved: number[] = [];
+    for (const [row, column, before, after] of cellsOutside(closed, open, box)) {
+      if (before.char !== after.char) {
+        moved.push(row);
+        continue;
+      }
+      // A blank cell has no visible foreground, and the scrim claims it.
+      if (before.char !== ' ') {
+        expect(channelDistance(after.fg, mix(before.fg, color, strength))).toBeLessThanOrEqual(1);
+      }
+      expect(channelDistance(after.bg, mix(before.bg, color, strength))).toBeLessThanOrEqual(1);
+      if (after.fg === before.fg && after.bg === before.bg) continue;
+      if (row < box.y) dimmed.above += 1;
+      else if (row >= box.y + box.height) dimmed.below += 1;
+      else if (column < box.x) dimmed.left += 1;
+      else dimmed.right += 1;
+    }
+    expect(dimmed.above).toBeGreaterThan(0);
+    expect(dimmed.below).toBeGreaterThan(0);
+    expect(dimmed.left).toBeGreaterThan(0);
+    expect(dimmed.right).toBeGreaterThan(0);
+    // The header gains its Escape hint, so its own rows are allowed to change
+    // characters. Nothing else outside the box moves: the scrim repaints cells,
+    // it does not lay anything out. The header sits in its own housing since
+    // #571, so its rows are read off the frame rather than assumed to be row 0.
+    const headerFrame = boxOf(testRenderer, 'header-frame');
+    const headerRows = new Set(
+      Array.from({length: headerFrame.height}, (_, offset) => headerFrame.y + offset),
+    );
+    expect(moved.filter(row => !headerRows.has(row))).toEqual([]);
+
+    const floor = themeName.startsWith('high-contrast') ? 7 : 4.5;
+    const modalBody = requireSpanColors(testRenderer, 'Available commands');
+    expect(modalBody).toEqual({fg: theme.textPrimary, bg: theme.elevatedSurface});
+    expect(contrastRatio(modalBody.fg, modalBody.bg)).toBeGreaterThanOrEqual(floor);
+    // Background text recedes below the floor the theme guarantees, and stays
+    // above the point where the run behind the modal would be erased.
+    const headerAfter = requireSpanColors(testRenderer, 'VibeSys');
+    expect(contrastRatio(headerBefore.fg, headerBefore.bg)).toBeGreaterThanOrEqual(floor);
+    const recessed = contrastRatio(headerAfter.fg, headerAfter.bg);
+    expect(recessed).toBeLessThan(floor);
+    expect(recessed).toBeGreaterThanOrEqual(1.9);
+  });
+
+  it('restores the frame exactly when the modal closes', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(behindTheModal('dark'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('transcript behind it'));
+    await testRenderer.waitForVisualIdle();
+    const before = frameCells(testRenderer);
+
+    controller.publish({...controller.state, overlay: helpOverlay});
+    await testRenderer.waitForFrame(value => value.includes('Available commands'));
+    await testRenderer.waitForVisualIdle();
+    controller.publish({...controller.state, overlay: null});
+    await testRenderer.waitForFrame(value => !value.includes('Available commands'));
+    await testRenderer.waitForVisualIdle();
+
+    expect(frameCells(testRenderer)).toEqual(before);
+  });
+
+  it('raises one scrim under whichever modals are open, and never over them', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(behindTheModal('dark'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('transcript behind it'));
+    const scrimBox = boxOf(testRenderer, 'scrim');
+    // One scrim under every modal: two of them stacked must not dim each other,
+    // and a command ack over the chat still needs the background held down.
+    expect(scrimBox.zIndex).toBeLessThan(boxOf(testRenderer, 'chat-overlay').zIndex);
+    expect(scrimBox.zIndex).toBeLessThan(boxOf(testRenderer, 'overlay').zIndex);
+    expect(scrimBox.zIndex).toBeLessThan(boxOf(testRenderer, 'theme-picker').zIndex);
+    expect(scrimBox.visible).toBe(false);
+
+    for (const modal of [
+      {chatOpen: true},
+      {overlay: helpOverlay},
+      {themePicker: {selected: 'dark' as const}},
+    ]) {
+      controller.publish({...behindTheModal('dark'), ...modal});
+      await testRenderer.flush();
+      expect(scrimBox.visible).toBe(true);
+      // The whole terminal, so the dim never stops at the pane the modal is in.
+      expect([scrimBox.x, scrimBox.y, scrimBox.width, scrimBox.height]).toEqual([0, 0, 100, 24]);
+      controller.publish(behindTheModal('dark'));
+      await testRenderer.flush();
+      expect(scrimBox.visible).toBe(false);
+    }
+  });
+});
+
+/** The renderable behind a screen region, for asserting what a scrim covers. */
+function boxOf(testRenderer: TestRendererSetup, id: string): Renderable {
+  const found = testRenderer.renderer.root.findDescendantById(id);
+  if (found === undefined) throw new Error(`no renderable with id ${id}`);
+  return found;
+}
+
+/** The colors of the span carrying `needle`, which the caller expects on screen. */
+function requireSpanColors(
+  testRenderer: TestRendererSetup,
+  needle: string,
+): {fg: string; bg: string} {
+  const colors = spanColors(testRenderer, needle);
+  if (colors === undefined) throw new Error(`no rendered span contains ${needle}`);
+  return colors;
+}
+
+/** The captured frame as a grid of cells, for asserting what a scrim repaints. */
+function frameCells(
+  testRenderer: TestRendererSetup,
+): Array<Array<{char: string; fg: string; bg: string}>> {
+  return testRenderer.captureSpans().lines.map(line => {
+    const row: Array<{char: string; fg: string; bg: string}> = [];
+    for (const span of line.spans) {
+      const fg = rgbToHex(span.fg).toLowerCase();
+      const bg = rgbToHex(span.bg).toLowerCase();
+      for (const char of span.text) row.push({char, fg, bg});
+    }
+    return row;
+  });
+}
+
+type Cell = {char: string; fg: string; bg: string};
+
+/** Every screen cell the modal does not cover, paired across the two frames. */
+function* cellsOutside(
+  closed: Cell[][],
+  open: Cell[][],
+  box: Renderable,
+): Generator<[number, number, Cell, Cell]> {
+  for (const [row, cells] of closed.entries()) {
+    for (const [column, before] of cells.entries()) {
+      const covered =
+        row >= box.y && row < box.y + box.height && column >= box.x && column < box.x + box.width;
+      const after = open[row]?.[column];
+      if (covered || after === undefined) continue;
+      yield [row, column, before, after];
+    }
+  }
+}
+
+/** The largest per-channel gap between two hex colors. */
+function channelDistance(left: string, right: string): number {
+  const channels = (hex: string): number[] =>
+    [1, 3, 5].map(at => Number.parseInt(hex.slice(at, at + 2), 16));
+  const [first, second] = [channels(left), channels(right)];
+  return Math.max(...first.map((value, index) => Math.abs(value - (second[index] ?? 0))));
 }
 
 class FakeController implements SessionController {

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -36,6 +36,7 @@ import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RightPaneView, rightPaneWidth, splitFits} from './right-pane.js';
 import {RoundRailView, roundRailVisible, roundRailWidth} from './round-rail.js';
+import {ScrimView} from './scrim.js';
 import {createMarkdownStyle} from './styles.js';
 import {resolveTheme, type ThemeName} from './theme.js';
 import {ThemePickerView} from './theme-picker.js';
@@ -228,6 +229,7 @@ export function createOpenTuiApp(
   const errorBanner = new ErrorBannerView(renderer, theme, () => controller.dismissErrorBanner());
   const agentMap = new AgentMapView(renderer, controller, theme);
   const conversationActivityBar = new ActivityBarView(renderer, theme, 'conversation-activity-bar');
+  const scrim = new ScrimView(renderer, theme);
   const overlay = new OverlayView(renderer, theme);
   const experimentLog = new ExperimentLogView(renderer, controller, theme);
   const rightPane = new RightPaneView(renderer, theme, () => controller.focusPane('right'));
@@ -324,6 +326,7 @@ export function createOpenTuiApp(
   workspace.add(bottom);
   body.add(workspace);
   root.add(body);
+  root.add(scrim.output);
   root.add(overlay.output);
   root.add(themePicker.output);
   root.add(chat.output);
@@ -345,6 +348,7 @@ export function createOpenTuiApp(
     errorBanner.applyTheme(theme);
     agentMap.applyTheme(theme);
     conversationActivityBar.applyTheme(theme);
+    scrim.applyTheme(theme);
     overlay.applyTheme(theme);
     experimentLog.applyTheme(theme);
     rightPane.applyTheme(theme);
@@ -402,6 +406,11 @@ export function createOpenTuiApp(
         : chatPaneWidth(renderer.terminalWidth, rightWidth)
       : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
+    // The three real modals only. The narrow-terminal pane fallback is
+    // deliberately excluded: raising the scrim there erases the pane frames
+    // behind it rather than dimming them, so the fallback needs its own
+    // treatment before it can join this predicate.
+    const modalOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
     paintHeader(renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME));
     errorBanner.render(state);
     // The log carries its own key hints in its footer, so when it shares the
@@ -509,6 +518,9 @@ export function createOpenTuiApp(
     experimentLog.render(state);
     experimentLog.output.visible = showExperimentLog;
     rightPane.render(state, showRightPane, rightWidth);
+    // Painted after every pane and before every modal, so the whole background
+    // recedes and the modals above it keep their own colours.
+    scrim.render(modalOpen);
     overlay.render(state, paneFallback);
     themePicker.render(state);
     chat.render(state);

--- a/clients/tui/src/ui/scrim.ts
+++ b/clients/tui/src/ui/scrim.ts
@@ -1,0 +1,50 @@
+import {BoxRenderable, type CliRenderer, hexToRgb, type RGBA} from '@opentui/core';
+import {scrim, type Theme} from './theme.js';
+
+/** The theme's scrim as a translucent paint the renderer blends per cell. */
+function scrimPaint(theme: Theme): RGBA {
+  const {color, strength} = scrim(theme);
+  const paint = hexToRgb(color);
+  paint.a = strength;
+  return paint;
+}
+
+/**
+ * The dim behind an open modal. One box covering the whole screen, painted
+ * after everything below it and before every modal above it, so the entire
+ * background recedes while the modal keeps its own colours and reads as the
+ * only surface accepting keys.
+ *
+ * It is absolutely positioned and joins no flex row or column, and the paint is
+ * translucent rather than opaque, so a cell behind it keeps its character and
+ * changes only colour. Opening and closing the modal therefore moves nothing.
+ */
+export class ScrimView {
+  readonly output: BoxRenderable;
+
+  constructor(renderer: CliRenderer, theme: Theme) {
+    this.output = new BoxRenderable(renderer, {
+      id: 'scrim',
+      width: '100%',
+      height: '100%',
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      backgroundColor: scrimPaint(theme),
+      // Above every pane and the lists that rise out of them (5), below the
+      // chat modal (20), the command overlay (25), and the theme picker (30):
+      // one scrim covers the background whichever of them are open, and two
+      // stacked modals never dim each other.
+      zIndex: 15,
+      visible: false,
+    });
+  }
+
+  applyTheme(theme: Theme): void {
+    this.output.backgroundColor = scrimPaint(theme);
+  }
+
+  render(modalOpen: boolean): void {
+    this.output.visible = modalOpen;
+  }
+}

--- a/clients/tui/src/ui/theme.test.ts
+++ b/clients/tui/src/ui/theme.test.ts
@@ -9,6 +9,7 @@ import {
   mix,
   relativeLuminance,
   resolveTheme,
+  scrim,
   THEME_NAMES,
   type Theme,
 } from './theme.js';
@@ -212,6 +213,46 @@ describe('semantic roles', () => {
       expect(dark.conversation.assistant.background).not.toBe(
         light.conversation.assistant.background,
       );
+    }
+  });
+});
+
+describe('modal scrim', () => {
+  const themes = listThemes();
+
+  it.each(
+    themes.map(theme => [theme.name, theme] as const),
+  )('%s recedes behind a modal without erasing what is behind it', (name: string, theme: Theme) => {
+    const {color, strength} = scrim(theme);
+    // The theme's own canvas, so the background fades into the surface it
+    // already sits on rather than toward a tone the palette never uses.
+    expect(color).toBe(theme.canvas);
+    expect(strength).toBeGreaterThan(0);
+    expect(strength).toBeLessThan(1);
+
+    const floor = name.startsWith('high-contrast') ? 7 : 4.5;
+    const recessed = contrastRatio(mix(theme.textPrimary, color, strength), color);
+    expect(contrastRatio(theme.textPrimary, theme.canvas)).toBeGreaterThanOrEqual(floor);
+    // Body text lands on WCAG's large-text floor whichever theme it started
+    // from: still recognizable, and well under the comfortable-reading floor
+    // the theme guarantees, which now belongs to the modal alone.
+    expect(recessed).toBeLessThanOrEqual(3);
+    expect(recessed).toBeGreaterThanOrEqual(2.5);
+    expect(recessed).toBeLessThan(floor);
+  });
+
+  it('solves a different strength per theme rather than reusing one blend', () => {
+    const strengths = themes.map(theme => scrim(theme).strength);
+    // Solarized Dark starts at 5.6:1 body text and High Contrast Dark at 21:1,
+    // so one blend cannot recede both. The spread is the point, not a defect.
+    expect(new Set(strengths).size).toBe(themes.length);
+    expect(Math.max(...strengths) - Math.min(...strengths)).toBeGreaterThan(0.2);
+  });
+
+  it('never leaves a modal fully transparent or the background erased', () => {
+    for (const theme of themes) {
+      expect(scrim(theme).strength).toBeGreaterThan(0.3);
+      expect(scrim(theme).strength).toBeLessThan(0.85);
     }
   });
 });

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -177,6 +177,54 @@ export function ensureContrast(foreground: string, background: string, minRatio:
   return candidate;
 }
 
+/**
+ * The dim a modal paints over everything behind it, as a colour and how far
+ * each background cell is pulled toward it. Applied by the renderer as an
+ * alpha blend over the finished frame, so it changes colour without moving a
+ * single cell.
+ */
+export interface Scrim {
+  /** Colour every background cell is pulled toward. */
+  color: string;
+  /** How far it is pulled: 0 leaves the frame alone, 1 replaces it. */
+  strength: number;
+}
+
+/**
+ * Contrast the scrim leaves between background text and what it sits on. WCAG's
+ * large-text floor: the run behind the modal stays recognizable, and the
+ * comfortable-reading floor each theme guarantees (4.5, or 7 on the
+ * high-contrast pair) is left to the modal, the one surface the scrim does not
+ * paint over.
+ */
+const SCRIM_RESIDUAL_CONTRAST = 3;
+
+/** A scrim that erases the background is a screen, not a dim. */
+const MAX_SCRIM_STRENGTH = 0.85;
+
+const SCRIM_STEPS = 100;
+
+/**
+ * Pulls the background toward the theme's own canvas, so it fades into the
+ * surface it already sits on instead of toward a blend the palette never uses.
+ * That darkens a dark theme and washes out a light one without an appearance
+ * branch, and it never invents a mid-tone a high-contrast palette excludes.
+ *
+ * The strength is solved per theme rather than fixed, because the themes do not
+ * start from the same contrast: one blend deep enough to recede Solarized
+ * Dark's 5.6:1 body text leaves High Contrast Dark's 21:1 fully readable.
+ * Solving for a residual lands every theme at the same recessed legibility.
+ */
+export function scrim(theme: Theme): Scrim {
+  const color = theme.canvas;
+  for (let step = 1; step <= SCRIM_STEPS; step += 1) {
+    const strength = (step / SCRIM_STEPS) * MAX_SCRIM_STRENGTH;
+    const faded = mix(theme.textPrimary, color, strength);
+    if (contrastRatio(faded, color) <= SCRIM_RESIDUAL_CONTRAST) return {color, strength};
+  }
+  return {color, strength: MAX_SCRIM_STRENGTH};
+}
+
 interface ThemeSpec {
   name: ThemeName;
   label: string;


### PR DESCRIPTION
> **Overlaps #634 by @zatchbell1311-wq**, which fixes #566 against current main.
> This PR is an alternative for comparison, not a competing claim. Its
> distinguishing piece is the per-theme scrim strength derivation in
> `ui/theme.ts`; if #634 is the one taken, that derivation is the part worth
> lifting.

## Problem

A modal draws over live content with no scrim, so the transcript behind and
beside it stays fully legible and nothing indicates which surface is taking
keys. With `/help` open the operator has two competing texts on screen.

Repro from #566: `clients/tui/dev/mock-ui.sh --tmux 150x40 --speed 0`, then
`/help`. The issue calls this "a legibility failure rather than a polish issue:
the operator cannot tell where a keystroke will land."

Refs #566.

## Solution

`ScrimView` is one absolutely positioned box covering the terminal at zIndex 15:
above every pane and the lists that rise out of them, below the chat modal (20),
the command overlay (25), and the theme picker (30). One scrim serves all three,
so two stacked modals never dim each other. The paint is translucent and the
renderer blends it per cell, so a background cell keeps its character and
changes only color. Nothing joins the flex layout, so nothing reflows.

`scrim(theme)` in `ui/theme.ts` is the single place the dim is computed. It
pulls toward the theme's own `canvas`, so neither light nor high-contrast
palettes get a tone they exclude. Strength is solved per theme rather than
fixed, because the themes do not start from the same contrast: measured
strengths run 0.374 to 0.655, and the binding theme is Solarized Dark, not the
high-contrast pair.

### Architecture

`ui/scrim.ts` owns the box and nothing else. `ui/theme.ts` owns the derivation.
`ui/app.ts` owns only the predicate for when it is raised.

## Verification

### Correctness properties

- The scrim repaints cells and lays out nothing, so opening a modal moves no
  character outside the modal's rectangle. **This property no longer holds on
  current main**, which is the substance of the failures below.
- One scrim serves all three modals, so stacked modals never dim each other.
- Every theme keeps modal body text at its own contrast floor.

### Testing

`pnpm check:ts`, `pnpm check:ts-architecture`, `pnpm check:clients`: clean.
`pnpm test:clients`: 704 pass, 0 fail.

Rebasing onto current main took real work, recorded here because it changed the
change:

- Conflicts resolved toward main's current APIs: `RoundStripView` to
  `RoundRailView`, the curated header (#571) now owning the Escape hint, and
  `overlay.render` taking `paneFallback` as its own argument.
- The per-theme `dims every cell` tests assert that opening a modal moves no
  character outside the modal. That held, but the test assumed the header was
  row 0; since #571 the header sits in its own housing, so its content row is 1.
  The test now reads the header's rows off `header-frame` rather than assuming.
- **The scrim no longer rises for the narrow-terminal pane fallback.** An
  earlier pass wired the fallback into the predicate, on the reasoning that it
  is a modal in everything but name. Measured against main, that erases the
  Agents and Transcript frames rather than dimming them: `paneBorders` finds
  only `▸ Performance` on screen with the fallback open and the scrim raised.
  That is a real defect in the interaction, not a test-method problem, so the
  predicate covers the three real modals only and the fallback is left for
  follow-up. The comment in `app.ts` says so.
