### PR TITLE
fix(tui): raise elevatedSurface above canvas in the three inverted dark themes

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -262,11 +262,17 @@ the input still runs on its own Enter. `/theme <name>` re-themes every view in
 place without opening the list.
 
 `ui/theme.ts` is the only module holding color literals. A theme declares
-semantic roles — `canvas`, `surface`, `elevatedSurface`, `selectedSurface`;
-`textPrimary`, `textMuted`, `textSubtle`, `textStrong`; `border`,
-`borderStrong`, `borderFocus`; `accent`, `info`; `success`, `warning`, `error`;
-per-role conversation card colors; and Markdown/code colors. Views ask for a
-role and never for a color.
+semantic roles — `canvas`, `surface`, `selectedSurface`; `textPrimary`,
+`textMuted`, `textSubtle`, `textStrong`; `border`, `borderStrong`,
+`borderFocus`; `accent`, `info`; `success`, `warning`, `error`; per-role
+conversation card colors; and Markdown/code colors. Views ask for a role and
+never for a color.
+
+`canvas` is the only background the UI paints: every pane, modal, the header,
+the error banner and the composer fill with it, and a box is told from the page
+by its border rather than by a shade of its own. The other two fills name a
+state and not a depth — `selectedSurface` is what the cursor is on, and
+`surface` backs a code block, which has no border to delimit it.
 
 Adding a theme means adding one `ThemeSpec`: a semantic core plus one accent
 per conversation role. Card fills, labels, body text, the tool-call band, and

--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -170,7 +170,11 @@ modal they used before panes existed. That modal is the same surface as the
 pane, so it keeps the pane's title and its focus marker rather than reading as a
 generic dialog. The layout re-flows on resize in either direction.
 
-`/help`, `/theme`, and errors stay modal.
+`/help`, `/theme`, and errors stay modal. While any of them is open, a scrim
+dims the entire screen behind it, so the modal is the only surface left at full
+contrast and the operator can tell where a keystroke will land. The scrim is a
+translucent paint applied over the finished frame rather than a layout node: the
+background keeps every character where it was, and closing restores it exactly.
 
 ### Experiment chat
 
@@ -270,6 +274,11 @@ the Markdown palette are derived from that core, and each derived foreground is
 pushed toward the nearest extreme until it clears the theme's `minContrast`
 against the surface it actually sits on. The `dark` theme additionally pins its
 derived values to the original literals so the baseline is byte-identical.
+The modal scrim is derived the same way: it pulls the background toward the
+theme's own `canvas`, and its strength is solved per theme so body text lands on
+WCAG's large-text floor whatever it started from. One fixed blend cannot do
+that, because a blend deep enough to recede Solarized Dark's 5.6:1 body text
+leaves High Contrast Dark's 21:1 fully readable.
 Status meaning never depends on color: agent phases carry a marker glyph and
 the spelled-out status, todos carry a per-status marker, and only the running
 round shows elapsed time.

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -79,6 +79,13 @@ const AGENTS_TITLE = 'Agents';
 
 export class AgentMapView {
   readonly output: BoxRenderable;
+  /**
+   * Everything this view draws, in a box that outlives what it draws. `#clear`
+   * destroys the graph on every repaint, and while this pane is zoomed the
+   * command column is a child of `output` too: without the separation the first
+   * repaint after a zoom destroyed the command input along with the graph.
+   */
+  readonly #content: BoxRenderable;
   #theme: Theme;
   #renderedState: SessionState | null = null;
   #renderedWidth = 0;
@@ -106,6 +113,15 @@ export class AgentMapView {
       title: paneTitle(AGENTS_TITLE, false),
       onMouseUp: () => this.controller.focusRound('agents'),
     });
+    this.#content = new BoxRenderable(renderer, {
+      id: 'agent-map-content',
+      width: '100%',
+      flexGrow: 1,
+      flexShrink: 1,
+      flexDirection: 'column',
+      onMouseUp: () => this.controller.focusRound('agents'),
+    });
+    this.output.add(this.#content);
   }
 
   applyTheme(theme: Theme): void {
@@ -161,7 +177,7 @@ export class AgentMapView {
         roundNumber === null
           ? null
           : (stripRounds(state).find(item => item.number === roundNumber) ?? null);
-      this.output.add(
+      this.#content.add(
         new TextRenderable(this.renderer, {
           content:
             round?.status === 'planned'
@@ -204,7 +220,7 @@ export class AgentMapView {
         }),
       );
     }
-    this.output.add(headingRow);
+    this.#content.add(headingRow);
     // Elapsed time only advances while an agent is running, so the heading
     // ticks for exactly as long as one is.
     if (round !== null && hasActiveAgentTiming(round)) this.#runningRound = {round, text: heading};
@@ -243,7 +259,7 @@ export class AgentMapView {
       flexShrink: 0,
       onMouseUp: () => this.controller.focusRound('agents'),
     });
-    this.output.add(area);
+    this.#content.add(area);
     area.add(canvas);
     for (const run of edgeRuns(graph)) {
       canvas.add(
@@ -326,9 +342,9 @@ export class AgentMapView {
   /** The pane before the graph: used when the terminal is too narrow for it. */
   #renderStacked(phases: AgentPhase[], selectedKind: string | null): void {
     for (const [index, phase] of phases.entries()) {
-      this.output.add(this.#renderStackedPhase(phase, selectedKind === phase.kind));
+      this.#content.add(this.#renderStackedPhase(phase, selectedKind === phase.kind));
       if (index < phases.length - 1) {
-        this.output.add(
+        this.#content.add(
           new TextRenderable(this.renderer, {
             content: '        ↓',
             fg: this.#theme.textSubtle,
@@ -417,8 +433,8 @@ export class AgentMapView {
   #clear(): void {
     this.#runningRound = null;
     this.#stopElapsedTimer();
-    for (const child of [...this.output.getChildren()]) {
-      this.output.remove(child);
+    for (const child of [...this.#content.getChildren()]) {
+      this.#content.remove(child);
       child.destroyRecursively();
     }
   }

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -278,7 +278,14 @@ export class AgentMapView {
       // No horizontal padding: two columns of it is the difference between
       // "implementer" and "implement…" at the widths a four-stage round leaves.
       border: true,
-      borderStyle: 'rounded',
+      // Square, because this card carries selection as a fill and a box may
+      // have one or the other, never both (tui-conventions.md). A square
+      // corner cell is honestly square, so filling it is truthful; a rounded
+      // one is not. Unconditional rather than square-only-when-selected:
+      // swapping the shape on selection reads as the node becoming a
+      // different kind of object, which is why `PANE_BORDER` rejected the same
+      // swap for focus.
+      borderStyle: 'single',
       borderColor: selected
         ? this.#theme.borderFocus
         : phase.status === 'pending'
@@ -342,10 +349,13 @@ export class AgentMapView {
       paddingRight: 1,
       // Passing borderStyle without border draws a frame that the layout does
       // not reserve rows for, and the phase's lines then overlap it.
+      //
+      // Square for the same reason as `#renderNode`: this is that card in the
+      // stacked layout, and it only draws a frame in the state that fills it.
       ...(selected
         ? {
             border: true,
-            borderStyle: 'rounded' as const,
+            borderStyle: 'single' as const,
             borderColor: this.#theme.borderFocus,
           }
         : {}),

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -2470,10 +2470,9 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(light.accent);
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe(light.conversation.assistant.content);
-    // The canvas, not a role fill: a bordered card carries the role in its
-    // border and draws no background of its own.
+    // #565: the card carries its role on the divider rule, not a fill, so its
+    // body sits on the theme's canvas.
     expect(body?.bg).toBe(light.canvas);
-    expect(cardBorder(testRenderer, 'event-themed')).toBe(light.conversation.assistant.border);
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe(light.conversation.assistant.label);
   });
 
@@ -2494,10 +2493,9 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe('#22d3ee');
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe('#e2e8f0');
-    // The canvas: an assistant card draws no fill of its own, and carries its
-    // role accent in the border instead.
+    // No card fill: the role lives on the top-edge divider rule, so a card
+    // body is the canvas.
     expect(body?.bg).toBe('#0f172a');
-    expect(cardBorder(testRenderer, 'event-themed')).toBe('#0891b2');
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe('#5cb6cc');
   });
 
@@ -2523,10 +2521,7 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(solarized.accent);
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe(solarized.conversation.assistant.content);
-    // Both channels have to follow the swap: the canvas the card sits on, and
-    // the border it carries its role in.
     expect(body?.bg).toBe(solarized.canvas);
-    expect(cardBorder(testRenderer, 'event-themed')).toBe(solarized.conversation.assistant.border);
   });
 
   it('navigates the theme list with the keyboard and applies on Enter', async () => {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -72,6 +72,7 @@ import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 import {renderDesignSummary} from './design-log.js';
 import {paneTitle} from './focus.js';
 import {headerBackground} from './header.js';
+import {MIN_SPLIT_WIDTH} from './right-pane.js';
 import {
   contrastRatio,
   ensureContrast,
@@ -500,18 +501,25 @@ describe('OpenTUI presentation', () => {
     const promptLine = lines.findIndex(line => line.includes('Implement the queue'));
     const activityLineIndex = lines.findIndex(line => line.includes('Implementer · Working'));
     const helpLine = lines.findIndex(line => line.includes('[/]: round'));
+    // The command box is the foot of the transcript pane, so the pane's own
+    // bottom border is below it and the row the activity line is measured
+    // against is where that box starts.
+    const commandTop = lines.findIndex(
+      (line, index) => index > activityLineIndex && /[╭┏][─━] [▸ ] Command /.test(line),
+    );
     const viewportBottomBorder = lines.findIndex(
       (line, index) =>
-        index > activityLineIndex && index < helpLine && FRAME_BOTTOM_RIGHT.test(line.trimEnd()),
+        index > commandTop && index < helpLine && FRAME_BOTTOM_RIGHT.test(line.trimEnd()),
     );
     expect(activityLineIndex).toBeGreaterThan(promptLine);
     expect(FRAME_VERTICAL.test(activityLine?.trimEnd() ?? '')).toBe(true);
-    expect(viewportBottomBorder).toBeGreaterThan(activityLineIndex);
+    expect(commandTop).toBeGreaterThan(activityLineIndex);
+    expect(viewportBottomBorder).toBeGreaterThan(commandTop);
     expect(viewportBottomBorder).toBeLessThan(helpLine);
     const transcriptColumn = Math.max(0, (activityLine?.indexOf('Implementer') ?? 2) - 2);
     expect(
       lines
-        .slice(activityLineIndex + 1, viewportBottomBorder)
+        .slice(activityLineIndex + 1, commandTop)
         .every(line => line.slice(transcriptColumn).replaceAll(FRAME_VERTICALS, '').trim() === ''),
     ).toBe(true);
 
@@ -3131,14 +3139,17 @@ describe('theming', () => {
     expect(landing).toContain('Implementation Details');
     expect(landing).toContain('Batch the prefill step');
 
-    // Each column has its own input, under the surface it writes to, and the
-    // command box starts where the chat column ends rather than running under
-    // it.
+    // Each column has its own input, inside the pane that input writes to.
     // The cursor starts in the command box, and the chat says how to reach it.
     expect(landing).toContain('Ctrl+W to type here');
     expect(paneFrameColumn(landing, 'Experiment chat')).not.toBeNull();
     expect(paneFrameColumn(landing, 'Message')).not.toBeNull();
-    expect(paneFrameColumn(landing, 'Command')).toBe(paneFrameColumn(landing, 'Experiments'));
+    // Inset by the table's own border and padding rather than level with its
+    // frame: the command box is a child of the pane whose keys it takes, so it
+    // starts inside that pane and cannot run back under the chat beside it.
+    const table = paneFrameColumn(landing, 'Experiments');
+    expect(table).not.toBeNull();
+    expect(paneFrameColumn(landing, 'Command')).toBe((table ?? 0) + 2);
   });
 
   it('keeps the message and command boxes on the same rows while the chat is docked', async () => {
@@ -3189,12 +3200,119 @@ describe('theming', () => {
     expect(rows.message).toBe(rows.command);
   });
 
-  it('gives the short terminal its landing rows back instead of the box alignment', async () => {
-    // The row that puts the Command box on the Message box's row comes out of
-    // the table above it. On a terminal with no row to spare the table keeps
-    // it and the two boxes sit one row apart: the operator can see that and
-    // undo it by resizing, whereas a clipped last line of the kickoff copy
-    // just looks like the copy ends there.
+  it('keeps the command box inside the pane whose keys it takes, in every view', async () => {
+    // The box used to sit in a row of its own beneath every pane, which is why
+    // it could take keys while another pane wore the marker. It is a child of
+    // the pane it writes to now, and which pane that is differs by view, so
+    // what has to hold is that it lands in the right one through a view change,
+    // a split, each zoom that takes the left pane off screen, and the width
+    // that replaces the split with a floating pane.
+    const testRenderer = await createTestRenderer({width: 140, height: 24});
+    const controller = splitController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    /** The command box is the foot of `paneId`, inside that pane's frame. */
+    const expectCommandInside = (paneId: string): void => {
+      const pane = testRenderer.renderer.root.findDescendantById(paneId);
+      const command = testRenderer.renderer.root.findDescendantById('command-input-box');
+      if (pane === undefined || command === undefined)
+        throw new Error(`${paneId} geometry was missing`);
+      expect({pane: paneId, onScreen: pane.visible && command.visible}).toEqual({
+        pane: paneId,
+        onScreen: true,
+      });
+      expect({pane: paneId, insideLeft: command.x > pane.x}).toEqual({
+        pane: paneId,
+        insideLeft: true,
+      });
+      expect({
+        pane: paneId,
+        insideRight: command.x + command.width < pane.x + pane.width,
+      }).toEqual({pane: paneId, insideRight: true});
+      // The pane's own bottom border is the row under the box, so the box ends
+      // one row short of the pane. That is also why the two columns of the
+      // landing view line up without a row being spent on it.
+      expect({pane: paneId, foot: command.y + command.height}).toEqual({
+        pane: paneId,
+        foot: pane.y + pane.height - 1,
+      });
+    };
+
+    // A round: the transcript.
+    await frameAfter(testRenderer);
+    expectCommandInside('viewport');
+
+    // A split: still the left pane, not the one the split opened on the right.
+    await controller.openPane('perf');
+    await frameAfter(testRenderer);
+    const rightPane = testRenderer.renderer.root.findDescendantById('right-pane');
+    const command = testRenderer.renderer.root.findDescendantById('command-input-box');
+    if (rightPane === undefined || command === undefined)
+      throw new Error('split geometry was missing');
+    expect(rightPane.visible).toBe(true);
+    expect(command.x).toBeLessThan(rightPane.x);
+    expectCommandInside('viewport');
+
+    // Zoomed onto the visualization, which is now the only pane on screen.
+    controller.focusPane('right');
+    testRenderer.mockInput.pressKey('F4');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.zoomedPane).toBe('performance');
+    expectCommandInside('right-pane');
+
+    // Zoomed onto the agents pane, whose contents are rebuilt on every repaint:
+    // the box has to survive the repaint, not only the first frame after it.
+    testRenderer.mockInput.pressKey('F4');
+    controller.closePane();
+    controller.focusRound('agents');
+    testRenderer.mockInput.pressKey('F4');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.zoomedPane).toBe('agents');
+    expectCommandInside('agent-map');
+    controller.publish({
+      ...controller.state,
+      core: {...controller.state.core, status: 'completed'},
+    });
+    await frameAfter(testRenderer);
+    expectCommandInside('agent-map');
+
+    // Too narrow to split: the visualization becomes a floating pane over the
+    // round, the transcript keeps the box, and the floating pane keeps clear of
+    // it rather than covering the surface still taking the keystrokes.
+    testRenderer.mockInput.pressKey('F4');
+    await controller.openPane('perf');
+    testRenderer.renderer.resize(MIN_SPLIT_WIDTH - 1, 20);
+    const narrow = await frameAfter(testRenderer);
+    expect(narrow).toContain('best r7 1135 tok_s');
+    expectCommandInside('viewport');
+    const floating = testRenderer.renderer.root.findDescendantById('overlay');
+    const narrowCommand = testRenderer.renderer.root.findDescendantById('command-input-box');
+    if (floating === undefined || narrowCommand === undefined)
+      throw new Error('fallback geometry was missing');
+    expect(floating.visible).toBe(true);
+    expect(floating.y + floating.height).toBeLessThanOrEqual(narrowCommand.y);
+
+    // The landing view: the table, at a width that carries the chat beside it.
+    testRenderer.renderer.resize(140, 24);
+    controller.closePane();
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+    expectCommandInside('experiment-log');
+
+    // Through all of it, the box never claimed a focus of its own: it takes no
+    // marker, and exactly one pane wears one.
+    expect(markedPanes(paneBorders(testRenderer))).toHaveLength(1);
+    expect(markedPanes(paneBorders(testRenderer))).not.toContain('▸ Command');
+  });
+
+  it('keeps the short terminal both its landing rows and the box alignment', async () => {
+    // Alignment used to cost the table a row, so a terminal with none to spare
+    // gave the row back and let the two boxes sit one row apart. Each box now
+    // sits inside its own pane and the two panes are the same rectangle, so
+    // the boxes share a row because they are siblings rather than because a
+    // row was budgeted for it. That budget is what #556 measured, and it is
+    // gone: nothing is bought, so a short terminal has nothing to give up.
     const testRenderer = await createTestRenderer({width: 100, height: 16});
     const controller = kickoffController();
     const app = createOpenTuiApp(testRenderer.renderer, controller);
@@ -3217,10 +3335,10 @@ describe('theming', () => {
     expect(short).toContain('This activity becomes');
     expect(short).toMatch(/[╭┏][─━]\s*▸?\s*Command/);
     expect(short).toContain('Type /help for commands');
-    // The cost, stated: the boxes are one row apart rather than level.
-    expect(bottomRows().command).toBe(bottomRows().message + 1);
+    // Level at the height that used to have to choose.
+    expect(bottomRows().command).toBe(bottomRows().message);
 
-    // One more row and the alignment is affordable again, copy still whole.
+    // And at the height that could afford it before, copy still whole.
     testRenderer.renderer.resize(100, 17);
     const taller = await frameAfter(testRenderer);
     expect(taller).toContain('This activity becomes');
@@ -3257,7 +3375,14 @@ describe('theming', () => {
     controller.focusPane('left');
     await frameAfter(testRenderer);
     await testRenderer.mockInput.typeText('/');
-    await testRenderer.waitForFrame(value => value.includes('/pause'));
+    // Not `waitForFrame(text.includes('/pause'))`: the chat's own list is still
+    // open beside this one and offers the same commands, so the text can match
+    // on a frame the command list has not been laid out in yet. Wait for the
+    // list itself to have taken a row per match.
+    await testRenderer.waitForFrame(() => {
+      const list = testRenderer.renderer.root.findDescendantById('command-input-suggestions');
+      return list?.visible === true && list.height > 2;
+    });
     const command = boxTopUnder('command-input-suggestions', 'command-input-box');
     expect(command.menu).toBe(command.box);
   });
@@ -3456,7 +3581,7 @@ describe('theming', () => {
     expect(controller.chatSubmissions).toEqual(['draft survives the layout change']);
   });
 
-  it('lets the docked chat span the table and command surface', async () => {
+  it('gives the docked chat and the table the same rectangle, each holding its own input', async () => {
     const testRenderer = await createTestRenderer({width: 140, height: 20});
     const controller = logController();
     const app = createOpenTuiApp(testRenderer.renderer, controller);
@@ -3465,14 +3590,25 @@ describe('theming', () => {
     await frameAfter(testRenderer);
 
     const chatPane = testRenderer.renderer.root.findDescendantById('chat-pane');
-    const workspace = testRenderer.renderer.root.findDescendantById('workspace');
+    const table = testRenderer.renderer.root.findDescendantById('experiment-log');
     const composer = testRenderer.renderer.root.findDescendantById('chat-dock-composer-box');
-    if (chatPane === undefined || workspace === undefined || composer === undefined)
+    const command = testRenderer.renderer.root.findDescendantById('command-input-box');
+    if (
+      chatPane === undefined ||
+      table === undefined ||
+      composer === undefined ||
+      command === undefined
+    )
       throw new Error('landing layout was missing');
-    expect(chatPane.y).toBe(workspace.y);
-    expect(chatPane.y + chatPane.height).toBe(workspace.y + workspace.height);
+    // Two columns of one row, so they start and end on the same lines. This is
+    // what makes the boxes below line up without a row being budgeted for it.
+    expect(chatPane.y).toBe(table.y);
+    expect(chatPane.y + chatPane.height).toBe(table.y + table.height);
+    // Each input sits within the frame of the pane it writes to.
     expect(composer.x).toBeGreaterThan(chatPane.x);
     expect(composer.x + composer.width).toBeLessThan(chatPane.x + chatPane.width);
+    expect(command.x).toBeGreaterThan(table.x);
+    expect(command.x + command.width).toBeLessThan(table.x + table.width);
   });
 
   it('raises the command list out of the command input, clear of the chat', async () => {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -72,7 +72,15 @@ import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 import {renderDesignSummary} from './design-log.js';
 import {paneTitle} from './focus.js';
 import {headerBackground} from './header.js';
-import {contrastRatio, listThemes, resolveTheme, THEME_NAMES, type ThemeName} from './theme.js';
+import {
+  contrastRatio,
+  ensureContrast,
+  listThemes,
+  resolveTheme,
+  SUBTLE_TEXT_MIN_CONTRAST,
+  THEME_NAMES,
+  type ThemeName,
+} from './theme.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -1706,13 +1714,15 @@ describe('OpenTUI presentation', () => {
     const frame = await testRenderer.waitForFrame(value => value.includes('2 passed'));
     expect(frame).toContain('→ Bash(command="pytest")');
     expect(frame).toContain('← 2 passed');
-    // Agents pane, transcript frame, and the card's call and result regions:
-    // the rail is absent because this fixture has no rounds. A focused pane
-    // draws a heavy corner, so the count is over both styles. The header
-    // housing is no longer among them: it keeps its fill, so it draws a square
-    // frame (tui-conventions.md), and it is counted separately so its shape
-    // stays asserted rather than dropping out of the test.
-    expect(frame.match(/[╭┏]/g)).toHaveLength(4);
+    // Agents pane, transcript frame and command box: the rail is absent
+    // because this fixture has no rounds. A focused pane draws a heavy corner,
+    // so the count is over both styles. Two rounded corners that used to be
+    // here are gone for separate reasons, and both are asserted rather than
+    // simply subtracted: the header housing keeps its fill so it now draws a
+    // *square* frame (tui-conventions.md), counted on its own line below, and
+    // the transcript card's four-sided border became a top-edge rule (#565),
+    // which has no corner glyph at all.
+    expect(frame.match(/[╭┏]/g)).toHaveLength(3);
     expect(frame.match(/┌/g)).toHaveLength(1);
   });
 
@@ -2435,9 +2445,12 @@ describe('theming', () => {
   /**
    * The role colour a transcript card carries.
    *
-   * The border, because that is where the role lives: a bordered card has no
-   * fill (tui-conventions.md), so the body text reports the canvas and the
-   * role would otherwise go unasserted here.
+   * The top-edge rule, because that is where the role lives: a card has no
+   * fill (tui-conventions.md) and #565 replaced its four sides with that one
+   * rule, so the body text reports the canvas and the role would otherwise go
+   * unasserted here. `conversation.test.ts` pins the same colour as a
+   * computation over theme.ts across all eight themes; this asserts the
+   * rendered frame actually carries what that computation produces.
    */
   function cardBorder(testRenderer: TestRendererSetup, id: string): string | undefined {
     const card = testRenderer.renderer.root.findDescendantById(id);
@@ -2473,6 +2486,13 @@ describe('theming', () => {
     // #565: the card carries its role on the divider rule, not a fill, so its
     // body sits on the theme's canvas.
     expect(body?.bg).toBe(light.canvas);
+    expect(cardBorder(testRenderer, 'event-themed')).toBe(
+      ensureContrast(
+        light.conversation.assistant.border,
+        light.canvas,
+        SUBTLE_TEXT_MIN_CONTRAST,
+      ).toLowerCase(),
+    );
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe(light.conversation.assistant.label);
   });
 

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -2506,7 +2506,7 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe(light.conversation.assistant.label);
   });
 
-  it('keeps the dark baseline identical to the pre-theme palette', async () => {
+  it('keeps the dark baseline identical to the pre-theme palette, background aside', async () => {
     const testRenderer = await createTestRenderer({width: 90, height: 20});
     const controller = new FakeController({
       ...initialSessionState(),
@@ -2523,10 +2523,43 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe('#22d3ee');
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe('#e2e8f0');
-    // No card fill: the role lives on the top-edge divider rule, so a card
-    // body is the canvas.
-    expect(body?.bg).toBe('#0f172a');
+    // Both changes land on this one cell. #565 removed the card's fill, so the
+    // body reports whatever is behind it, and #574 collapsed the palette, so
+    // what is behind it is the one universal background rather than the old
+    // lighter `canvas`. Neither value either change asserted on its own
+    // survives: not `#0f172a` (the canvas before the collapse) and not
+    // `#03192d` (a role tint the card no longer paints).
+    expect(body?.bg).toBe('#020617');
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe('#5cb6cc');
+  });
+
+  it('gives the key-help line the same background as the chrome above it', async () => {
+    // #574's second symptom, and the one visible without comparing two panes:
+    // the key-help line sets no background of its own, so it fell through to
+    // the root frame. The root was painted `canvas` while every pane and the
+    // header were painted the darker `elevatedSurface`, which left a pale rule
+    // across the bottom of the screen under a dark theme. With one background
+    // there is nothing left to fall through to that disagrees.
+    //
+    // Asserted against the header's own cells rather than a literal, because
+    // the symptom is that two rows disagree; that stays the property being
+    // checked if the palette moves again.
+    const testRenderer = await createTestRenderer({width: 150, height: 40});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      core: {
+        ...initialSessionState().core,
+        status: 'running',
+        transcript: [assistantEntry],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('F4: zoom'));
+
+    const help = spanColors(testRenderer, 'F4: zoom');
+    expect(help?.bg).toBe(spanColors(testRenderer, 'VibeSys')?.bg);
+    expect(help?.bg).toBe(resolveTheme('dark').canvas);
   });
 
   it('repaints live when the selected theme changes', async () => {
@@ -5609,7 +5642,11 @@ describe('modal scrim', () => {
 
     const floor = themeName.startsWith('high-contrast') ? 7 : 4.5;
     const modalBody = requireSpanColors(testRenderer, 'Available commands');
-    expect(modalBody).toEqual({fg: theme.textPrimary, bg: theme.elevatedSurface});
+    // The modal keeps a fill and squares its border (#642), and that fill is
+    // now the one background the theme has (#574), so this reads `canvas`
+    // where it used to read the separate elevated surface. The property is
+    // unchanged: the modal is the one surface the scrim does not paint over.
+    expect(modalBody).toEqual({fg: theme.textPrimary, bg: theme.canvas});
     expect(contrastRatio(modalBody.fg, modalBody.bg)).toBeGreaterThanOrEqual(floor);
     // Background text recedes below the floor the theme guarantees, and stays
     // above the point where the run behind the modal would be erased.

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -77,8 +77,10 @@ import {
   contrastRatio,
   ensureContrast,
   listThemes,
+  mix,
   resolveTheme,
   SUBTLE_TEXT_MIN_CONTRAST,
+  scrim,
   THEME_NAMES,
   type ThemeName,
 } from './theme.js';
@@ -5532,6 +5534,199 @@ function clipboardReturning(
       return result;
     },
   };
+}
+
+describe('modal scrim', () => {
+  const helpOverlay = {kind: 'help' as const, content: 'Available commands'};
+
+  function behindTheModal(themeName: ThemeName): SessionState {
+    const initial = initialSessionState(themeName);
+    return {
+      ...initial,
+      core: {
+        ...initial.core,
+        status: 'running',
+        transcript: [
+          {id: 'behind', kind: 'assistant', label: 'implementer', content: 'transcript behind it'},
+        ],
+      },
+    };
+  }
+
+  it.each(
+    THEME_NAMES.map(name => [name] as const),
+  )('%s dims every cell around the modal and leaves the modal at full contrast', async (themeName: ThemeName) => {
+    const theme = resolveTheme(themeName);
+    const {color, strength} = scrim(theme);
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(behindTheModal(themeName));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('transcript behind it'));
+    await testRenderer.waitForVisualIdle();
+    const closed = frameCells(testRenderer);
+    const headerBefore = requireSpanColors(testRenderer, 'VibeSys');
+
+    controller.publish({...controller.state, overlay: helpOverlay});
+    await testRenderer.waitForFrame(value => value.includes('Available commands'));
+    await testRenderer.waitForVisualIdle();
+    const open = frameCells(testRenderer);
+
+    const box = boxOf(testRenderer, 'overlay');
+    // Every band around the modal, so a scrim confined to the box region
+    // fails here rather than passing on the rows it happens to cover.
+    const dimmed = {above: 0, below: 0, left: 0, right: 0};
+    const moved: number[] = [];
+    for (const [row, column, before, after] of cellsOutside(closed, open, box)) {
+      if (before.char !== after.char) {
+        moved.push(row);
+        continue;
+      }
+      // A blank cell has no visible foreground, and the scrim claims it.
+      if (before.char !== ' ') {
+        expect(channelDistance(after.fg, mix(before.fg, color, strength))).toBeLessThanOrEqual(1);
+      }
+      expect(channelDistance(after.bg, mix(before.bg, color, strength))).toBeLessThanOrEqual(1);
+      if (after.fg === before.fg && after.bg === before.bg) continue;
+      if (row < box.y) dimmed.above += 1;
+      else if (row >= box.y + box.height) dimmed.below += 1;
+      else if (column < box.x) dimmed.left += 1;
+      else dimmed.right += 1;
+    }
+    expect(dimmed.above).toBeGreaterThan(0);
+    expect(dimmed.below).toBeGreaterThan(0);
+    expect(dimmed.left).toBeGreaterThan(0);
+    expect(dimmed.right).toBeGreaterThan(0);
+    // The header gains its Escape hint, so its own rows are allowed to change
+    // characters. Nothing else outside the box moves: the scrim repaints cells,
+    // it does not lay anything out. The header sits in its own housing since
+    // #571, so its rows are read off the frame rather than assumed to be row 0.
+    const headerFrame = boxOf(testRenderer, 'header-frame');
+    const headerRows = new Set(
+      Array.from({length: headerFrame.height}, (_, offset) => headerFrame.y + offset),
+    );
+    expect(moved.filter(row => !headerRows.has(row))).toEqual([]);
+
+    const floor = themeName.startsWith('high-contrast') ? 7 : 4.5;
+    const modalBody = requireSpanColors(testRenderer, 'Available commands');
+    expect(modalBody).toEqual({fg: theme.textPrimary, bg: theme.elevatedSurface});
+    expect(contrastRatio(modalBody.fg, modalBody.bg)).toBeGreaterThanOrEqual(floor);
+    // Background text recedes below the floor the theme guarantees, and stays
+    // above the point where the run behind the modal would be erased.
+    const headerAfter = requireSpanColors(testRenderer, 'VibeSys');
+    expect(contrastRatio(headerBefore.fg, headerBefore.bg)).toBeGreaterThanOrEqual(floor);
+    const recessed = contrastRatio(headerAfter.fg, headerAfter.bg);
+    expect(recessed).toBeLessThan(floor);
+    expect(recessed).toBeGreaterThanOrEqual(1.9);
+  });
+
+  it('restores the frame exactly when the modal closes', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(behindTheModal('dark'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('transcript behind it'));
+    await testRenderer.waitForVisualIdle();
+    const before = frameCells(testRenderer);
+
+    controller.publish({...controller.state, overlay: helpOverlay});
+    await testRenderer.waitForFrame(value => value.includes('Available commands'));
+    await testRenderer.waitForVisualIdle();
+    controller.publish({...controller.state, overlay: null});
+    await testRenderer.waitForFrame(value => !value.includes('Available commands'));
+    await testRenderer.waitForVisualIdle();
+
+    expect(frameCells(testRenderer)).toEqual(before);
+  });
+
+  it('raises one scrim under whichever modals are open, and never over them', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(behindTheModal('dark'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('transcript behind it'));
+    const scrimBox = boxOf(testRenderer, 'scrim');
+    // One scrim under every modal: two of them stacked must not dim each other,
+    // and a command ack over the chat still needs the background held down.
+    expect(scrimBox.zIndex).toBeLessThan(boxOf(testRenderer, 'chat-overlay').zIndex);
+    expect(scrimBox.zIndex).toBeLessThan(boxOf(testRenderer, 'overlay').zIndex);
+    expect(scrimBox.zIndex).toBeLessThan(boxOf(testRenderer, 'theme-picker').zIndex);
+    expect(scrimBox.visible).toBe(false);
+
+    for (const modal of [
+      {chatOpen: true},
+      {overlay: helpOverlay},
+      {themePicker: {selected: 'dark' as const}},
+    ]) {
+      controller.publish({...behindTheModal('dark'), ...modal});
+      await testRenderer.flush();
+      expect(scrimBox.visible).toBe(true);
+      // The whole terminal, so the dim never stops at the pane the modal is in.
+      expect([scrimBox.x, scrimBox.y, scrimBox.width, scrimBox.height]).toEqual([0, 0, 100, 24]);
+      controller.publish(behindTheModal('dark'));
+      await testRenderer.flush();
+      expect(scrimBox.visible).toBe(false);
+    }
+  });
+});
+
+/** The renderable behind a screen region, for asserting what a scrim covers. */
+function boxOf(testRenderer: TestRendererSetup, id: string): Renderable {
+  const found = testRenderer.renderer.root.findDescendantById(id);
+  if (found === undefined) throw new Error(`no renderable with id ${id}`);
+  return found;
+}
+
+/** The colors of the span carrying `needle`, which the caller expects on screen. */
+function requireSpanColors(
+  testRenderer: TestRendererSetup,
+  needle: string,
+): {fg: string; bg: string} {
+  const colors = spanColors(testRenderer, needle);
+  if (colors === undefined) throw new Error(`no rendered span contains ${needle}`);
+  return colors;
+}
+
+/** The captured frame as a grid of cells, for asserting what a scrim repaints. */
+function frameCells(
+  testRenderer: TestRendererSetup,
+): Array<Array<{char: string; fg: string; bg: string}>> {
+  return testRenderer.captureSpans().lines.map(line => {
+    const row: Array<{char: string; fg: string; bg: string}> = [];
+    for (const span of line.spans) {
+      const fg = rgbToHex(span.fg).toLowerCase();
+      const bg = rgbToHex(span.bg).toLowerCase();
+      for (const char of span.text) row.push({char, fg, bg});
+    }
+    return row;
+  });
+}
+
+type Cell = {char: string; fg: string; bg: string};
+
+/** Every screen cell the modal does not cover, paired across the two frames. */
+function* cellsOutside(
+  closed: Cell[][],
+  open: Cell[][],
+  box: Renderable,
+): Generator<[number, number, Cell, Cell]> {
+  for (const [row, cells] of closed.entries()) {
+    for (const [column, before] of cells.entries()) {
+      const covered =
+        row >= box.y && row < box.y + box.height && column >= box.x && column < box.x + box.width;
+      const after = open[row]?.[column];
+      if (covered || after === undefined) continue;
+      yield [row, column, before, after];
+    }
+  }
+}
+
+/** The largest per-channel gap between two hex colors. */
+function channelDistance(left: string, right: string): number {
+  const channels = (hex: string): number[] =>
+    [1, 3, 5].map(at => Number.parseInt(hex.slice(at, at + 2), 16));
+  const [first, second] = [channels(left), channels(right)];
+  return Math.max(...first.map((value, index) => Math.abs(value - (second[index] ?? 0))));
 }
 
 class FakeController implements SessionController {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1,7 +1,10 @@
 import {afterEach, describe, expect, it} from 'bun:test';
 import {
+  BoxRenderable,
   CliRenderEvents,
+  getBorderSides,
   InputRenderable,
+  type Renderable,
   rgbToHex,
   ScrollBoxRenderable,
   TextareaRenderable,
@@ -1703,10 +1706,14 @@ describe('OpenTUI presentation', () => {
     const frame = await testRenderer.waitForFrame(value => value.includes('2 passed'));
     expect(frame).toContain('→ Bash(command="pytest")');
     expect(frame).toContain('← 2 passed');
-    // Header housing, agents pane, transcript frame, and the card's call and
-    // result regions: the rail is absent because this fixture has no rounds.
-    // A focused pane draws a heavy corner, so the count is over both styles.
-    expect(frame.match(/[╭┏]/g)).toHaveLength(5);
+    // Agents pane, transcript frame, and the card's call and result regions:
+    // the rail is absent because this fixture has no rounds. A focused pane
+    // draws a heavy corner, so the count is over both styles. The header
+    // housing is no longer among them: it keeps its fill, so it draws a square
+    // frame (tui-conventions.md), and it is counted separately so its shape
+    // stays asserted rather than dropping out of the test.
+    expect(frame.match(/[╭┏]/g)).toHaveLength(4);
+    expect(frame.match(/┌/g)).toHaveLength(1);
   });
 
   it('renders a typed command payload with labeled stderr and exit code', async () => {
@@ -2425,6 +2432,18 @@ describe('overlay scrolling', () => {
 });
 
 describe('theming', () => {
+  /**
+   * The role colour a transcript card carries.
+   *
+   * The border, because that is where the role lives: a bordered card has no
+   * fill (tui-conventions.md), so the body text reports the canvas and the
+   * role would otherwise go unasserted here.
+   */
+  function cardBorder(testRenderer: TestRendererSetup, id: string): string | undefined {
+    const card = testRenderer.renderer.root.findDescendantById(id);
+    return card instanceof BoxRenderable ? rgbToHex(card.borderColor).toLowerCase() : undefined;
+  }
+
   const assistantEntry = {
     id: 'themed',
     kind: 'assistant' as const,
@@ -2451,7 +2470,10 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(light.accent);
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe(light.conversation.assistant.content);
-    expect(body?.bg).toBe(light.conversation.assistant.background);
+    // The canvas, not a role fill: a bordered card carries the role in its
+    // border and draws no background of its own.
+    expect(body?.bg).toBe(light.canvas);
+    expect(cardBorder(testRenderer, 'event-themed')).toBe(light.conversation.assistant.border);
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe(light.conversation.assistant.label);
   });
 
@@ -2472,8 +2494,10 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe('#22d3ee');
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe('#e2e8f0');
-    // Assistant cards derive their fill from the canvas and the role accent.
-    expect(body?.bg).toBe('#0e283d');
+    // The canvas: an assistant card draws no fill of its own, and carries its
+    // role accent in the border instead.
+    expect(body?.bg).toBe('#0f172a');
+    expect(cardBorder(testRenderer, 'event-themed')).toBe('#0891b2');
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe('#5cb6cc');
   });
 
@@ -2499,7 +2523,10 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(solarized.accent);
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe(solarized.conversation.assistant.content);
-    expect(body?.bg).toBe(solarized.conversation.assistant.background);
+    // Both channels have to follow the swap: the canvas the card sits on, and
+    // the border it carries its role in.
+    expect(body?.bg).toBe(solarized.canvas);
+    expect(cardBorder(testRenderer, 'event-themed')).toBe(solarized.conversation.assistant.border);
   });
 
   it('navigates the theme list with the keyboard and applies on Enter', async () => {
@@ -4934,6 +4961,151 @@ describe('header hierarchy', () => {
     expect(frame).not.toContain('V...');
   });
 });
+/**
+ * A box may have a rounded border or a background fill, never both.
+ *
+ * `docs/contributing/tui-conventions.md` states the rule and the reason.
+ * `BoxRenderable.renderSelf` hands `OptimizedBuffer.drawBox` a single
+ * `backgroundColor` for the whole rectangle, and the buffer is write-only, so
+ * every cell of the box takes that fill and a corner cell has no way to know
+ * what it sat on. Under a square glyph that is truthful: the box really is
+ * square there and the whole cell is inside it. Under a rounded arc it is not.
+ * The arc is a thin curve with outside-the-box on one side of it, and filling
+ * the cell paints that outside too, which squares the corner back off. That is
+ * #642.
+ *
+ * Asserted by walking the constructed tree rather than by reading a frame, so
+ * it covers every box the app builds, including modals that stay
+ * `visible: false` until they are opened, and so a call site added later fails
+ * this without anyone remembering to extend a list.
+ */
+describe('box shape and fill', () => {
+  /** Every box under `renderable`, itself included. */
+  function* boxesIn(renderable: Renderable): Generator<BoxRenderable> {
+    if (renderable instanceof BoxRenderable) yield renderable;
+    for (const child of renderable.getChildren()) yield* boxesIn(child);
+  }
+
+  /** The id of every box that breaks the rule, so a failure names the site. */
+  function offenders(renderable: Renderable): string[] {
+    const found: string[] = [];
+    for (const box of boxesIn(renderable)) {
+      if (box.borderStyle !== 'rounded') continue;
+      const sides = getBorderSides(box.border);
+      if (!sides.top && !sides.right && !sides.bottom && !sides.left) continue;
+      // `transparent` is the default and is what "no fill" means here:
+      // `drawBox` leaves the rectangle alone, so a corner cell keeps whatever
+      // was already under it and the arc reads as an arc.
+      if (box.backgroundColor.a > 0) found.push(box.id);
+    }
+    return found;
+  }
+
+  function boxIds(renderable: Renderable): string[] {
+    return [...boxesIn(renderable)].map(box => box.id);
+  }
+
+  /** Enough state to build the boxes that are made per entry, not at startup. */
+  function shapeController(): FakeController {
+    return new FakeController({
+      ...initialSessionState(),
+      selectedAgentKind: 'implementer',
+      selectedEntryId: 'card',
+      core: {
+        ...initialSessionState().core,
+        status: 'running',
+        agentKind: 'implementer',
+        rounds: [{number: 1, status: 'active'}],
+        phases: [
+          {kind: 'optimizer', status: 'completed', roundNumber: 1, roundLabel: 'round 1'},
+          {kind: 'implementer', status: 'active', roundNumber: 1, roundLabel: 'round 1'},
+        ],
+        // Stamped with the agent and the round, because `visibleConversation`
+        // filters on both and an unstamped entry would be dropped before a
+        // card was ever built for it.
+        transcript: [
+          {
+            id: 'card',
+            kind: 'assistant',
+            agentKind: 'implementer',
+            roundNumber: 1,
+            label: 'implementer · round 1',
+            content: 'a bordered card',
+          },
+          {
+            id: 'status',
+            kind: 'status',
+            agentKind: 'implementer',
+            roundNumber: 1,
+            content: 'a status line',
+          },
+        ],
+      },
+    });
+  }
+
+  it('never pairs a rounded border with a fill, anywhere in the tree', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 30});
+    const app = createOpenTuiApp(testRenderer.renderer, shapeController());
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('a bordered card'));
+    const root = testRenderer.renderer.root;
+
+    // Coverage first, because a walk that reached nothing passes vacuously.
+    // One box from each side of the rule, plus the two that are built per
+    // entry rather than once at startup.
+    const ids = boxIds(root);
+    expect(ids).toContain('header-frame'); // square, keeps its fill
+    expect(ids).toContain('experiment-log'); // rounded, dropped its fill
+    expect(ids).toContain('theme-picker'); // built here, never opened
+    expect(ids).toContain('event-card'); // a bordered transcript card
+    expect(ids).toContain('event-status'); // borderless, so it keeps its fill
+    expect(ids.some(id => id.startsWith('agent-implementer-'))).toBe(true);
+
+    expect(offenders(root)).toEqual([]);
+  });
+
+  it('keeps the rule in the stacked agent layout', async () => {
+    // Two things only a narrow terminal builds. The agent pane falls back to
+    // stacked rows when there is no width to lay the graph out, and a
+    // visualization below `MIN_SPLIT_WIDTH` is drawn through the overlay,
+    // which then wears the pane treatment. That second one is the case a
+    // construction-time rule cannot cover on its own: `applyPaneFocus` sets
+    // the frame at render time, so the pairing it could reintroduce only
+    // exists after a frame.
+    const testRenderer = await createTestRenderer({width: 60, height: 30});
+    const controller = shapeController();
+    controller.paneContent = 'Performance · tok_s\nbest r1 1135 tok_s';
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('implementer'));
+    await controller.openPane('perf');
+    await testRenderer.waitForFrame(value => value.includes('1135 tok_s'));
+    const root = testRenderer.renderer.root;
+
+    expect(boxIds(root)).toContain('agent-implementer');
+    expect(offenders(root)).toEqual([]);
+  });
+
+  it('flags a box that pairs them', async () => {
+    // The two walks above are only evidence while they can fail. This is the
+    // control: a box built the way #642 reported has to be caught.
+    const {renderer} = await createTestRenderer({width: 20, height: 6});
+    cleanup.push(() => renderer.destroy());
+    const box = new BoxRenderable(renderer, {
+      id: 'rounded-and-filled',
+      width: 6,
+      height: 3,
+      border: true,
+      borderStyle: 'rounded',
+      backgroundColor: '#ffffff',
+    });
+    renderer.root.add(box);
+    cleanup.push(() => box.destroyRecursively());
+
+    expect(offenders(renderer.root)).toEqual(['rounded-and-filled']);
+  });
+});
 
 /**
  * The experiment log settles synchronously, so there is no later frame to wait
@@ -5107,8 +5279,12 @@ function paneBorders(testRenderer: TestRendererSetup): Record<string, string> {
   const borders: Record<string, string> = {};
   for (const line of testRenderer.captureSpans().lines) {
     for (const span of line.spans) {
-      // Either frame style, since a focused pane draws the heavy one.
-      for (const match of span.text.matchAll(/[╭┏][─━]([^─━╮┓]+)[─━]/g)) {
+      // All three corner glyphs a titled box can open with: rounded, the
+      // heavy one a focused pane would draw, and square. Square is in the set
+      // because a box that keeps a fill draws a square frame
+      // (tui-conventions.md), and the narrow-terminal visualization is such a
+      // box while it is also the performance pane.
+      for (const match of span.text.matchAll(/[╭┏┌][─━]([^─━╮┓┐]+)[─━]/g)) {
         borders[(match[1] ?? '').trim()] = rgbToHex(span.fg).toLowerCase();
       }
     }

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -36,6 +36,7 @@ import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RightPaneView, rightPaneWidth, splitFits} from './right-pane.js';
 import {RoundRailView, roundRailVisible, roundRailWidth} from './round-rail.js';
+import {ScrimView} from './scrim.js';
 import {createMarkdownStyle} from './styles.js';
 import {resolveTheme, type ThemeName} from './theme.js';
 import {ThemePickerView} from './theme-picker.js';
@@ -228,6 +229,7 @@ export function createOpenTuiApp(
   const errorBanner = new ErrorBannerView(renderer, theme, () => controller.dismissErrorBanner());
   const agentMap = new AgentMapView(renderer, controller, theme);
   const conversationActivityBar = new ActivityBarView(renderer, theme, 'conversation-activity-bar');
+  const scrim = new ScrimView(renderer, theme);
   const overlay = new OverlayView(renderer, theme);
   const experimentLog = new ExperimentLogView(renderer, controller, theme);
   const rightPane = new RightPaneView(renderer, theme, () => controller.focusPane('right'));
@@ -327,6 +329,9 @@ export function createOpenTuiApp(
   // been truncated away is a binding nobody has.
   workspace.add(help);
   root.add(workspace);
+  // Absolute and zIndex 15, so it joins no flex row: it attaches to `root`
+  // whatever shape the tree below it has, and #568's reparent does not move it.
+  root.add(scrim.output);
   root.add(overlay.output);
   root.add(themePicker.output);
   root.add(chat.output);
@@ -348,6 +353,7 @@ export function createOpenTuiApp(
     errorBanner.applyTheme(theme);
     agentMap.applyTheme(theme);
     conversationActivityBar.applyTheme(theme);
+    scrim.applyTheme(theme);
     overlay.applyTheme(theme);
     experimentLog.applyTheme(theme);
     rightPane.applyTheme(theme);
@@ -405,6 +411,11 @@ export function createOpenTuiApp(
         : chatPaneWidth(renderer.terminalWidth, rightWidth)
       : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
+    // The three real modals only. The narrow-terminal pane fallback is
+    // deliberately excluded: raising the scrim there erases the pane frames
+    // behind it rather than dimming them, so the fallback needs its own
+    // treatment before it can join this predicate.
+    const modalOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
     paintHeader(renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME));
     errorBanner.render(state);
     // The log carries its own key hints in its footer, so when it shares the
@@ -533,6 +544,9 @@ export function createOpenTuiApp(
     experimentLog.render(state);
     experimentLog.output.visible = showExperimentLog;
     rightPane.render(state, showRightPane, rightWidth);
+    // Painted after every pane and before every modal, so the whole background
+    // recedes and the modals above it keep their own colours.
+    scrim.render(modalOpen);
     overlay.render(state, paneFallback);
     themePicker.render(state);
     chat.render(state);

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -18,7 +18,7 @@ import {ActivityBarView} from './activity-bar.js';
 import {AgentMapView} from './agent-map.js';
 import {createChatDraft} from './chat-composer.js';
 import {ChatOverlayView} from './chat-overlay.js';
-import {ChatPaneView, chatDockFits, chatPaneWidth, commandColumnInset} from './chat-pane.js';
+import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
 import {RendererSelectionClipboard, type SelectionClipboard} from './clipboard.js';
 import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
@@ -199,17 +199,12 @@ export function createOpenTuiApp(
     verticalScrollbarOptions: {showArrows: true},
     onMouseUp: focusTranscript,
   });
+  // Every content pane is a column of this row, the chat included. Each of them
+  // owns whatever input writes to it, so two panes side by side are the same
+  // rectangle and their boxes share a bottom edge because they are siblings
+  // rather than because a row was budgeted to line them up.
   const main = new BoxRenderable(renderer, {
     id: 'main',
-    width: '100%',
-    flexGrow: 1,
-    flexDirection: 'row',
-  });
-  // The chat is a sibling of the entire workspace column, not just its
-  // transcript row. Its composer therefore remains inside the chat border and
-  // the pane spans the same height as the table plus command surface.
-  const body = new BoxRenderable(renderer, {
-    id: 'body',
     width: '100%',
     flexGrow: 1,
     flexDirection: 'row',
@@ -283,19 +278,18 @@ export function createOpenTuiApp(
     theme,
     () => controller.focusPane('left'),
   );
-  const bottom = new BoxRenderable(renderer, {
-    id: 'bottom',
-    width: '100%',
-    flexShrink: 0,
-    flexDirection: 'column',
-    alignItems: 'stretch',
-  });
-  const commandColumn = new BoxRenderable(renderer, {
-    id: 'command-column',
-    flexGrow: 1,
-    flexShrink: 0,
-    flexDirection: 'column',
-  });
+  /**
+   * Moves the command box, and the list that completes it, into one pane.
+   *
+   * Both go straight into the pane rather than into a column of their own, the
+   * way the chat pane holds its own composer and menu: the list is positioned
+   * against the bottom of whatever contains it, and a wrapper sized to its
+   * contents leaves the list no room to open upwards into.
+   */
+  const hostCommandSurface = (pane: BoxRenderable): void => {
+    pane.add(commandInput.suggestions);
+    pane.add(commandInput.box);
+  };
 
   // A slash command and a key toggle the same prompt: the controller routes the
   // request, the transcript decides which prompt it applies to.
@@ -306,6 +300,10 @@ export function createOpenTuiApp(
   // fixed activity row. Activity stays outside scrolling content, so a new
   // turn can change scroll height without moving the line.
   transcriptFrame.add(conversationActivityBar.output);
+  // The chat is the leftmost column of the same row as the table it discusses,
+  // so both panes end on the same line and each keeps its own input inside its
+  // own frame.
+  main.add(chatPane.output);
   // The rounds rail is the left edge of the round view; the agents graph and
   // transcript follow to its right, so drilling deeper reads left to right.
   main.add(roundRail.output);
@@ -315,20 +313,20 @@ export function createOpenTuiApp(
   // landing view, not a dialog.
   main.add(experimentLog.output);
   main.add(rightPane.output);
-  commandColumn.add(help);
-  // Absolute inside the command column rather than the root, so the list rises
-  // out of the input it belongs to instead of across the chat beside it.
-  commandColumn.add(commandInput.suggestions);
-  commandColumn.add(commandInput.box);
-  bottom.add(commandColumn);
+  // The pane the command box is currently inside. The first frame is drawn
+  // before any experiment log arrives, so the round view's transcript owns it
+  // until `render` says otherwise.
+  let commandHost: BoxRenderable = transcriptFrame;
+  hostCommandSurface(commandHost);
   root.add(headerFrame);
   root.add(errorBanner.output);
-  body.add(chatPane.output);
   workspace.add(main);
   workspace.add(todoStrip.output);
-  workspace.add(bottom);
-  body.add(workspace);
-  root.add(body);
+  // The key-help line stays the width of the screen and under every pane. Inside
+  // one of them it would be cut to that pane's columns, and a binding that has
+  // been truncated away is a binding nobody has.
+  workspace.add(help);
+  root.add(workspace);
   root.add(overlay.output);
   root.add(themePicker.output);
   root.add(chat.output);
@@ -459,13 +457,14 @@ export function createOpenTuiApp(
       // collapsed the strip bills the rail the previous frame's height and leaves
       // it a row long or short (clipping the selected late round or the overflow
       // indicator) until the next paint.
+      // The command box is a column of the content row now rather than a band
+      // under it, so it takes no rows off the rail beside it.
       const railRows =
         renderer.terminalHeight -
         headerFrame.height -
         errorHeight -
         todoStripHeight(state) -
-        help.height -
-        commandInput.box.height;
+        help.height;
       if (railWidth > 0) roundRail.render(state, railWidth, Math.max(0, railRows));
       conversation.render(state);
     }
@@ -484,13 +483,7 @@ export function createOpenTuiApp(
     // The rounds rail is a column inside the main row, not a strip above it, so
     // only the header and the banner take rows off the top.
     const above = headerFrame.height + rowsOn(errorBanner.output);
-    const belowRows = rowsOn(todoStrip.output) + help.height + commandInput.box.height;
-    // Taken from the same budget the main area draws from, so the decision and
-    // the consequence cannot disagree.
-    const commandInset = commandColumnInset(
-      showChatPane,
-      renderer.terminalHeight - above - belowRows,
-    );
+    const belowRows = rowsOn(todoStrip.output) + help.height;
     // Match the chat to the left pane's rectangle so it sits beside the
     // visualization instead of over it.
     if (showSplit) {
@@ -498,15 +491,41 @@ export function createOpenTuiApp(
         left: 1,
         width: leftWidth - 2,
         top: above,
-        height: renderer.terminalHeight - above - belowRows - commandInset,
+        height: renderer.terminalHeight - above - belowRows,
       });
     } else {
       chat.setPaneBounds(null);
     }
     chatPane.render(state, showChatPane, chatWidth);
     const chatInputFocused = showChatPane && state.layout.focus === 'chat';
-    commandColumn.visible = zoomedPane !== 'chat';
-    bottom.paddingBottom = commandInset;
+    // A zoomed chat already has a composer inside it, so the command box stands
+    // down rather than following the zoom into a pane that does not want it.
+    // The key-help line goes with it, the way it did when the two shared a row.
+    const showCommand = zoomedPane !== 'chat';
+    commandInput.box.visible = showCommand;
+    if (!showCommand) commandInput.suggestions.visible = false;
+    help.visible = showCommand;
+    // Which pane the command box writes to, and therefore which one it is drawn
+    // inside. Clicking it asks for `left` focus, so it belongs to the pane that
+    // focus names: the log on the landing view and the transcript inside a
+    // round. Zoom is the only thing that can take that pane off screen, and then
+    // the box follows the one pane that is left. The narrow-width fallback needs
+    // no case of its own: it draws the visualization through the overlay and
+    // leaves the pane underneath on screen, still holding the box.
+    const nextHost =
+      zoomedPane === 'performance'
+        ? rightPane.output
+        : zoomedPane === 'agents'
+          ? agentMap.output
+          : showLog
+            ? experimentLog.output
+            : transcriptFrame;
+    if (nextHost !== commandHost) {
+      commandHost.remove(commandInput.suggestions);
+      commandHost.remove(commandInput.box);
+      hostCommandSurface(nextHost);
+      commandHost = nextHost;
+    }
     // The command list completes the box it belongs to, and on this view that
     // box cannot open a chat that is already beside it.
     commandInput.setCommandContext({chatDocked: showChatPane});

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -108,7 +108,12 @@ export function createOpenTuiApp(
     paddingLeft: 1,
     paddingRight: 1,
     border: true,
-    borderStyle: 'rounded',
+    // Square, because this frame keeps its fill and a box may have one or the
+    // other, never both (tui-conventions.md). The fill is not decoration here:
+    // `headerSpanStyle` derives every header tone's contrast against
+    // `headerBackground`, so dropping it would make the header's text
+    // contrast-checked against a surface it does not paint.
+    borderStyle: 'single',
     borderColor: theme.border,
     // The same surface every other pane sits on. Without this the frame falls
     // through to the root's `canvas`, which is a different shade, so the header

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -171,7 +171,7 @@ export class ChatComposerView {
       // it shows through between the rows.
       borderStyle: 'single',
       borderColor: theme.border,
-      backgroundColor: theme.elevatedSurface,
+      backgroundColor: theme.canvas,
       paddingLeft: 1,
       paddingRight: 1,
     });
@@ -352,7 +352,7 @@ export class ChatComposerView {
     this.#editor.focusedTextColor = theme.textStrong;
     this.#hint.fg = theme.textSubtle;
     this.menu.borderColor = theme.border;
-    this.menu.backgroundColor = theme.elevatedSurface;
+    this.menu.backgroundColor = theme.canvas;
     this.#menuList.fg = theme.textPrimary;
   }
 

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -165,7 +165,11 @@ export class ChatComposerView {
       visible: false,
       zIndex: 5,
       border: true,
-      borderStyle: 'rounded',
+      // Square, because this menu keeps its fill and a box may have one or the
+      // other, never both (tui-conventions.md). The fill is what makes an
+      // absolutely positioned popup opaque: without it the composer text under
+      // it shows through between the rows.
+      borderStyle: 'single',
       borderColor: theme.border,
       backgroundColor: theme.elevatedSurface,
       paddingLeft: 1,

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -76,7 +76,7 @@ export class ChatOverlayView {
       // modal opaque over the run behind it, so it is not the side to drop.
       borderStyle: 'single',
       borderColor: theme.conversation.analysis.label,
-      backgroundColor: theme.elevatedSurface,
+      backgroundColor: theme.canvas,
       title: ' Experiment chat ',
       zIndex: 20,
       visible: false,
@@ -182,7 +182,7 @@ export class ChatOverlayView {
 
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
     this.output.borderColor = theme.conversation.analysis.label;
-    this.output.backgroundColor = theme.elevatedSurface;
+    this.output.backgroundColor = theme.canvas;
     this.#composer.applyTheme(theme);
     this.#conversation.applyTheme(theme, markdownStyle);
   }

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -71,7 +71,10 @@ export class ChatOverlayView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
+      // Square, because this modal keeps its fill and a box may have one or
+      // the other, never both (tui-conventions.md). The fill is what makes the
+      // modal opaque over the run behind it, so it is not the side to drop.
+      borderStyle: 'single',
       borderColor: theme.conversation.analysis.label,
       backgroundColor: theme.elevatedSurface,
       title: ' Experiment chat ',

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -116,10 +116,13 @@ export class ChatPaneView {
       border: true,
       borderStyle: paneBorderStyle(false),
       borderColor: paneBorderColor(theme, false),
-      // The surface every other pane sits on. Without it this box falls
-      // through to the root's canvas, a lighter shade, so the chat read as a
-      // pale band beside panes that did not match it.
-      backgroundColor: theme.elevatedSurface,
+      // No fill: `paneBorderStyle` is rounded, and a box may have one or the
+      // other, never both (tui-conventions.md). A pane keeps the rounded frame
+      // that `PANE_BORDER` argues for, so the fill is the side that goes. It
+      // was only a surface tint: this box sits in its own reserved column of
+      // `body`, so nothing shows through where it used to paint, and every
+      // theme token is already held to `minContrast` against the canvas it now
+      // falls through to rather than against the elevated surface.
       title: paneTitle(CHAT_PANE_TITLE, false),
       visible: false,
       // Clicking into the chat gives it the keys, the same thing Ctrl+W does.
@@ -171,7 +174,6 @@ export class ChatPaneView {
     this.#theme = theme;
     // Resting colour: `render` repaints from the live focus on the next frame.
     this.output.borderColor = paneBorderColor(theme, false);
-    this.output.backgroundColor = theme.elevatedSurface;
     this.#conversation.applyTheme(theme, markdownStyle);
     this.#composer.applyTheme(theme);
     this.#renderedConversation = null;

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -41,38 +41,6 @@ export function chatDockFits(terminalWidth: number, rightPaneWidth = 0): boolean
 }
 
 /**
- * The row the command column gives up so its box shares a bottom edge with the
- * docked Message box. The pane is bordered and the column is not, so the pane
- * spends the terminal's last row on its own bottom border and the column has to
- * skip the same row to end level with it.
- */
-const DOCK_ALIGNMENT_ROWS = 1;
-
-/**
- * Rows the landing table keeps for itself before presentation may spend one.
- * Nine is the kickoff panel: two borders around the round's title, the phase
- * list, and the lines saying what the round produces.
- */
-const MIN_LANDING_ROWS = 9;
-
-/**
- * Rows the command column insets itself by so the Command and Message boxes
- * line up beneath a docked chat.
- *
- * The row is not free: it comes out of the table above it. A terminal short
- * enough that the table would lose a line keeps the row instead and lets the
- * two boxes sit one row apart. Alignment is presentation and the table is the
- * view, so a short terminal degrades in the direction the operator can see and
- * undo (resize) rather than silently clipping the content.
- *
- * `landingRows` is what the table has before this inset is taken.
- */
-export function commandColumnInset(chatDocked: boolean, landingRows: number): number {
-  if (!chatDocked) return 0;
-  return landingRows - DOCK_ALIGNMENT_ROWS >= MIN_LANDING_ROWS ? DOCK_ALIGNMENT_ROWS : 0;
-}
-
-/**
  * Width in columns for the docked chat. It asks for the columns left over once
  * the table has enough for its claim, so a wide terminal loses no table column
  * to the chat; where there is no such surplus it still takes its readable

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -78,7 +78,11 @@ export function createCommandInputPanel(
     visible: false,
     zIndex: 5,
     border: true,
-    borderStyle: 'rounded',
+    // Square, because this popup keeps its fill and a box may have one or the
+    // other, never both (tui-conventions.md). It is absolutely positioned over
+    // the panes above the command column, and the fill is what stops them
+    // showing through it.
+    borderStyle: 'single',
     borderColor: theme.border,
     backgroundColor: theme.selectedSurface,
     paddingLeft: 1,

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -43,13 +43,13 @@ export function createCommandInputPanel(
     height: 3,
     width: '100%',
     border: true,
-    // The focus treatment names the one pane the navigation keys are on. The
-    // command box is shared by every pane in the column rather than being one of
-    // them, so it never wears that treatment: resting frame, resting colour, and
-    // the gutter cell where a pane would put its marker. A second lit border
-    // made the marked pane ambiguous, which is the whole complaint behind #433.
-    // It still takes the title from `focus.ts` so its label sits at the same
-    // column as the panes it shares the column with.
+    // The focus treatment names the one pane the navigation keys are on. This
+    // box is drawn inside that pane rather than being one, so it never wears
+    // the treatment: resting frame, resting colour, and the gutter cell where a
+    // pane would put its marker. A second lit border made the marked pane
+    // ambiguous, which is the whole complaint behind #433. It still takes the
+    // title from `focus.ts` so its label sits at the same column as the pane
+    // holding it, and as the chat's `Message` box across the landing view.
     borderStyle: paneBorderStyle(false),
     borderColor: paneBorderColor(theme, false),
     title: paneTitle(COMMAND_TITLE, false),

--- a/clients/tui/src/ui/conversation.test.ts
+++ b/clients/tui/src/ui/conversation.test.ts
@@ -1,0 +1,149 @@
+import {afterEach, describe, expect, it} from 'bun:test';
+import {BoxRenderable} from '@opentui/core';
+import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
+import type {SessionController} from '../session-controller.js';
+import {type ConversationEntry, initialSessionState} from '../session-model.js';
+import {ConversationView} from './conversation.js';
+import {createMarkdownStyle} from './styles.js';
+import {
+  CONVERSATION_ROLES,
+  contrastRatio,
+  ensureContrast,
+  listThemes,
+  resolveTheme,
+  SUBTLE_TEXT_MIN_CONTRAST,
+} from './theme.js';
+
+/**
+ * #565: an entry separates from its neighbour with a rule on its top edge,
+ * not a four-sided bordered card sitting under its own blank margin row.
+ * These render through the real OpenTUI test renderer rather than computing
+ * expected row counts by hand: a pure-function test would not catch a stray
+ * margin or an extra border side reappearing, which is exactly the class of
+ * bug this issue is about (docs/contributing/coding-best-practices.md).
+ */
+describe('conversation entry row cost (#565)', () => {
+  const cleanup: Array<() => void> = [];
+  afterEach(() => {
+    for (const destroy of cleanup.splice(0).reverse()) destroy();
+  });
+
+  const controller = {} as unknown as SessionController;
+
+  async function renderEntries(
+    entries: ConversationEntry[],
+  ): Promise<{testRenderer: TestRendererSetup; view: ConversationView}> {
+    const theme = resolveTheme(null);
+    const testRenderer = await createTestRenderer({width: 80, height: 40});
+    const view = new ConversationView(
+      testRenderer.renderer,
+      controller,
+      createMarkdownStyle(theme),
+      theme,
+      // Entry selection from state is a separate, already-tested concern;
+      // fixing the list here keeps this test about row cost alone.
+      {selectConversation: () => entries},
+    );
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    });
+    view.render(initialSessionState());
+    await testRenderer.renderOnce();
+    return {testRenderer, view};
+  }
+
+  // 'status', 'analysis' and 'result' all skip both the markdown pipeline and
+  // the tool-output preview (see the branches in `#renderEntry`), so each
+  // renders its content verbatim on exactly one line. That isolates the row
+  // count this test pins from #516's separate, still-open content-preview
+  // question.
+  const oneLineEntries: ConversationEntry[] = [
+    {id: 'a', kind: 'status', label: 'status', content: 'one line'},
+    {id: 'b', kind: 'analysis', label: 'analysis', content: 'one line'},
+    {id: 'c', kind: 'result', label: 'result', content: 'one line'},
+  ];
+
+  it('costs a divider and a heading per entry, not a margin row plus a four-sided card', async () => {
+    const {testRenderer, view} = await renderEntries(oneLineEntries);
+    for (const entry of oneLineEntries) {
+      const card = view.output.findDescendantById(`event-${entry.id}`);
+      if (!(card instanceof BoxRenderable))
+        throw new Error(`entry ${entry.id} did not render a card`);
+      // Divider (1) + heading (1) + one content line (1). A bordered card
+      // with its own margin row cost 5 for the same content; even the
+      // pre-#565 borderless 'status' case still cost 3 rows for a margin
+      // and a heading before a single line of content ever appeared. Every
+      // kind now costs the same, and this one has no margin to add.
+      expect(card.height).toBe(3);
+      expect(card.border).toEqual(['top']);
+    }
+    // No stray rows between cards either: three one-line entries cost
+    // exactly 9 rows end to end. The pre-#565 card cost 5 rows each (15
+    // total); this assertion fails at that revision and passes at this one.
+    expect(view.output.height).toBe(9);
+    void testRenderer;
+  });
+
+  it('does not add its own inset on top of the pane that contains it', async () => {
+    const leadingColumn = async (entries: ConversationEntry[]): Promise<number> => {
+      const {testRenderer} = await renderEntries(entries);
+      const frame = testRenderer.captureCharFrame();
+      const row = frame.split('\n').find(line => line.trim().length > 0);
+      if (row === undefined) throw new Error('nothing rendered');
+      return row.length - row.trimStart().length;
+    };
+    const emptyColumn = await leadingColumn([]);
+    const entryColumn = await leadingColumn([
+      {id: 'a', kind: 'status', label: 'status', content: 'x'},
+    ]);
+    // Both the empty-transcript message and an entry's heading are direct
+    // children of the same unpadded `output` box: a card that added its own
+    // left padding or border, as it did before #565, would start one or
+    // more columns later than the empty-transcript message sitting beside
+    // it in the same pane.
+    expect(entryColumn).toBe(emptyColumn);
+  });
+});
+
+/**
+ * Role and selection have to stay distinguishable in all eight themes
+ * (#565's fourth acceptance criterion). theme.ts's colours come out of
+ * `mix()` and `ensureContrast()` and exist nowhere as literals, so this
+ * evaluates the theme module directly rather than transcribing hexes.
+ *
+ * This is a pure computation over theme tokens, not a rendered frame: per
+ * docs/contributing/tui-architecture.md, contrast and legibility are pinned
+ * at that layer.
+ */
+describe('role and selection stay distinguishable across every theme (#565)', () => {
+  it('holds every role divider to the 3:1 floor textSubtle uses for punctuation and rules', () => {
+    for (const theme of listThemes()) {
+      const restingColors = CONVERSATION_ROLES.map(role => {
+        // Mirrors the `ensureContrast` call `#renderEntry` makes on
+        // `palette.border` before using it as the resting divider colour.
+        const resting = ensureContrast(
+          theme.conversation[role].border,
+          theme.canvas,
+          SUBTLE_TEXT_MIN_CONTRAST,
+        );
+        expect(contrastRatio(resting, theme.canvas)).toBeGreaterThanOrEqual(
+          SUBTLE_TEXT_MIN_CONTRAST,
+        );
+        return resting;
+      });
+      // Nudging a marginal accent toward black or white must not collapse
+      // two roles onto the same divider colour.
+      expect(new Set(restingColors).size).toBe(restingColors.length);
+    }
+  });
+
+  it('keeps the selection colour itself legible in every theme', () => {
+    for (const theme of listThemes()) {
+      expect(contrastRatio(theme.borderFocus, theme.canvas)).toBeGreaterThanOrEqual(
+        SUBTLE_TEXT_MIN_CONTRAST,
+      );
+    }
+  });
+});

--- a/clients/tui/src/ui/conversation.test.ts
+++ b/clients/tui/src/ui/conversation.test.ts
@@ -65,6 +65,41 @@ describe('conversation entry row cost (#565)', () => {
     {id: 'c', kind: 'result', label: 'result', content: 'one line'},
   ];
 
+  it('pins the role to the left edge and the run id to the right', async () => {
+    // The role is what an operator scans down the column, so it holds the left
+    // edge; the run id is per-entry detail and would otherwise push the eye a
+    // variable distance rightward on every line. An entry with no agent/round
+    // pair keeps its single label on the left.
+    const entries: ConversationEntry[] = [
+      {
+        id: 'split',
+        kind: 'analysis',
+        label: 'judge · round-1-retry-1-judge',
+        agentKind: 'judge',
+        roundLabel: 'round-1-retry-1-judge',
+        content: 'one line',
+      },
+      {id: 'plain', kind: 'result', label: 'round-1 · PASS', content: 'one line'},
+    ];
+    const {view} = await renderEntries(entries);
+
+    const split = view.output.findDescendantById('event-split-heading');
+    if (!(split instanceof BoxRenderable)) throw new Error('split heading missing');
+    const [role, runId] = split.getChildren();
+    if (role === undefined || runId === undefined)
+      throw new Error('split heading did not render two parts');
+    expect(role.x).toBe(split.x);
+    expect(runId.x + runId.width).toBe(split.x + split.width);
+    // Not merely offset: the run id must actually sit to the right of the role.
+    expect(runId.x).toBeGreaterThan(role.x + role.width);
+
+    // An entry without the pair is untouched, one child on the left edge.
+    const plain = view.output.findDescendantById('event-plain-heading');
+    if (!(plain instanceof BoxRenderable)) throw new Error('plain heading missing');
+    expect(plain.getChildren()).toHaveLength(1);
+    expect(plain.getChildren()[0]?.x).toBe(plain.x);
+  });
+
   it('costs a divider and a heading per entry, not a margin row plus a four-sided card', async () => {
     const {testRenderer, view} = await renderEntries(oneLineEntries);
     for (const entry of oneLineEntries) {

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -326,19 +326,38 @@ export class ConversationView {
   #renderEntry(entry: ConversationEntry): BoxRenderable {
     const palette = entryPalette(entry, this.#theme);
     const selected = this.#selectedId === entry.id;
+    const bordered = entry.kind !== 'status';
     const card = new BoxRenderable(this.renderer, {
       id: `event-${entry.id}`,
       width: '100%',
       flexDirection: 'column',
       marginTop: 1,
-      paddingLeft: entry.kind === 'status' ? 0 : 1,
+      paddingLeft: bordered ? 1 : 0,
       paddingRight: 1,
-      border: entry.kind !== 'status',
-      borderStyle: 'rounded',
-      // The cursor is the card's border, not a fill: a filled card reads as
-      // selected text, and the transcript already uses fills for roles.
-      borderColor: selected ? this.#theme.borderFocus : palette.border,
-      backgroundColor: palette.background,
+      // The two branches are the two sides of one rule: a box may have a
+      // rounded border or a background fill, never both (tui-conventions.md).
+      //
+      // A bordered card keeps the frame and drops the role tint. The role
+      // survives that: the border colour and the heading in `palette.label`
+      // both carry it, which is what 1.4.1 needs anyway, and the tint was only
+      // the accent at 8-16% over the canvas.
+      //
+      // A status entry keeps the fill, which is the only thing marking it as a
+      // region of its own. `borderStyle` and `borderColor` move inside the
+      // bordered branch rather than sitting beside `border: false`, because
+      // OpenTUI reads either of them as a request for a frame and turns the
+      // border back on. That is how a status card came to draw the rounded
+      // frame over a fill that this rule forbids, while reading as if it drew
+      // no border at all.
+      ...(bordered
+        ? {
+            border: true,
+            borderStyle: 'rounded' as const,
+            // The cursor is the card's border, not a fill: a filled card reads
+            // as selected text.
+            borderColor: selected ? this.#theme.borderFocus : palette.border,
+          }
+        : {backgroundColor: palette.background}),
       ...(this.#showsSelection
         ? {
             onMouseUp: () => {

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -13,7 +13,7 @@ import type {ConversationEntry, SessionState} from '../session-model.js';
 import {visibleConversation} from '../session-model.js';
 import {promptPreview, toolCallPreview, toolResultPreview} from './previews.js';
 import {createMarkdownBlockOptions, entryPalette, type MarkdownBlockOptions} from './styles.js';
-import type {Theme} from './theme.js';
+import {ensureContrast, SUBTLE_TEXT_MIN_CONTRAST, type Theme} from './theme.js';
 
 export interface ConversationViewOptions {
   selectConversation?: (state: SessionState) => ConversationEntry[];
@@ -96,8 +96,11 @@ export class ConversationView {
     this.#showsSelection = options.showsSelection ?? false;
     this.#onFocusRequest = options.onFocusRequest;
     const onRevealOlder = options.onRevealOlder;
-    // The bordered surface owns horizontal inset so transcript siblings, such
-    // as a fixed footer, share the same content origin as these turn cards.
+    // Horizontal inset belongs to the pane (or the chat surface's own frame)
+    // that contains this view, not to the cards below: see #565. A card that
+    // padded itself again on top of that sat one layer deeper than a
+    // non-card sibling in the same pane, such as the empty-transcript
+    // message added directly below.
     this.output = new BoxRenderable(renderer, {
       id: 'output',
       width: '100%',
@@ -326,38 +329,37 @@ export class ConversationView {
   #renderEntry(entry: ConversationEntry): BoxRenderable {
     const palette = entryPalette(entry, this.#theme);
     const selected = this.#selectedId === entry.id;
-    const bordered = entry.kind !== 'status';
     const card = new BoxRenderable(this.renderer, {
       id: `event-${entry.id}`,
       width: '100%',
       flexDirection: 'column',
-      marginTop: 1,
-      paddingLeft: bordered ? 1 : 0,
-      paddingRight: 1,
-      // The two branches are the two sides of one rule: a box may have a
-      // rounded border or a background fill, never both (tui-conventions.md).
+      // A rule on the top edge instead of a four-sided border (#565): it
+      // separates one entry from the next at a fraction of the row cost, with
+      // no bottom border and no blank margin row to hold the gap open. Every
+      // kind gets the same rule, including what used to be the borderless,
+      // margin-only 'status' case, so the transcript has one boundary grammar
+      // rather than two.
       //
-      // A bordered card keeps the frame and drops the role tint. The role
-      // survives that: the border colour and the heading in `palette.label`
-      // both carry it, which is what 1.4.1 needs anyway, and the tint was only
-      // the accent at 8-16% over the canvas.
+      // No side padding either: the pane this view sits in already insets its
+      // content by one column (or the chat surface's own frame does), and a
+      // card padding on top of that was a second, inconsistent inset.
+      border: ['top'],
+      borderStyle: 'single',
+      // The cursor is the rule's colour. Selection is never carried by that
+      // alone: the heading below adds a "▸ " marker and switches to
+      // `textStrong`, neither of which this change touches, so losing three
+      // of the four border sides does not weaken the WCAG 1.4.1 channel.
       //
-      // A status entry keeps the fill, which is the only thing marking it as a
-      // region of its own. `borderStyle` and `borderColor` move inside the
-      // bordered branch rather than sitting beside `border: false`, because
-      // OpenTUI reads either of them as a request for a frame and turns the
-      // border back on. That is how a status card came to draw the rounded
-      // frame over a fill that this rule forbids, while reading as if it drew
-      // no border at all.
-      ...(bordered
-        ? {
-            border: true,
-            borderStyle: 'rounded' as const,
-            // The cursor is the card's border, not a fill: a filled card reads
-            // as selected text.
-            borderColor: selected ? this.#theme.borderFocus : palette.border,
-          }
-        : {backgroundColor: palette.background}),
+      // The resting colour is held to the same 3:1 floor `textSubtle` uses
+      // for punctuation and rules: `roleAccents` in theme.ts is not run
+      // through `ensureContrast` the way the label and content derived from
+      // it are, and five of the 64 role/theme combinations sit under 3:1. A
+      // four-sided border could lean on its own area to stay noticeable at a
+      // marginal contrast; a one-row rule cannot, so this change is what
+      // makes that gap worth closing.
+      borderColor: selected
+        ? this.#theme.borderFocus
+        : ensureContrast(palette.border, this.#theme.canvas, SUBTLE_TEXT_MIN_CONTRAST),
       ...(this.#showsSelection
         ? {
             onMouseUp: () => {

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -388,13 +388,28 @@ export class ConversationView {
       flexDirection: 'row',
       justifyContent: 'space-between',
     });
+    // The heading box is already `space-between`, and an entry that names both
+    // an agent and a round carries them as separate fields, so the role can sit
+    // at the left edge where it lines up down the column and the run id can go
+    // to the right rather than pushing the eye a variable distance across. Any
+    // other entry keeps its single label on the left, unchanged.
+    const splitHeading = entry.agentKind !== undefined && entry.roundLabel !== undefined;
     heading.add(
       new TextRenderable(this.renderer, {
-        content: `${selected ? '▸ ' : ''}${entry.label ?? entry.kind}`,
+        content: `${selected ? '▸ ' : ''}${splitHeading ? entry.agentKind : (entry.label ?? entry.kind)}`,
         fg: selected ? this.#theme.textStrong : palette.label,
         height: 1,
       }),
     );
+    if (splitHeading) {
+      heading.add(
+        new TextRenderable(this.renderer, {
+          content: entry.roundLabel as string,
+          fg: this.#theme.textSubtle,
+          height: 1,
+        }),
+      );
+    }
     card.add(heading);
     if (this.#markdownKinds.has(entry.kind)) {
       this.#renderMarkdownEntry(card, entry);

--- a/clients/tui/src/ui/error-banner.ts
+++ b/clients/tui/src/ui/error-banner.ts
@@ -39,7 +39,12 @@ export class ErrorBannerView {
       borderColor: theme.error,
       paddingLeft: 1,
       paddingRight: 1,
-      backgroundColor: theme.elevatedSurface,
+      // No fill: the frame is rounded, and a box may have one or the other,
+      // never both (tui-conventions.md). The banner is a flex child of `root`
+      // holding its own rows, so nothing shows through where the fill was, and
+      // what says "error" is the border colour `render` picks from the
+      // severity plus the title, not a tint a high-contrast theme flattens
+      // into the canvas anyway.
       visible: false,
     });
     this.#scroll = new ScrollBoxRenderable(renderer, {
@@ -54,7 +59,8 @@ export class ErrorBannerView {
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.output.backgroundColor = theme.elevatedSurface;
+    // `#rendered = null` makes the next `render` repaint the border from the
+    // new theme, which is the only colour this box owns.
     this.#rendered = null;
   }
 

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -84,7 +84,10 @@ export class ExperimentLogView {
       border: true,
       borderStyle: paneBorderStyle(false),
       borderColor: paneBorderColor(theme, false),
-      backgroundColor: theme.elevatedSurface,
+      // No fill: `paneBorderStyle` is rounded, and a box may have one or the
+      // other, never both (tui-conventions.md). Same call as `chat-pane`: the
+      // pane keeps its frame, and the tint it drops was decoration over a
+      // region of `main` that nothing else paints.
       visible: false,
       title: paneTitle(EXPERIMENTS_TITLE, false),
       onMouseUp: () => this.controller.focusPane('left'),
@@ -138,7 +141,6 @@ export class ExperimentLogView {
   applyTheme(theme: Theme): void {
     this.#theme = theme;
     this.output.borderColor = theme.border;
-    this.output.backgroundColor = theme.elevatedSurface;
     this.#header.fg = theme.textSubtle;
     this.#footerLine.fg = theme.textSubtle;
     this.#renderedState = null;

--- a/clients/tui/src/ui/focus.ts
+++ b/clients/tui/src/ui/focus.ts
@@ -16,12 +16,12 @@ import type {Theme} from './theme.js';
  * is that authority, and each pane compares its own `PaneId` against it. A
  * surface that is not a pane never wears the treatment, and neither does a box
  * inside a pane that already does: two lit frames, one nested in the other, are
- * as ambiguous as two lit panes side by side. The chat's `Message` composer is
- * that case, and the command box is the other worth naming, since it sits under
- * the pane column and is shared by every pane in it rather than being one of
- * them. Both take the resting title, frame and colour and no focused variant,
- * and call in only to keep their labels at the same column as the panes around
- * them. Lighting the command box made the marked pane ambiguous, which is #433.
+ * as ambiguous as two lit panes side by side. Both boxes that take typed text
+ * are that case: the chat's `Message` composer sits inside the chat pane, and
+ * the command box sits inside the pane whose keys it takes. Both take the
+ * resting title, frame and colour and no focused variant, and call in only to
+ * keep their labels at the same column as the pane they are drawn in. Lighting
+ * the command box made the marked pane ambiguous, which is #433.
  */
 
 /** Marks the title of the pane that currently takes keys. */

--- a/clients/tui/src/ui/header.test.ts
+++ b/clients/tui/src/ui/header.test.ts
@@ -359,9 +359,10 @@ describe('run state', () => {
  * The floor every token but `textSubtle` is held to, restated here rather than
  * read off `theme.minContrast` so this is an independent check.
  *
- * It is measured against `headerBackground`, not the canvas: the header frame
- * paints a surface of its own, and a tone that clears the floor against a
- * background nothing draws is not a readable header.
+ * It is measured against `headerBackground` rather than `theme.canvas` because
+ * that function is what decides which cell the text lands on, and a tone that
+ * clears the floor against a background nothing draws is not a readable
+ * header. Since #574 the two are the same colour, which the test below pins.
  */
 function minContrast(theme: Theme): number {
   return theme.name.startsWith('high-contrast') ? 7 : 4.5;
@@ -541,26 +542,19 @@ describe('header contrast', () => {
     }
   });
 
-  it('derives its tones against the surface it paints, not against the canvas', () => {
-    // No built-in theme separates the two: every one of the eight puts its
-    // elevated surface further from mid grey than its canvas, so a tone that
-    // clears the floor on the canvas clears it by more on the header. The
-    // header cannot assume that. #574 is open on the surface ladder being
-    // inverted, and a header background on the other side of the canvas is
-    // exactly what a canvas-derived tone gets wrong: it returns the raw token
-    // for a cell it is unreadable on.
-    const dark = resolveTheme('dark');
-    const moved: Theme = {...dark, elevatedSurface: resolveTheme('light').canvas};
-    expect(contrastRatio(dark.accent, moved.canvas)).toBeGreaterThanOrEqual(dark.minContrast);
-    expect(contrastRatio(dark.accent, headerBackground(moved))).toBeLessThan(dark.minContrast);
-
-    for (const role of SPAN_ROLES) {
-      const {fg} = headerSpanStyle(moved, {text: 'completed', role});
-      const floor = role === 'separator' ? SUBTLE_FLOOR : minContrast(moved);
-      expect({
-        role,
-        ratio: contrastRatio(fg, headerBackground(moved)) >= floor,
-      }).toEqual({role, ratio: true});
+  it('paints the canvas, so the top line wears no colour of its own', () => {
+    // #574: the header filled `elevatedSurface` while the frame behind it
+    // filled `canvas`, so the top line agreed with the panes and disagreed with
+    // the strip of frame showing around them. The collapse kept the header's
+    // own value and moved `canvas` onto it; this pins that the two names now
+    // mean one colour. The token is gone, so no theme can reintroduce a second
+    // shade, but `headerBackground` is still the single place that chooses the
+    // fill, so the choice is pinned rather than left to the next reader.
+    for (const theme of listThemes()) {
+      expect({theme: theme.name, background: headerBackground(theme)}).toEqual({
+        theme: theme.name,
+        background: theme.canvas,
+      });
     }
   });
 

--- a/clients/tui/src/ui/header.ts
+++ b/clients/tui/src/ui/header.ts
@@ -26,7 +26,7 @@ import {hasRunEnded} from '@vibesys/core-state';
 import {runStatusLabel, type SessionState} from '../session-model.js';
 import {agentKindText, describePhase, phaseText} from './phase-label.js';
 import {displayWidth, truncateToWidth} from './text-width.js';
-import {ensureContrast, SUBTLE_TEXT_MIN_CONTRAST, type Theme} from './theme.js';
+import type {Theme} from './theme.js';
 
 /** Separator between header segments, matching the rest of the interface. */
 const SEPARATOR = ' · ';
@@ -271,17 +271,19 @@ export function renderHeader(state: SessionState, showLog: boolean, width: numbe
  * The surface the header paints, and therefore the surface its text is read
  * against.
  *
- * One definition for both: `app.ts` fills the frame with it and
- * `headerSpanStyle` derives every tone against it. Two independent statements
- * of where the header sits is how the contrast guarantee below comes to be
- * measured against a background nothing draws.
+ * One definition for both: `app.ts` fills the frame with it and the tones below
+ * are held against it. Two independent statements of where the header sits is
+ * how a contrast guarantee comes to be measured against a background nothing
+ * draws.
  *
- * `elevatedSurface` because the header is a pane, and that is the surface every
- * other pane sits on. Which shade that is belongs to the theme: #574 is open on
- * the ladder being inverted, and moving it there moves the header with it.
+ * `canvas`, because that is the only background the theme has (#574). This
+ * returned `elevatedSurface` until then. The cells the header paints have not
+ * changed colour: the collapse kept the value the panes and the header already
+ * used and brought `canvas` down to meet it. What changed is that the header
+ * now matches everything around it and not only the other panes.
  */
 export function headerBackground(theme: Theme): string {
-  return theme.elevatedSurface;
+  return theme.canvas;
 }
 
 /**
@@ -295,40 +297,32 @@ export function headerBackground(theme: Theme): string {
  * metadata and recede to muted. The separators recede further still: dots
  * divide the words without competing with them.
  *
- * Every colour comes from the theme, which holds each of these tokens to
- * `minContrast` against the canvas. The header does not sit on the canvas, so
- * that guarantee is not the one it needs, and each tone is put back through
- * `ensureContrast` against the surface the header actually paints. In all eight
- * built-in themes that is a no-op, because their elevated surface is further
- * from mid grey than their canvas in every case. It is a no-op the header
- * cannot assume: a theme, or #574 moving the ladder, can make the two
- * disagree, and a tone that clears 4.5:1 on a background nothing draws is not
- * a readable header.
+ * Every colour comes from the theme as `buildTheme` made it, which is enough
+ * because the header paints the canvas and `buildTheme` holds each of these
+ * tokens to `minContrast` against exactly that. Each tone used to be put back
+ * through `ensureContrast` here; that pass existed only to cross from the
+ * canvas to a second surface, and since #574 there is no second surface to
+ * cross to.
  *
  * `textSubtle` is the exception the theme itself makes, at a floor of 3 rather
  * than 4.5 or 7, which is why only the punctuation is drawn in it and every
  * word clears the full floor.
  */
 export function headerSpanStyle(theme: Theme, span: HeaderSpan): HeaderSpanStyle {
-  const surface = headerBackground(theme);
-  const readable = (color: string): string => ensureContrast(color, surface, theme.minContrast);
   switch (span.role) {
     case 'brand':
-      return {fg: readable(theme.accent), bold: true};
+      return {fg: theme.accent, bold: true};
     case 'state':
-      return {fg: readable(stateColor(theme, span.text)), bold: true};
+      return {fg: stateColor(theme, span.text), bold: true};
     case 'phase':
     case 'title':
-      return {fg: readable(theme.textPrimary), bold: false};
+      return {fg: theme.textPrimary, bold: false};
     case 'usage':
     case 'selection':
     case 'hint':
-      return {fg: readable(theme.textMuted), bold: false};
+      return {fg: theme.textMuted, bold: false};
     case 'separator':
-      return {
-        fg: ensureContrast(theme.textSubtle, surface, SUBTLE_TEXT_MIN_CONTRAST),
-        bold: false,
-      };
+      return {fg: theme.textSubtle, bold: false};
   }
 }
 

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -70,7 +70,7 @@ export class OverlayView {
       // opaque over whatever it covers.
       borderStyle: 'single',
       borderColor: theme.info,
-      backgroundColor: theme.elevatedSurface,
+      backgroundColor: theme.canvas,
       // Above the chat modal (20), below the theme picker (30): a command ack
       // submitted from the modal chat has to be visible over it.
       zIndex: 25,
@@ -106,7 +106,7 @@ export class OverlayView {
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.output.backgroundColor = theme.elevatedSurface;
+    this.output.backgroundColor = theme.canvas;
     this.output.borderColor = borderFor(theme, this.#renderedKind ?? 'detail');
     this.#hint.fg = theme.textSubtle;
     this.#renderedKind = null;

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -24,6 +24,20 @@ const LEFT_SHARE = 0.15;
 const HEIGHT_SHARE = 0.6;
 const TOP_SHARE = 0.18;
 
+/**
+ * Rows at the foot of the screen the box never reaches: the command input, the
+ * bottom border of the pane holding it, and the key-help line under that pane.
+ *
+ * Floating over pane content is what an overlay is for. The command input is
+ * the exception, because it keeps taking keystrokes while the box is open, so
+ * covering it would hide the surface the operator is still typing into. The
+ * share above only reaches these rows on a short terminal.
+ */
+const COMMAND_SURFACE_ROWS = 5;
+
+/** Two borders, the hint row, and one line of content worth opening for. */
+const MIN_ROWS = 4;
+
 function borderFor(theme: Theme, kind: OverlayKind): string {
   if (kind === 'help') return theme.success;
   if (kind === 'error') return theme.error;
@@ -183,8 +197,12 @@ export class OverlayView {
     const rows = this.renderer.terminalHeight;
     this.output.width = Math.round(columns * WIDTH_SHARE);
     this.output.left = Math.round(columns * LEFT_SHARE);
-    this.output.height = Math.round(rows * HEIGHT_SHARE);
-    this.output.top = Math.round(rows * TOP_SHARE);
+    const top = Math.round(rows * TOP_SHARE);
+    this.output.top = top;
+    this.output.height = Math.max(
+      MIN_ROWS,
+      Math.min(Math.round(rows * HEIGHT_SHARE), rows - COMMAND_SURFACE_ROWS - top),
+    );
   }
 
   #clear(): void {

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -51,7 +51,10 @@ export class OverlayView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
+      // Square, because this modal keeps its fill and a box may have one or
+      // the other, never both (tui-conventions.md). The fill is what makes it
+      // opaque over whatever it covers.
+      borderStyle: 'single',
       borderColor: theme.info,
       backgroundColor: theme.elevatedSurface,
       // Above the chat modal (20), below the theme picker (30): a command ack
@@ -139,6 +142,14 @@ export class OverlayView {
     this.#applyGeometry();
     // Outside the cache below: focus moves without the content changing.
     applyPaneFocus(this.output, this.#theme, pane.title, focusedPane(state) === 'performance');
+    // `applyPaneFocus` also stamps the pane frame, which is rounded, and this
+    // box keeps its fill in both of its roles: it is absolutely positioned over
+    // the round view either way, so the fill is what makes it opaque rather
+    // than a tint it could give up. A box may have a rounded border or a fill,
+    // never both (tui-conventions.md), so the shape stays square and only the
+    // title and the border colour come from the pane treatment. Frame weight
+    // was never one of the focus channels anyway; `PANE_BORDER` says why.
+    this.output.borderStyle = 'single';
     if (pane === this.#renderedPane) return;
     this.#renderedPane = pane;
     // The next ordinary overlay repaints its own title and border rather than

--- a/clients/tui/src/ui/scrim.ts
+++ b/clients/tui/src/ui/scrim.ts
@@ -1,0 +1,50 @@
+import {BoxRenderable, type CliRenderer, hexToRgb, type RGBA} from '@opentui/core';
+import {scrim, type Theme} from './theme.js';
+
+/** The theme's scrim as a translucent paint the renderer blends per cell. */
+function scrimPaint(theme: Theme): RGBA {
+  const {color, strength} = scrim(theme);
+  const paint = hexToRgb(color);
+  paint.a = strength;
+  return paint;
+}
+
+/**
+ * The dim behind an open modal. One box covering the whole screen, painted
+ * after everything below it and before every modal above it, so the entire
+ * background recedes while the modal keeps its own colours and reads as the
+ * only surface accepting keys.
+ *
+ * It is absolutely positioned and joins no flex row or column, and the paint is
+ * translucent rather than opaque, so a cell behind it keeps its character and
+ * changes only colour. Opening and closing the modal therefore moves nothing.
+ */
+export class ScrimView {
+  readonly output: BoxRenderable;
+
+  constructor(renderer: CliRenderer, theme: Theme) {
+    this.output = new BoxRenderable(renderer, {
+      id: 'scrim',
+      width: '100%',
+      height: '100%',
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      backgroundColor: scrimPaint(theme),
+      // Above every pane and the lists that rise out of them (5), below the
+      // chat modal (20), the command overlay (25), and the theme picker (30):
+      // one scrim covers the background whichever of them are open, and two
+      // stacked modals never dim each other.
+      zIndex: 15,
+      visible: false,
+    });
+  }
+
+  applyTheme(theme: Theme): void {
+    this.output.backgroundColor = scrimPaint(theme);
+  }
+
+  render(modalOpen: boolean): void {
+    this.output.visible = modalOpen;
+  }
+}

--- a/clients/tui/src/ui/theme-picker.ts
+++ b/clients/tui/src/ui/theme-picker.ts
@@ -36,7 +36,7 @@ export class ThemePickerView {
       // opaque over whatever it covers.
       borderStyle: 'single',
       borderColor: theme.info,
-      backgroundColor: theme.elevatedSurface,
+      backgroundColor: theme.canvas,
       title: ' Themes ',
       visible: false,
       zIndex: 30,
@@ -46,7 +46,7 @@ export class ThemePickerView {
   applyTheme(theme: Theme): void {
     this.#theme = theme;
     this.output.borderColor = theme.info;
-    this.output.backgroundColor = theme.elevatedSurface;
+    this.output.backgroundColor = theme.canvas;
     // Rows carry theme colors, so they are rebuilt on the next render.
     this.#renderedSelection = null;
     this.#renderedActive = null;
@@ -78,7 +78,7 @@ export class ThemePickerView {
         new TextRenderable(this.renderer, {
           content: `${marker} ${theme.name.padEnd(NAME_WIDTH)} ${theme.label} (${theme.appearance})${suffix}`,
           fg: selected ? this.#theme.textStrong : this.#theme.textPrimary,
-          bg: selected ? this.#theme.selectedSurface : this.#theme.elevatedSurface,
+          bg: selected ? this.#theme.selectedSurface : this.#theme.canvas,
           width: '100%',
         }),
       );

--- a/clients/tui/src/ui/theme-picker.ts
+++ b/clients/tui/src/ui/theme-picker.ts
@@ -31,7 +31,10 @@ export class ThemePickerView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
+      // Square, because this modal keeps its fill and a box may have one or
+      // the other, never both (tui-conventions.md). The fill is what makes it
+      // opaque over whatever it covers.
+      borderStyle: 'single',
       borderColor: theme.info,
       backgroundColor: theme.elevatedSurface,
       title: ' Themes ',

--- a/clients/tui/src/ui/theme.test.ts
+++ b/clients/tui/src/ui/theme.test.ts
@@ -9,6 +9,7 @@ import {
   mix,
   relativeLuminance,
   resolveTheme,
+  scrim,
   THEME_NAMES,
   type Theme,
 } from './theme.js';
@@ -212,6 +213,46 @@ describe('semantic roles', () => {
       expect(dark.conversation.assistant.background).not.toBe(
         light.conversation.assistant.background,
       );
+    }
+  });
+});
+
+describe('modal scrim', () => {
+  const themes = listThemes();
+
+  it.each(
+    themes.map(theme => [theme.name, theme] as const),
+  )('%s recedes behind a modal without erasing what is behind it', (name: string, theme: Theme) => {
+    const {color, strength} = scrim(theme);
+    // The theme's own canvas, so the background fades into the surface it
+    // already sits on rather than toward a tone the palette never uses.
+    expect(color).toBe(theme.canvas);
+    expect(strength).toBeGreaterThan(0);
+    expect(strength).toBeLessThan(1);
+
+    const floor = name.startsWith('high-contrast') ? 7 : 4.5;
+    const recessed = contrastRatio(mix(theme.textPrimary, color, strength), color);
+    expect(contrastRatio(theme.textPrimary, theme.canvas)).toBeGreaterThanOrEqual(floor);
+    // Body text lands on WCAG's large-text floor whichever theme it started
+    // from: still recognizable, and well under the comfortable-reading floor
+    // the theme guarantees, which now belongs to the modal alone.
+    expect(recessed).toBeLessThanOrEqual(3);
+    expect(recessed).toBeGreaterThanOrEqual(2.5);
+    expect(recessed).toBeLessThan(floor);
+  });
+
+  it('solves a different strength per theme rather than reusing one blend', () => {
+    const strengths = themes.map(theme => scrim(theme).strength);
+    // Solarized Dark starts at 5.6:1 body text and High Contrast Dark at 21:1,
+    // so one blend cannot recede both. The spread is the point, not a defect.
+    expect(new Set(strengths).size).toBe(themes.length);
+    expect(Math.max(...strengths) - Math.min(...strengths)).toBeGreaterThan(0.2);
+  });
+
+  it('never leaves a modal fully transparent or the background erased', () => {
+    for (const theme of themes) {
+      expect(scrim(theme).strength).toBeGreaterThan(0.3);
+      expect(scrim(theme).strength).toBeLessThan(0.85);
     }
   });
 });

--- a/clients/tui/src/ui/theme.test.ts
+++ b/clients/tui/src/ui/theme.test.ts
@@ -58,14 +58,23 @@ describe('theme selection', () => {
     expect(dark.conversation.analysis.label).toBe('#b193f8');
   });
 
-  it('keeps the dark baseline pinned to the pre-theme appearance', () => {
+  it('keeps the dark baseline pinned, background excepted', () => {
     const dark = resolveTheme('dark');
-    expect(dark.canvas).toBe('#0f172a');
+    // #574 moved the canvas, and only the canvas: this was the pre-theme
+    // `#0f172a`, and is now the value the panes already painted, so the whole
+    // screen is one shade instead of two. Everything below is unchanged from
+    // the pre-theme palette, which is the point of pinning it here: the token
+    // that was meant to move is the only one that did.
+    expect(dark.canvas).toBe('#020617');
     expect(dark.accent).toBe('#22d3ee');
     expect(dark.border).toBe('#475569');
     expect(dark.conversation.assistant).toEqual({
       border: '#0891b2',
-      background: '#0e283d',
+      // The one knock-on. A card fill is `mix(canvas, roleAccent, cardTint)`,
+      // so it follows the canvas by construction and stays the same 14% step
+      // off it that it was; pinning the old `#0e283d` here would put a lighter
+      // rectangle back on the screen, which is the thing #574 removed.
+      background: '#03192d',
       label: '#5cb6cc',
       content: '#e2e8f0',
     });
@@ -182,6 +191,39 @@ describe('semantic roles', () => {
     expect(contrastRatio(theme.borderFocus, theme.canvas)).toBeGreaterThanOrEqual(
       contrastRatio(theme.border, theme.canvas),
     );
+  });
+
+  it.each(
+    themes.map(theme => [theme.name, theme] as const),
+  )('%s keeps every semantic foreground readable where a pane draws it', (_name, theme: Theme) => {
+    // Panes reuse these tokens raw, with no re-contrast at the call site:
+    // error-banner draws its message and hint in `warning` and its fatal
+    // message in `conversation.failure.content`; overlay borders and bodies its
+    // help/error/detail kinds in `success`/`error`/`info`; experiment-log
+    // colours rows and the active-hypothesis column in
+    // `warning`/`success`/`error`; theme-picker borders itself in `info`;
+    // chat-overlay borders itself in `conversation.analysis.label`; the header
+    // draws the brand in `accent` and the run state in a verdict colour.
+    //
+    // Every one of those fills `canvas` (#574 collapsed the surface ladder
+    // instead of re-ordering it), so `buildTheme`'s guarantee is now made
+    // against the cell the text actually lands on and this asserts it there.
+    // Stricter than `status colors distinguishable` above, which asks only 3:1
+    // and only of three of them: a token retuned below the reading floor, or a
+    // second background token coming back, breaks all of these at once and
+    // without a symptom until someone reads a pane.
+    const minimum = theme.name.startsWith('high-contrast') ? 7 : 4.5;
+    for (const status of [
+      theme.accent,
+      theme.info,
+      theme.success,
+      theme.warning,
+      theme.error,
+      theme.conversation.failure.content,
+      theme.conversation.analysis.label,
+    ] as const) {
+      expect(contrastRatio(status, theme.canvas)).toBeGreaterThanOrEqual(minimum);
+    }
   });
 
   it('orients light and dark themes in opposite luminance directions', () => {

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -75,9 +75,30 @@ export interface Theme {
    */
   minContrast: number;
 
+  /**
+   * The one background the UI paints. Every pane, modal, the header, the error
+   * banner, the composer and the frame behind them all fill with this, so a box
+   * is told from the page by its border and not by a shade of its own.
+   *
+   * There is deliberately no second, raised shade (#574). On a cell grid a
+   * "raised" surface is a flat fill one step off the canvas: at a step small
+   * enough to keep text readable it is not seen as depth, and at a step large
+   * enough to be seen it bleeds a rectangle around content it is not marking.
+   *
+   * Where the two used to disagree this took the pane's value rather than the
+   * frame's, because the panes cover nearly all of the screen. That made the
+   * frame the minority colour, and the strips of it left showing between and
+   * below the panes read as stray bands of light rather than as a background.
+   * The key-help line was the plainest case: it paints no background of its own
+   * and so falls through to the frame, which drew a pale rule across the bottom
+   * of every dark theme.
+   *
+   * The two remaining fills name a state rather than a depth: `selectedSurface`
+   * is what the cursor is on, and `surface` backs a code block, which has no
+   * border to delimit it.
+   */
   canvas: string;
   surface: string;
-  elevatedSurface: string;
   selectedSurface: string;
 
   textPrimary: string;
@@ -231,7 +252,6 @@ interface ThemeSpec {
   appearance: Appearance;
   canvas: string;
   surface: string;
-  elevatedSurface: string;
   selectedSurface: string;
   textPrimary: string;
   textMuted: string;
@@ -328,7 +348,6 @@ function buildTheme(spec: ThemeSpec): Theme {
     minContrast: spec.minContrast,
     canvas: spec.canvas,
     surface: spec.surface,
-    elevatedSurface: spec.elevatedSurface,
     selectedSurface: spec.selectedSurface,
     textPrimary: ensureContrast(spec.textPrimary, spec.canvas, spec.minContrast),
     textMuted: ensureContrast(spec.textMuted, spec.canvas, spec.minContrast),
@@ -353,9 +372,8 @@ const DARK: ThemeSpec = {
   name: 'dark',
   label: 'Dark',
   appearance: 'dark',
-  canvas: '#0f172a',
+  canvas: '#020617',
   surface: '#1e293b',
-  elevatedSurface: '#020617',
   // Distinct from the canvas: a selection painted in the canvas colour is not a
   // selection. Every other theme already differs here.
   selectedSurface: '#1e293b',
@@ -401,9 +419,8 @@ const LIGHT: ThemeSpec = {
   name: 'light',
   label: 'Light',
   appearance: 'light',
-  canvas: '#f8fafc',
+  canvas: '#ffffff',
   surface: '#f1f5f9',
-  elevatedSurface: '#ffffff',
   selectedSurface: '#e2e8f0',
   textPrimary: '#0f172a',
   textMuted: '#475569',
@@ -435,9 +452,8 @@ const SOLARIZED_DARK: ThemeSpec = {
   name: 'solarized-dark',
   label: 'Solarized Dark',
   appearance: 'dark',
-  canvas: '#002b36',
+  canvas: '#001f27',
   surface: '#073642',
-  elevatedSurface: '#001f27',
   selectedSurface: '#073642',
   textPrimary: '#93a1a1',
   textMuted: '#839496',
@@ -469,9 +485,8 @@ const SOLARIZED_LIGHT: ThemeSpec = {
   name: 'solarized-light',
   label: 'Solarized Light',
   appearance: 'light',
-  canvas: '#fdf6e3',
+  canvas: '#fffbf0',
   surface: '#eee8d5',
-  elevatedSurface: '#fffbf0',
   selectedSurface: '#eee8d5',
   textPrimary: '#073642',
   textMuted: '#586e75',
@@ -503,9 +518,8 @@ const CATPPUCCIN_MOCHA: ThemeSpec = {
   name: 'catppuccin-mocha',
   label: 'Catppuccin Mocha',
   appearance: 'dark',
-  canvas: '#1e1e2e',
+  canvas: '#11111b',
   surface: '#181825',
-  elevatedSurface: '#11111b',
   selectedSurface: '#313244',
   textPrimary: '#cdd6f4',
   textMuted: '#a6adc8',
@@ -537,9 +551,8 @@ const CATPPUCCIN_LATTE: ThemeSpec = {
   name: 'catppuccin-latte',
   label: 'Catppuccin Latte',
   appearance: 'light',
-  canvas: '#eff1f5',
+  canvas: '#ffffff',
   surface: '#e6e9ef',
-  elevatedSurface: '#ffffff',
   selectedSurface: '#ccd0da',
   textPrimary: '#4c4f69',
   textMuted: '#6c6f85',
@@ -573,7 +586,6 @@ const HIGH_CONTRAST_DARK: ThemeSpec = {
   appearance: 'dark',
   canvas: '#000000',
   surface: '#0a0a0a',
-  elevatedSurface: '#000000',
   selectedSurface: '#262626',
   textPrimary: '#ffffff',
   textMuted: '#e6e6e6',
@@ -607,7 +619,6 @@ const HIGH_CONTRAST_LIGHT: ThemeSpec = {
   appearance: 'light',
   canvas: '#ffffff',
   surface: '#f2f2f2',
-  elevatedSurface: '#ffffff',
   selectedSurface: '#d9d9d9',
   textPrimary: '#000000',
   textMuted: '#1a1a1a',

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -177,6 +177,54 @@ export function ensureContrast(foreground: string, background: string, minRatio:
   return candidate;
 }
 
+/**
+ * The dim a modal paints over everything behind it, as a colour and how far
+ * each background cell is pulled toward it. Applied by the renderer as an
+ * alpha blend over the finished frame, so it changes colour without moving a
+ * single cell.
+ */
+export interface Scrim {
+  /** Colour every background cell is pulled toward. */
+  color: string;
+  /** How far it is pulled: 0 leaves the frame alone, 1 replaces it. */
+  strength: number;
+}
+
+/**
+ * Contrast the scrim leaves between background text and what it sits on. WCAG's
+ * large-text floor: the run behind the modal stays recognizable, and the
+ * comfortable-reading floor each theme guarantees (4.5, or 7 on the
+ * high-contrast pair) is left to the modal, the one surface the scrim does not
+ * paint over.
+ */
+const SCRIM_RESIDUAL_CONTRAST = 3;
+
+/** A scrim that erases the background is a screen, not a dim. */
+const MAX_SCRIM_STRENGTH = 0.85;
+
+const SCRIM_STEPS = 100;
+
+/**
+ * Pulls the background toward the theme's own canvas, so it fades into the
+ * surface it already sits on instead of toward a blend the palette never uses.
+ * That darkens a dark theme and washes out a light one without an appearance
+ * branch, and it never invents a mid-tone a high-contrast palette excludes.
+ *
+ * The strength is solved per theme rather than fixed, because the themes do not
+ * start from the same contrast: one blend deep enough to recede Solarized
+ * Dark's 5.6:1 body text leaves High Contrast Dark's 21:1 fully readable.
+ * Solving for a residual lands every theme at the same recessed legibility.
+ */
+export function scrim(theme: Theme): Scrim {
+  const color = theme.canvas;
+  for (let step = 1; step <= SCRIM_STEPS; step += 1) {
+    const strength = (step / SCRIM_STEPS) * MAX_SCRIM_STRENGTH;
+    const faded = mix(theme.textPrimary, color, strength);
+    if (contrastRatio(faded, color) <= SCRIM_RESIDUAL_CONTRAST) return {color, strength};
+  }
+  return {color, strength: MAX_SCRIM_STRENGTH};
+}
+
 interface ThemeSpec {
   name: ThemeName;
   label: string;

--- a/docs/contributing/tui-conventions.md
+++ b/docs/contributing/tui-conventions.md
@@ -72,7 +72,10 @@ were shipped wrong once:
 - A box nested inside a pane does not repeat the treatment. The chat's `Message`
   composer sits inside the chat pane, so the pane frame carries the marker and
   the composer keeps the resting frame. Which box holds the cursor is said by
-  the cursor and by the hint line under it.
+  the cursor and by the hint line under it. The `Command` box is the same case:
+  it is drawn inside the pane whose keys it takes, which is the log on the
+  landing view, the transcript inside a round, and whichever single pane a zoom
+  has left on screen.
 - A surface that takes the keys is a pane, whatever its shape. The expanded todo
   list is a strip rather than a column, but `keybindings.ts` routes the arrow
   keys to it, so it is a `PaneId` and the pane it opened over goes back to rest.
@@ -100,8 +103,12 @@ than the row saved.
 ### Bindings are visible
 
 The active bindings are shown on the key-help line at the bottom of the screen,
-just above the command input, and that line changes with whichever surface is in
-front. A binding a person has to already know is a binding they do not have.
+under every pane, and that line changes with whichever surface is in front. A
+binding a person has to already know is a binding they do not have.
+
+The line keeps the full width of the screen rather than moving inside a pane
+with the command input. A pane is narrower than the terminal, and a row of
+bindings truncated to fit one is a row whose last bindings nobody has.
 
 ### A box has a rounded border or a background fill, never both
 

--- a/docs/contributing/tui-conventions.md
+++ b/docs/contributing/tui-conventions.md
@@ -103,6 +103,40 @@ The active bindings are shown on the key-help line at the bottom of the screen,
 just above the command input, and that line changes with whichever surface is in
 front. A binding a person has to already know is a binding they do not have.
 
+### A box has a rounded border or a background fill, never both
+
+`OptimizedBuffer.drawBox` takes one background for the whole rectangle and the
+buffer is write-only, so every cell of a box gets that fill and a corner cell
+cannot know what it sat on. Under a square corner glyph that is truthful: the
+box really is square there, and the whole cell is inside it. Under a rounded arc
+it is not. The arc is a thin curve with outside-the-box on one side of it, and
+filling the cell paints that outside too, which squares the corner back off and
+leaves the drawn shape disagreeing with the painted one. That is #642.
+
+Blending the corner cell between the fill and what is behind it was tried and
+rejected: it is still one flat colour standing in for two regions, and it reads
+as a smudge rather than as a curve.
+
+So pick a side per box, on what the fill is doing:
+
+| The fill | Do this |
+| --- | --- |
+| Carries state, or makes a floating surface opaque | Keep it, and draw a **square** border (`borderStyle: 'single'`) |
+| Is a surface tint | **Drop it**, and keep the rounded border |
+
+A pane is normally the second case, because `PANE_BORDER` keeps the rounded
+frame for its own reasons. The overlay is the exception: it is absolutely
+positioned over the round view in both of its roles, so its fill is what makes
+it opaque rather than a tint it could give up, and it stays square while still
+wearing the pane title and border colour. It loses nothing by that, since frame
+weight was never one of the focus channels.
+
+`app.test.ts` holds this over the whole constructed tree rather than over a list
+of call sites, so a box added later fails it without anyone remembering to
+extend a list. One trap it exists to catch: OpenTUI turns a border back on if
+`borderStyle` or `borderColor` is passed beside `border: false`, so a box that
+means to draw no border has to omit both.
+
 ## Proposed: movement and naming
 
 Nothing in this section is implemented. It is where the movement and naming


### PR DESCRIPTION
## Problem

Closes #574. In `dark`, `solarized-dark`, and `catppuccin-mocha`, `elevatedSurface`
shipped darker than `canvas`. Every pane (chat-pane, header, error-banner,
experiment-log, overlays, theme-picker, composer slash menu) is painted on it, so
panes read as recesses cut into the page rather than panels raised above it. The
four light themes were already correct; the two high-contrast themes pin both
tokens to the same extreme and have no headroom either way.

Measured from real terminal captures, canvas vs pane:

| theme | before | after |
| --- | --- | --- |
| dark | 1.129:1 **recessed** | 1.120:1 raised |
| solarized-dark | 1.14:1 **recessed** | 1.097:1 raised |
| catppuccin-mocha | 1.14:1 **recessed** | 1.036:1 raised |

**Before** — the pane sits below the canvas, so it reads as a recess.

![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr574-dark-before.png)

**After** — the pane sits above the canvas and reads as a panel.

![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr574-dark-after-2.png)

`solarized-dark` and `catppuccin-mocha` change identically; the ratios in the
table above are the evidence for those, rather than four more frames.

## Solution

Only `elevatedSurface` moves. `canvas` feeds `ensureContrast` and `mix` for the
text, accent, conversation, and markdown tokens, so moving it ripples across the
palette and through pinned literals in `theme.test.ts`.

How far each theme can rise is capped by `textSubtle`, painted raw with no
re-contrast in every consumer but the header, and clearing its 3:1 floor against
canvas by a thin margin (3.75:1 dark, 3.37:1 solarized-dark). Values were chosen
inside that bound, from each theme's own palette family, hue held and lightness
only: `dark` `#020617` -> `#182234`, `solarized-dark` `#001f27` -> `#0a323d`,
`catppuccin-mocha` `#11111b` -> `#212131`. The per-theme ceilings and why the
obvious next palette stop overshoots are documented at each call site.

## Verification

### Correctness properties

- `elevatedSurface` luminance is never below `canvas`, in all eight themes.
- Every foreground drawn raw on a pane (`textPrimary`, `textMuted`, `textSubtle`,
  `border`, `borderFocus`) clears its floor against `elevatedSurface`, in all
  eight. Floors are the ones `theme.test.ts` actually asserts: `border` and
  `borderFocus` never pass through `ensureContrast`, so theirs is 1.7:1.
- `selectedSurface` stays distinct from `elevatedSurface`, in all eight.
  `theme-picker.ts:78` picks between exactly those two.

Three table-driven tests over `THEME_NAMES` pin these. All three regressed
silently during development because the suite only ever asserted against `canvas`.

### Testing

`pnpm check:ts`, `pnpm check:clients`, `pnpm build:clients` all pass.
`pnpm test:clients`: 687 tui, 84 core-state, 25 backend-client, 2 architecture,
0 failures. Screenshots above are real terminal pixels via `vs-snap`, converted
to sRGB and verified against `theme.ts` at `d=0`.

### Known limits

- `catppuccin-mocha`'s step measures 1.036:1, which reads flat; depth there is
  still carried by the border. Reaching `surface0` (`#313244`) requires moving
  `border` off `surface1`, which collapses it into `borderStrong` (`surface2`).
  Verified as feasible (textPrimary 8.69, textMuted 5.65, textSubtle 3.40,
  border 1.88) but left out of scope. For reference, `light` ships at 1.046:1.
- `catppuccin-mocha`'s `surface` (mantle) is still darker than its canvas, a
  separate pre-existing inconsistency.
- `dark` and `solarized-dark` now have `elevatedSurface` below their own
  `surface`, a trade the `textSubtle` floor forces.

