### PR TITLE
fix(tui): put a box fill on an inner box so its border contains it

### DIFF
--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -24,6 +24,7 @@ import {
   stageKinds,
 } from './agent-graph.js';
 import {agentRuntimeLabel} from './agent-runtime-label.js';
+import {fillLayer} from './box-fill.js';
 import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {elapsedLabel} from './previews.js';
 import type {Theme} from './theme.js';
@@ -336,17 +337,26 @@ export class AgentMapView {
       // No horizontal padding: two columns of it is the difference between
       // "implementer" and "implement…" at the widths a four-stage round leaves.
       border: true,
-      borderStyle: 'rounded',
+      // Square, and not because of the fill: that sits on an inner layer
+      // (tui-conventions.md), so the shape is free either way and this is a
+      // look decision. A stage reads as a slot in a pipeline rather than as a
+      // card, and the map's edges arrive at its sides. Unconditional rather
+      // than square-only-when-selected, because swapping the shape on
+      // selection reads as the node becoming a different kind of object,
+      // which is why `PANE_BORDER` rejected the same swap for focus.
+      borderStyle: 'single',
       borderColor: selected
         ? this.#theme.borderFocus
         : phase.status === 'pending'
           ? this.#theme.borderStrong
           : color,
-      ...(selected ? {backgroundColor: this.#theme.selectedSurface} : {}),
       // Clicking a node filters the transcript to it, and clicking the selected
       // one clears the filter: the same toggle Tab and Esc give the keyboard.
       onMouseUp: () => this.controller.selectAgent(phase.kind),
     });
+    // Inside the frame, so the fill stops at the border line instead of
+    // painting the ring the edges arrive at (tui-conventions.md).
+    if (selected) fillLayer(box, `agent-${phase.kind}-${node.y}-fill`, this.#theme.selectedSurface);
     const inner = node.width - 2;
     box.add(
       new TextRenderable(this.renderer, {
@@ -400,16 +410,19 @@ export class AgentMapView {
       paddingRight: 1,
       // Passing borderStyle without border draws a frame that the layout does
       // not reserve rows for, and the phase's lines then overlap it.
+      //
+      // Square for the same reason as `#renderNode`: this is that node in the
+      // stacked layout, so the two layouts read as one object.
       ...(selected
         ? {
             border: true,
-            borderStyle: 'rounded' as const,
+            borderStyle: 'single' as const,
             borderColor: this.#theme.borderFocus,
           }
         : {}),
-      ...(selected ? {backgroundColor: this.#theme.selectedSurface} : {}),
       onMouseUp: () => this.controller.selectAgent(phase.kind),
     });
+    if (selected) fillLayer(row, `agent-${phase.kind}-fill`, this.#theme.selectedSurface);
     const color = statusColor(this.#theme, phase.status);
     row.add(
       new TextRenderable(this.renderer, {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1,7 +1,10 @@
 import {afterEach, describe, expect, it} from 'bun:test';
 import {
+  BoxRenderable,
   CliRenderEvents,
+  getBorderSides,
   InputRenderable,
+  type Renderable,
   rgbToHex,
   ScrollBoxRenderable,
   TextareaRenderable,
@@ -5182,6 +5185,203 @@ describe('header hierarchy', () => {
     expect(frame).not.toContain('V...');
   });
 });
+/**
+ * A fill lives on an inner box, so a border ring shows what is behind the box.
+ *
+ * `docs/contributing/tui-conventions.md` states the rule and the reason.
+ * `BoxRenderable` hands `OptimizedBuffer.drawBox` one `backgroundColor` for the
+ * whole rectangle and the buffer is write-only, so a fill set on a bordered box
+ * paints the ring as well: the painted rectangle ends up one cell larger than
+ * the drawn line on all four sides, the line sits in a solid block, and under a
+ * rounded arc the fill paints the outside of the curve and squares the corner
+ * back off. That is #642.
+ *
+ * Asserted by walking the constructed tree rather than by reading a frame, so
+ * it covers every box the app builds, including the modals that stay
+ * `visible: false` until they are opened, and so a call site added later fails
+ * this without anyone remembering to extend a list.
+ */
+describe('box fills', () => {
+  /**
+   * The boxes that keep an outer fill, which is the one exception.
+   *
+   * Each of them floats over other content, so the fill has to reach the border
+   * ring or what is behind shows through it. A list rather than a structural
+   * test because floating is not a property a box carries: the agent map's
+   * cards are absolutely positioned too, and they are laid out on a canvas
+   * rather than over anything, so `position` would exempt them as well. Every
+   * entry here is an exception someone reviewed, which is the point of holding
+   * them in one place.
+   */
+  const OVERLAY_IDS = new Set([
+    'overlay',
+    'theme-picker',
+    'chat-overlay',
+    'command-input-suggestions',
+  ]);
+
+  /** One per composer, and a composer is built per surface, so match the suffix. */
+  function isOverlay(id: string): boolean {
+    return OVERLAY_IDS.has(id) || id.endsWith('-composer-menu');
+  }
+
+  /** Every box under `renderable`, itself included. */
+  function* boxesIn(renderable: Renderable): Generator<BoxRenderable> {
+    if (renderable instanceof BoxRenderable) yield renderable;
+    for (const child of renderable.getChildren()) yield* boxesIn(child);
+  }
+
+  /** The id of every box that breaks the rule, so a failure names the site. */
+  function offenders(renderable: Renderable): string[] {
+    const found: string[] = [];
+    for (const box of boxesIn(renderable)) {
+      const sides = getBorderSides(box.border);
+      if (!sides.top && !sides.right && !sides.bottom && !sides.left) continue;
+      // `transparent` is the default and is what "no fill of its own" means
+      // here: `drawBox` leaves the rectangle alone, so the ring keeps whatever
+      // was already under it.
+      if (box.backgroundColor.a === 0) continue;
+      // An overlay may keep the outer fill, but only square. The fill reaches
+      // the ring either way, and a ring of fill under a rounded arc is #642.
+      if (isOverlay(box.id) && box.borderStyle !== 'rounded') continue;
+      found.push(box.id);
+    }
+    return found;
+  }
+
+  function boxIds(renderable: Renderable): string[] {
+    return [...boxesIn(renderable)].map(box => box.id);
+  }
+
+  /** A box that is there and is actually painting something. */
+  function isPainted(root: Renderable, id: string): boolean {
+    const box = root.findDescendantById(id);
+    return box instanceof BoxRenderable && box.backgroundColor.a > 0;
+  }
+
+  /** Enough state to build the boxes that are made per entry, not at startup. */
+  function shapeController(): FakeController {
+    return new FakeController({
+      ...initialSessionState(),
+      selectedAgentKind: 'implementer',
+      selectedEntryId: 'card',
+      core: {
+        ...initialSessionState().core,
+        status: 'running',
+        agentKind: 'implementer',
+        rounds: [{number: 1, status: 'active'}],
+        phases: [
+          {kind: 'optimizer', status: 'completed', roundNumber: 1, roundLabel: 'round 1'},
+          {kind: 'implementer', status: 'active', roundNumber: 1, roundLabel: 'round 1'},
+        ],
+        // Stamped with the agent and the round, because `visibleConversation`
+        // filters on both and an unstamped entry would be dropped before a
+        // card was ever built for it.
+        transcript: [
+          {
+            id: 'card',
+            kind: 'assistant',
+            agentKind: 'implementer',
+            roundNumber: 1,
+            label: 'implementer · round 1',
+            content: 'a bordered card',
+          },
+          {
+            id: 'status',
+            kind: 'status',
+            agentKind: 'implementer',
+            roundNumber: 1,
+            content: 'a status line',
+          },
+        ],
+      },
+    });
+  }
+
+  it('keeps a fill off every bordered box that is not an overlay', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 30});
+    const app = createOpenTuiApp(testRenderer.renderer, shapeController());
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('a bordered card'));
+    const root = testRenderer.renderer.root;
+
+    // Coverage first, because a walk that reached nothing passes vacuously.
+    // One box from each side of the rule, plus the two that are built per
+    // entry rather than once at startup.
+    const ids = boxIds(root);
+    expect(ids).toContain('header-frame'); // bordered, fill moved inwards
+    expect(ids).toContain('experiment-log'); // a pane, the same way
+    expect(ids).toContain('theme-picker'); // an overlay, built here, never opened
+    expect(ids).toContain('event-card'); // a bordered transcript card
+    expect(ids).toContain('event-status'); // borderless, so it keeps its own fill
+    expect(ids.some(id => id.startsWith('agent-implementer-'))).toBe(true);
+
+    expect(offenders(root)).toEqual([]);
+  });
+
+  it('moves a fill inwards rather than dropping it', async () => {
+    // The other half of the rule, and the one a walk for offenders cannot see:
+    // deleting a fill satisfies that walk too, and it was how this branch first
+    // tried to answer #642. Every site that used to fill its own rectangle has
+    // to still be painting one, on a layer inside the border.
+    const testRenderer = await createTestRenderer({width: 120, height: 30});
+    const app = createOpenTuiApp(testRenderer.renderer, shapeController());
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('a bordered card'));
+    const root = testRenderer.renderer.root;
+
+    for (const id of ['header-fill', 'experiment-log-fill', 'event-card-fill']) {
+      expect([id, isPainted(root, id)]).toEqual([id, true]);
+    }
+  });
+
+  it('keeps the rule in the stacked agent layout', async () => {
+    // Two things only a narrow terminal builds. The agent pane falls back to
+    // stacked rows when there is no width to lay the graph out, and a
+    // visualization below `MIN_SPLIT_WIDTH` is drawn through the overlay,
+    // which then wears the pane treatment. That second one is the case a
+    // construction-time rule cannot cover on its own: `applyPaneFocus` sets
+    // the frame at render time, so the rounded overlay it could reintroduce
+    // only exists after a frame.
+    const testRenderer = await createTestRenderer({width: 60, height: 30});
+    const controller = shapeController();
+    controller.paneContent = 'Performance · tok_s\nbest r1 1135 tok_s';
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('implementer'));
+    await controller.openPane('perf');
+    await testRenderer.waitForFrame(value => value.includes('1135 tok_s'));
+    const root = testRenderer.renderer.root;
+
+    expect(boxIds(root)).toContain('agent-implementer');
+    expect(offenders(root)).toEqual([]);
+  });
+
+  it('flags a bordered box that fills its own rectangle', async () => {
+    // The walks above are only evidence while they can fail. These are the
+    // controls: a box built the way #642 reported, and the overlay exception
+    // used to take a rounded frame back, which is the same bug again.
+    const {renderer} = await createTestRenderer({width: 20, height: 6});
+    cleanup.push(() => renderer.destroy());
+    for (const [id, borderStyle] of [
+      ['bordered-and-filled', 'rounded'],
+      ['overlay', 'rounded'],
+    ] as const) {
+      const box = new BoxRenderable(renderer, {
+        id,
+        width: 6,
+        height: 3,
+        border: true,
+        borderStyle,
+        backgroundColor: '#ffffff',
+      });
+      renderer.root.add(box);
+      cleanup.push(() => box.destroyRecursively());
+    }
+
+    expect(offenders(renderer.root)).toEqual(['bordered-and-filled', 'overlay']);
+  });
+});
 
 /**
  * The experiment log settles synchronously, so there is no later frame to wait
@@ -5355,8 +5555,12 @@ function paneBorders(testRenderer: TestRendererSetup): Record<string, string> {
   const borders: Record<string, string> = {};
   for (const line of testRenderer.captureSpans().lines) {
     for (const span of line.spans) {
-      // Either frame style, since a focused pane draws the heavy one.
-      for (const match of span.text.matchAll(/[╭┏][─━]([^─━╮┓]+)[─━]/g)) {
+      // All three corner glyphs a titled box can open with: rounded, the
+      // heavy one a focused pane would draw, and square. Square is in the set
+      // because an overlay keeps an outer fill and so draws a square frame
+      // (tui-conventions.md), and the narrow-terminal visualization is drawn
+      // through the overlay while it is also the performance pane.
+      for (const match of span.text.matchAll(/[╭┏┌][─━]([^─━╮┓┐]+)[─━]/g)) {
         borders[(match[1] ?? '').trim()] = rgbToHex(span.fg).toLowerCase();
       }
     }

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -16,6 +16,7 @@ import {
 } from '../session-model.js';
 import {ActivityBarView} from './activity-bar.js';
 import {AgentMapView} from './agent-map.js';
+import {fillLayer} from './box-fill.js';
 import {createChatDraft} from './chat-composer.js';
 import {ChatOverlayView} from './chat-overlay.js';
 import {ChatPaneView, chatDockFits, chatPaneWidth, commandColumnInset} from './chat-pane.js';
@@ -108,16 +109,19 @@ export function createOpenTuiApp(
     paddingLeft: 1,
     paddingRight: 1,
     border: true,
+    // Rounded, like the panes below it. The fill is on an inner layer, so
+    // there is nothing in the corner cell to bleed past the arc
+    // (tui-conventions.md).
     borderStyle: 'rounded',
     borderColor: theme.border,
-    // The same surface every other pane sits on. Without this the frame falls
-    // through to the root's `canvas`, which is a different shade, so the header
-    // read as a band laid over the UI rather than a pane within it. That is
-    // the exact quality the housing exists to remove. Through
-    // `headerBackground` because `headerSpanStyle` derives the text tones
-    // against the same call: the fill and the contrast basis are one fact.
-    backgroundColor: headerBackground(theme),
   });
+  // The same surface every other pane sits on. Without this the frame falls
+  // through to the root's `canvas`, which is a different shade, so the header
+  // read as a band laid over the UI rather than a pane within it. That is the
+  // exact quality the housing exists to remove. Through `headerBackground`
+  // because `headerSpanStyle` derives every header tone's contrast against the
+  // same call: the fill and the contrast basis are one fact.
+  const headerFill = fillLayer(headerFrame, 'header-fill', headerBackground(theme));
   // One renderable per span, because a terminal cell carries one foreground
   // colour and the header's roles do not share one. The row is allocated once
   // at its maximum and repainted in place: the spans change on every frame, and
@@ -338,7 +342,7 @@ export function createOpenTuiApp(
     markdownStyle = createMarkdownStyle(theme);
     root.backgroundColor = theme.canvas;
     headerFrame.borderColor = theme.border;
-    headerFrame.backgroundColor = headerBackground(theme);
+    headerFill.backgroundColor = headerBackground(theme);
     transcriptFrame.borderColor = theme.border;
     help.fg = theme.textSubtle;
     roundRail.applyTheme(theme);

--- a/clients/tui/src/ui/box-fill.ts
+++ b/clients/tui/src/ui/box-fill.ts
@@ -1,0 +1,39 @@
+import {BoxRenderable} from '@opentui/core';
+
+/**
+ * Paints `color` across the inside of `box`, up to but not over its border.
+ *
+ * A `backgroundColor` on the box itself cannot do that. `BoxRenderable`
+ * forwards it to `OptimizedBuffer.drawBox` as one background for the whole
+ * rectangle, and the buffer is write-only, so every cell takes the fill and the
+ * border glyph is drawn on top of it. The painted rectangle is then one cell
+ * larger than the drawn line on all four sides: the line sits in a solid block
+ * with fill on both sides of it, and under a rounded arc the fill paints the
+ * outside of the curve and squares the corner back off. That is #642.
+ *
+ * A separate box carrying the fill leaves the border ring showing whatever the
+ * box sits on, so a cell reads canvas, then line, then fill, and a corner cell
+ * has no fill in it to bleed past the arc.
+ *
+ * Absolutely positioned and inserted first rather than wrapped around the
+ * content, so it adds no row, no padding and no containing block and the box's
+ * children stay exactly where they were. It carries no mouse handlers, and
+ * OpenTUI bubbles a mouse event to the parent, so it does not take clicks off
+ * the box it fills.
+ */
+export function fillLayer(box: BoxRenderable, id: string, color: string): BoxRenderable {
+  const fill = new BoxRenderable(box.ctx, {
+    id,
+    position: 'absolute',
+    // The four insets are measured from the padding box, which is the box
+    // inside its border, so this is exactly the interior and nothing else.
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    backgroundColor: color,
+  });
+  // First, so every child added later paints over it.
+  box.add(fill, 0);
+  return fill;
+}

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -165,7 +165,12 @@ export class ChatComposerView {
       visible: false,
       zIndex: 5,
       border: true,
-      borderStyle: 'rounded',
+      // Square with an outer fill, the overlay exception to the fill rule
+      // (tui-conventions.md): this menu floats over the composer, so the fill
+      // has to reach the border ring or the text under it shows through there,
+      // and a fill that reaches the ring can only be honest under a square
+      // corner.
+      borderStyle: 'single',
       borderColor: theme.border,
       backgroundColor: theme.elevatedSurface,
       paddingLeft: 1,

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -71,7 +71,10 @@ export class ChatOverlayView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
+      // Square with an outer fill, the overlay exception (tui-conventions.md):
+      // the fill is what makes this modal opaque over the run behind it, ring
+      // included, and a fill that reaches the ring needs a square corner.
+      borderStyle: 'single',
       borderColor: theme.conversation.analysis.label,
       backgroundColor: theme.elevatedSurface,
       title: ' Experiment chat ',

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -11,6 +11,7 @@ import {
   chatThreadHeading,
   type SessionState,
 } from '../session-model.js';
+import {fillLayer} from './box-fill.js';
 import {ChatComposerView, type ChatDraft} from './chat-composer.js';
 import {ConversationView} from './conversation.js';
 import {LOG_CLAIM_PANEL_WIDTH, LOG_COMPACT_PANEL_WIDTH} from './experiment-log.js';
@@ -92,6 +93,7 @@ export function chatPaneWidth(terminalWidth: number, rightPaneWidth = 0): number
  */
 export class ChatPaneView {
   readonly output: BoxRenderable;
+  readonly #fill: BoxRenderable;
   readonly #scroll: ScrollBoxRenderable;
   readonly #conversation: ConversationView;
   readonly #composer: ChatComposerView;
@@ -116,10 +118,6 @@ export class ChatPaneView {
       border: true,
       borderStyle: paneBorderStyle(false),
       borderColor: paneBorderColor(theme, false),
-      // The surface every other pane sits on. Without it this box falls
-      // through to the root's canvas, a lighter shade, so the chat read as a
-      // pale band beside panes that did not match it.
-      backgroundColor: theme.elevatedSurface,
       title: paneTitle(CHAT_PANE_TITLE, false),
       visible: false,
       // Clicking into the chat gives it the keys, the same thing Ctrl+W does.
@@ -127,6 +125,11 @@ export class ChatPaneView {
       // table, so the operator could not tell where their keys were going.
       onMouseUp: () => controller.focusPane('chat'),
     });
+    // The surface every other pane sits on. Without it this box falls through
+    // to the root's canvas, a lighter shade, so the chat read as a pale band
+    // beside panes that did not match it. On its own layer, so the pane keeps
+    // the rounded frame `PANE_BORDER` argues for (tui-conventions.md).
+    this.#fill = fillLayer(this.output, 'chat-pane-fill', theme.elevatedSurface);
     this.#scroll = new ScrollBoxRenderable(renderer, {
       id: 'chat-pane-scroll',
       width: '100%',
@@ -171,7 +174,7 @@ export class ChatPaneView {
     this.#theme = theme;
     // Resting colour: `render` repaints from the live focus on the next frame.
     this.output.borderColor = paneBorderColor(theme, false);
-    this.output.backgroundColor = theme.elevatedSurface;
+    this.#fill.backgroundColor = theme.elevatedSurface;
     this.#conversation.applyTheme(theme, markdownStyle);
     this.#composer.applyTheme(theme);
     this.#renderedConversation = null;

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -78,7 +78,11 @@ export function createCommandInputPanel(
     visible: false,
     zIndex: 5,
     border: true,
-    borderStyle: 'rounded',
+    // Square with an outer fill, the overlay exception (tui-conventions.md):
+    // this popup floats over the panes above the command column, so its fill
+    // has to reach the border ring to stop them showing through, and that is
+    // only honest under a square corner.
+    borderStyle: 'single',
     borderColor: theme.border,
     backgroundColor: theme.selectedSurface,
     paddingLeft: 1,

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -11,6 +11,7 @@ import {hasRunEnded} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
 import {visibleConversation} from '../session-model.js';
+import {fillLayer} from './box-fill.js';
 import {promptPreview, toolCallPreview, toolResultPreview} from './previews.js';
 import {
   conversationRole,
@@ -339,17 +340,22 @@ export class ConversationView {
       marginTop: bare && entry.kind !== 'status' ? 0 : 1,
       paddingLeft: bare ? 0 : 1,
       paddingRight: 1,
-      backgroundColor: palette.background,
       // `border: false` is not enough on its own: OpenTUI turns the border
       // back on whenever any border styling option is present, so a borderless
-      // entry has to omit `borderStyle` and `borderColor` as well.
+      // entry has to omit `borderStyle` and `borderColor` as well. That is how
+      // a bare card came to draw a rounded frame while reading as if it drew
+      // none.
+      //
+      // A bare card draws no frame, so its role tint goes straight on the card.
+      // A bordered card takes its tint on an inner layer instead, below.
       ...(bare
-        ? {border: false}
+        ? {border: false, backgroundColor: palette.background}
         : {
             border: true,
             borderStyle: 'rounded' as const,
             // The cursor is the card's border, not a fill: a filled card reads
-            // as selected text, and the transcript already uses fills for roles.
+            // as selected text, and the transcript already uses fills for
+            // roles.
             borderColor: selected ? this.#theme.borderFocus : palette.border,
           }),
       ...(this.#showsSelection
@@ -373,6 +379,9 @@ export class ConversationView {
             }
           : {}),
     });
+    // Inside the frame rather than under it, so the arc keeps the canvas in its
+    // corner cells (tui-conventions.md).
+    if (!bare) fillLayer(card, `event-${entry.id}-fill`, palette.background);
     const heading = new BoxRenderable(this.renderer, {
       id: `event-${entry.id}-heading`,
       width: '100%',

--- a/clients/tui/src/ui/error-banner.ts
+++ b/clients/tui/src/ui/error-banner.ts
@@ -1,5 +1,6 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
 import type {ErrorBannerState, SessionState} from '../session-model.js';
+import {fillLayer} from './box-fill.js';
 import type {Theme} from './theme.js';
 
 /** Enough rows to read a useful diagnostic without pushing the run off screen. */
@@ -18,6 +19,7 @@ function context(banner: ErrorBannerState): string {
  */
 export class ErrorBannerView {
   readonly output: BoxRenderable;
+  readonly #fill: BoxRenderable;
   readonly #scroll: ScrollBoxRenderable;
   #theme: Theme;
   #rendered: ErrorBannerState | null = null;
@@ -39,9 +41,11 @@ export class ErrorBannerView {
       borderColor: theme.error,
       paddingLeft: 1,
       paddingRight: 1,
-      backgroundColor: theme.elevatedSurface,
       visible: false,
     });
+    // The surface the diagnostic reads on, on its own layer so the banner keeps
+    // its rounded frame (tui-conventions.md).
+    this.#fill = fillLayer(this.output, 'error-banner-fill', theme.elevatedSurface);
     this.#scroll = new ScrollBoxRenderable(renderer, {
       id: 'error-banner-scroll',
       width: '100%',
@@ -54,7 +58,9 @@ export class ErrorBannerView {
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.output.backgroundColor = theme.elevatedSurface;
+    this.#fill.backgroundColor = theme.elevatedSurface;
+    // `#rendered = null` makes the next `render` repaint the border from the
+    // new theme.
     this.#rendered = null;
   }
 

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -15,6 +15,7 @@ import {
   selectedExperimentIndexItem,
   unownedExperimentRounds,
 } from '../session-model.js';
+import {fillLayer} from './box-fill.js';
 import {formatFileChange} from './design-log.js';
 import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {elapsedLabel} from './previews.js';
@@ -58,6 +59,7 @@ interface Columns {
 
 export class ExperimentLogView {
   readonly output: BoxRenderable;
+  readonly #fill: BoxRenderable;
   readonly #header: TextRenderable;
   readonly #rows: ScrollBoxRenderable;
   readonly #footerLine: TextRenderable;
@@ -84,11 +86,13 @@ export class ExperimentLogView {
       border: true,
       borderStyle: paneBorderStyle(false),
       borderColor: paneBorderColor(theme, false),
-      backgroundColor: theme.elevatedSurface,
       visible: false,
       title: paneTitle(EXPERIMENTS_TITLE, false),
       onMouseUp: () => this.controller.focusPane('left'),
     });
+    // The pane surface, on its own layer so the rounded frame stays rounded
+    // (tui-conventions.md). Same call as `chat-pane`.
+    this.#fill = fillLayer(this.output, 'experiment-log-fill', theme.elevatedSurface);
     this.#header = new TextRenderable(renderer, {
       content: '',
       fg: theme.textSubtle,
@@ -138,7 +142,7 @@ export class ExperimentLogView {
   applyTheme(theme: Theme): void {
     this.#theme = theme;
     this.output.borderColor = theme.border;
-    this.output.backgroundColor = theme.elevatedSurface;
+    this.#fill.backgroundColor = theme.elevatedSurface;
     this.#header.fg = theme.textSubtle;
     this.#footerLine.fg = theme.textSubtle;
     this.#renderedState = null;

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -62,7 +62,10 @@ export class OverlayView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
+      // Square with an outer fill, the overlay exception (tui-conventions.md):
+      // the fill is what makes this modal opaque over whatever it covers, ring
+      // included, and a fill that reaches the ring needs a square corner.
+      borderStyle: 'single',
       borderColor: theme.info,
       backgroundColor: theme.elevatedSurface,
       // Above the chat modal (20), below the theme picker (30): a command ack
@@ -155,6 +158,12 @@ export class OverlayView {
     this.#applyGeometry();
     // Outside the cache below: focus moves without the content changing.
     applyPaneFocus(this.output, this.#theme, pane.title, focusedPane(state) === 'performance');
+    // `applyPaneFocus` also stamps the pane frame, which is rounded. This box
+    // is an overlay in both of its roles, so it keeps the outer fill and with
+    // it the square corner (tui-conventions.md), and takes only the title and
+    // the border colour from the pane treatment. Frame weight was never one of
+    // the focus channels anyway; `PANE_BORDER` says why.
+    this.output.borderStyle = 'single';
     if (pane === this.#renderedPane) return;
     this.#renderedPane = pane;
     // The next ordinary overlay repaints its own title and border rather than

--- a/clients/tui/src/ui/theme-picker.ts
+++ b/clients/tui/src/ui/theme-picker.ts
@@ -31,7 +31,10 @@ export class ThemePickerView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
+      // Square with an outer fill, the overlay exception (tui-conventions.md):
+      // the fill is what makes this modal opaque over whatever it covers, ring
+      // included, and a fill that reaches the ring needs a square corner.
+      borderStyle: 'single',
       borderColor: theme.info,
       backgroundColor: theme.elevatedSurface,
       title: ' Themes ',

--- a/docs/contributing/tui-conventions.md
+++ b/docs/contributing/tui-conventions.md
@@ -103,6 +103,45 @@ The active bindings are shown on the key-help line at the bottom of the screen,
 just above the command input, and that line changes with whichever surface is in
 front. A binding a person has to already know is a binding they do not have.
 
+### A fill lives on an inner box
+
+`OptimizedBuffer.drawBox` takes one background for the whole rectangle and the
+buffer is write-only, so a `backgroundColor` on a bordered box fills the border
+ring as well. The painted rectangle is then a cell larger than the drawn line on
+all four sides: the line sits in a solid block with fill on both sides of it,
+and under a rounded arc the fill paints the outside of the curve and squares the
+corner back off. That is #642.
+
+So the fill goes on an inner box that occupies the interior, and the outer box
+draws only the border. A cell then reads canvas, then line, then fill, and a
+corner cell holds no fill to bleed past the arc. `box-fill.ts` is the one way to
+do it: a layer inset to zero on all four sides, absolutely positioned so it adds
+no row, no padding and no containing block and the box's children stay where
+they were.
+
+**Exception: an overlay keeps an outer fill.** A box that floats over other
+content needs an opaque edge, or what is behind shows through its border ring.
+That fill reaches the ring by design, so an overlay draws a **square** border
+(`borderStyle: 'single'`): a ring of fill under a rounded arc is #642 again. The
+three modals and the two suggestion popups are the whole list.
+
+Two other answers were tried and rejected, so they are settled rather than open.
+Blending the corner cell between the fill and what was behind it is still one
+flat colour standing in for two regions, and reads as a smudge rather than a
+curve. Forcing every filled box square fixes the corner and leaves the fill
+overhanging the border on all four sides, which is the same disagreement between
+the drawn shape and the painted one, one cell further out.
+
+`app.test.ts` holds both halves over the whole constructed tree rather than over
+a list of call sites, so a box added later fails it without anyone remembering
+to extend a list: no non-overlay box fills its own rectangle, and a site that
+used to fill one still paints a layer inside its border. The exception is an
+explicit list there, because floating over something is not a property a box
+carries: the agent map's cards are absolutely positioned too. One trap the walk
+exists to catch: OpenTUI turns a border back on if `borderStyle` or
+`borderColor` is passed beside `border: false`, so a box that means to draw no
+border has to omit both.
+
 ## Proposed: movement and naming
 
 Nothing in this section is implemented. It is where the movement and naming


### PR DESCRIPTION
## Problem

Closes #642.

`BoxRenderable.backgroundColor` fills the **entire rectangle, including the
border ring**. `renderSelf` hands `OptimizedBuffer.drawBox` one `backgroundColor`
for the whole box, and that buffer is write-only: `setCell` and `fillRect` never
read back, so a border cell cannot know what it sat on and there is no per-cell
background to give it. Every cell takes the one fill and the border glyph is
drawn over it.

A cell-level probe through the test renderer, box with `border: true`,
`borderStyle: 'single'`, `backgroundColor: #1e293b`:

```
y=1  "┌────────┐"=#1e293b          <- border row carries the FILL
y=2  "│"=#1e293b "hi"=#1e293b "│"=#1e293b
```

So the fill's rectangle is one cell larger than the drawn line on every side and
overhangs the border. Under a rounded arc it also paints the outside of the
curve and squares the corner back off, which is the reported symptom.

### Before / after

The selected implementer card in the agent map, 150x40, dark, identical crop.
Base is `main`. Both frames were re-shot on 2026-09-10 against `ea6f907`, after
the TUI merge wave (#619, #620, #623, #625, #626, #634) moved the surrounding
chrome.

| Before (this PR's base) | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr646-corner-before-0910.png) | ![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr646-corner-after-0910.png) |

## Solution

**A fill lives on an inner box, so the border ring shows what is behind the
box.** The rule is in `docs/contributing/tui-conventions.md`. The same probe:

```
outer: border true, no backgroundColor;  inner: inset 0 on all sides, fill
y=1  "╭────────╮"=#000000          <- border row is now the CANVAS
y=2  "│"=#000000 "hi"=#1e293b "│"=#000000
```

Canvas, then line, then fill. Because no fill sits in the corner cell, there is
nothing to bleed past the arc, so #642 is fixed at its source and the
rounded-versus-square constraint is no longer needed for in-flow boxes.

`box-fill.ts` is the one way to do it: a layer inset to zero on all four sides,
absolutely positioned so it adds no row, no padding and no containing block, and
no child moves. It carries no mouse handlers, and OpenTUI bubbles a mouse event
to the parent, so it takes no clicks off the box it fills.

**Exception: an overlay keeps an outer fill.** A box that floats over other
content needs an opaque edge, or what is behind shows through its border ring.
That fill reaches the ring by design, so an overlay stays **square**: a ring of
fill under a rounded arc is #642 again.

| Site | Fill | Shape | Why |
| --- | --- | --- | --- |
| `app` header frame | inner | rounded | Fill is `headerSpanStyle`'s contrast basis, so it stays; rounded matches the panes it houses |
| `chat-pane` | inner | rounded | Pane; `PANE_BORDER` keeps the rounded frame |
| `experiment-log` | inner | rounded | Pane; same |
| `error-banner` | inner | rounded | In-flow child of `root`; nothing forces square now |
| `conversation` bordered card | inner | rounded | Role tint returns, inset |
| `agent-map` graph node | inner | **square** | Owner's call, on looks: a stage reads as a slot in a pipeline, and the map's edges arrive at its sides |
| `agent-map` stacked row | inner | **square** | Same node, narrow layout |
| `conversation` status card | outer | no border | Draws no frame, so an outer fill is already correct |
| `overlay` (`/help`, command ack) | outer | square | Overlay exception |
| `theme-picker` | outer | square | Overlay exception |
| `chat-overlay` | outer | square | Overlay exception |
| `chat-composer` menu | outer | square | Overlay exception, absolute popup |
| `command-input` suggestions | outer | square | Overlay exception, absolute popup |

Two earlier answers on this branch are recorded in the commit and the doc as
**rejected**, so nobody reintroduces them. *Blending* the corner cell between the
fill and what was behind it is one flat colour standing in for two regions and
reads as a smudge rather than a curve; it also cost a `FilledRoundedBox` subclass
and a `behindColor` thunk through twelve call sites. *Forcing every filled box
square* fixes the corner and leaves the fill overhanging the border on all four
sides, which is the same disagreement one cell further out.

### A thirteenth site the grep missed

`conversation.ts` asked for `border: entry.kind !== 'status'` beside an
unconditional `borderStyle`. OpenTUI turns the border **back on** whenever
`borderStyle`, `borderColor`, `focusedBorderColor` or `customBorderChars`
accompanies a falsy `border`, so every status card drew a rounded frame while
reading, at the call site, as though it drew none. The border and its styling now
share one branch.

### Interaction with #652

#652 collapses the surface palette to a single background. Under this rule that
is harmless: a modal's fill is what makes it opaque, and an in-flow box's inner
fill simply matches the canvas rather than bleeding. This branch does not depend
on #652 either way.

## Verification

### Correctness properties

- No box that draws any border side carries its own non-transparent
  `backgroundColor`, unless it is one of the five listed overlays.
- An overlay's outer fill is only ever paired with a square border.
- The rule cannot be satisfied by *deleting* a fill: every site that used to fill
  its own rectangle still paints a layer inside its border.
- An inner fill changes no geometry: it is absolutely positioned and inset to
  zero, so it adds no row, padding or containing block.
- A box that means to draw no border omits `borderStyle` and `borderColor`.

### Testing

```
pnpm check:ts                 # biome, 86 files, clean
pnpm check:ts-architecture    # 91 modules / 337 deps, no violations
pnpm check:clients            # tsc, clean
pnpm test:clients             # 688 + 84 + 25 pass, 0 fail
uv run python scripts/check_doc_links.py   # 328 files, no broken links
```

`describe('box fills')` in `app.test.ts` replaces `describe('box shape and
fill')`. It keeps the tree-walking form and the positive control, and asserts the
new invariant plus its other half:

- walks the whole constructed tree, with coverage assertions so it cannot pass
  vacuously;
- asserts the inner layers exist and are painted, so a fill cannot be dropped
  instead of moved;
- a narrow-terminal case covering the stacked agent rows and the overlay's
  render-time pane path, which is the one pairing created after a frame rather
  than at construction;
- a positive control with two boxes: a bordered filled box, and an overlay that
  took a rounded frame back.

The overlay exception is an **explicit id list**, not a structural test.
`position: 'absolute'` does not separate the cases: the agent map's cards are
absolutely positioned too and are not overlays, so a structural test would exempt
exactly the box the owner asked to be inset. Every entry in the list is a
reviewed exception.

Four assertions moved to the new truth (none edited merely to pass):

- the three `theming` reads go back to the role fill, because a bordered card
  paints one again; the `cardBorder` helper added for the fill-less card is gone;
- the corner count goes back to five rounded/heavy corners, because the header
  housing is rounded again;
- `paneBorders` keeps the square corner glyph it learned, because the
  narrow-terminal visualization is drawn through the overlay and overlays stay
  square.

### Manual

`clients/tui/dev/mock-ui.sh --tmux 150x40 --speed 0`, then `/open-round --1`,
Tab into the agent map, select a node, plus `/help`, `/theme`, a light-theme
switch and the command-suggestion popup. Decoding the ANSI capture cell by cell:

- header: ring `#0f172a` (canvas), interior `#020617` (`headerBackground`);
- transcript card inside the chat pane: ring `#020617` (the pane's fill),
  interior `#0e283d` (the role fill). Canvas, line, fill at three nesting levels;
- selected agent node: interior `#1e293b` (`selectedSurface`), border rows
  canvas;
- `/help`, theme picker and the suggestion popup: square, fill through the ring,
  fully opaque over the content behind;
- after switching to light, every inner fill repainted from the new theme, which
  exercises the `applyTheme` path.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


