### PR TITLE
fix(tui): solve the modal scrim strength per theme instead of a fixed opacity

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -178,7 +178,11 @@ modal they used before panes existed. That modal is the same surface as the
 pane, so it keeps the pane's title and its focus marker rather than reading as a
 generic dialog. The layout re-flows on resize in either direction.
 
-`/help`, `/theme`, and errors stay modal.
+`/help`, `/theme`, and errors stay modal. While any of them is open, a scrim
+dims the entire screen behind it, so the modal is the only surface left at full
+contrast and the operator can tell where a keystroke will land. The scrim is a
+translucent paint on an absolutely positioned box that joins no flex row: the
+background keeps every character where it was, and closing restores it exactly.
 
 ### Experiment chat
 
@@ -278,6 +282,11 @@ the Markdown palette are derived from that core, and each derived foreground is
 pushed toward the nearest extreme until it clears the theme's `minContrast`
 against the surface it actually sits on. The `dark` theme additionally pins its
 derived values to the original literals so the baseline is byte-identical.
+The modal scrim is derived the same way: it pulls the background toward the
+theme's own `canvas`, and its strength is solved per theme so body text lands on
+WCAG's large-text floor whatever it started from. One fixed blend cannot do
+that, because a blend deep enough to recede Solarized Dark's 5.6:1 body text
+leaves High Contrast Dark's 21:1 fully readable.
 Status meaning never depends on color: agent phases carry a marker glyph and
 the spelled-out status, todos carry a per-status marker, and only the running
 round shows elapsed time.

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -77,8 +77,10 @@ import {
   contrastRatio,
   ensureContrast,
   listThemes,
+  mix,
   resolveTheme,
   SUBTLE_TEXT_MIN_CONTRAST,
+  scrim,
   THEME_NAMES,
   type ThemeName,
 } from './theme.js';
@@ -5854,6 +5856,199 @@ function clipboardReturning(
       return result;
     },
   };
+}
+
+describe('modal scrim', () => {
+  const helpOverlay = {kind: 'help' as const, content: 'Available commands'};
+
+  function behindTheModal(themeName: ThemeName): SessionState {
+    const initial = initialSessionState(themeName);
+    return {
+      ...initial,
+      core: {
+        ...initial.core,
+        status: 'running',
+        transcript: [
+          {id: 'behind', kind: 'assistant', label: 'implementer', content: 'transcript behind it'},
+        ],
+      },
+    };
+  }
+
+  it.each(
+    THEME_NAMES.map(name => [name] as const),
+  )('%s dims every cell around the modal and leaves the modal at full contrast', async (themeName: ThemeName) => {
+    const theme = resolveTheme(themeName);
+    const {color, strength} = scrim(theme);
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(behindTheModal(themeName));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('transcript behind it'));
+    await testRenderer.waitForVisualIdle();
+    const closed = frameCells(testRenderer);
+    const headerBefore = requireSpanColors(testRenderer, 'VibeSys');
+
+    controller.publish({...controller.state, overlay: helpOverlay});
+    await testRenderer.waitForFrame(value => value.includes('Available commands'));
+    await testRenderer.waitForVisualIdle();
+    const open = frameCells(testRenderer);
+
+    const box = boxOf(testRenderer, 'overlay');
+    // Every band around the modal, so a scrim confined to the box region
+    // fails here rather than passing on the rows it happens to cover.
+    const dimmed = {above: 0, below: 0, left: 0, right: 0};
+    const moved: number[] = [];
+    for (const [row, column, before, after] of cellsOutside(closed, open, box)) {
+      if (before.char !== after.char) {
+        moved.push(row);
+        continue;
+      }
+      // A blank cell has no visible foreground, and the scrim claims it.
+      if (before.char !== ' ') {
+        expect(channelDistance(after.fg, mix(before.fg, color, strength))).toBeLessThanOrEqual(1);
+      }
+      expect(channelDistance(after.bg, mix(before.bg, color, strength))).toBeLessThanOrEqual(1);
+      if (after.fg === before.fg && after.bg === before.bg) continue;
+      if (row < box.y) dimmed.above += 1;
+      else if (row >= box.y + box.height) dimmed.below += 1;
+      else if (column < box.x) dimmed.left += 1;
+      else dimmed.right += 1;
+    }
+    expect(dimmed.above).toBeGreaterThan(0);
+    expect(dimmed.below).toBeGreaterThan(0);
+    expect(dimmed.left).toBeGreaterThan(0);
+    expect(dimmed.right).toBeGreaterThan(0);
+    // The header gains its Escape hint, so its own rows are allowed to change
+    // characters. Nothing else outside the box moves: the scrim repaints cells,
+    // it does not lay anything out. The header sits in its own housing since
+    // #571, so its rows are read off the frame rather than assumed to be row 0.
+    const headerFrame = boxOf(testRenderer, 'header-frame');
+    const headerRows = new Set(
+      Array.from({length: headerFrame.height}, (_, offset) => headerFrame.y + offset),
+    );
+    expect(moved.filter(row => !headerRows.has(row))).toEqual([]);
+
+    const floor = themeName.startsWith('high-contrast') ? 7 : 4.5;
+    const modalBody = requireSpanColors(testRenderer, 'Available commands');
+    expect(modalBody).toEqual({fg: theme.textPrimary, bg: theme.elevatedSurface});
+    expect(contrastRatio(modalBody.fg, modalBody.bg)).toBeGreaterThanOrEqual(floor);
+    // Background text recedes below the floor the theme guarantees, and stays
+    // above the point where the run behind the modal would be erased.
+    const headerAfter = requireSpanColors(testRenderer, 'VibeSys');
+    expect(contrastRatio(headerBefore.fg, headerBefore.bg)).toBeGreaterThanOrEqual(floor);
+    const recessed = contrastRatio(headerAfter.fg, headerAfter.bg);
+    expect(recessed).toBeLessThan(floor);
+    expect(recessed).toBeGreaterThanOrEqual(1.9);
+  });
+
+  it('restores the frame exactly when the modal closes', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(behindTheModal('dark'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('transcript behind it'));
+    await testRenderer.waitForVisualIdle();
+    const before = frameCells(testRenderer);
+
+    controller.publish({...controller.state, overlay: helpOverlay});
+    await testRenderer.waitForFrame(value => value.includes('Available commands'));
+    await testRenderer.waitForVisualIdle();
+    controller.publish({...controller.state, overlay: null});
+    await testRenderer.waitForFrame(value => !value.includes('Available commands'));
+    await testRenderer.waitForVisualIdle();
+
+    expect(frameCells(testRenderer)).toEqual(before);
+  });
+
+  it('raises one scrim under whichever modals are open, and never over them', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(behindTheModal('dark'));
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('transcript behind it'));
+    const scrimBox = boxOf(testRenderer, 'overlay-scrim');
+    // One scrim under every modal: two of them stacked must not dim each other,
+    // and a command ack over the chat still needs the background held down.
+    expect(scrimBox.zIndex).toBeLessThan(boxOf(testRenderer, 'chat-overlay').zIndex);
+    expect(scrimBox.zIndex).toBeLessThan(boxOf(testRenderer, 'overlay').zIndex);
+    expect(scrimBox.zIndex).toBeLessThan(boxOf(testRenderer, 'theme-picker').zIndex);
+    expect(scrimBox.visible).toBe(false);
+
+    for (const modal of [
+      {chatOpen: true},
+      {overlay: helpOverlay},
+      {themePicker: {selected: 'dark' as const}},
+    ]) {
+      controller.publish({...behindTheModal('dark'), ...modal});
+      await testRenderer.flush();
+      expect(scrimBox.visible).toBe(true);
+      // The whole terminal, so the dim never stops at the pane the modal is in.
+      expect([scrimBox.x, scrimBox.y, scrimBox.width, scrimBox.height]).toEqual([0, 0, 100, 24]);
+      controller.publish(behindTheModal('dark'));
+      await testRenderer.flush();
+      expect(scrimBox.visible).toBe(false);
+    }
+  });
+});
+
+/** The renderable behind a screen region, for asserting what a scrim covers. */
+function boxOf(testRenderer: TestRendererSetup, id: string): Renderable {
+  const found = testRenderer.renderer.root.findDescendantById(id);
+  if (found === undefined) throw new Error(`no renderable with id ${id}`);
+  return found;
+}
+
+/** The colors of the span carrying `needle`, which the caller expects on screen. */
+function requireSpanColors(
+  testRenderer: TestRendererSetup,
+  needle: string,
+): {fg: string; bg: string} {
+  const colors = spanColors(testRenderer, needle);
+  if (colors === undefined) throw new Error(`no rendered span contains ${needle}`);
+  return colors;
+}
+
+/** The captured frame as a grid of cells, for asserting what a scrim repaints. */
+function frameCells(
+  testRenderer: TestRendererSetup,
+): Array<Array<{char: string; fg: string; bg: string}>> {
+  return testRenderer.captureSpans().lines.map(line => {
+    const row: Array<{char: string; fg: string; bg: string}> = [];
+    for (const span of line.spans) {
+      const fg = rgbToHex(span.fg).toLowerCase();
+      const bg = rgbToHex(span.bg).toLowerCase();
+      for (const char of span.text) row.push({char, fg, bg});
+    }
+    return row;
+  });
+}
+
+type Cell = {char: string; fg: string; bg: string};
+
+/** Every screen cell the modal does not cover, paired across the two frames. */
+function* cellsOutside(
+  closed: Cell[][],
+  open: Cell[][],
+  box: Renderable,
+): Generator<[number, number, Cell, Cell]> {
+  for (const [row, cells] of closed.entries()) {
+    for (const [column, before] of cells.entries()) {
+      const covered =
+        row >= box.y && row < box.y + box.height && column >= box.x && column < box.x + box.width;
+      const after = open[row]?.[column];
+      if (covered || after === undefined) continue;
+      yield [row, column, before, after];
+    }
+  }
+}
+
+/** The largest per-channel gap between two hex colors. */
+function channelDistance(left: string, right: string): number {
+  const channels = (hex: string): number[] =>
+    [1, 3, 5].map(at => Number.parseInt(hex.slice(at, at + 2), 16));
+  const [first, second] = [channels(left), channels(right)];
+  return Math.max(...first.map((value, index) => Math.abs(value - (second[index] ?? 0))));
 }
 
 class FakeController implements SessionController {

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -1,7 +1,7 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
 import {focusedPane, type RightPane, type SessionState} from '../session-model.js';
 import {applyPaneFocus} from './focus.js';
-import type {Theme} from './theme.js';
+import {scrim, type Theme} from './theme.js';
 
 type OverlayKind = NonNullable<SessionState['overlay']>['kind'];
 
@@ -64,8 +64,12 @@ export class OverlayView {
       position: 'absolute',
       width: '100%',
       height: '100%',
-      backgroundColor: theme.canvas,
-      opacity: 0.7,
+      // The dim is solved per theme rather than fixed: the themes do not start
+      // from the same contrast, so one blend deep enough to recede Solarized
+      // Dark's body text leaves High Contrast Dark's fully readable. `scrim`
+      // in theme.ts is the single place that derivation lives (#566).
+      backgroundColor: scrim(theme).color,
+      opacity: scrim(theme).strength,
       zIndex: 19,
       visible: false,
     });
@@ -122,7 +126,8 @@ export class OverlayView {
   applyTheme(theme: Theme): void {
     this.#theme = theme;
     this.output.backgroundColor = theme.elevatedSurface;
-    this.scrim.backgroundColor = theme.canvas;
+    this.scrim.backgroundColor = scrim(theme).color;
+    this.scrim.opacity = scrim(theme).strength;
     this.output.borderColor = borderFor(theme, this.#renderedKind ?? 'detail');
     this.#hint.fg = theme.textSubtle;
     this.#renderedKind = null;

--- a/clients/tui/src/ui/theme.test.ts
+++ b/clients/tui/src/ui/theme.test.ts
@@ -9,6 +9,7 @@ import {
   mix,
   relativeLuminance,
   resolveTheme,
+  scrim,
   THEME_NAMES,
   type Theme,
 } from './theme.js';
@@ -212,6 +213,46 @@ describe('semantic roles', () => {
       expect(dark.conversation.assistant.background).not.toBe(
         light.conversation.assistant.background,
       );
+    }
+  });
+});
+
+describe('modal scrim', () => {
+  const themes = listThemes();
+
+  it.each(
+    themes.map(theme => [theme.name, theme] as const),
+  )('%s recedes behind a modal without erasing what is behind it', (name: string, theme: Theme) => {
+    const {color, strength} = scrim(theme);
+    // The theme's own canvas, so the background fades into the surface it
+    // already sits on rather than toward a tone the palette never uses.
+    expect(color).toBe(theme.canvas);
+    expect(strength).toBeGreaterThan(0);
+    expect(strength).toBeLessThan(1);
+
+    const floor = name.startsWith('high-contrast') ? 7 : 4.5;
+    const recessed = contrastRatio(mix(theme.textPrimary, color, strength), color);
+    expect(contrastRatio(theme.textPrimary, theme.canvas)).toBeGreaterThanOrEqual(floor);
+    // Body text lands on WCAG's large-text floor whichever theme it started
+    // from: still recognizable, and well under the comfortable-reading floor
+    // the theme guarantees, which now belongs to the modal alone.
+    expect(recessed).toBeLessThanOrEqual(3);
+    expect(recessed).toBeGreaterThanOrEqual(2.5);
+    expect(recessed).toBeLessThan(floor);
+  });
+
+  it('solves a different strength per theme rather than reusing one blend', () => {
+    const strengths = themes.map(theme => scrim(theme).strength);
+    // Solarized Dark starts at 5.6:1 body text and High Contrast Dark at 21:1,
+    // so one blend cannot recede both. The spread is the point, not a defect.
+    expect(new Set(strengths).size).toBe(themes.length);
+    expect(Math.max(...strengths) - Math.min(...strengths)).toBeGreaterThan(0.2);
+  });
+
+  it('never leaves a modal fully transparent or the background erased', () => {
+    for (const theme of themes) {
+      expect(scrim(theme).strength).toBeGreaterThan(0.3);
+      expect(scrim(theme).strength).toBeLessThan(0.85);
     }
   });
 });

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -177,6 +177,54 @@ export function ensureContrast(foreground: string, background: string, minRatio:
   return candidate;
 }
 
+/**
+ * The dim a modal paints over everything behind it, as a colour and how far
+ * each background cell is pulled toward it. Applied by the renderer as an
+ * alpha blend over the finished frame, so it changes colour without moving a
+ * single cell.
+ */
+export interface Scrim {
+  /** Colour every background cell is pulled toward. */
+  color: string;
+  /** How far it is pulled: 0 leaves the frame alone, 1 replaces it. */
+  strength: number;
+}
+
+/**
+ * Contrast the scrim leaves between background text and what it sits on. WCAG's
+ * large-text floor: the run behind the modal stays recognizable, and the
+ * comfortable-reading floor each theme guarantees (4.5, or 7 on the
+ * high-contrast pair) is left to the modal, the one surface the scrim does not
+ * paint over.
+ */
+const SCRIM_RESIDUAL_CONTRAST = 3;
+
+/** A scrim that erases the background is a screen, not a dim. */
+const MAX_SCRIM_STRENGTH = 0.85;
+
+const SCRIM_STEPS = 100;
+
+/**
+ * Pulls the background toward the theme's own canvas, so it fades into the
+ * surface it already sits on instead of toward a blend the palette never uses.
+ * That darkens a dark theme and washes out a light one without an appearance
+ * branch, and it never invents a mid-tone a high-contrast palette excludes.
+ *
+ * The strength is solved per theme rather than fixed, because the themes do not
+ * start from the same contrast: one blend deep enough to recede Solarized
+ * Dark's 5.6:1 body text leaves High Contrast Dark's 21:1 fully readable.
+ * Solving for a residual lands every theme at the same recessed legibility.
+ */
+export function scrim(theme: Theme): Scrim {
+  const color = theme.canvas;
+  for (let step = 1; step <= SCRIM_STEPS; step += 1) {
+    const strength = (step / SCRIM_STEPS) * MAX_SCRIM_STRENGTH;
+    const faded = mix(theme.textPrimary, color, strength);
+    if (contrastRatio(faded, color) <= SCRIM_RESIDUAL_CONTRAST) return {color, strength};
+  }
+  return {color, strength: MAX_SCRIM_STRENGTH};
+}
+
 interface ThemeSpec {
   name: ThemeName;
   label: string;


### PR DESCRIPTION
> **Scope changed under review.** #634 merged as `3d2afe7` while this branch was
> open and now owns the scrim itself: `OverlayView` paints a full-screen box at
> zIndex 19, raised on the same predicate this branch had derived. The
> `ScrimView` module and the `app.ts` wiring this PR originally carried are
> redundant against it and are dropped rather than added a second time. What
> survives is the part #634 does not have: the per-theme strength derivation.
>
> Provenance: reopened from #639, position 4/5 of stack #649. Its old base #640
> is closed as superseded by #647; GitHub will not let a stacked PR change its
> base and `gh stack link` will not drop a member, so retargeting needed a fresh
> PR from the same branch. Base is #648.

## Problem

#634 paints `theme.canvas` at a fixed `opacity: 0.7` for all eight themes, and
the themes do not start from the same contrast. One blend deep enough to recede
Solarized Dark's 5.6:1 body text leaves High Contrast Dark's 21:1 fully
readable, so a single literal cannot serve both ends of the set.

Refs #566.

## Solution

`scrim(theme)` in `ui/theme.ts` solves the strength per theme for a fixed
residual against that theme's own `canvas`. Measured strengths run 0.374 to
0.655, and the binding theme is Solarized Dark, not the high-contrast pair.
`OverlayView` takes its background and opacity from the solver rather than from
the literal, so the dim has one place it is computed.

Pulling toward the theme's own `canvas` also means neither the light nor the
high-contrast palettes get a tone they exclude.

### Architecture

`ui/theme.ts` owns the derivation; `ui/overlay.ts` consumes it. No new module,
and `app.ts` is untouched: the predicate that decides when the scrim is raised
already lives there from #634.

### Before / after

`/help` open over a zoomed round-1 transcript, 150x40, dark, full window.
Re-shot 2026-09-10. Before is this PR's base #648 at `bd16a38`, showing #634's
fixed 0.7; after is this branch at `9d04ec7`, showing the derived strength. The
scrim strength is the only difference between the frames.

**Before**

![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr651-scrim-before-0910.png)

**After**

![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr651-scrim-after-0910.png)

Layout is character-for-character identical; only colour moves, which is the
point. The scrim is a translucent paint blended per cell, so opening a modal
shifts nothing. Sampled out of the written PNGs:

| cell | role | before, fixed 0.7 | after, derived |
| --- | --- | --- | --- |
| `1,2` ink | header accent `#22d3ee` | `#154f64` | `#165b71` |
| `1,24` ink | `textPrimary` `#e2e8f0` | `#4e5565` | `#5b6271` |
| `19,2` fill | analysis card `#202146` | `#141a33` | `#151b34` |
| `19,3` ink | analysis label `#b193f8` | `#3e3c67` | `#494474` |

Solving the blend toward `theme.canvas` from `textPrimary` gives alpha **0.701**
before and **0.640** after, against the 0.6375 the solver derives for dark.

**A note for anyone re-shooting this:** vs-snap's colour audit cannot pass on
this change. Every dimmed cell is a blend, so by construction it is not a
`theme.ts` colour and the audit reports it OFF-THEME against the nearest named
one (`! dominant foreground #5b6271 is not a theme colour`). Verify by reading
the PNGs and sampling named cells, not by the audit.

## Verification

### Correctness properties

- The scrim repaints cells and lays out nothing, so opening a modal moves no
  character outside the modal's rectangle.
- One scrim serves all three modals, so stacked modals never dim each other.
- Every theme keeps modal body text at its own contrast floor.

### Testing

`app.test.ts` asserts, for each of the eight themes, that every cell outside the
modal's rectangle is its own colour blended toward that theme's scrim, that
dimmed cells appear above, below, left and right of the box, that no character
outside the box moves, and that the modal's body keeps `textPrimary` on
`elevatedSurface`. Held against #634's fixed 0.7, **four of the eight fail**
those assertions: dark, light, solarized-dark and solarized-light.
`theme.test.ts` pins the derivation itself.

`pnpm check:ts`, `pnpm check:ts-architecture`, `pnpm check:clients`: clean.
`pnpm test:clients`: 0 fail; the TUI suite is 775 pass across 30 files.

### Known follow-up, inherited not introduced

The scrim does not rise for the narrow-terminal pane fallback: the predicate at
`app.ts:543` covers the three real modals only. An earlier revision of this
branch wired the fallback in, on the reasoning that it is a modal in everything
but name, and measuring it showed that erases the Agents and Transcript frames
rather than dimming them (`paneBorders` finds only `▸ Performance` with the
fallback open and the scrim raised). That predicate now belongs to #634, so this
is recorded as a real defect in the interaction rather than something this PR
changes.
