### PR TITLE
feat(tui): replace transcript card borders with a top-edge divider

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -72,7 +72,15 @@ import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 import {renderDesignSummary} from './design-log.js';
 import {paneTitle} from './focus.js';
 import {headerBackground} from './header.js';
-import {contrastRatio, listThemes, resolveTheme, THEME_NAMES, type ThemeName} from './theme.js';
+import {
+  contrastRatio,
+  ensureContrast,
+  listThemes,
+  resolveTheme,
+  SUBTLE_TEXT_MIN_CONTRAST,
+  THEME_NAMES,
+  type ThemeName,
+} from './theme.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -1798,10 +1806,14 @@ describe('OpenTUI presentation', () => {
     const frame = await testRenderer.waitForFrame(value => value.includes('2 passed'));
     expect(frame).toContain('→ Bash pytest');
     expect(frame).toContain('← 2 passed');
-    // Header housing, agents pane, transcript frame, and the card's call and
-    // result regions: the rail is absent because this fixture has no rounds.
-    // A focused pane draws a heavy corner, so the count is over both styles.
-    expect(frame.match(/[╭┏]/g)).toHaveLength(5);
+    // Header housing, agents pane, transcript frame, and the command box: the
+    // rail is absent because this fixture has no rounds. A focused pane draws a
+    // heavy corner, so the count is over both styles. The transcript card used
+    // to contribute a fifth: #565 replaced its four-sided border with a
+    // top-edge rule, which draws no corner glyph at all. The call and result
+    // regions #620 added are bands inside the card, not bordered boxes, so they
+    // never contributed one.
+    expect(frame.match(/[╭┏]/g)).toHaveLength(4);
   });
 
   it('renders a typed command payload with labeled stderr and exit code', async () => {
@@ -1975,10 +1987,12 @@ describe('OpenTUI presentation', () => {
     const frame = await testRenderer.waitForFrame(value => value.includes('[codex error]'));
     expect(frame).toContain('[codex turn started]');
     expect(frame).toContain('driver: agentshim');
-    // Header housing, agents pane, transcript frame, command bar, and the one
-    // card the error diagnostic still earns. The two quiet diagnostics draw no
-    // border at all, so they add nothing to the count.
-    expect(frame.match(/[╭┏]/g)).toHaveLength(5);
+    // Header housing, agents pane, transcript frame, and the command bar. The
+    // two quiet diagnostics draw no border at all, so they add nothing to the
+    // count, and the one card the error diagnostic still earns no longer adds
+    // one either: #565 turned that four-sided border into a top-edge rule,
+    // which has no corner glyph.
+    expect(frame.match(/[╭┏]/g)).toHaveLength(4);
   });
 
   it('renders an unanswered tool call once, with no response band', async () => {
@@ -1997,8 +2011,9 @@ describe('OpenTUI presentation', () => {
     // The response band is the only thing that draws a left arrow followed by
     // text; the footer's key hint is the glyph pair, not this.
     expect(frame).not.toContain('← ');
-    // One card: the header, the two panes, the command bar, and this turn.
-    expect(frame.match(/[╭┏]/g)).toHaveLength(5);
+    // The header, the two panes, and the command bar. This turn's card no
+    // longer adds a corner: #565 made it a top-edge rule instead of a border.
+    expect(frame.match(/[╭┏]/g)).toHaveLength(4);
   });
 
   it('collapses, prettifies, and expands long JSON tool responses', async () => {
@@ -2676,6 +2691,21 @@ describe('overlay scrolling', () => {
 });
 
 describe('theming', () => {
+  /**
+   * The role colour a transcript card carries.
+   *
+   * The top-edge rule, because that is where the role lives: a card has no
+   * fill (tui-conventions.md) and #565 replaced its four sides with that one
+   * rule, so the body text reports the canvas and the role would otherwise go
+   * unasserted here. `conversation.test.ts` pins the same colour as a
+   * computation over theme.ts across all eight themes; this asserts the
+   * rendered frame actually carries what that computation produces.
+   */
+  function cardBorder(testRenderer: TestRendererSetup, id: string): string | undefined {
+    const card = testRenderer.renderer.root.findDescendantById(id);
+    return card instanceof BoxRenderable ? rgbToHex(card.borderColor).toLowerCase() : undefined;
+  }
+
   const assistantEntry = {
     id: 'themed',
     kind: 'assistant' as const,
@@ -2705,6 +2735,13 @@ describe('theming', () => {
     // #565: the card carries its role on the divider rule, not a fill, so its
     // body sits on the theme's canvas.
     expect(body?.bg).toBe(light.canvas);
+    expect(cardBorder(testRenderer, 'event-themed')).toBe(
+      ensureContrast(
+        light.conversation.assistant.border,
+        light.canvas,
+        SUBTLE_TEXT_MIN_CONTRAST,
+      ).toLowerCase(),
+    );
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe(light.conversation.assistant.label);
   });
 
@@ -5315,7 +5352,7 @@ describe('box fills', () => {
     expect(ids).toContain('header-frame'); // bordered, fill moved inwards
     expect(ids).toContain('experiment-log'); // a pane, the same way
     expect(ids).toContain('theme-picker'); // an overlay, built here, never opened
-    expect(ids).toContain('event-card'); // a bordered transcript card
+    expect(ids).toContain('event-card'); // a transcript card, now a top-edge rule
     expect(ids).toContain('event-status'); // borderless, so it keeps its own fill
     expect(ids.some(id => id.startsWith('agent-implementer-'))).toBe(true);
 
@@ -5333,7 +5370,10 @@ describe('box fills', () => {
     await testRenderer.waitForFrame(value => value.includes('a bordered card'));
     const root = testRenderer.renderer.root;
 
-    for (const id of ['header-fill', 'experiment-log-fill', 'event-card-fill']) {
+    // 'event-card-fill' is deliberately absent: #565 removed the transcript
+    // card's border and its fill together, so there is no longer a rounded
+    // corner to keep a fill out of, and nothing left to move inwards.
+    for (const id of ['header-fill', 'experiment-log-fill']) {
       expect([id, isPainted(root, id)]).toEqual([id, true]);
     }
   });

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -2702,7 +2702,9 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(light.accent);
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe(light.conversation.assistant.content);
-    expect(body?.bg).toBe(light.conversation.assistant.background);
+    // #565: the card carries its role on the divider rule, not a fill, so its
+    // body sits on the theme's canvas.
+    expect(body?.bg).toBe(light.canvas);
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe(light.conversation.assistant.label);
   });
 
@@ -2723,8 +2725,9 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe('#22d3ee');
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe('#e2e8f0');
-    // Assistant cards derive their fill from the canvas and the role accent.
-    expect(body?.bg).toBe('#0e283d');
+    // No card fill: the role lives on the top-edge divider rule, so a card
+    // body is the canvas.
+    expect(body?.bg).toBe('#0f172a');
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe('#5cb6cc');
   });
 
@@ -2750,7 +2753,7 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(solarized.accent);
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe(solarized.conversation.assistant.content);
-    expect(body?.bg).toBe(solarized.conversation.assistant.background);
+    expect(body?.bg).toBe(solarized.canvas);
   });
 
   it('navigates the theme list with the keyboard and applies on Enter', async () => {

--- a/clients/tui/src/ui/conversation.test.ts
+++ b/clients/tui/src/ui/conversation.test.ts
@@ -1,0 +1,149 @@
+import {afterEach, describe, expect, it} from 'bun:test';
+import {BoxRenderable} from '@opentui/core';
+import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
+import type {SessionController} from '../session-controller.js';
+import {type ConversationEntry, initialSessionState} from '../session-model.js';
+import {ConversationView} from './conversation.js';
+import {createMarkdownStyle} from './styles.js';
+import {
+  CONVERSATION_ROLES,
+  contrastRatio,
+  ensureContrast,
+  listThemes,
+  resolveTheme,
+  SUBTLE_TEXT_MIN_CONTRAST,
+} from './theme.js';
+
+/**
+ * #565: an entry separates from its neighbour with a rule on its top edge,
+ * not a four-sided bordered card sitting under its own blank margin row.
+ * These render through the real OpenTUI test renderer rather than computing
+ * expected row counts by hand: a pure-function test would not catch a stray
+ * margin or an extra border side reappearing, which is exactly the class of
+ * bug this issue is about (docs/contributing/coding-best-practices.md).
+ */
+describe('conversation entry row cost (#565)', () => {
+  const cleanup: Array<() => void> = [];
+  afterEach(() => {
+    for (const destroy of cleanup.splice(0).reverse()) destroy();
+  });
+
+  const controller = {} as unknown as SessionController;
+
+  async function renderEntries(
+    entries: ConversationEntry[],
+  ): Promise<{testRenderer: TestRendererSetup; view: ConversationView}> {
+    const theme = resolveTheme(null);
+    const testRenderer = await createTestRenderer({width: 80, height: 40});
+    const view = new ConversationView(
+      testRenderer.renderer,
+      controller,
+      createMarkdownStyle(theme),
+      theme,
+      // Entry selection from state is a separate, already-tested concern;
+      // fixing the list here keeps this test about row cost alone.
+      {selectConversation: () => entries},
+    );
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    });
+    view.render(initialSessionState());
+    await testRenderer.renderOnce();
+    return {testRenderer, view};
+  }
+
+  // 'status', 'analysis' and 'result' all skip both the markdown pipeline and
+  // the tool-output preview (see the branches in `#renderEntry`), so each
+  // renders its content verbatim on exactly one line. That isolates the row
+  // count this test pins from #516's separate, still-open content-preview
+  // question.
+  const oneLineEntries: ConversationEntry[] = [
+    {id: 'a', kind: 'status', label: 'status', content: 'one line'},
+    {id: 'b', kind: 'analysis', label: 'analysis', content: 'one line'},
+    {id: 'c', kind: 'result', label: 'result', content: 'one line'},
+  ];
+
+  it('costs a divider and a heading per entry, not a margin row plus a four-sided card', async () => {
+    const {testRenderer, view} = await renderEntries(oneLineEntries);
+    for (const entry of oneLineEntries) {
+      const card = view.output.findDescendantById(`event-${entry.id}`);
+      if (!(card instanceof BoxRenderable))
+        throw new Error(`entry ${entry.id} did not render a card`);
+      // Divider (1) + heading (1) + one content line (1). A bordered card
+      // with its own margin row cost 5 for the same content; even the
+      // pre-#565 borderless 'status' case still cost 3 rows for a margin
+      // and a heading before a single line of content ever appeared. Every
+      // kind now costs the same, and this one has no margin to add.
+      expect(card.height).toBe(3);
+      expect(card.border).toEqual(['top']);
+    }
+    // No stray rows between cards either: three one-line entries cost
+    // exactly 9 rows end to end. The pre-#565 card cost 5 rows each (15
+    // total); this assertion fails at that revision and passes at this one.
+    expect(view.output.height).toBe(9);
+    void testRenderer;
+  });
+
+  it('does not add its own inset on top of the pane that contains it', async () => {
+    const leadingColumn = async (entries: ConversationEntry[]): Promise<number> => {
+      const {testRenderer} = await renderEntries(entries);
+      const frame = testRenderer.captureCharFrame();
+      const row = frame.split('\n').find(line => line.trim().length > 0);
+      if (row === undefined) throw new Error('nothing rendered');
+      return row.length - row.trimStart().length;
+    };
+    const emptyColumn = await leadingColumn([]);
+    const entryColumn = await leadingColumn([
+      {id: 'a', kind: 'status', label: 'status', content: 'x'},
+    ]);
+    // Both the empty-transcript message and an entry's heading are direct
+    // children of the same unpadded `output` box: a card that added its own
+    // left padding or border, as it did before #565, would start one or
+    // more columns later than the empty-transcript message sitting beside
+    // it in the same pane.
+    expect(entryColumn).toBe(emptyColumn);
+  });
+});
+
+/**
+ * Role and selection have to stay distinguishable in all eight themes
+ * (#565's fourth acceptance criterion). theme.ts's colours come out of
+ * `mix()` and `ensureContrast()` and exist nowhere as literals, so this
+ * evaluates the theme module directly rather than transcribing hexes.
+ *
+ * This is a pure computation over theme tokens, not a rendered frame: per
+ * docs/contributing/tui-architecture.md, contrast and legibility are pinned
+ * at that layer.
+ */
+describe('role and selection stay distinguishable across every theme (#565)', () => {
+  it('holds every role divider to the 3:1 floor textSubtle uses for punctuation and rules', () => {
+    for (const theme of listThemes()) {
+      const restingColors = CONVERSATION_ROLES.map(role => {
+        // Mirrors the `ensureContrast` call `#renderEntry` makes on
+        // `palette.border` before using it as the resting divider colour.
+        const resting = ensureContrast(
+          theme.conversation[role].border,
+          theme.canvas,
+          SUBTLE_TEXT_MIN_CONTRAST,
+        );
+        expect(contrastRatio(resting, theme.canvas)).toBeGreaterThanOrEqual(
+          SUBTLE_TEXT_MIN_CONTRAST,
+        );
+        return resting;
+      });
+      // Nudging a marginal accent toward black or white must not collapse
+      // two roles onto the same divider colour.
+      expect(new Set(restingColors).size).toBe(restingColors.length);
+    }
+  });
+
+  it('keeps the selection colour itself legible in every theme', () => {
+    for (const theme of listThemes()) {
+      expect(contrastRatio(theme.borderFocus, theme.canvas)).toBeGreaterThanOrEqual(
+        SUBTLE_TEXT_MIN_CONTRAST,
+      );
+    }
+  });
+});

--- a/clients/tui/src/ui/conversation.test.ts
+++ b/clients/tui/src/ui/conversation.test.ts
@@ -65,23 +65,69 @@ describe('conversation entry row cost (#565)', () => {
     {id: 'c', kind: 'result', label: 'result', content: 'one line'},
   ];
 
+  it('pins the role to the left edge and the run id to the right', async () => {
+    // The role is what an operator scans down the column, so it holds the left
+    // edge; the run id is per-entry detail and would otherwise push the eye a
+    // variable distance rightward on every line. An entry with no agent/round
+    // pair keeps its single label on the left.
+    const entries: ConversationEntry[] = [
+      {
+        id: 'split',
+        kind: 'analysis',
+        label: 'judge · round-1-retry-1-judge',
+        agentKind: 'judge',
+        roundLabel: 'round-1-retry-1-judge',
+        content: 'one line',
+      },
+      {id: 'plain', kind: 'result', label: 'round-1 · PASS', content: 'one line'},
+    ];
+    const {view} = await renderEntries(entries);
+
+    const split = view.output.findDescendantById('event-split-heading');
+    if (!(split instanceof BoxRenderable)) throw new Error('split heading missing');
+    const [role, runId] = split.getChildren();
+    if (role === undefined || runId === undefined)
+      throw new Error('split heading did not render two parts');
+    expect(role.x).toBe(split.x);
+    expect(runId.x + runId.width).toBe(split.x + split.width);
+    // Not merely offset: the run id must actually sit to the right of the role.
+    expect(runId.x).toBeGreaterThan(role.x + role.width);
+
+    // An entry without the pair is untouched, one child on the left edge.
+    const plain = view.output.findDescendantById('event-plain-heading');
+    if (!(plain instanceof BoxRenderable)) throw new Error('plain heading missing');
+    expect(plain.getChildren()).toHaveLength(1);
+    expect(plain.getChildren()[0]?.x).toBe(plain.x);
+  });
+
   it('costs a divider and a heading per entry, not a margin row plus a four-sided card', async () => {
+    // Divider (1) + heading (1) + one content line (1) for an entry drawn as a
+    // card. A bordered card with its own margin row cost 5 rows for the same
+    // content.
+    //
+    // 'status' is the one kind that does not draw the divider, and that is not
+    // this change's doing: #620 demoted lifecycle chatter to bare lines, so a
+    // status entry draws no frame at all and costs a heading plus its content.
+    // Giving it the rule would undo that demotion, so the row cost is asserted
+    // per kind rather than as one number for all of them.
+    const expected: Record<string, {height: number; border: boolean | 'top'[]}> = {
+      a: {height: 2, border: false},
+      b: {height: 3, border: ['top']},
+      c: {height: 3, border: ['top']},
+    };
     const {testRenderer, view} = await renderEntries(oneLineEntries);
     for (const entry of oneLineEntries) {
       const card = view.output.findDescendantById(`event-${entry.id}`);
       if (!(card instanceof BoxRenderable))
         throw new Error(`entry ${entry.id} did not render a card`);
-      // Divider (1) + heading (1) + one content line (1). A bordered card
-      // with its own margin row cost 5 for the same content; even the
-      // pre-#565 borderless 'status' case still cost 3 rows for a margin
-      // and a heading before a single line of content ever appeared. Every
-      // kind now costs the same, and this one has no margin to add.
-      expect(card.height).toBe(3);
-      expect(card.border).toEqual(['top']);
+      const want = expected[entry.id];
+      if (want === undefined) throw new Error(`no expectation for ${entry.id}`);
+      expect([entry.id, card.height]).toEqual([entry.id, want.height]);
+      expect([entry.id, card.border]).toEqual([entry.id, want.border]);
     }
-    // No stray rows between cards either: three one-line entries cost
-    // exactly 9 rows end to end. The pre-#565 card cost 5 rows each (15
-    // total); this assertion fails at that revision and passes at this one.
+    // No stray rows between cards either: the three entries cost exactly 9 rows
+    // end to end (2 + 3 + 3, plus the single margin row the bare status entry
+    // keeps from #620). The pre-#565 card cost 5 rows each, 15 total.
     expect(view.output.height).toBe(9);
     void testRenderer;
   });

--- a/clients/tui/src/ui/conversation.test.ts
+++ b/clients/tui/src/ui/conversation.test.ts
@@ -1,9 +1,9 @@
 import {afterEach, describe, expect, it} from 'bun:test';
-import {BoxRenderable, type Renderable} from '@opentui/core';
+import {BoxRenderable, type Renderable, rgbToHex, TextRenderable} from '@opentui/core';
 import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
 import type {SessionController} from '../session-controller.js';
 import {type ConversationEntry, initialSessionState} from '../session-model.js';
-import {ConversationView} from './conversation.js';
+import {ConversationView, styleSourceTags} from './conversation.js';
 import {createMarkdownStyle} from './styles.js';
 import {
   CONVERSATION_ROLES,
@@ -12,6 +12,7 @@ import {
   listThemes,
   resolveTheme,
   SUBTLE_TEXT_MIN_CONTRAST,
+  type Theme,
 } from './theme.js';
 
 const cleanup: Array<() => void> = [];
@@ -28,8 +29,7 @@ interface Mounted {
   draw(entries: ConversationEntry[], selectedId?: string | null): Promise<void>;
 }
 
-async function mount(): Promise<Mounted> {
-  const theme = resolveTheme(null);
+async function mount(theme: Theme = resolveTheme(null)): Promise<Mounted> {
   const testRenderer = await createTestRenderer({width: 80, height: 40});
   // The list is swapped per draw rather than fixed at construction, because
   // the incremental paths below need one view to see several lists.
@@ -60,8 +60,9 @@ async function mount(): Promise<Mounted> {
 async function renderEntries(
   entries: ConversationEntry[],
   selectedId: string | null = null,
+  theme?: Theme,
 ): Promise<Mounted> {
-  const mounted = await mount();
+  const mounted = await mount(theme);
   await mounted.draw(entries, selectedId);
   return mounted;
 }
@@ -427,5 +428,132 @@ describe('role and selection stay distinguishable across every theme (#565)', ()
         SUBTLE_TEXT_MIN_CONTRAST,
       );
     }
+  });
+});
+
+/**
+ * #647 review: a reviewer asked that the run id keep the card's colour
+ * instead of fading to `textSubtle`, and that a bracketed source tag
+ * (`[git-tracking]`, `[framework-validation]`) stand out from the rest of its
+ * line. `styleSourceTags` is exported and tested directly for the same reason
+ * `unwrapShellCommand` is in previews.ts: the line-splitting and anchoring is
+ * the whole of the behaviour, and a full render obscures which case failed.
+ */
+describe('styleSourceTags (#647)', () => {
+  const palette = resolveTheme(null).conversation.analysis;
+
+  function styledChunks(content: string): {text: string; fg: string | undefined}[] {
+    const styled = styleSourceTags(content, palette);
+    if (typeof styled === 'string') throw new Error('expected a styled result, got a plain string');
+    return styled.chunks.map(chunk => ({
+      text: chunk.text,
+      fg: chunk.fg === undefined ? undefined : rgbToHex(chunk.fg).toLowerCase(),
+    }));
+  }
+
+  it('colors a leading tag in the label color and the rest of the line in the content color', () => {
+    expect(styledChunks('[git-tracking] trusted input baseline: 4cf7a6767b6f')).toEqual([
+      {text: '[git-tracking]', fg: palette.label.toLowerCase()},
+      {text: ' trusted input baseline: 4cf7a6767b6f', fg: palette.content.toLowerCase()},
+    ]);
+  });
+
+  it('returns untagged content unchanged, including empty content', () => {
+    expect(styleSourceTags('plain line', palette)).toBe('plain line');
+    expect(styleSourceTags('', palette)).toBe('');
+  });
+
+  it('leaves a bracket that is not at the start of the line untouched', () => {
+    expect(styleSourceTags('see [x] here', palette)).toBe('see [x] here');
+  });
+
+  it('colors a line that is only a tag, with no trailing content chunk', () => {
+    expect(styledChunks('[git-tracking]')).toEqual([
+      {text: '[git-tracking]', fg: palette.label.toLowerCase()},
+    ]);
+  });
+
+  it('colors each tagged line independently across multi-line content', () => {
+    const content = '[git-tracking] one\nplain\n[framework-validation] two';
+    expect(styledChunks(content)).toEqual([
+      {text: '[git-tracking]', fg: palette.label.toLowerCase()},
+      {text: ' one', fg: palette.content.toLowerCase()},
+      {text: '\n', fg: palette.content.toLowerCase()},
+      {text: 'plain', fg: palette.content.toLowerCase()},
+      {text: '\n', fg: palette.content.toLowerCase()},
+      {text: '[framework-validation]', fg: palette.label.toLowerCase()},
+      {text: ' two', fg: palette.content.toLowerCase()},
+    ]);
+  });
+});
+
+/**
+ * The two colour changes wired into `#renderEntry`: the run id and the
+ * plain-text content `TextRenderable` (~480-491 and ~513-517). These render
+ * through the real OpenTUI test renderer, per
+ * docs/contributing/coding-best-practices.md, rather than asserting on the
+ * helper alone, so a future refactor that stops passing the styled result to
+ * either `TextRenderable` still fails here.
+ */
+describe('transcript source tags and run ids take the card label color (#647)', () => {
+  it('colors the run id exactly like the role, selected or not, in every theme', async () => {
+    for (const theme of listThemes()) {
+      for (const selectedId of [null, 'a'] as const) {
+        const {view} = await renderEntries([from(judge, 'a', 'one line')], selectedId, theme);
+        try {
+          const heading = view.output.findDescendantById('event-a-heading');
+          if (!(heading instanceof BoxRenderable)) throw new Error('heading missing');
+          const [role, runId] = heading.getChildren();
+          if (!(role instanceof TextRenderable) || !(runId instanceof TextRenderable)) {
+            throw new Error('heading did not render a role and a run id');
+          }
+          expect(rgbToHex(runId.fg).toLowerCase()).toBe(rgbToHex(role.fg).toLowerCase());
+          // Pinned against textSubtle directly: a coincidental match on the
+          // line above would not by itself prove textSubtle is gone.
+          expect(rgbToHex(runId.fg).toLowerCase()).not.toBe(theme.textSubtle.toLowerCase());
+        } finally {
+          // 16 renderers (8 themes × 2 selection states) accumulate console
+          // listeners if left for the shared `afterEach`; destroy each as
+          // soon as it is checked instead.
+          cleanup.pop()?.();
+        }
+      }
+    }
+  });
+
+  it('colors the bracketed tag on a real diagnostic line (bad-cpp-round1.jsonl) in the label color', async () => {
+    // Shape of fixture line 4: a diagnostic entry whose content is exactly
+    // one `[git-tracking]`-tagged line, trailing newline included, the way
+    // `agent_output_chunk` delivers it.
+    const entries: ConversationEntry[] = [
+      {
+        id: 'd1',
+        kind: 'diagnostic',
+        label: 'launcher',
+        content: '[git-tracking] trusted input baseline: 4cf7a6767b6f\n',
+      },
+    ];
+    const {view} = await renderEntries(entries);
+    const card = cardOf(view, 'd1');
+    const text = card.getChildren().find(child => child instanceof TextRenderable);
+    if (!(text instanceof TextRenderable)) throw new Error('content text missing');
+    const palette = resolveTheme(null).conversation.analysis;
+    const [tag, rest] = text.content.chunks;
+    expect(tag?.text).toBe('[git-tracking]');
+    expect(rest?.text).toBe(' trusted input baseline: 4cf7a6767b6f');
+    if (tag?.fg === undefined || rest?.fg === undefined) throw new Error('chunk missing a colour');
+    expect(rgbToHex(tag.fg).toLowerCase()).toBe(palette.label.toLowerCase());
+    expect(rgbToHex(rest.fg).toLowerCase()).toBe(palette.content.toLowerCase());
+  });
+
+  it('leaves an untagged line as a single content-colored chunk', async () => {
+    const {view} = await renderEntries([from(judge, 'a', 'plain content')]);
+    const card = cardOf(view, 'a');
+    const text = card.getChildren().find(child => child instanceof TextRenderable);
+    if (!(text instanceof TextRenderable)) throw new Error('content text missing');
+    const palette = resolveTheme(null).conversation.analysis;
+    expect(text.content.chunks).toHaveLength(1);
+    expect(text.content.chunks[0]?.text).toBe('plain content');
+    expect(rgbToHex(text.fg).toLowerCase()).toBe(palette.content.toLowerCase());
   });
 });

--- a/clients/tui/src/ui/conversation.test.ts
+++ b/clients/tui/src/ui/conversation.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, describe, expect, it} from 'bun:test';
-import {BoxRenderable} from '@opentui/core';
+import {BoxRenderable, type Renderable} from '@opentui/core';
 import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
 import type {SessionController} from '../session-controller.js';
 import {type ConversationEntry, initialSessionState} from '../session-model.js';
@@ -14,6 +14,98 @@ import {
   SUBTLE_TEXT_MIN_CONTRAST,
 } from './theme.js';
 
+const cleanup: Array<() => void> = [];
+afterEach(() => {
+  for (const destroy of cleanup.splice(0).reverse()) destroy();
+});
+
+const controller = {} as unknown as SessionController;
+
+interface Mounted {
+  testRenderer: TestRendererSetup;
+  view: ConversationView;
+  /** Draws a list into the same view, so incremental paths are exercised. */
+  draw(entries: ConversationEntry[], selectedId?: string | null): Promise<void>;
+}
+
+async function mount(): Promise<Mounted> {
+  const theme = resolveTheme(null);
+  const testRenderer = await createTestRenderer({width: 80, height: 40});
+  // The list is swapped per draw rather than fixed at construction, because
+  // the incremental paths below need one view to see several lists.
+  let entries: ConversationEntry[] = [];
+  const view = new ConversationView(
+    testRenderer.renderer,
+    controller,
+    createMarkdownStyle(theme),
+    theme,
+    {selectConversation: () => entries, showsSelection: true},
+  );
+  testRenderer.renderer.root.add(view.output);
+  cleanup.push(() => {
+    view.output.destroyRecursively();
+    testRenderer.renderer.destroy();
+  });
+  return {
+    testRenderer,
+    view,
+    draw: async (next, selectedId = null) => {
+      entries = next;
+      view.render({...initialSessionState(), selectedEntryId: selectedId});
+      await testRenderer.renderOnce();
+    },
+  };
+}
+
+async function renderEntries(
+  entries: ConversationEntry[],
+  selectedId: string | null = null,
+): Promise<Mounted> {
+  const mounted = await mount();
+  await mounted.draw(entries, selectedId);
+  return mounted;
+}
+
+function cardOf(view: ConversationView, id: string): BoxRenderable {
+  const card = view.output.findDescendantById(`event-${id}`);
+  if (!(card instanceof BoxRenderable)) throw new Error(`entry ${id} did not render a card`);
+  return card;
+}
+
+/**
+ * An entry from a named agent in a named round: the pair a heading splits.
+ *
+ * 'analysis' because run collapsing is about entries drawn as cards. #620's
+ * bare kinds ('status', and unflagged 'diagnostic'/'subprocess') keep their own
+ * grammar and are covered separately below.
+ */
+function from(
+  who: {agentKind: string; roundLabel: string},
+  id: string,
+  content: string,
+): ConversationEntry {
+  return {id, kind: 'analysis', label: `${who.agentKind} · ${who.roundLabel}`, ...who, content};
+}
+
+const judge = {agentKind: 'judge', roundLabel: 'round-1-retry-1-judge'};
+const implementer = {agentKind: 'implementer', roundLabel: 'round-1-implementer'};
+const judgeAgain = {agentKind: 'judge', roundLabel: 'round-2-judge'};
+
+/**
+ * The tree a view built, minus the auto-generated ids that differ between two
+ * renderers. Chrome is structure, so an incremental path that gets it wrong
+ * lands here as a card with the wrong height, border, or children.
+ */
+function shapeOf(view: ConversationView): string {
+  const describeNode = (node: Renderable, depth: number): string[] => [
+    `${'  '.repeat(depth)}${node.id.startsWith('event-') ? node.id : node.constructor.name}` +
+      ` x=${node.x} y=${node.y} w=${node.width} h=${node.height}` +
+      (node instanceof BoxRenderable ? ` border=${JSON.stringify(node.border)}` : ''),
+    ...node.getChildren().flatMap(child => describeNode(child, depth + 1)),
+  ];
+  return describeNode(view.output, 0).join('\n');
+}
+
 /**
  * #565: an entry separates from its neighbour with a rule on its top edge,
  * not a four-sided bordered card sitting under its own blank margin row.
@@ -23,37 +115,6 @@ import {
  * bug this issue is about (docs/contributing/coding-best-practices.md).
  */
 describe('conversation entry row cost (#565)', () => {
-  const cleanup: Array<() => void> = [];
-  afterEach(() => {
-    for (const destroy of cleanup.splice(0).reverse()) destroy();
-  });
-
-  const controller = {} as unknown as SessionController;
-
-  async function renderEntries(
-    entries: ConversationEntry[],
-  ): Promise<{testRenderer: TestRendererSetup; view: ConversationView}> {
-    const theme = resolveTheme(null);
-    const testRenderer = await createTestRenderer({width: 80, height: 40});
-    const view = new ConversationView(
-      testRenderer.renderer,
-      controller,
-      createMarkdownStyle(theme),
-      theme,
-      // Entry selection from state is a separate, already-tested concern;
-      // fixing the list here keeps this test about row cost alone.
-      {selectConversation: () => entries},
-    );
-    testRenderer.renderer.root.add(view.output);
-    cleanup.push(() => {
-      view.output.destroyRecursively();
-      testRenderer.renderer.destroy();
-    });
-    view.render(initialSessionState());
-    await testRenderer.renderOnce();
-    return {testRenderer, view};
-  }
-
   // 'status', 'analysis' and 'result' all skip both the markdown pipeline and
   // the tool-output preview (see the branches in `#renderEntry`), so each
   // renders its content verbatim on exactly one line. That isolates the row
@@ -133,23 +194,198 @@ describe('conversation entry row cost (#565)', () => {
   });
 
   it('does not add its own inset on top of the pane that contains it', async () => {
-    const leadingColumn = async (entries: ConversationEntry[]): Promise<number> => {
-      const {testRenderer} = await renderEntries(entries);
-      const frame = testRenderer.captureCharFrame();
-      const row = frame.split('\n').find(line => line.trim().length > 0);
-      if (row === undefined) throw new Error('nothing rendered');
-      return row.length - row.trimStart().length;
-    };
-    const emptyColumn = await leadingColumn([]);
-    const entryColumn = await leadingColumn([
-      {id: 'a', kind: 'status', label: 'status', content: 'x'},
-    ]);
-    // Both the empty-transcript message and an entry's heading are direct
-    // children of the same unpadded `output` box: a card that added its own
-    // left padding or border, as it did before #565, would start one or
-    // more columns later than the empty-transcript message sitting beside
-    // it in the same pane.
-    expect(entryColumn).toBe(emptyColumn);
+    const empty = await renderEntries([]);
+    const message = empty.view.output.getChildren()[0];
+    const {view} = await renderEntries([{id: 'a', kind: 'status', label: 'status', content: 'x'}]);
+    const heading = view.output.findDescendantById('event-a-heading');
+    if (!(heading instanceof BoxRenderable)) throw new Error('heading missing');
+    const [role] = heading.getChildren();
+    if (message === undefined || role === undefined) throw new Error('nothing rendered');
+    // A card adds no inset of its own beyond the one column every entry
+    // reserves for the selection rule, and the empty-transcript message takes
+    // that same column: before #565 a card padded itself on top of the pane's
+    // inset and started several columns right of the message sitting beside it
+    // in the same pane, and a gutter only some of the children honoured would
+    // reopen that gap by one column.
+    expect(role.x).toBe(message.x);
+    expect(role.x).toBe(view.output.x + 1);
+  });
+
+  it('spends one divider and one heading on a run of entries from one speaker', async () => {
+    const run = ['a', 'b', 'c', 'd', 'e', 'f'].map(id => from(judge, id, `line ${id}`));
+    const {view} = await renderEntries(run);
+    // 2 + N, not 3N. Six one-line judge entries cost 8 rows; they cost 18
+    // before this change, restating `judge` and `round-1-retry-1-judge` six
+    // times each for no added information.
+    expect(view.output.height).toBe(2 + run.length);
+    const [first, ...rest] = run.map(entry => cardOf(view, entry.id));
+    expect(first?.height).toBe(3);
+    expect(first?.border).toEqual(['top']);
+    for (const card of rest) {
+      expect(card.height).toBe(1);
+      // `false`, not an empty side list: OpenTUI turns a border back on if a
+      // style or colour is passed beside it (tui-conventions.md).
+      expect(card.border).toBe(false);
+    }
+    for (const entry of run.slice(1))
+      expect(view.output.findDescendantById(`event-${entry.id}-heading`)).toBeUndefined();
+  });
+
+  it('redraws the chrome when the speaker changes', async () => {
+    const entries = [
+      from(judge, 'j1', 'one'),
+      from(judge, 'j2', 'two'),
+      from(implementer, 'i1', 'three'),
+      from(judgeAgain, 'j3', 'four'),
+      // No agent/round pair, so the speaker is the label: two in a row are one
+      // run, and the differing label after them opens another.
+      {id: 's1', kind: 'result' as const, label: 'launcher', content: 'five'},
+      {id: 's2', kind: 'result' as const, label: 'launcher', content: 'six'},
+      {id: 's3', kind: 'result' as const, label: 'backend', content: 'seven'},
+    ];
+    const {view} = await renderEntries(entries);
+    const opensRun = (id: string): boolean => cardOf(view, id).height === 3;
+    expect(opensRun('j1')).toBe(true);
+    expect(opensRun('j2')).toBe(false);
+    expect(opensRun('i1')).toBe(true);
+    // The same agent in a different round is a different speaker: the run key
+    // is the pair the heading splits on, not the role alone.
+    expect(opensRun('j3')).toBe(true);
+    expect(opensRun('s1')).toBe(true);
+    expect(opensRun('s2')).toBe(false);
+    expect(opensRun('s3')).toBe(true);
+    expect(view.output.height).toBe(3 + 1 + 3 + 3 + 3 + 1 + 3);
+  });
+
+  it('collapses a run of #620 bare entries without giving one a divider', async () => {
+    // Bare lifecycle lines are most of what run collapsing buys: a run of them
+    // is one agent talking, and it restated the agent above every line. They
+    // lose the repeated heading like any other entry and never gain the
+    // divider, which is the half of the chrome #620's demotion is about.
+    const entries: ConversationEntry[] = [
+      {id: 'b1', kind: 'status', label: 'launcher', content: 'one'},
+      {id: 'b2', kind: 'status', label: 'launcher', content: 'two'},
+      {id: 'b3', kind: 'status', label: 'launcher', content: 'three'},
+      from(judge, 'j1', 'four'),
+      from(judge, 'j2', 'five'),
+    ];
+    const {view} = await renderEntries(entries);
+    for (const id of ['b1', 'b2', 'b3']) expect([id, cardOf(view, id).border]).toEqual([id, false]);
+    // The opener keeps heading and content; the rest of the run is content
+    // alone, and #620's margin row goes with the heading rather than splitting
+    // the run with a blank line.
+    expect(cardOf(view, 'b1').height).toBe(2);
+    expect(cardOf(view, 'b2').height).toBe(1);
+    expect(cardOf(view, 'b3').height).toBe(1);
+    expect(view.output.findDescendantById('event-b2-heading')).toBeUndefined();
+    expect(view.output.findDescendantById('event-b3-heading')).toBeUndefined();
+    // A card after them is a different speaker, so it opens a run of its own
+    // and gets the divider a card gets.
+    expect(cardOf(view, 'j1').border).toEqual(['top']);
+    expect(cardOf(view, 'j1').height).toBe(3);
+    expect(cardOf(view, 'j2').height).toBe(1);
+    // One margin row (b1) + 2 + 1 + 1 + 3 + 1.
+    expect(view.output.height).toBe(1 + 2 + 1 + 1 + 3 + 1);
+  });
+
+  it('shows the cursor on an entry inside a run without moving its content', async () => {
+    const run = [from(judge, 'a', 'one'), from(judge, 'b', 'two'), from(judge, 'c', 'three')];
+    const resting = await renderEntries(run);
+    const selected = await renderEntries(run, 'b');
+    const card = cardOf(selected.view, 'b');
+    // An entry inside a run draws no heading, so it has no marker cell and no
+    // `textStrong` label to carry the cursor. A rule down its left edge is a
+    // channel every entry has, and it is a glyph rather than a colour, which
+    // is what WCAG 1.4.1 asks for (tui-conventions.md).
+    expect(card.border).toEqual(['left']);
+    expect(selected.testRenderer.captureCharFrame()).toContain('│two');
+    // It costs no row and shifts no text: the column it draws into is the one
+    // an unselected card reserves with padding, so moving the cursor through a
+    // run leaves the transcript exactly where it was.
+    expect(card.height).toBe(cardOf(resting.view, 'b').height);
+    expect(selected.view.output.height).toBe(resting.view.output.height);
+    expect(card.getChildren()[0]?.x).toBe(cardOf(resting.view, 'b').getChildren()[0]?.x);
+    // The entry that opens the run keeps both rules and stays put too.
+    const head = cardOf(await renderEntries(run, 'a').then(mounted => mounted.view), 'a');
+    expect(head.border).toEqual(['top', 'left']);
+    expect(head.getChildren()[0]?.x).toBe(cardOf(resting.view, 'a').getChildren()[0]?.x);
+  });
+});
+
+/**
+ * Chrome now depends on the entry above, and the view renders incrementally:
+ * it appends a tail, prepends revealed history, and replaces one changed card
+ * in place, without rebuilding (`CONVERSATION_WINDOW_THRESHOLD` exists so it
+ * never has to). Each of those can leave a neighbour holding chrome it should
+ * have lost, or missing chrome it should have gained, so each is pinned
+ * against a fresh render of the same list.
+ */
+describe('speaker runs survive incremental rendering (#565)', () => {
+  it('appends without redrawing what is already on screen', async () => {
+    const shown = [from(judge, 'a', 'one'), from(judge, 'b', 'two')];
+    const grown = [...shown, from(judge, 'c', 'three'), from(implementer, 'i', 'four')];
+    const mounted = await mount();
+    await mounted.draw(shown);
+    const [head, second] = mounted.view.output.getChildren();
+    await mounted.draw(grown);
+
+    // Incremental, not a rebuild: the cards already on screen are the same
+    // renderables, and only the new tail was built.
+    expect(mounted.view.output.getChildren()[0]).toBe(head);
+    expect(mounted.view.output.getChildren()[1]).toBe(second);
+    // The appended judge entry continues the run; the implementer opens one.
+    expect(cardOf(mounted.view, 'c').height).toBe(1);
+    expect(cardOf(mounted.view, 'i').height).toBe(3);
+    const fresh = await renderEntries(grown);
+    expect(shapeOf(mounted.view)).toBe(shapeOf(fresh.view));
+    expect(mounted.testRenderer.captureCharFrame()).toBe(fresh.testRenderer.captureCharFrame());
+  });
+
+  it('takes the heading off the entry that a prepend pushes out of first place', async () => {
+    const tail = [from(judge, 'b', 'two'), from(judge, 'c', 'three')];
+    const full = [from(judge, 'a', 'one'), ...tail];
+    const mounted = await mount();
+    await mounted.draw(tail);
+    // 'b' opened the view, so it drew a heading for being first.
+    expect(cardOf(mounted.view, 'b').height).toBe(3);
+    const kept = mounted.view.output.getChildren()[1];
+    await mounted.draw(full);
+
+    // It is not first any more and the entry revealed above it is the same
+    // speaker, so its chrome goes.
+    expect(cardOf(mounted.view, 'b').height).toBe(1);
+    expect(cardOf(mounted.view, 'a').height).toBe(3);
+    // Only that one neighbour was redrawn; the rest of the tail is untouched.
+    expect(mounted.view.output.getChildren()[2]).toBe(kept);
+    const fresh = await renderEntries(full);
+    expect(shapeOf(mounted.view)).toBe(shapeOf(fresh.view));
+    expect(mounted.testRenderer.captureCharFrame()).toBe(fresh.testRenderer.captureCharFrame());
+  });
+
+  it('redraws the neighbour whose chrome a replaced entry decides', async () => {
+    const head = from(judge, 'a', 'one');
+    const last = from(judge, 'c', 'three');
+    const asJudge = [head, from(judge, 'b', 'two'), last];
+    // The same entry re-emitted, same id, different speaker: it breaks the run
+    // it was part of, so 'c' below it has to gain the chrome it did not draw.
+    const asImplementer = [head, from(implementer, 'b', 'two'), last];
+    const mounted = await mount();
+    await mounted.draw(asJudge);
+    expect(cardOf(mounted.view, 'c').height).toBe(1);
+
+    await mounted.draw(asImplementer);
+    expect(cardOf(mounted.view, 'b').height).toBe(3);
+    expect(cardOf(mounted.view, 'c').height).toBe(3);
+    const changed = await renderEntries(asImplementer);
+    expect(shapeOf(mounted.view)).toBe(shapeOf(changed.view));
+    expect(mounted.testRenderer.captureCharFrame()).toBe(changed.testRenderer.captureCharFrame());
+
+    // And back: the neighbour loses the chrome again when the run re-forms.
+    await mounted.draw(asJudge);
+    expect(cardOf(mounted.view, 'c').height).toBe(1);
+    const restored = await renderEntries(asJudge);
+    expect(shapeOf(mounted.view)).toBe(shapeOf(restored.view));
+    expect(mounted.testRenderer.captureCharFrame()).toBe(restored.testRenderer.captureCharFrame());
   });
 });
 

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -11,7 +11,6 @@ import {hasRunEnded} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
 import {visibleConversation} from '../session-model.js';
-import {fillLayer} from './box-fill.js';
 import {promptPreview, toolCallPreview, toolResultPreview} from './previews.js';
 import {
   conversationRole,
@@ -19,7 +18,7 @@ import {
   entryPalette,
   type MarkdownBlockOptions,
 } from './styles.js';
-import type {Theme} from './theme.js';
+import {ensureContrast, SUBTLE_TEXT_MIN_CONTRAST, type Theme} from './theme.js';
 
 export interface ConversationViewOptions {
   selectConversation?: (state: SessionState) => ConversationEntry[];
@@ -102,8 +101,11 @@ export class ConversationView {
     this.#showsSelection = options.showsSelection ?? false;
     this.#onFocusRequest = options.onFocusRequest;
     const onRevealOlder = options.onRevealOlder;
-    // The bordered surface owns horizontal inset so transcript siblings, such
-    // as a fixed footer, share the same content origin as these turn cards.
+    // Horizontal inset belongs to the pane (or the chat surface's own frame)
+    // that contains this view, not to the cards below: see #565. A card that
+    // padded itself again on top of that sat one layer deeper than a
+    // non-card sibling in the same pane, such as the empty-transcript
+    // message added directly below.
     this.output = new BoxRenderable(renderer, {
       id: 'output',
       width: '100%',
@@ -337,26 +339,43 @@ export class ConversationView {
       id: `event-${entry.id}`,
       width: '100%',
       flexDirection: 'column',
-      marginTop: bare && entry.kind !== 'status' ? 0 : 1,
-      paddingLeft: bare ? 0 : 1,
-      paddingRight: 1,
-      // `border: false` is not enough on its own: OpenTUI turns the border
-      // back on whenever any border styling option is present, so a borderless
-      // entry has to omit `borderStyle` and `borderColor` as well. That is how
-      // a bare card came to draw a rounded frame while reading as if it drew
-      // none.
+      // A carded entry gets a rule on its top edge instead of a four-sided
+      // border (#565): it separates one entry from the next at a fraction of
+      // the row cost, with no bottom border and no blank margin row to hold
+      // the gap open. No side padding either: the pane this view sits in
+      // already insets its content by one column (or the chat surface's own
+      // frame does), and a card padding on top of that was a second,
+      // inconsistent inset.
       //
-      // A bare card draws no frame, so its role tint goes straight on the card.
-      // A bordered card takes its tint on an inner layer instead, below.
+      // A bare entry keeps its own grammar rather than joining that one.
+      // #620 demoted lifecycle chatter to bare lines deliberately, so giving
+      // it a rule would undo that demotion; only entries that were cards
+      // trade a border for a divider here. A bare entry draws no frame, so
+      // its role tint goes straight on the card. `border: false` is not
+      // enough on its own: OpenTUI turns the border back on whenever any
+      // border styling option is present, so a borderless entry has to omit
+      // `borderStyle` and `borderColor` as well.
+      marginTop: bare && entry.kind === 'status' ? 1 : 0,
       ...(bare
         ? {border: false, backgroundColor: palette.background}
         : {
-            border: true,
-            borderStyle: 'rounded' as const,
-            // The cursor is the card's border, not a fill: a filled card reads
-            // as selected text, and the transcript already uses fills for
-            // roles.
-            borderColor: selected ? this.#theme.borderFocus : palette.border,
+            border: ['top'] as const,
+            borderStyle: 'single' as const,
+            // The cursor is the rule's colour. Selection is never carried by
+            // that alone: the heading below adds a "▸ " marker and switches
+            // to `textStrong`, neither of which this change touches, so losing
+            // three of the four border sides does not weaken the WCAG 1.4.1
+            // channel.
+            //
+            // The resting colour is held to the same 3:1 floor `textSubtle`
+            // uses for punctuation and rules: `roleAccents` in theme.ts is not
+            // run through `ensureContrast` the way the label and content
+            // derived from it are, and five of the 64 role/theme combinations
+            // sit under 3:1. A four-sided border could lean on its own area to
+            // stay noticeable at a marginal contrast; a one-row rule cannot.
+            borderColor: selected
+              ? this.#theme.borderFocus
+              : ensureContrast(palette.border, this.#theme.canvas, SUBTLE_TEXT_MIN_CONTRAST),
           }),
       ...(this.#showsSelection
         ? {
@@ -379,9 +398,6 @@ export class ConversationView {
             }
           : {}),
     });
-    // Inside the frame rather than under it, so the arc keeps the canvas in its
-    // corner cells (tui-conventions.md).
-    if (!bare) fillLayer(card, `event-${entry.id}-fill`, palette.background);
     const heading = new BoxRenderable(this.renderer, {
       id: `event-${entry.id}-heading`,
       width: '100%',

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -405,13 +405,28 @@ export class ConversationView {
       flexDirection: 'row',
       justifyContent: 'space-between',
     });
+    // The heading box is already `space-between`, and an entry that names both
+    // an agent and a round carries them as separate fields, so the role can sit
+    // at the left edge where it lines up down the column and the run id can go
+    // to the right rather than pushing the eye a variable distance across. Any
+    // other entry keeps its single label on the left, unchanged.
+    const splitHeading = entry.agentKind !== undefined && entry.roundLabel !== undefined;
     heading.add(
       new TextRenderable(this.renderer, {
-        content: `${selected ? '▸ ' : ''}${entry.label ?? entry.kind}`,
+        content: `${selected ? '▸ ' : ''}${splitHeading ? entry.agentKind : (entry.label ?? entry.kind)}`,
         fg: selected ? this.#theme.textStrong : palette.label,
         height: 1,
       }),
     );
+    if (splitHeading) {
+      heading.add(
+        new TextRenderable(this.renderer, {
+          content: entry.roundLabel as string,
+          fg: this.#theme.textSubtle,
+          height: 1,
+        }),
+      );
+    }
     card.add(heading);
     if (this.#markdownKinds.has(entry.kind)) {
       this.#renderMarkdownEntry(card, entry);

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -1,10 +1,13 @@
 import {
   BoxRenderable,
   type CliRenderer,
+  fg,
   MarkdownRenderable,
+  StyledText,
   type SyntaxStyle,
   // The terminal mouse event, not the DOM global of the same name.
   type MouseEvent as TerminalMouseEvent,
+  type TextChunk,
   TextRenderable,
 } from '@opentui/core';
 import {hasRunEnded} from '@vibesys/core-state';
@@ -15,6 +18,7 @@ import {promptPreview, toolCallPreview, toolResultPreview} from './previews.js';
 import {
   conversationRole,
   createMarkdownBlockOptions,
+  type EntryPalette,
   entryPalette,
   type MarkdownBlockOptions,
 } from './styles.js';
@@ -485,7 +489,10 @@ export class ConversationView {
         heading.add(
           new TextRenderable(this.renderer, {
             content: runId,
-            fg: this.#theme.textSubtle,
+            // Same expression as the role text on the left: the run id is
+            // part of the same heading, not a subordinate detail, so it
+            // keeps the card's colour instead of fading to textSubtle.
+            fg: selected ? this.#theme.textStrong : palette.label,
             height: 1,
           }),
         );
@@ -513,7 +520,7 @@ export class ConversationView {
       const content = prompt ? prompt.content : (output?.content ?? entry.content);
       card.add(
         new TextRenderable(this.renderer, {
-          content,
+          content: styleSourceTags(content, palette),
           fg: palette.content,
           width: '100%',
           // A command line, a stderr trace, or a banner runs past the card;
@@ -624,6 +631,38 @@ export class ConversationView {
       }
     }
   }
+}
+
+/** A bracketed source tag at the start of a line: `[git-tracking]`, `[framework-validation]`. */
+const SOURCE_TAG = /^\[[A-Za-z0-9][\w-]*\]/;
+
+/**
+ * Colors a leading bracketed source tag in the card's label color; the rest
+ * of that line, and any line without one, stays in the content color.
+ * `SOURCE_TAG` is anchored to the start of the line, so a bracket elsewhere in
+ * a line (`see [x] here`) is left alone.
+ *
+ * Returns `content` unchanged when no line carries a tag, so an untagged
+ * entry keeps rendering as the single content-colored string it always has.
+ * Exported so the line-splitting and anchoring are tested directly, the way
+ * previews.ts exports `unwrapShellCommand` for the same reason.
+ */
+export function styleSourceTags(content: string, palette: EntryPalette): StyledText | string {
+  const lines = content.split('\n');
+  if (!lines.some(line => SOURCE_TAG.test(line))) return content;
+  const chunks: TextChunk[] = [];
+  lines.forEach((line, index) => {
+    const tag = SOURCE_TAG.exec(line);
+    if (tag !== null) {
+      chunks.push(fg(palette.label)(tag[0]));
+      const rest = line.slice(tag[0].length);
+      if (rest !== '') chunks.push(fg(palette.content)(rest));
+    } else if (line !== '') {
+      chunks.push(fg(palette.content)(line));
+    }
+    if (index < lines.length - 1) chunks.push(fg(palette.content)('\n'));
+  });
+  return new StyledText(chunks);
 }
 
 /**

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -256,8 +256,12 @@ export class ConversationView {
     )
       return;
     if (isEntryPrefix(this.#renderedConversation, entries)) {
-      for (const entry of entries.slice(this.#renderedConversation.length)) {
-        const card = this.#renderEntry(entry);
+      // Appending cannot change any rendered card: chrome depends on the entry
+      // above, and every entry already on screen keeps the one it had.
+      for (let index = this.#renderedConversation.length; index < entries.length; index += 1) {
+        const entry = entries[index];
+        if (entry === undefined) continue;
+        const card = this.#renderEntry(entry, entries[index - 1]);
         this.output.add(card);
         this.#renderedCards.push(card);
       }
@@ -271,25 +275,36 @@ export class ConversationView {
       for (let index = revealed - 1; index >= 0; index -= 1) {
         const entry = entries[index];
         if (entry === undefined) continue;
-        const card = this.#renderEntry(entry);
+        const card = this.#renderEntry(entry, entries[index - 1]);
         this.output.add(card, 0);
         cards.unshift(card);
       }
       this.#renderedCards = [...cards, ...this.#renderedCards];
       this.#renderedConversation = entries;
+      // The old head drew its chrome for being first. It is not first any more,
+      // so it loses that chrome when the entry now above it is the same
+      // speaker. Exactly one card can be in that position, so this is one
+      // re-render, not a rebuild.
+      const head = entries[revealed];
+      const above = entries[revealed - 1];
+      if (head !== undefined && above !== undefined && sameSpeaker(above, head))
+        this.#replaceCard(revealed, entries);
       return;
     }
     const changedIndex = singleChangedEntryIndex(this.#renderedConversation, entries);
     if (changedIndex !== -1) {
-      const previousCard = this.#renderedCards[changedIndex];
+      const before = this.#renderedConversation[changedIndex];
       const entry = entries[changedIndex];
-      if (previousCard !== undefined && entry !== undefined) {
-        this.output.remove(previousCard);
-        previousCard.destroyRecursively();
-        const card = this.#renderEntry(entry);
-        this.output.add(card, changedIndex);
-        this.#renderedCards[changedIndex] = card;
+      if (
+        this.#renderedCards[changedIndex] !== undefined &&
+        before !== undefined &&
+        entry !== undefined
+      ) {
         this.#renderedConversation = entries;
+        this.#replaceCard(changedIndex, entries);
+        // A replacement that changes who is speaking also decides the chrome of
+        // the entry below it, which is the only other card that can be affected.
+        if (!sameSpeaker(before, entry)) this.#replaceCard(changedIndex + 1, entries);
         return;
       }
     }
@@ -299,15 +314,31 @@ export class ConversationView {
       const card = new TextRenderable(this.renderer, {
         content: this.#emptyContent,
         fg: this.#theme.textSubtle,
+        // Shares the gutter every card reserves for the selection rule, so the
+        // empty-transcript message keeps the same left edge as an entry's
+        // heading rather than sitting one column outside it.
+        marginLeft: 1,
       });
       this.output.add(card);
       return;
     }
-    for (const entry of entries) {
-      const card = this.#renderEntry(entry);
+    for (const [index, entry] of entries.entries()) {
+      const card = this.#renderEntry(entry, entries[index - 1]);
       this.output.add(card);
       this.#renderedCards.push(card);
     }
+  }
+
+  /** Re-renders one already-rendered card in place, chrome included. */
+  #replaceCard(index: number, entries: ConversationEntry[]): void {
+    const previousCard = this.#renderedCards[index];
+    const entry = entries[index];
+    if (previousCard === undefined || entry === undefined) return;
+    this.output.remove(previousCard);
+    previousCard.destroyRecursively();
+    const card = this.#renderEntry(entry, entries[index - 1]);
+    this.output.add(card, index);
+    this.#renderedCards[index] = card;
   }
 
   #togglePrompt(id: string): void {
@@ -331,42 +362,73 @@ export class ConversationView {
     return true;
   }
 
-  #renderEntry(entry: ConversationEntry): BoxRenderable {
+  /**
+   * Draws one entry. `previous` is the entry rendered directly above it, or
+   * `undefined` for the first one in the view, which is what decides whether
+   * this entry opens a speaker run and so draws the divider and heading.
+   */
+  #renderEntry(entry: ConversationEntry, previous: ConversationEntry | undefined): BoxRenderable {
     const palette = entryPalette(entry, this.#theme);
     const selected = this.#selectedId === entry.id;
     const bare = isBareEntry(entry);
+    // The first rendered entry always draws its chrome, whatever sits above it
+    // in the model: the window and the scrollback both start mid-run, and the
+    // topmost row on screen is the one that most has to say who is speaking.
+    // It also keeps chrome a function of the rendered window alone, so no
+    // incremental path has to look outside it.
+    //
+    // #620's bare entries take this rule too, and they are most of what it
+    // buys: a run of provider lifecycle lines is one agent talking, and it
+    // restated the agent and the round above every line.
+    const opensRun = previous === undefined || !sameSpeaker(previous, entry);
+    const borderSides: ('top' | 'left')[] = [];
+    // A carded entry gets a rule on its top edge instead of a four-sided
+    // border (#565): it separates one entry from the next at a fraction of the
+    // row cost, with no bottom border and no blank margin row to hold the gap
+    // open. It is drawn only where the speaker changes: consecutive entries
+    // from one agent are one block, and a divider inside that block separates
+    // nothing.
+    //
+    // A bare entry never draws it, opener or not. #620 demoted lifecycle
+    // chatter to frameless tinted lines, and handing one a rule would undo that
+    // demotion; only entries that were cards trade a border for a divider here.
+    // Losing the repeated heading is the density win, keeping the frame off is
+    // #620's, and the two compose.
+    if (opensRun && !bare) borderSides.push('top');
+    // The cursor. An entry inside a run has no heading to carry a "▸ " marker,
+    // so selection moves out of the heading and onto a rule down the entry's
+    // left edge, which every entry can draw and which costs no row. The column
+    // it needs is reserved by `paddingLeft` when the entry is not selected, so
+    // the glyph swaps in and out without the content moving under the cursor
+    // (tui-conventions.md, "nothing moves that does not have to"); this is the
+    // same reserved-gutter treatment `paneTitle` gives a pane. The glyph is the
+    // non-colour channel WCAG 1.4.1 asks for, and `borderFocus` plus the
+    // heading's `textStrong` reinforce it where a heading exists.
+    if (selected) borderSides.push('left');
     const card = new BoxRenderable(this.renderer, {
       id: `event-${entry.id}`,
       width: '100%',
       flexDirection: 'column',
-      // A carded entry gets a rule on its top edge instead of a four-sided
-      // border (#565): it separates one entry from the next at a fraction of
-      // the row cost, with no bottom border and no blank margin row to hold
-      // the gap open. No side padding either: the pane this view sits in
-      // already insets its content by one column (or the chat surface's own
-      // frame does), and a card padding on top of that was a second,
-      // inconsistent inset.
-      //
-      // A bare entry keeps its own grammar rather than joining that one.
-      // #620 demoted lifecycle chatter to bare lines deliberately, so giving
-      // it a rule would undo that demotion; only entries that were cards
-      // trade a border for a divider here. A bare entry draws no frame, so
-      // its role tint goes straight on the card. `border: false` is not
-      // enough on its own: OpenTUI turns the border back on whenever any
-      // border styling option is present, so a borderless entry has to omit
-      // `borderStyle` and `borderColor` as well.
-      marginTop: bare && entry.kind === 'status' ? 1 : 0,
-      ...(bare
-        ? {border: false, backgroundColor: palette.background}
+      // No side padding beyond that gutter: the pane this view sits in already
+      // insets its content by one column (or the chat surface's own frame
+      // does), and a card padding on top of that was a second, inconsistent
+      // inset.
+      ...(selected ? {} : {paddingLeft: 1}),
+      // #620's margin row above a bare status entry is separation chrome, so
+      // it is drawn where the divider would be: once, on the run opener. Inside
+      // a run it would be a blank row splitting one speaker's block.
+      marginTop: bare && entry.kind === 'status' && opensRun ? 1 : 0,
+      // A bare entry draws no frame, so its role tint goes straight on the
+      // card rather than on a border.
+      ...(bare ? {backgroundColor: palette.background} : {}),
+      // OpenTUI turns a border back on if `borderStyle` or `borderColor` is
+      // passed beside `border: false`, so an entry that draws neither rule has
+      // to omit both (tui-conventions.md).
+      ...(borderSides.length === 0
+        ? {border: false}
         : {
-            border: ['top'] as const,
+            border: borderSides,
             borderStyle: 'single' as const,
-            // The cursor is the rule's colour. Selection is never carried by
-            // that alone: the heading below adds a "▸ " marker and switches
-            // to `textStrong`, neither of which this change touches, so losing
-            // three of the four border sides does not weaken the WCAG 1.4.1
-            // channel.
-            //
             // The resting colour is held to the same 3:1 floor `textSubtle`
             // uses for punctuation and rules: `roleAccents` in theme.ts is not
             // run through `ensureContrast` the way the label and content
@@ -398,36 +460,38 @@ export class ConversationView {
             }
           : {}),
     });
-    const heading = new BoxRenderable(this.renderer, {
-      id: `event-${entry.id}-heading`,
-      width: '100%',
-      height: 1,
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-    });
-    // The heading box is already `space-between`, and an entry that names both
-    // an agent and a round carries them as separate fields, so the role can sit
-    // at the left edge where it lines up down the column and the run id can go
-    // to the right rather than pushing the eye a variable distance across. Any
-    // other entry keeps its single label on the left, unchanged.
-    const splitHeading = entry.agentKind !== undefined && entry.roundLabel !== undefined;
-    heading.add(
-      new TextRenderable(this.renderer, {
-        content: `${selected ? '▸ ' : ''}${splitHeading ? entry.agentKind : (entry.label ?? entry.kind)}`,
-        fg: selected ? this.#theme.textStrong : palette.label,
+    if (opensRun) {
+      const heading = new BoxRenderable(this.renderer, {
+        id: `event-${entry.id}-heading`,
+        width: '100%',
         height: 1,
-      }),
-    );
-    if (splitHeading) {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+      });
+      // The heading box is already `space-between`, and an entry that names
+      // both an agent and a round carries them as separate fields, so the role
+      // can sit at the left edge where it lines up down the column and the run
+      // id can go to the right rather than pushing the eye a variable distance
+      // across. Any other entry keeps its single label on the left, unchanged.
+      const {role, runId} = speaker(entry);
       heading.add(
         new TextRenderable(this.renderer, {
-          content: entry.roundLabel as string,
-          fg: this.#theme.textSubtle,
+          content: role,
+          fg: selected ? this.#theme.textStrong : palette.label,
           height: 1,
         }),
       );
+      if (runId !== null) {
+        heading.add(
+          new TextRenderable(this.renderer, {
+            content: runId,
+            fg: this.#theme.textSubtle,
+            height: 1,
+          }),
+        );
+      }
+      card.add(heading);
     }
-    card.add(heading);
     if (this.#markdownKinds.has(entry.kind)) {
       this.#renderMarkdownEntry(card, entry);
     } else if (
@@ -576,6 +640,24 @@ function isBareEntry(entry: ConversationEntry): boolean {
   if (entry.kind === 'status') return true;
   if (entry.kind !== 'diagnostic' && entry.kind !== 'subprocess') return false;
   return conversationRole(entry) !== 'failure';
+}
+
+/**
+ * Who an entry is from, as the heading splits it: an entry that names both an
+ * agent and a round is that pair, and anything else is its single label. One
+ * definition, so the heading and the run grouping cannot disagree about where
+ * a run ends.
+ */
+function speaker(entry: ConversationEntry): {role: string; runId: string | null} {
+  return entry.agentKind !== undefined && entry.roundLabel !== undefined
+    ? {role: entry.agentKind, runId: entry.roundLabel}
+    : {role: entry.label ?? entry.kind, runId: null};
+}
+
+function sameSpeaker(left: ConversationEntry, right: ConversationEntry): boolean {
+  const before = speaker(left);
+  const after = speaker(right);
+  return before.role === after.role && before.runId === after.runId;
 }
 
 function sameEntries(left: ConversationEntry[], right: ConversationEntry[]): boolean {


### PR DESCRIPTION
## Problem

Closes #565.

Every transcript entry is a rounded bordered box with its own `marginTop` and
left/right padding, so a one-line status costs 5 rows to say one thing and a
screenful reads as a stack of containers rather than a sequence of events. The
card's padding also disagreed with the pane around it: cards inset their content,
the panes containing them do not, so an entry sat one layer deeper than a
non-card sibling in the same pane.


The same 16 rows of transcript, 150x40, dark theme, both starting on an entry
boundary and ending on the same pane floor. Three filled four-sided cards before,
five rule-separated entries after.

**Before (`main`)**

**After**

Note the heading in the after frame: the role holds the left edge and the run id
is pushed right, which is the second commit on this branch.

Role stays legible on the rule rather than the fill: `conversation.analysis.border`
for judge, success green for the benchmark. Card background across the crop goes
from 48.72% success fill plus 24.36% analysis fill to 100% canvas; pinned at
`22,70`, `#132f30` to `#0f172a`. Across the full pane the same run shows 6
entries before and 10 after.

### Before / after

150x40, dark, full window. Base is #646.

**Before** — `judge · round-1-retry-1-judge` is restated on every one of six
consecutive entries, and each `Benchmark` / `round-1 · PASS` card draws a
four-sided border.

![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr647-density-before.png)

**After** — one heading for the whole judge run, role pinned left and run id
right, with fresh chrome only where the speaker changes. Cards are separated by
a top rule instead of a border.

![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr647-density-after.png)

## Solution

The issue prices two directions and asks that one be chosen. This takes
**dividers**, not the collapsible accordion: a rule between entries separates as
well as a border on four sides at a fraction of the row cost, and the accordion
would add interaction state, a keybinding, and a rule for what a collapsed entry
shows, none of which this issue asks for.

Each entry is now `border: ['top']` / `borderStyle: 'single'` with no margin and
no card padding, relying on the pane's existing inset. A one-line entry costs 3
rows instead of 5. The `'status'` kind's old borderless carve-out is gone, so the
transcript has one boundary grammar rather than two.

Selection is unaffected: the heading's `▸ ` marker and `textStrong` colour carry
it independently of border colour, per `tui-conventions.md`'s rule that focus is
never carried by colour alone.

### Scope note

The resting divider colour now runs through `ensureContrast` at the same 3:1
floor `textSubtle` uses. `roleAccents` skips that check, and 5 of 64 role/theme
combinations sit under 3:1. That is a pre-existing gap, but a four-sided border
could lean on its own area to stay visible at marginal contrast and a one-row
rule cannot, which is what makes this change the point to close it.

Rebased onto #646, which now enforces that a box may have a rounded border or a
fill, never both. This card ends up on the compliant side of that rule for a
different reason: it has no rounded border left to reconcile, because #565
replaces the four-sided frame with a single top-edge rule. The `cardBehindColor`
option an earlier version of #646 threaded through here is gone with it.

**Conflicts with #640 as written.** #640 keeps the four-sided border and replaces
the fill with a left-edge role stripe positioned against that border. This removes
the border it measures from. The two are competing answers to the same question
and one has to give; flagging rather than resolving it unilaterally.

### Adjacent scope: the heading row

A second commit pins the role to the left edge and the run id to the right. An
entry heading rendered one string, `agentKind · roundLabel`, so a column read
`judge · round-1-retry-1-judge` over and over with both starting at the left
edge, pushing the eye a variable distance rightward to find where the detail
ended. The heading box was already `flexDirection: 'row'` with
`justifyContent: 'space-between'` and only ever had one child, so this needs no
new layout: it reads the `agentKind` and `roundLabel` fields already on
`ConversationEntry` rather than splitting the joined label back apart. An entry
without that pair, such as a `result` labelled `round-1 · PASS`, is unchanged.

This is horizontal scannability rather than row cost, so it is adjacent to #565
rather than part of it. It is folded in here because it rewrites the same heading
row this PR already touches, and a separate branch would only conflict with this
one on `conversation.ts`.


### Second commit: chrome once per speaker run

An entry draws its divider and heading **only when the speaker changes**;
consecutive entries from the same agent render as content lines alone. Speaker
is `agentKind` + `roundLabel` when both are present, else `label ?? kind`,
derived in one place so the heading and the grouping cannot disagree.

**Measured on the `bad-cpp-round1` fixture at 148 columns** (131 entries, 8
speaker runs): **1142 rows to 898, a 21% cut.** A run of N same-speaker entries
costs `2 + N` rows instead of `3N`.

Two things a reviewer should look at:

- **Selection moved out of the heading**, because an entry inside a run has
  none. It is now a left-edge rule in `borderFocus`, with unselected entries
  reserving that column via `paddingLeft: 1`, so nothing shifts as the cursor
  travels. The alternative — give a selected run member its own heading —
  inserts a row under the cursor, which `tui-conventions.md` forbids.
- **A second surface changed.** The chat pane reuses `ConversationView`, so
  consecutive chat messages with the same label now share a heading too. Same
  rule, and its tests pass, but it is a visible change somewhere this PR does
  not otherwise touch.

Rendering here is incremental, so this was the hard part: append builds each new
card against its predecessor; prepend re-renders the entry that used to be first
iff the newly revealed entry above it is the same speaker; replace rebuilds the
changed card and, if its speaker changed, the single card below it. No path
rebuilds the transcript. Three tests assert that append, prepend and replace
each produce the same tree as a fresh render — mutation-checked, so breaking any
one path fails exactly one test.

### Third commit: source tags and run ids take the card's label colour

Review feedback: the `[git-tracking]` / `[framework-validation]` prefixes blended into
the event stream, and the run id (`round-1-retry-1-judge`) sat in grey instead of the
card's own colour.

- The run id now uses the same expression as the role on the left of the heading
  (`palette.label`, `textStrong` when selected), so a heading reads as one colour.
- A bracketed tag at the start of a line (`^\[[A-Za-z0-9][\w-]*\]`) renders in
  `palette.label`; the rest of the line keeps `palette.content`. Brackets anywhere
  else are untouched. Only the plain-text path is affected (diagnostic entries);
  Markdown entries are not.
- The content stays one wrapping `TextRenderable` fed a `StyledText`, the first use
  of `StyledText` in the client. The header's row-of-spans pattern cannot word-wrap.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr647-colors-before.png) | ![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr647-colors-after.png) |

## Verification

### Correctness properties

- An entry costs 3 rows plus its content, uniformly across kinds.
- An entry adds no horizontal inset beyond its containing pane's.
- The divider clears 3:1 against the canvas in all 8 themes, and no two roles
  collapse onto one colour.

### Testing

`pnpm check:ts`, `pnpm check:ts-architecture`, `pnpm check:clients` all clean.
`pnpm test:clients`: 689 TUI pass, 0 fail (684 on `main`, +1 from #642, +4 here).
After the third commit: 762 pass, 0 fail, 20 of them new in `conversation.test.ts`
(tagged, untagged, mid-line bracket, and run-id colour across all themes).

New `conversation.test.ts` pins the 3-row cost through the renderer (fails at the
merge base at 5 rows / 15 for three entries) and the two theme properties as
computations over `theme.ts`. Replay harness at 150x40 shows 6 fully visible
entries before and 10 after; at 150x18, 2 before and 3 after. Light theme
identical, geometry does not depend on it.

### Not fixed here

In 5 theme/role pairs the role accent already equals `borderFocus`, so selecting
that role's entry produces no colour change. Present on `main`, untouched by this
diff, and a `theme.ts`-level issue rather than a density one.
