### PR TITLE
feat(tui): give a transcript card a role stripe instead of a role fill

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -2478,7 +2478,9 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(light.accent);
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe(light.conversation.assistant.content);
-    expect(body?.bg).toBe(light.conversation.assistant.background);
+    // A card carries its role on a left edge stripe rather than a fill, so its
+    // body sits on the theme's canvas.
+    expect(body?.bg).toBe(light.canvas);
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe(light.conversation.assistant.label);
   });
 
@@ -2499,8 +2501,8 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe('#22d3ee');
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe('#e2e8f0');
-    // Assistant cards derive their fill from the canvas and the role accent.
-    expect(body?.bg).toBe('#0e283d');
+    // No card fill: the role is a stripe, so a card body is the canvas.
+    expect(body?.bg).toBe('#0f172a');
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe('#5cb6cc');
   });
 
@@ -2526,7 +2528,7 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(solarized.accent);
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe(solarized.conversation.assistant.content);
-    expect(body?.bg).toBe(solarized.conversation.assistant.background);
+    expect(body?.bg).toBe(solarized.canvas);
   });
 
   it('navigates the theme list with the keyboard and applies on Enter', async () => {

--- a/clients/tui/src/ui/conversation.test.ts
+++ b/clients/tui/src/ui/conversation.test.ts
@@ -1,0 +1,333 @@
+import {afterEach, describe, expect, it} from 'bun:test';
+import {
+  BoxRenderable,
+  type CapturedFrame,
+  type Renderable,
+  rgbToHex,
+  TextRenderable,
+} from '@opentui/core';
+import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
+import type {SessionController} from '../session-controller.js';
+import type {ConversationEntry, SessionState} from '../session-model.js';
+import {initialSessionState} from '../session-model.js';
+import {ConversationView} from './conversation.js';
+import {createMarkdownStyle} from './styles.js';
+import {
+  CONVERSATION_ROLES,
+  type ConversationRole,
+  contrastRatio,
+  listThemes,
+  resolveTheme,
+  type Theme,
+} from './theme.js';
+
+const cleanup: (() => void)[] = [];
+
+afterEach(() => {
+  for (const dispose of cleanup.splice(0)) dispose();
+});
+
+/** The glyph the role stripe is drawn with. */
+const STRIPE = '▌';
+
+/**
+ * One entry per conversation role. `entryPalette` resolves the role from the
+ * kind and the tone, so this is the shortest transcript that covers all eight.
+ * None of them is a tool turn with a call and a response, which draws its own
+ * bands and would confuse a question about the card's own fill.
+ */
+const ROLE_ENTRIES: Record<ConversationRole, ConversationEntry> = {
+  assistant: {id: 'assistant', kind: 'assistant', content: 'assistant body', label: 'Assistant'},
+  user: {id: 'user', kind: 'user', content: 'user body', label: 'User'},
+  prompt: {id: 'prompt', kind: 'prompt', content: 'prompt body', label: 'Prompt'},
+  analysis: {id: 'analysis', kind: 'analysis', content: 'analysis body', label: 'Analysis'},
+  tool: {id: 'tool', kind: 'tool', content: 'tool body', label: 'Tool'},
+  neutral: {id: 'neutral', kind: 'result', content: 'result body', label: 'Result'},
+  success: {
+    id: 'success',
+    kind: 'result',
+    content: 'passed',
+    label: 'Judge',
+    tone: 'success',
+  },
+  failure: {
+    id: 'failure',
+    kind: 'result',
+    content: 'failed',
+    label: 'Judge',
+    tone: 'failure',
+  },
+};
+
+const STATUS_ENTRY: ConversationEntry = {
+  id: 'status',
+  kind: 'status',
+  content: 'started',
+  label: 'implementer',
+};
+
+/**
+ * The view reads `state` and calls back into the controller only from mouse
+ * handlers, which these tests never fire. Anything else being reached is a
+ * fact about the view worth failing on rather than stubbing away.
+ */
+function stubController(state: SessionState): SessionController {
+  return new Proxy(
+    {},
+    {
+      get(_target, property): unknown {
+        if (property === 'state') return state;
+        return () => {
+          throw new Error(`ConversationView called controller.${String(property)}`);
+        };
+      },
+    },
+  ) as SessionController;
+}
+
+interface Mounted {
+  testRenderer: TestRendererSetup;
+  view: ConversationView;
+  theme: Theme;
+}
+
+/**
+ * Mounts a transcript on a canvas the size of the real one, with markdown off
+ * so every card takes the verbatim-content path: the markdown renderable draws
+ * asynchronously, and none of these assertions is about markdown.
+ */
+async function mountTranscript(
+  entries: ConversationEntry[],
+  theme: Theme,
+  selectedEntryId: string | null = null,
+): Promise<Mounted> {
+  const testRenderer = await createTestRenderer({width: 60, height: 44});
+  const initial = initialSessionState(theme.name);
+  const state: SessionState = {
+    ...initial,
+    selectedEntryId,
+    // The run has ended, so the transcript is not streaming. `core.terminal`
+    // was replaced by the status-derived `hasRunEnded` in #572.
+    core: {...initial.core, status: 'completed' as const},
+  };
+  const canvas = new BoxRenderable(testRenderer.renderer, {
+    id: 'canvas',
+    width: '100%',
+    height: '100%',
+    flexDirection: 'column',
+    backgroundColor: theme.canvas,
+  });
+  testRenderer.renderer.root.add(canvas);
+  const view = new ConversationView(
+    testRenderer.renderer,
+    stubController(state),
+    createMarkdownStyle(theme),
+    theme,
+    {
+      // Not `state.core.transcript`: a user turn only ever reaches a chat
+      // conversation, so the run transcript's element type excludes it.
+      selectConversation: () => entries,
+      markdownKinds: [],
+      showsSelection: true,
+    },
+  );
+  canvas.add(view.output);
+  view.render(state);
+  await testRenderer.renderOnce();
+  cleanup.push(() => testRenderer.renderer.destroy());
+  return {testRenderer, view, theme};
+}
+
+interface Cell {
+  char: string;
+  fg: string;
+  bg: string;
+}
+
+/** Explodes a captured frame into cells so a single column can be inspected. */
+function cells(frame: CapturedFrame): Cell[][] {
+  return frame.lines.map(line => {
+    const row: Cell[] = [];
+    for (const span of line.spans) {
+      const fg = rgbToHex(span.fg).toLowerCase();
+      const bg = rgbToHex(span.bg).toLowerCase();
+      for (const char of [...span.text]) row.push({char, fg, bg});
+    }
+    return row;
+  });
+}
+
+/** Every renderable under the mounted view, cards and their contents alike. */
+function* descendants(mounted: Mounted): Generator<Renderable> {
+  const pending: Renderable[] = [mounted.view.output];
+  while (pending.length > 0) {
+    const node = pending.pop();
+    if (node === undefined) continue;
+    yield node;
+    pending.push(...node.getChildren());
+  }
+}
+
+function cardBox(mounted: Mounted, id: string): BoxRenderable {
+  const card = mounted.testRenderer.renderer.root.findDescendantById(`event-${id}`);
+  if (!(card instanceof BoxRenderable)) throw new Error(`no card for ${id}`);
+  return card;
+}
+
+/** The cell the stripe column holds on a card's first content row. */
+function stripeCell(mounted: Mounted, id: string): Cell {
+  const card = cardBox(mounted, id);
+  const grid = cells(mounted.testRenderer.captureSpans());
+  const cell = grid[card.y + 1]?.[card.x + 1];
+  if (cell === undefined) throw new Error(`card ${id} is off screen`);
+  return cell;
+}
+
+describe('transcript card role stripe', () => {
+  it('draws the role on the cards left edge, in the role colour', async () => {
+    const theme = resolveTheme('dark');
+    const mounted = await mountTranscript(Object.values(ROLE_ENTRIES), theme);
+    for (const role of CONVERSATION_ROLES) {
+      const entry = ROLE_ENTRIES[role];
+      const cell = stripeCell(mounted, entry.id);
+      expect(cell.char, `${role} stripe glyph`).toBe(STRIPE);
+      expect(cell.fg, `${role} stripe colour`).toBe(theme.conversation[role].label.toLowerCase());
+    }
+  });
+
+  it('runs the stripe the whole height of the card', async () => {
+    const theme = resolveTheme('dark');
+    const entry: ConversationEntry = {
+      id: 'tall',
+      kind: 'assistant',
+      label: 'Assistant',
+      content: 'one\ntwo\nthree\nfour',
+    };
+    const mounted = await mountTranscript([entry], theme);
+    const card = cardBox(mounted, 'tall');
+    const grid = cells(mounted.testRenderer.captureSpans());
+    // Every row between the card's top and bottom frame carries the stripe, so
+    // the role reads down the card rather than only beside its heading.
+    for (let row = card.y + 1; row < card.y + card.height - 1; row += 1) {
+      expect(grid[row]?.[card.x + 1]?.char, `row ${row - card.y}`).toBe(STRIPE);
+    }
+  });
+
+  it('keeps the stripe on the selected card, whose frame carries the cursor', async () => {
+    const theme = resolveTheme('dark');
+    const mounted = await mountTranscript(Object.values(ROLE_ENTRIES), theme, 'analysis');
+    const card = cardBox(mounted, 'analysis');
+    const grid = cells(mounted.testRenderer.captureSpans());
+    const stripe = grid[card.y + 1]?.[card.x + 1];
+    expect(stripe?.char).toBe(STRIPE);
+    expect(stripe?.fg).toBe(theme.conversation.analysis.label.toLowerCase());
+    // Selection owns the frame and only the frame.
+    expect(grid[card.y]?.[card.x]?.fg).toBe(theme.borderFocus.toLowerCase());
+    expect(grid[card.y]?.[card.x]?.fg).not.toBe(
+      grid[cardBox(mounted, 'user').y]?.[card.x]?.fg ?? '',
+    );
+  });
+
+  it('paints no role fill behind the card', async () => {
+    const theme = resolveTheme('dark');
+    const mounted = await mountTranscript(Object.values(ROLE_ENTRIES), theme);
+    const grid = cells(mounted.testRenderer.captureSpans());
+    const fills = new Set(
+      CONVERSATION_ROLES.map(role => theme.conversation[role].background.toLowerCase()),
+    );
+    const painted = new Set(grid.flatMap(row => row.map(cell => cell.bg)));
+    expect([...painted].filter(bg => fills.has(bg))).toEqual([]);
+    // Positive control: the cards are on screen and sit on the canvas.
+    expect(painted).toContain(theme.canvas.toLowerCase());
+    for (const role of CONVERSATION_ROLES) {
+      const card = cardBox(mounted, ROLE_ENTRIES[role].id);
+      const row = grid[card.y + 1] ?? [];
+      const backgrounds = new Set(row.slice(card.x, card.x + card.width).map(cell => cell.bg));
+      expect([...backgrounds], `${role} card row`).toEqual([theme.canvas.toLowerCase()]);
+    }
+  });
+});
+
+describe('transcript card alignment', () => {
+  it('reserves the stripe column rather than adding one', async () => {
+    const theme = resolveTheme('dark');
+    const mounted = await mountTranscript([...Object.values(ROLE_ENTRIES), STATUS_ENTRY], theme);
+    const grid = cells(mounted.testRenderer.captureSpans());
+    for (const role of CONVERSATION_ROLES) {
+      const entry = ROLE_ENTRIES[role];
+      const card = cardBox(mounted, entry.id);
+      const heading = mounted.testRenderer.renderer.root.findDescendantById(
+        `event-${entry.id}-heading`,
+      );
+      // Frame, stripe, then text: the same column the card's left padding used
+      // to put text in, so the stripe costs no cell.
+      expect(heading?.x, `${role} heading column`).toBe(card.x + 2);
+      const label = (entry.label ?? '').slice(0, 4);
+      expect(
+        grid[card.y + 1]
+          ?.slice(card.x + 2, card.x + 2 + label.length)
+          .map(cell => cell.char)
+          .join(''),
+        `${role} heading text`,
+      ).toBe(label);
+    }
+    // A status line reports on the run rather than speaking in it, so it gets
+    // no stripe. It still reserves the column, so it lines up with the cards
+    // around it instead of hanging a column to their left.
+    const status = cardBox(mounted, STATUS_ENTRY.id);
+    const statusHeading = mounted.testRenderer.renderer.root.findDescendantById(
+      `event-${STATUS_ENTRY.id}-heading`,
+    );
+    expect(statusHeading?.x).toBe(status.x + 2);
+    expect(grid[status.y + 1]?.[status.x + 1]?.char).toBe(' ');
+  });
+
+  it('puts every card body in the same column, striped or not', async () => {
+    const theme = resolveTheme('dark');
+    const entries = [...Object.values(ROLE_ENTRIES), STATUS_ENTRY];
+    const mounted = await mountTranscript(entries, theme);
+    const columns = new Set(
+      entries.map(entry => {
+        const card = cardBox(mounted, entry.id);
+        const heading = mounted.testRenderer.renderer.root.findDescendantById(
+          `event-${entry.id}-heading`,
+        );
+        return (heading?.x ?? -1) - card.x;
+      }),
+    );
+    expect(columns).toEqual(new Set([2]));
+  });
+
+  it('draws the stripe as a reserved column, not as text', async () => {
+    const theme = resolveTheme('dark');
+    const mounted = await mountTranscript([ROLE_ENTRIES.assistant], theme, 'assistant');
+    expect(stripeCell(mounted, 'assistant').char).toBe(STRIPE);
+    // Prefixed to the content instead, the glyph would indent with wrapped
+    // lines, move when the cursor marker appears, and land in a copied
+    // selection.
+    const written = [...descendants(mounted)]
+      .filter(node => node instanceof TextRenderable)
+      .map(node => node.content.toString());
+    expect(written.length).toBeGreaterThan(0);
+    expect(written.filter(content => content.includes(STRIPE))).toEqual([]);
+  });
+});
+
+describe('role stripes across themes', () => {
+  it.each(
+    listThemes().map(theme => [theme.name, theme] as const),
+  )('%s tells every role apart and keeps the stripe legible', async (_name, theme: Theme) => {
+    const mounted = await mountTranscript(Object.values(ROLE_ENTRIES), theme);
+    const stripes = new Map<ConversationRole, string>();
+    for (const role of CONVERSATION_ROLES) {
+      const cell = stripeCell(mounted, ROLE_ENTRIES[role].id);
+      expect(cell.char, `${role} stripe glyph`).toBe(STRIPE);
+      // 3:1 is the floor for a graphical element. Several raw role accents
+      // sit under it against their theme's canvas, which is why the stripe
+      // takes the derived label colour instead.
+      expect(contrastRatio(cell.fg, theme.canvas), `${role} stripe contrast`).toBeGreaterThan(3);
+      stripes.set(role, cell.fg);
+    }
+    expect(new Set(stripes.values()).size, 'distinct role stripes').toBe(CONVERSATION_ROLES.length);
+  });
+});

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -1,4 +1,6 @@
 import {
+  type BorderCharacters,
+  type BorderSides,
   BoxRenderable,
   type CliRenderer,
   MarkdownRenderable,
@@ -54,6 +56,42 @@ const CONVERSATION_WINDOW_THRESHOLD = 2_000;
 
 /** How many entries a windowed paint materializes, and grows by on demand. */
 const CONVERSATION_WINDOW = 200;
+
+/** The one side of the card body the stripe is drawn on. */
+const STRIPE_SIDE: BorderSides = 'left';
+
+/**
+ * A border set whose only reachable member is `vertical`: corners need two
+ * adjacent sides and the stripe has one, so the rest are spaces because
+ * `BorderCharacters` is a closed shape.
+ */
+function stripeChars(glyph: string): BorderCharacters {
+  return {
+    vertical: glyph,
+    horizontal: ' ',
+    topLeft: ' ',
+    topRight: ' ',
+    bottomLeft: ' ',
+    bottomRight: ' ',
+    topT: ' ',
+    bottomT: ' ',
+    leftT: ' ',
+    rightT: ' ',
+    cross: ' ',
+  };
+}
+
+/**
+ * A half block carries the role's hue at a glance while staying visibly not a
+ * border: the card's rounded frame already owns the box-drawing vocabulary, so
+ * a `│` inside it reads as a double frame. A full block would be the fill this
+ * replaces, only narrower, and would compete with the frame for the eye; the
+ * frame has to stay the loudest mark on the card because it carries the cursor.
+ */
+const ROLE_STRIPE = stripeChars('▌');
+
+/** The same column, unpainted, for a card that carries no conversation role. */
+const RESERVED_STRIPE = stripeChars(' ');
 
 export class ConversationView {
   readonly output: BoxRenderable;
@@ -326,19 +364,24 @@ export class ConversationView {
   #renderEntry(entry: ConversationEntry): BoxRenderable {
     const palette = entryPalette(entry, this.#theme);
     const selected = this.#selectedId === entry.id;
+    // A status line reports on the run rather than speaking in it, so it has no
+    // conversation role to stripe. It still reserves the column, and so still
+    // lines up with the cards around it.
+    const striped = entry.kind !== 'status';
     const card = new BoxRenderable(this.renderer, {
       id: `event-${entry.id}`,
       width: '100%',
       flexDirection: 'column',
       marginTop: 1,
-      paddingLeft: entry.kind === 'status' ? 0 : 1,
       paddingRight: 1,
       border: entry.kind !== 'status',
       borderStyle: 'rounded',
-      // The cursor is the card's border, not a fill: a filled card reads as
-      // selected text, and the transcript already uses fills for roles.
+      // The cursor is the card's border, and the role is the body's left edge
+      // stripe. Painting the role as a fill instead put it across every cell
+      // of the card, which reads as "this pane is highlighted" rather than
+      // "this card is role X", and it outweighed the cursor sitting on top of
+      // it. No fill at all: the card sits on the canvas.
       borderColor: selected ? this.#theme.borderFocus : palette.border,
-      backgroundColor: palette.background,
       ...(this.#showsSelection
         ? {
             onMouseUp: () => {
@@ -360,6 +403,29 @@ export class ConversationView {
             }
           : {}),
     });
+    // Everything the card holds hangs off the body, and the stripe is the
+    // body's left border. A border, rather than a stripe renderable or a glyph
+    // prefixed to each line, because it reserves its column: the column is the
+    // one the card's `paddingLeft` used to hold, so no text moves, and it costs
+    // the same cell whether or not a glyph is painted in it, so a card with a
+    // stripe and a card without still start their text in the same place. It
+    // also runs the body's full height, which a card holding a markdown block
+    // does not know in advance.
+    const body = new BoxRenderable(this.renderer, {
+      id: `event-${entry.id}-body`,
+      width: '100%',
+      flexDirection: 'column',
+      border: [STRIPE_SIDE],
+      customBorderChars: striped ? ROLE_STRIPE : RESERVED_STRIPE,
+      // The role's label colour, not its raw accent. The theme derives the
+      // label to clear its own contrast floor, so the stripe is legible in all
+      // eight themes, including the two high-contrast ones where several raw
+      // accents sit under 3:1 against the canvas. It is also the colour the
+      // card's own heading uses, so the stripe repeats the role rather than
+      // introducing a second colour for it.
+      borderColor: palette.label,
+    });
+    card.add(body);
     const heading = new BoxRenderable(this.renderer, {
       id: `event-${entry.id}-heading`,
       width: '100%',
@@ -374,15 +440,15 @@ export class ConversationView {
         height: 1,
       }),
     );
-    card.add(heading);
+    body.add(heading);
     if (this.#markdownKinds.has(entry.kind)) {
-      this.#renderMarkdownEntry(card, entry);
+      this.#renderMarkdownEntry(body, entry);
     } else if (
       entry.kind === 'tool' &&
       (entry.toolCall !== undefined ||
         (entry.toolName !== undefined && entry.toolArguments !== undefined))
     ) {
-      this.#renderToolTurn(card, entry);
+      this.#renderToolTurn(body, entry);
     } else {
       const prompt =
         entry.kind === 'prompt'
@@ -394,13 +460,13 @@ export class ConversationView {
           ? toolResultPreview(entry.content, entry.toolResult?.payload)
           : null;
       const content = prompt ? prompt.content : (output?.content ?? entry.content);
-      card.add(new TextRenderable(this.renderer, {content, fg: palette.content, width: '100%'}));
+      body.add(new TextRenderable(this.renderer, {content, fg: palette.content, width: '100%'}));
       if (output?.collapsible) {
         const hidden =
           output.hiddenLines > 0
             ? `${output.hiddenLines} more line${output.hiddenLines === 1 ? '' : 's'}`
             : `${output.hiddenCharacters} more characters`;
-        card.add(
+        body.add(
           new TextRenderable(this.renderer, {
             content: `… ${hidden} hidden`,
             fg: this.#theme.info,
@@ -409,7 +475,7 @@ export class ConversationView {
         );
       }
       if (prompt && (prompt.hiddenLines > 0 || this.#expandedPrompts.has(entry.id))) {
-        card.add(
+        body.add(
           new TextRenderable(this.renderer, {
             content: this.#expandedPrompts.has(entry.id)
               ? '▴ click to collapse'
@@ -423,13 +489,13 @@ export class ConversationView {
     return card;
   }
 
-  #renderMarkdownEntry(card: BoxRenderable, entry: ConversationEntry): void {
+  #renderMarkdownEntry(body: BoxRenderable, entry: ConversationEntry): void {
     const expanded = this.#expandedPrompts.has(entry.id);
     const preview =
       entry.kind === 'prompt'
         ? promptPreview(entry.content, expanded)
         : {content: entry.content, hiddenLines: 0};
-    card.add(
+    body.add(
       new MarkdownRenderable(this.renderer, {
         ...this.#markdownBlockOptions,
         content: preview.content,
@@ -437,7 +503,7 @@ export class ConversationView {
       }),
     );
     if (entry.kind === 'prompt' && (preview.hiddenLines > 0 || expanded)) {
-      card.add(
+      body.add(
         new TextRenderable(this.renderer, {
           content: expanded
             ? '▴ click or Ctrl+P to collapse'
@@ -449,13 +515,13 @@ export class ConversationView {
     }
   }
 
-  #renderToolTurn(card: BoxRenderable, entry: ConversationEntry): void {
+  #renderToolTurn(body: BoxRenderable, entry: ConversationEntry): void {
     const toolCall =
       entry.toolName !== undefined && entry.toolArguments !== undefined
         ? toolCallPreview(entry.toolName, entry.toolArguments)
         : (entry.toolCall ?? '');
     const toolResponse = entry.toolResult?.content ?? entry.toolResponse;
-    card.add(
+    body.add(
       new TextRenderable(this.renderer, {
         content: toolCall.trimEnd(),
         fg: this.#theme.toolCall.foreground,
@@ -466,7 +532,7 @@ export class ConversationView {
     if (toolResponse) {
       const expanded = this.#expandedTools.has(entry.id);
       const response = toolResultPreview(toolResponse, entry.toolResult?.payload, expanded);
-      card.add(
+      body.add(
         new TextRenderable(this.renderer, {
           content: `← ${response.content}`,
           fg: this.#theme.toolResult.foreground,
@@ -479,7 +545,7 @@ export class ConversationView {
           response.hiddenLines > 0
             ? `${response.hiddenLines} more line${response.hiddenLines === 1 ? '' : 's'}`
             : `${response.hiddenCharacters} more characters`;
-        card.add(
+        body.add(
           new TextRenderable(this.renderer, {
             content: expanded
               ? '▴ click or Enter to collapse response'


### PR DESCRIPTION
## Problem

A transcript card painted its conversation role as a full-width background fill
mixed from the canvas and the role accent, while selection was carried by the
card's border color. The fill is far heavier than a border: across a screen of
cards it reads as "this pane is highlighted" rather than "this card is role X",
and it outweighs the cursor drawn on top of it.

In the two high-contrast themes the fill also had almost no headroom to work
with: assistant in high-contrast-dark was `#001a1a` on a `#000000` canvas, which
is a role signal nobody can see.

No issue: this came out of the transcript-legibility work and is opened for
review on its own. It is adjacent to #516 (@AyanBinRafaih's #620), which
reshapes what a card *contains*; this changes how a card carries its role. They
touch the same surface, so whichever lands second will need a look at the other.

## Solution

The role moves to the card body's left edge as a half block, and the card paints
no fill at all.

```text
  before                        after
  ╭──────────────────────────╮  ╭──────────────────────────╮
  │ implementer · round-1    │  │▌implementer · round-1    │
  │ Short answer: yes. The   │  │▌Short answer: yes. The   │
  ╰──────────────────────────╯  ╰──────────────────────────╯
```

The stripe is the body's left border rather than a renderable or a text prefix.
A border reserves its column, and it is the column `paddingLeft` already held,
so no text moves. It costs the same cell whether or not a glyph is painted in
it, so a status line, which has no conversation role, reserves the column
unpainted and lines up with the cards around it instead of hanging a column to
their left. It also runs the body's full height, which a card holding a markdown
block does not know in advance.

A half block, not `│`: the card's rounded frame already owns the box-drawing
vocabulary and a second vertical inside it reads as a double frame. Not a full
block either, which is the same fill one column wide and competes with the
frame, and the frame has to stay the loudest mark on the card because it is what
carries the cursor.

### Architecture

Contained in `ui/conversation.ts`. `BorderCharacters` is a closed shape, so a
one-sided border is expressed by giving every unreachable member a space;
`stripeChars()` is that helper and the only new construct.

## Verification

### Correctness properties

- A status line reserves the stripe column unpainted, so every card and status
  line shares one left edge.
- No text moves relative to the previous fill-based card: the stripe occupies
  the column `paddingLeft` used to hold.
- Selection remains the border color, and with the fill gone it is now the
  strongest mark on the card in every theme.
- The role is legible in the high-contrast themes, where the fill was not.

### Testing

`bun test clients/tui/src/ui/app.test.ts clients/tui/src/ui/conversation.test.ts`:
175 pass, 0 fail.

Rebased onto current main. Two commits that were already merged via #572 were
dropped in the rebase, so this branch is now the single stripe commit.

## Screenshots

Real terminal captures at 150x40, round 1 transcript, F4-zoomed. Colours audited
against each worktree's `theme.ts`.

**Dark**: each card carries its role as a `▌` on the body's left edge, card
interiors on plain canvas. Sampled: analysis stripe `#b193f8` (exact), success
stripe `#6dd895` (d=1), card body `canvas #0f172a` (exact, no role fill).

![dark](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr640-stripe-dark.png)

**High-contrast-dark**, the theme where the old fill had no headroom: analysis
stripe `#eab4ff`, success stripe `#58ffac`, card bodies `canvas #000000`. The
role reads at full saturation on pure black, where the fill it replaces was
`#001a1a` and invisible.

![high contrast dark](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr640-stripe-hc-dark.png)
