### PR TITLE
fix(tui): draw the command input inside the pane whose keys it takes

### DIFF
--- a/clients/tui/src/ui/agent-map.test.ts
+++ b/clients/tui/src/ui/agent-map.test.ts
@@ -140,4 +140,34 @@ describe('agent graph row budget', () => {
     expect(nodes).toBe(1);
     expect(frame).not.toContain('↑');
   });
+
+  test('redrawing a stacked round does not stack extra hidden-count rows', async () => {
+    const testRenderer: TestRendererSetup = await createTestRenderer({width: 120, height: ROWS});
+    const view = new AgentMapView(
+      testRenderer.renderer,
+      {} as unknown as SessionController,
+      resolveTheme(null),
+    );
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.destroy();
+      view.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    });
+
+    const childCounts: number[] = [];
+    let frame = '';
+    for (let round = 0; round < 3; round += 1) {
+      // A fresh state object each time, so the render-skip guard (`state ===
+      // this.#renderedState`) does not short-circuit the redraw: each pass is a
+      // real repaint, the way a running round's own state updates would be.
+      view.render(stackedState(6), 120, 0, ROWS);
+      await testRenderer.renderOnce();
+      frame = testRenderer.captureCharFrame();
+      childCounts.push(view.output.getChildren().length);
+    }
+
+    expect(frame.match(/↑ 4/g) ?? []).toHaveLength(1);
+    expect(new Set(childCounts).size).toBe(1);
+  });
 });

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -97,6 +97,13 @@ const AGENTS_TITLE = 'Agents';
 
 export class AgentMapView {
   readonly output: BoxRenderable;
+  /**
+   * Everything this view draws, in a box that outlives what it draws. `#clear`
+   * destroys the graph on every repaint, and while this pane is zoomed the
+   * command column is a child of `output` too: without the separation the first
+   * repaint after a zoom destroyed the command input along with the graph.
+   */
+  readonly #content: BoxRenderable;
   #theme: Theme;
   #renderedState: SessionState | null = null;
   #renderedWidth = 0;
@@ -125,6 +132,15 @@ export class AgentMapView {
       title: paneTitle(AGENTS_TITLE, false),
       onMouseUp: () => this.controller.focusRound('agents'),
     });
+    this.#content = new BoxRenderable(renderer, {
+      id: 'agent-map-content',
+      width: '100%',
+      flexGrow: 1,
+      flexShrink: 1,
+      flexDirection: 'column',
+      onMouseUp: () => this.controller.focusRound('agents'),
+    });
+    this.output.add(this.#content);
   }
 
   applyTheme(theme: Theme): void {
@@ -192,7 +208,7 @@ export class AgentMapView {
         roundNumber === null
           ? null
           : (stripRounds(state).find(item => item.number === roundNumber) ?? null);
-      this.output.add(
+      this.#content.add(
         new TextRenderable(this.renderer, {
           content:
             round?.status === 'planned'
@@ -235,7 +251,7 @@ export class AgentMapView {
         }),
       );
     }
-    this.output.add(headingRow);
+    this.#content.add(headingRow);
     // Elapsed time only advances while an agent is running, so the heading
     // ticks for exactly as long as one is.
     if (round !== null && hasActiveAgentTiming(round)) this.#runningRound = {round, text: heading};
@@ -302,7 +318,7 @@ export class AgentMapView {
       flexShrink: 0,
       onMouseUp: () => this.controller.focusRound('agents'),
     });
-    this.output.add(area);
+    this.#content.add(area);
     area.add(canvas);
     for (const run of edgeRuns(graph)) {
       canvas.add(
@@ -387,9 +403,9 @@ export class AgentMapView {
   /** The pane before the graph: used when the terminal is too narrow for it. */
   #renderStacked(phases: AgentPhase[], selectedKind: string | null): void {
     for (const [index, phase] of phases.entries()) {
-      this.output.add(this.#renderStackedPhase(phase, selectedKind === phase.kind));
+      this.#content.add(this.#renderStackedPhase(phase, selectedKind === phase.kind));
       if (index < phases.length - 1) {
-        this.output.add(
+        this.#content.add(
           new TextRenderable(this.renderer, {
             content: '        ↓',
             fg: this.#theme.textSubtle,
@@ -478,8 +494,8 @@ export class AgentMapView {
   #clear(): void {
     this.#runningRound = null;
     this.#stopElapsedTimer();
-    for (const child of [...this.output.getChildren()]) {
-      this.output.remove(child);
+    for (const child of [...this.#content.getChildren()]) {
+      this.#content.remove(child);
       child.destroyRecursively();
     }
   }

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -288,7 +288,7 @@ export class AgentMapView {
     // out past the bottom border and simply never seen.
     const fitted = graphWindow(phases, graphRows);
     if (fitted.hidden > 0) {
-      this.output.add(
+      this.#content.add(
         new TextRenderable(this.renderer, {
           // The oldest attempts are the ones dropped, so the count points up at
           // them the way the rounds rail points at the rounds above its window.

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -72,6 +72,7 @@ import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 import {renderDesignSummary} from './design-log.js';
 import {paneTitle} from './focus.js';
 import {headerBackground} from './header.js';
+import {MIN_SPLIT_WIDTH} from './right-pane.js';
 import {
   contrastRatio,
   ensureContrast,
@@ -500,18 +501,25 @@ describe('OpenTUI presentation', () => {
     const promptLine = lines.findIndex(line => line.includes('Implement the queue'));
     const activityLineIndex = lines.findIndex(line => line.includes('Implementer · Working'));
     const helpLine = lines.findIndex(line => line.includes('[/]: round'));
+    // The command box is the foot of the transcript pane, so the pane's own
+    // bottom border is below it and the row the activity line is measured
+    // against is where that box starts.
+    const commandTop = lines.findIndex(
+      (line, index) => index > activityLineIndex && /[╭┏][─━] [▸ ] Command /.test(line),
+    );
     const viewportBottomBorder = lines.findIndex(
       (line, index) =>
-        index > activityLineIndex && index < helpLine && FRAME_BOTTOM_RIGHT.test(line.trimEnd()),
+        index > commandTop && index < helpLine && FRAME_BOTTOM_RIGHT.test(line.trimEnd()),
     );
     expect(activityLineIndex).toBeGreaterThan(promptLine);
     expect(FRAME_VERTICAL.test(activityLine?.trimEnd() ?? '')).toBe(true);
-    expect(viewportBottomBorder).toBeGreaterThan(activityLineIndex);
+    expect(commandTop).toBeGreaterThan(activityLineIndex);
+    expect(viewportBottomBorder).toBeGreaterThan(commandTop);
     expect(viewportBottomBorder).toBeLessThan(helpLine);
     const transcriptColumn = Math.max(0, (activityLine?.indexOf('Implementer') ?? 2) - 2);
     expect(
       lines
-        .slice(activityLineIndex + 1, viewportBottomBorder)
+        .slice(activityLineIndex + 1, commandTop)
         .every(line => line.slice(transcriptColumn).replaceAll(FRAME_VERTICALS, '').trim() === ''),
     ).toBe(true);
 
@@ -3380,14 +3388,17 @@ describe('theming', () => {
     expect(landing).toContain('Implementation Details');
     expect(landing).toContain('Batch the prefill step');
 
-    // Each column has its own input, under the surface it writes to, and the
-    // command box starts where the chat column ends rather than running under
-    // it.
+    // Each column has its own input, inside the pane that input writes to.
     // The cursor starts in the command box, and the chat says how to reach it.
     expect(landing).toContain('Ctrl+W to type here');
     expect(paneFrameColumn(landing, 'Experiment chat')).not.toBeNull();
     expect(paneFrameColumn(landing, 'Message')).not.toBeNull();
-    expect(paneFrameColumn(landing, 'Command')).toBe(paneFrameColumn(landing, 'Experiments'));
+    // Inset by the table's own border and padding rather than level with its
+    // frame: the command box is a child of the pane whose keys it takes, so it
+    // starts inside that pane and cannot run back under the chat beside it.
+    const table = paneFrameColumn(landing, 'Experiments');
+    expect(table).not.toBeNull();
+    expect(paneFrameColumn(landing, 'Command')).toBe((table ?? 0) + 2);
   });
 
   it('keeps the message and command boxes on the same rows while the chat is docked', async () => {
@@ -3438,12 +3449,119 @@ describe('theming', () => {
     expect(rows.message).toBe(rows.command);
   });
 
-  it('gives the short terminal its landing rows back instead of the box alignment', async () => {
-    // The row that puts the Command box on the Message box's row comes out of
-    // the table above it. On a terminal with no row to spare the table keeps
-    // it and the two boxes sit one row apart: the operator can see that and
-    // undo it by resizing, whereas a clipped last line of the kickoff copy
-    // just looks like the copy ends there.
+  it('keeps the command box inside the pane whose keys it takes, in every view', async () => {
+    // The box used to sit in a row of its own beneath every pane, which is why
+    // it could take keys while another pane wore the marker. It is a child of
+    // the pane it writes to now, and which pane that is differs by view, so
+    // what has to hold is that it lands in the right one through a view change,
+    // a split, each zoom that takes the left pane off screen, and the width
+    // that replaces the split with a floating pane.
+    const testRenderer = await createTestRenderer({width: 140, height: 24});
+    const controller = splitController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    /** The command box is the foot of `paneId`, inside that pane's frame. */
+    const expectCommandInside = (paneId: string): void => {
+      const pane = testRenderer.renderer.root.findDescendantById(paneId);
+      const command = testRenderer.renderer.root.findDescendantById('command-input-box');
+      if (pane === undefined || command === undefined)
+        throw new Error(`${paneId} geometry was missing`);
+      expect({pane: paneId, onScreen: pane.visible && command.visible}).toEqual({
+        pane: paneId,
+        onScreen: true,
+      });
+      expect({pane: paneId, insideLeft: command.x > pane.x}).toEqual({
+        pane: paneId,
+        insideLeft: true,
+      });
+      expect({
+        pane: paneId,
+        insideRight: command.x + command.width < pane.x + pane.width,
+      }).toEqual({pane: paneId, insideRight: true});
+      // The pane's own bottom border is the row under the box, so the box ends
+      // one row short of the pane. That is also why the two columns of the
+      // landing view line up without a row being spent on it.
+      expect({pane: paneId, foot: command.y + command.height}).toEqual({
+        pane: paneId,
+        foot: pane.y + pane.height - 1,
+      });
+    };
+
+    // A round: the transcript.
+    await frameAfter(testRenderer);
+    expectCommandInside('viewport');
+
+    // A split: still the left pane, not the one the split opened on the right.
+    await controller.openPane('perf');
+    await frameAfter(testRenderer);
+    const rightPane = testRenderer.renderer.root.findDescendantById('right-pane');
+    const command = testRenderer.renderer.root.findDescendantById('command-input-box');
+    if (rightPane === undefined || command === undefined)
+      throw new Error('split geometry was missing');
+    expect(rightPane.visible).toBe(true);
+    expect(command.x).toBeLessThan(rightPane.x);
+    expectCommandInside('viewport');
+
+    // Zoomed onto the visualization, which is now the only pane on screen.
+    controller.focusPane('right');
+    testRenderer.mockInput.pressKey('F4');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.zoomedPane).toBe('performance');
+    expectCommandInside('right-pane');
+
+    // Zoomed onto the agents pane, whose contents are rebuilt on every repaint:
+    // the box has to survive the repaint, not only the first frame after it.
+    testRenderer.mockInput.pressKey('F4');
+    controller.closePane();
+    controller.focusRound('agents');
+    testRenderer.mockInput.pressKey('F4');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.zoomedPane).toBe('agents');
+    expectCommandInside('agent-map');
+    controller.publish({
+      ...controller.state,
+      core: {...controller.state.core, status: 'completed'},
+    });
+    await frameAfter(testRenderer);
+    expectCommandInside('agent-map');
+
+    // Too narrow to split: the visualization becomes a floating pane over the
+    // round, the transcript keeps the box, and the floating pane keeps clear of
+    // it rather than covering the surface still taking the keystrokes.
+    testRenderer.mockInput.pressKey('F4');
+    await controller.openPane('perf');
+    testRenderer.renderer.resize(MIN_SPLIT_WIDTH - 1, 20);
+    const narrow = await frameAfter(testRenderer);
+    expect(narrow).toContain('best r7 1135 tok_s');
+    expectCommandInside('viewport');
+    const floating = testRenderer.renderer.root.findDescendantById('overlay');
+    const narrowCommand = testRenderer.renderer.root.findDescendantById('command-input-box');
+    if (floating === undefined || narrowCommand === undefined)
+      throw new Error('fallback geometry was missing');
+    expect(floating.visible).toBe(true);
+    expect(floating.y + floating.height).toBeLessThanOrEqual(narrowCommand.y);
+
+    // The landing view: the table, at a width that carries the chat beside it.
+    testRenderer.renderer.resize(140, 24);
+    controller.closePane();
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+    expectCommandInside('experiment-log');
+
+    // Through all of it, the box never claimed a focus of its own: it takes no
+    // marker, and exactly one pane wears one.
+    expect(markedPanes(paneBorders(testRenderer))).toHaveLength(1);
+    expect(markedPanes(paneBorders(testRenderer))).not.toContain('▸ Command');
+  });
+
+  it('keeps the short terminal both its landing rows and the box alignment', async () => {
+    // Alignment used to cost the table a row, so a terminal with none to spare
+    // gave the row back and let the two boxes sit one row apart. Each box now
+    // sits inside its own pane and the two panes are the same rectangle, so
+    // the boxes share a row because they are siblings rather than because a
+    // row was budgeted for it. That budget is what #556 measured, and it is
+    // gone: nothing is bought, so a short terminal has nothing to give up.
     const testRenderer = await createTestRenderer({width: 100, height: 16});
     const controller = kickoffController();
     const app = createOpenTuiApp(testRenderer.renderer, controller);
@@ -3466,10 +3584,10 @@ describe('theming', () => {
     expect(short).toContain('This activity becomes');
     expect(short).toMatch(/[╭┏][─━]\s*▸?\s*Command/);
     expect(short).toContain('Type /help for commands');
-    // The cost, stated: the boxes are one row apart rather than level.
-    expect(bottomRows().command).toBe(bottomRows().message + 1);
+    // Level at the height that used to have to choose.
+    expect(bottomRows().command).toBe(bottomRows().message);
 
-    // One more row and the alignment is affordable again, copy still whole.
+    // And at the height that could afford it before, copy still whole.
     testRenderer.renderer.resize(100, 17);
     const taller = await frameAfter(testRenderer);
     expect(taller).toContain('This activity becomes');
@@ -3506,7 +3624,14 @@ describe('theming', () => {
     controller.focusPane('left');
     await frameAfter(testRenderer);
     await testRenderer.mockInput.typeText('/');
-    await testRenderer.waitForFrame(value => value.includes('/pause'));
+    // Not `waitForFrame(text.includes('/pause'))`: the chat's own list is still
+    // open beside this one and offers the same commands, so the text can match
+    // on a frame the command list has not been laid out in yet. Wait for the
+    // list itself to have taken a row per match.
+    await testRenderer.waitForFrame(() => {
+      const list = testRenderer.renderer.root.findDescendantById('command-input-suggestions');
+      return list?.visible === true && list.height > 2;
+    });
     const command = boxTopUnder('command-input-suggestions', 'command-input-box');
     expect(command.menu).toBe(command.box);
   });
@@ -3705,7 +3830,7 @@ describe('theming', () => {
     expect(controller.chatSubmissions).toEqual(['draft survives the layout change']);
   });
 
-  it('lets the docked chat span the table and command surface', async () => {
+  it('gives the docked chat and the table the same rectangle, each holding its own input', async () => {
     const testRenderer = await createTestRenderer({width: 140, height: 20});
     const controller = logController();
     const app = createOpenTuiApp(testRenderer.renderer, controller);
@@ -3714,14 +3839,25 @@ describe('theming', () => {
     await frameAfter(testRenderer);
 
     const chatPane = testRenderer.renderer.root.findDescendantById('chat-pane');
-    const workspace = testRenderer.renderer.root.findDescendantById('workspace');
+    const table = testRenderer.renderer.root.findDescendantById('experiment-log');
     const composer = testRenderer.renderer.root.findDescendantById('chat-dock-composer-box');
-    if (chatPane === undefined || workspace === undefined || composer === undefined)
+    const command = testRenderer.renderer.root.findDescendantById('command-input-box');
+    if (
+      chatPane === undefined ||
+      table === undefined ||
+      composer === undefined ||
+      command === undefined
+    )
       throw new Error('landing layout was missing');
-    expect(chatPane.y).toBe(workspace.y);
-    expect(chatPane.y + chatPane.height).toBe(workspace.y + workspace.height);
+    // Two columns of one row, so they start and end on the same lines. This is
+    // what makes the boxes below line up without a row being budgeted for it.
+    expect(chatPane.y).toBe(table.y);
+    expect(chatPane.y + chatPane.height).toBe(table.y + table.height);
+    // Each input sits within the frame of the pane it writes to.
     expect(composer.x).toBeGreaterThan(chatPane.x);
     expect(composer.x + composer.width).toBeLessThan(chatPane.x + chatPane.width);
+    expect(command.x).toBeGreaterThan(table.x);
+    expect(command.x + command.width).toBeLessThan(table.x + table.width);
   });
 
   it('raises the command list out of the command input, clear of the chat', async () => {

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -19,7 +19,7 @@ import {AgentMapView} from './agent-map.js';
 import {fillLayer} from './box-fill.js';
 import {createChatDraft} from './chat-composer.js';
 import {ChatOverlayView} from './chat-overlay.js';
-import {ChatPaneView, chatDockFits, chatPaneWidth, commandColumnInset} from './chat-pane.js';
+import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
 import {RendererSelectionClipboard, type SelectionClipboard} from './clipboard.js';
 import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
@@ -198,17 +198,12 @@ export function createOpenTuiApp(
     verticalScrollbarOptions: {showArrows: true},
     onMouseUp: focusTranscript,
   });
+  // Every content pane is a column of this row, the chat included. Each of them
+  // owns whatever input writes to it, so two panes side by side are the same
+  // rectangle and their boxes share a bottom edge because they are siblings
+  // rather than because a row was budgeted to line them up.
   const main = new BoxRenderable(renderer, {
     id: 'main',
-    width: '100%',
-    flexGrow: 1,
-    flexDirection: 'row',
-  });
-  // The chat is a sibling of the entire workspace column, not just its
-  // transcript row. Its composer therefore remains inside the chat border and
-  // the pane spans the same height as the table plus command surface.
-  const body = new BoxRenderable(renderer, {
-    id: 'body',
     width: '100%',
     flexGrow: 1,
     flexDirection: 'row',
@@ -282,19 +277,18 @@ export function createOpenTuiApp(
     theme,
     () => controller.focusPane('left'),
   );
-  const bottom = new BoxRenderable(renderer, {
-    id: 'bottom',
-    width: '100%',
-    flexShrink: 0,
-    flexDirection: 'column',
-    alignItems: 'stretch',
-  });
-  const commandColumn = new BoxRenderable(renderer, {
-    id: 'command-column',
-    flexGrow: 1,
-    flexShrink: 0,
-    flexDirection: 'column',
-  });
+  /**
+   * Moves the command box, and the list that completes it, into one pane.
+   *
+   * Both go straight into the pane rather than into a column of their own, the
+   * way the chat pane holds its own composer and menu: the list is positioned
+   * against the bottom of whatever contains it, and a wrapper sized to its
+   * contents leaves the list no room to open upwards into.
+   */
+  const hostCommandSurface = (pane: BoxRenderable): void => {
+    pane.add(commandInput.suggestions);
+    pane.add(commandInput.box);
+  };
 
   // A slash command and a key toggle the same prompt: the controller routes the
   // request, the transcript decides which prompt it applies to.
@@ -305,6 +299,10 @@ export function createOpenTuiApp(
   // fixed activity row. Activity stays outside scrolling content, so a new
   // turn can change scroll height without moving the line.
   transcriptFrame.add(conversationActivityBar.output);
+  // The chat is the leftmost column of the same row as the table it discusses,
+  // so both panes end on the same line and each keeps its own input inside its
+  // own frame.
+  main.add(chatPane.output);
   // The rounds rail is the left edge of the round view; the agents graph and
   // transcript follow to its right, so drilling deeper reads left to right.
   main.add(roundRail.output);
@@ -314,20 +312,20 @@ export function createOpenTuiApp(
   // landing view, not a dialog.
   main.add(experimentLog.output);
   main.add(rightPane.output);
-  commandColumn.add(help);
-  // Absolute inside the command column rather than the root, so the list rises
-  // out of the input it belongs to instead of across the chat beside it.
-  commandColumn.add(commandInput.suggestions);
-  commandColumn.add(commandInput.box);
-  bottom.add(commandColumn);
+  // The pane the command box is currently inside. The first frame is drawn
+  // before any experiment log arrives, so the round view's transcript owns it
+  // until `render` says otherwise.
+  let commandHost: BoxRenderable = transcriptFrame;
+  hostCommandSurface(commandHost);
   root.add(headerFrame);
   root.add(errorBanner.output);
-  body.add(chatPane.output);
   workspace.add(main);
   workspace.add(todoStrip.output);
-  workspace.add(bottom);
-  body.add(workspace);
-  root.add(body);
+  // The key-help line stays the width of the screen and under every pane. Inside
+  // one of them it would be cut to that pane's columns, and a binding that has
+  // been truncated away is a binding nobody has.
+  workspace.add(help);
+  root.add(workspace);
   root.add(overlay.scrim);
   root.add(overlay.output);
   root.add(themePicker.output);
@@ -447,14 +445,16 @@ export function createOpenTuiApp(
       // previous frame's height and leaves them a row long or short (clipping
       // the selected late round, the overflow indicator, or a graph node) until
       // the next paint.
+      //
+      // The command box is a column inside one of those panes now rather than a
+      // band under them, so it takes no rows off this budget.
       const mainRows = Math.max(
         0,
         renderer.terminalHeight -
           headerFrame.height -
           errorHeight -
           todoStripHeight(state) -
-          help.height -
-          commandInput.box.height,
+          help.height,
       );
       agentMap.render(
         state,
@@ -489,13 +489,7 @@ export function createOpenTuiApp(
     // The rounds rail is a column inside the main row, not a strip above it, so
     // only the header and the banner take rows off the top.
     const above = headerFrame.height + rowsOn(errorBanner.output);
-    const belowRows = rowsOn(todoStrip.output) + help.height + commandInput.box.height;
-    // Taken from the same budget the main area draws from, so the decision and
-    // the consequence cannot disagree.
-    const commandInset = commandColumnInset(
-      showChatPane,
-      renderer.terminalHeight - above - belowRows,
-    );
+    const belowRows = rowsOn(todoStrip.output) + help.height;
     // Match the chat to the left pane's rectangle so it sits beside the
     // visualization instead of over it.
     if (showSplit) {
@@ -503,15 +497,41 @@ export function createOpenTuiApp(
         left: 1,
         width: leftWidth - 2,
         top: above,
-        height: renderer.terminalHeight - above - belowRows - commandInset,
+        height: renderer.terminalHeight - above - belowRows,
       });
     } else {
       chat.setPaneBounds(null);
     }
     chatPane.render(state, showChatPane, chatWidth);
     const chatInputFocused = showChatPane && state.layout.focus === 'chat';
-    commandColumn.visible = zoomedPane !== 'chat';
-    bottom.paddingBottom = commandInset;
+    // A zoomed chat already has a composer inside it, so the command box stands
+    // down rather than following the zoom into a pane that does not want it.
+    // The key-help line goes with it, the way it did when the two shared a row.
+    const showCommand = zoomedPane !== 'chat';
+    commandInput.box.visible = showCommand;
+    if (!showCommand) commandInput.suggestions.visible = false;
+    help.visible = showCommand;
+    // Which pane the command box writes to, and therefore which one it is drawn
+    // inside. Clicking it asks for `left` focus, so it belongs to the pane that
+    // focus names: the log on the landing view and the transcript inside a
+    // round. Zoom is the only thing that can take that pane off screen, and then
+    // the box follows the one pane that is left. The narrow-width fallback needs
+    // no case of its own: it draws the visualization through the overlay and
+    // leaves the pane underneath on screen, still holding the box.
+    const nextHost =
+      zoomedPane === 'performance'
+        ? rightPane.output
+        : zoomedPane === 'agents'
+          ? agentMap.output
+          : showLog
+            ? experimentLog.output
+            : transcriptFrame;
+    if (nextHost !== commandHost) {
+      commandHost.remove(commandInput.suggestions);
+      commandHost.remove(commandInput.box);
+      hostCommandSurface(nextHost);
+      commandHost = nextHost;
+    }
     // The command list completes the box it belongs to, and on this view that
     // box cannot open a chat that is already beside it.
     commandInput.setCommandContext({chatDocked: showChatPane});

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -42,38 +42,6 @@ export function chatDockFits(terminalWidth: number, rightPaneWidth = 0): boolean
 }
 
 /**
- * The row the command column gives up so its box shares a bottom edge with the
- * docked Message box. The pane is bordered and the column is not, so the pane
- * spends the terminal's last row on its own bottom border and the column has to
- * skip the same row to end level with it.
- */
-const DOCK_ALIGNMENT_ROWS = 1;
-
-/**
- * Rows the landing table keeps for itself before presentation may spend one.
- * Nine is the kickoff panel: two borders around the round's title, the phase
- * list, and the lines saying what the round produces.
- */
-const MIN_LANDING_ROWS = 9;
-
-/**
- * Rows the command column insets itself by so the Command and Message boxes
- * line up beneath a docked chat.
- *
- * The row is not free: it comes out of the table above it. A terminal short
- * enough that the table would lose a line keeps the row instead and lets the
- * two boxes sit one row apart. Alignment is presentation and the table is the
- * view, so a short terminal degrades in the direction the operator can see and
- * undo (resize) rather than silently clipping the content.
- *
- * `landingRows` is what the table has before this inset is taken.
- */
-export function commandColumnInset(chatDocked: boolean, landingRows: number): number {
-  if (!chatDocked) return 0;
-  return landingRows - DOCK_ALIGNMENT_ROWS >= MIN_LANDING_ROWS ? DOCK_ALIGNMENT_ROWS : 0;
-}
-
-/**
  * Width in columns for the docked chat. It asks for the columns left over once
  * the table has enough for its claim, so a wide terminal loses no table column
  * to the chat; where there is no such surplus it still takes its readable

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -43,13 +43,13 @@ export function createCommandInputPanel(
     height: 3,
     width: '100%',
     border: true,
-    // The focus treatment names the one pane the navigation keys are on. The
-    // command box is shared by every pane in the column rather than being one of
-    // them, so it never wears that treatment: resting frame, resting colour, and
-    // the gutter cell where a pane would put its marker. A second lit border
-    // made the marked pane ambiguous, which is the whole complaint behind #433.
-    // It still takes the title from `focus.ts` so its label sits at the same
-    // column as the panes it shares the column with.
+    // The focus treatment names the one pane the navigation keys are on. This
+    // box is drawn inside that pane rather than being one, so it never wears
+    // the treatment: resting frame, resting colour, and the gutter cell where a
+    // pane would put its marker. A second lit border made the marked pane
+    // ambiguous, which is the whole complaint behind #433. It still takes the
+    // title from `focus.ts` so its label sits at the same column as the pane
+    // holding it, and as the chat's `Message` box across the landing view.
     borderStyle: paneBorderStyle(false),
     borderColor: paneBorderColor(theme, false),
     title: paneTitle(COMMAND_TITLE, false),

--- a/clients/tui/src/ui/focus.ts
+++ b/clients/tui/src/ui/focus.ts
@@ -16,12 +16,12 @@ import type {Theme} from './theme.js';
  * is that authority, and each pane compares its own `PaneId` against it. A
  * surface that is not a pane never wears the treatment, and neither does a box
  * inside a pane that already does: two lit frames, one nested in the other, are
- * as ambiguous as two lit panes side by side. The chat's `Message` composer is
- * that case, and the command box is the other worth naming, since it sits under
- * the pane column and is shared by every pane in it rather than being one of
- * them. Both take the resting title, frame and colour and no focused variant,
- * and call in only to keep their labels at the same column as the panes around
- * them. Lighting the command box made the marked pane ambiguous, which is #433.
+ * as ambiguous as two lit panes side by side. Both boxes that take typed text
+ * are that case: the chat's `Message` composer sits inside the chat pane, and
+ * the command box sits inside the pane whose keys it takes. Both take the
+ * resting title, frame and colour and no focused variant, and call in only to
+ * keep their labels at the same column as the pane they are drawn in. Lighting
+ * the command box made the marked pane ambiguous, which is #433.
  */
 
 /** Marks the title of the pane that currently takes keys. */

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -24,6 +24,20 @@ const LEFT_SHARE = 0.15;
 const HEIGHT_SHARE = 0.6;
 const TOP_SHARE = 0.18;
 
+/**
+ * Rows at the foot of the screen the box never reaches: the command input, the
+ * bottom border of the pane holding it, and the key-help line under that pane.
+ *
+ * Floating over pane content is what an overlay is for. The command input is
+ * the exception, because it keeps taking keystrokes while the box is open, so
+ * covering it would hide the surface the operator is still typing into. The
+ * share above only reaches these rows on a short terminal.
+ */
+const COMMAND_SURFACE_ROWS = 5;
+
+/** Two borders, the hint row, and one line of content worth opening for. */
+const MIN_ROWS = 4;
+
 function borderFor(theme: Theme, kind: OverlayKind): string {
   if (kind === 'help') return theme.success;
   if (kind === 'error') return theme.error;
@@ -197,8 +211,12 @@ export class OverlayView {
     const rows = this.renderer.terminalHeight;
     this.output.width = Math.round(columns * WIDTH_SHARE);
     this.output.left = Math.round(columns * LEFT_SHARE);
-    this.output.height = Math.round(rows * HEIGHT_SHARE);
-    this.output.top = Math.round(rows * TOP_SHARE);
+    const top = Math.round(rows * TOP_SHARE);
+    this.output.top = top;
+    this.output.height = Math.max(
+      MIN_ROWS,
+      Math.min(Math.round(rows * HEIGHT_SHARE), rows - COMMAND_SURFACE_ROWS - top),
+    );
   }
 
   #clear(): void {

--- a/docs/contributing/tui-conventions.md
+++ b/docs/contributing/tui-conventions.md
@@ -72,7 +72,10 @@ were shipped wrong once:
 - A box nested inside a pane does not repeat the treatment. The chat's `Message`
   composer sits inside the chat pane, so the pane frame carries the marker and
   the composer keeps the resting frame. Which box holds the cursor is said by
-  the cursor and by the hint line under it.
+  the cursor and by the hint line under it. The `Command` box is the same case:
+  it is drawn inside the pane whose keys it takes, which is the log on the
+  landing view, the transcript inside a round, and whichever single pane a zoom
+  has left on screen.
 - A surface that takes the keys is a pane, whatever its shape. The expanded todo
   list is a strip rather than a column, but `keybindings.ts` routes the arrow
   keys to it, so it is a `PaneId` and the pane it opened over goes back to rest.
@@ -100,8 +103,12 @@ than the row saved.
 ### Bindings are visible
 
 The active bindings are shown on the key-help line at the bottom of the screen,
-just above the command input, and that line changes with whichever surface is in
-front. A binding a person has to already know is a binding they do not have.
+under every pane, and that line changes with whichever surface is in front. A
+binding a person has to already know is a binding they do not have.
+
+The line keeps the full width of the screen rather than moving inside a pane
+with the command input. A pane is narrower than the terminal, and a row of
+bindings truncated to fit one is a row whose last bindings nobody has.
 
 ### A fill lives on an inner box
 


### PR DESCRIPTION
## Problem

Closes #568.

The command input sat outside every pane, in a row of its own beneath them, and
took keys regardless of which pane was focused. #572 made it permanently neutral
so it stops claiming a focus it does not own; that labels the ambiguity rather
than removing it. Structurally the input belongs to the pane it acts on.


The bottom eight rows of the landing view, 150x40, dark theme, full width.

**Before (`main`)** — the Experiments pane closes above the key-help line and the
Command box floats below it on bare canvas, with no bottom edge on the right.

**After** — the Command box sits two columns inside the pane border, the pane
closes beneath it level with the chat pane's floor, and key-help moves full width
below both.

The containment is the claim here; the cell-level pin that used to sit in this
paragraph named `elevatedSurface`, a token #652 deletes, and was measured against
a different base. The regression test walks all five views and asserts the box is
the foot of the expected pane, which is the property rather than one cell.
Canvas share across the crop drops 48.96% to 24.30%, re-measured on the 2026-09-10 frames. The earlier 40.75% to 12.83% was measured against a different base; same direction, roughly halved.

Two notes for review. The Message and Command boxes are already level on `main`
at this size, since `commandColumnInset` bought that, so the visible delta here
is containment and the shared bottom edge, not alignment. And this branch is
stacked on #647, so its transcript entries already show the divider style; that
is stack content, not a capture artifact.

### Before / after

The bottom rows of the landing view, 150x40, dark, full width. Base is #647.

**Before** — the command box floats below the focused Experiments pane, whose border closes
above the key-help line.

![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr648-input-before-0910.png)

**After** — the box sits inside the pane border, and key-help is last.

![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr648-input-after-0910.png)

## Solution

The issue offers two structures: reparent on every view change, or one owning
container whose title and content change per view. **Reparent**, because the
container does not actually remove the reparent. It absorbs the landing/round
swap, since the log and transcript are never on screen together, but not F4 zoom
onto the visualization or onto the agents pane, where the left pane leaves the
screen entirely and a different pane holds every key. It would still need a
reparent for those, and it cannot be both panes at once in the `/perf` split,
while costing the hoist of three panes' frames, titles and focus calls into
`app.ts`. The reparent is smaller and more correct.

### Architecture

- `body` and `bottom` deleted; `workspace` goes straight into `root`.
- `chatPane` moved from a sibling of `workspace` into `main` as its leftmost
  column, which is what makes the Message and Command boxes share a bottom edge
  structurally rather than by a budgeted row.
- `commandColumn` deleted. The input's box and suggestions go directly into the
  host pane, matching how `chat-pane.ts` already holds its composer and menu. The
  wrapper was also actively harmful: sized to its own contents, it left the
  completion list no room to open upward.
- Host selector: `performance` zoom to `rightPane`, `agents` zoom to `agentMap`,
  else the log on landing, else the transcript.
- `AgentMapView` gained a `#content` box. Its `#clear()` destroys every child of
  `output` per repaint, which was destroying the command input after a zoom.
- key-help stays outside the panes, full width. Inside one it truncates.

## Verification

### Correctness properties

- The command box is the foot of the pane whose keys it takes, in all five views.
- Exactly one pane carries the focus treatment and it is never Command (#572).
- The Message and Command boxes stay level at every terminal height.

### Testing

`pnpm check:ts`, `pnpm check:ts-architecture`, `pnpm check:clients` all clean.
`pnpm test:clients`: 690 TUI pass, 0 fail.

New regression test walks landing, round, `/perf`, all three F4 zooms and the
narrow fallback, asserting the box is the foot of the expected pane; it fails at
the merge base on the first state.

**Two of #556's six geometry assertions moved, both because the mechanism they
measured is gone.** "gives the short terminal its landing rows back" priced a
tradeoff: alignment cost the table a row, so a 100x16 terminal gave alignment up.
The boxes are siblings in one rectangle now, so alignment is free and there is no
budget to trade; the content assertions it also made are unchanged and still
pass. The second asserted the Command frame starts at the Experiments frame's
column, which is no longer true of a child of that pane. The other four pass
untouched.

A third, unrelated test was waiting on `/pause` text that the chat's own open
list also emits, so it could pass before the command list was laid out. That was
a latent race; it now waits on the list's geometry.

### Limitations

- Verified through tmux text capture; screenshots follow separately.
- Clicking the command box calls `focusPane('left')` even while it is hosted in
  the zoomed Performance pane, so focus can end up `left` under a `performance`
  zoom. Behaviour is unchanged from before this PR, but the new nesting makes it
  easier to reach.

### Follow-up commit: clear the hidden-count row with the graph

Moving every agent-pane child into `#content` missed one. The `↑ n` row, drawn when a
round's stacked attempts do not all fit, was still added to `output`, which `#clear()`
no longer empties. Every redraw of such a round therefore added another `↑ n` row and
pushed the graph up, and any state change while a stacked round was on screen was enough
to trigger it. On `main` this cannot happen, because `#clear()` there empties all of
`output`, so the bug is introduced by this PR and fixed inside it.

One call site changes (`this.output.add` becomes `this.#content.add`), which puts the row
back under `#clear`'s ownership and leaves it drawn where it already was. A regression test
renders a stacked round three times with a fresh state object each pass and asserts exactly
one `↑ n` row and a constant child count; on the previous commit it sees three rows.

No frame for this one: no shipped fixture stacks enough attempts to make the row appear, so
the test is the evidence rather than a screenshot.





