### PR TITLE
fix(tui): paint one background instead of a surface ladder

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -270,11 +270,17 @@ the input still runs on its own Enter. `/theme <name>` re-themes every view in
 place without opening the list.
 
 `ui/theme.ts` is the only module holding color literals. A theme declares
-semantic roles — `canvas`, `surface`, `elevatedSurface`, `selectedSurface`;
-`textPrimary`, `textMuted`, `textSubtle`, `textStrong`; `border`,
-`borderStrong`, `borderFocus`; `accent`, `info`; `success`, `warning`, `error`;
-per-role conversation card colors; and Markdown/code colors. Views ask for a
-role and never for a color.
+semantic roles — `canvas`, `surface`, `selectedSurface`; `textPrimary`,
+`textMuted`, `textSubtle`, `textStrong`; `border`, `borderStrong`,
+`borderFocus`; `accent`, `info`; `success`, `warning`, `error`; per-role
+conversation card colors; and Markdown/code colors. Views ask for a role and
+never for a color.
+
+`canvas` is the only background the UI paints: every pane, modal, the header,
+the error banner and the composer fill with it, and a box is told from the page
+by its border rather than by a shade of its own. The other two fills name a
+state and not a depth — `selectedSurface` is what the cursor is on, and
+`surface` backs a code block, which has no border to delimit it.
 
 Adding a theme means adding one `ThemeSpec`: a semantic core plus one accent
 per conversation role. Card fills, labels, body text, the tool-call band, and

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -2755,7 +2755,7 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe(light.conversation.assistant.label);
   });
 
-  it('keeps the dark baseline identical to the pre-theme palette', async () => {
+  it('keeps the dark baseline identical to the pre-theme palette, background aside', async () => {
     const testRenderer = await createTestRenderer({width: 90, height: 20});
     const controller = new FakeController({
       ...initialSessionState(),
@@ -2772,10 +2772,43 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe('#22d3ee');
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe('#e2e8f0');
-    // No card fill: the role lives on the top-edge divider rule, so a card
-    // body is the canvas.
-    expect(body?.bg).toBe('#0f172a');
+    // Both changes land on this one cell. #565 removed the card's fill, so the
+    // body reports whatever is behind it, and #574 collapsed the palette, so
+    // what is behind it is the one universal background rather than the old
+    // lighter `canvas`. Neither value either change asserted on its own
+    // survives: not `#0f172a` (the canvas before the collapse) and not
+    // `#03192d` (a role tint the card no longer paints).
+    expect(body?.bg).toBe('#020617');
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe('#5cb6cc');
+  });
+
+  it('gives the key-help line the same background as the chrome above it', async () => {
+    // #574's second symptom, and the one visible without comparing two panes:
+    // the key-help line sets no background of its own, so it fell through to
+    // the root frame. The root was painted `canvas` while every pane and the
+    // header were painted the darker `elevatedSurface`, which left a pale rule
+    // across the bottom of the screen under a dark theme. With one background
+    // there is nothing left to fall through to that disagrees.
+    //
+    // Asserted against the header's own cells rather than a literal, because
+    // the symptom is that two rows disagree; that stays the property being
+    // checked if the palette moves again.
+    const testRenderer = await createTestRenderer({width: 150, height: 40});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      core: {
+        ...initialSessionState().core,
+        status: 'running',
+        transcript: [assistantEntry],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('F4: zoom'));
+
+    const help = spanColors(testRenderer, 'F4: zoom');
+    expect(help?.bg).toBe(spanColors(testRenderer, 'VibeSys')?.bg);
+    expect(help?.bg).toBe(resolveTheme('dark').canvas);
   });
 
   it('repaints live when the selected theme changes', async () => {
@@ -5931,7 +5964,11 @@ describe('modal scrim', () => {
 
     const floor = themeName.startsWith('high-contrast') ? 7 : 4.5;
     const modalBody = requireSpanColors(testRenderer, 'Available commands');
-    expect(modalBody).toEqual({fg: theme.textPrimary, bg: theme.elevatedSurface});
+    // The modal keeps a fill and squares its border (#642), and that fill is
+    // now the one background the theme has (#574), so this reads `canvas`
+    // where it used to read the separate elevated surface. The property is
+    // unchanged: the modal is the one surface the scrim does not paint over.
+    expect(modalBody).toEqual({fg: theme.textPrimary, bg: theme.canvas});
     expect(contrastRatio(modalBody.fg, modalBody.bg)).toBeGreaterThanOrEqual(floor);
     // Background text recedes below the floor the theme guarantees, and stays
     // above the point where the run behind the modal would be erased.

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -172,7 +172,7 @@ export class ChatComposerView {
       // corner.
       borderStyle: 'single',
       borderColor: theme.border,
-      backgroundColor: theme.elevatedSurface,
+      backgroundColor: theme.canvas,
       paddingLeft: 1,
       paddingRight: 1,
     });
@@ -353,7 +353,7 @@ export class ChatComposerView {
     this.#editor.focusedTextColor = theme.textStrong;
     this.#hint.fg = theme.textSubtle;
     this.menu.borderColor = theme.border;
-    this.menu.backgroundColor = theme.elevatedSurface;
+    this.menu.backgroundColor = theme.canvas;
     this.#menuList.fg = theme.textPrimary;
   }
 

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -76,7 +76,7 @@ export class ChatOverlayView {
       // included, and a fill that reaches the ring needs a square corner.
       borderStyle: 'single',
       borderColor: theme.conversation.analysis.label,
-      backgroundColor: theme.elevatedSurface,
+      backgroundColor: theme.canvas,
       title: ' Experiment chat ',
       zIndex: 20,
       visible: false,
@@ -182,7 +182,7 @@ export class ChatOverlayView {
 
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
     this.output.borderColor = theme.conversation.analysis.label;
-    this.output.backgroundColor = theme.elevatedSurface;
+    this.output.backgroundColor = theme.canvas;
     this.#composer.applyTheme(theme);
     this.#conversation.applyTheme(theme, markdownStyle);
   }

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -97,7 +97,7 @@ export class ChatPaneView {
     // to the root's canvas, a lighter shade, so the chat read as a pale band
     // beside panes that did not match it. On its own layer, so the pane keeps
     // the rounded frame `PANE_BORDER` argues for (tui-conventions.md).
-    this.#fill = fillLayer(this.output, 'chat-pane-fill', theme.elevatedSurface);
+    this.#fill = fillLayer(this.output, 'chat-pane-fill', theme.canvas);
     this.#scroll = new ScrollBoxRenderable(renderer, {
       id: 'chat-pane-scroll',
       width: '100%',
@@ -142,7 +142,7 @@ export class ChatPaneView {
     this.#theme = theme;
     // Resting colour: `render` repaints from the live focus on the next frame.
     this.output.borderColor = paneBorderColor(theme, false);
-    this.#fill.backgroundColor = theme.elevatedSurface;
+    this.#fill.backgroundColor = theme.canvas;
     this.#conversation.applyTheme(theme, markdownStyle);
     this.#composer.applyTheme(theme);
     this.#renderedConversation = null;

--- a/clients/tui/src/ui/error-banner.ts
+++ b/clients/tui/src/ui/error-banner.ts
@@ -45,7 +45,7 @@ export class ErrorBannerView {
     });
     // The surface the diagnostic reads on, on its own layer so the banner keeps
     // its rounded frame (tui-conventions.md).
-    this.#fill = fillLayer(this.output, 'error-banner-fill', theme.elevatedSurface);
+    this.#fill = fillLayer(this.output, 'error-banner-fill', theme.canvas);
     this.#scroll = new ScrollBoxRenderable(renderer, {
       id: 'error-banner-scroll',
       width: '100%',
@@ -58,7 +58,7 @@ export class ErrorBannerView {
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.#fill.backgroundColor = theme.elevatedSurface;
+    this.#fill.backgroundColor = theme.canvas;
     // `#rendered = null` makes the next `render` repaint the border from the
     // new theme.
     this.#rendered = null;

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -92,7 +92,7 @@ export class ExperimentLogView {
     });
     // The pane surface, on its own layer so the rounded frame stays rounded
     // (tui-conventions.md). Same call as `chat-pane`.
-    this.#fill = fillLayer(this.output, 'experiment-log-fill', theme.elevatedSurface);
+    this.#fill = fillLayer(this.output, 'experiment-log-fill', theme.canvas);
     this.#header = new TextRenderable(renderer, {
       content: '',
       fg: theme.textSubtle,
@@ -142,7 +142,7 @@ export class ExperimentLogView {
   applyTheme(theme: Theme): void {
     this.#theme = theme;
     this.output.borderColor = theme.border;
-    this.#fill.backgroundColor = theme.elevatedSurface;
+    this.#fill.backgroundColor = theme.canvas;
     this.#header.fg = theme.textSubtle;
     this.#footerLine.fg = theme.textSubtle;
     this.#renderedState = null;

--- a/clients/tui/src/ui/header.test.ts
+++ b/clients/tui/src/ui/header.test.ts
@@ -359,9 +359,10 @@ describe('run state', () => {
  * The floor every token but `textSubtle` is held to, restated here rather than
  * read off `theme.minContrast` so this is an independent check.
  *
- * It is measured against `headerBackground`, not the canvas: the header frame
- * paints a surface of its own, and a tone that clears the floor against a
- * background nothing draws is not a readable header.
+ * It is measured against `headerBackground` rather than `theme.canvas` because
+ * that function is what decides which cell the text lands on, and a tone that
+ * clears the floor against a background nothing draws is not a readable
+ * header. Since #574 the two are the same colour, which the test below pins.
  */
 function minContrast(theme: Theme): number {
   return theme.name.startsWith('high-contrast') ? 7 : 4.5;
@@ -541,26 +542,19 @@ describe('header contrast', () => {
     }
   });
 
-  it('derives its tones against the surface it paints, not against the canvas', () => {
-    // No built-in theme separates the two: every one of the eight puts its
-    // elevated surface further from mid grey than its canvas, so a tone that
-    // clears the floor on the canvas clears it by more on the header. The
-    // header cannot assume that. #574 is open on the surface ladder being
-    // inverted, and a header background on the other side of the canvas is
-    // exactly what a canvas-derived tone gets wrong: it returns the raw token
-    // for a cell it is unreadable on.
-    const dark = resolveTheme('dark');
-    const moved: Theme = {...dark, elevatedSurface: resolveTheme('light').canvas};
-    expect(contrastRatio(dark.accent, moved.canvas)).toBeGreaterThanOrEqual(dark.minContrast);
-    expect(contrastRatio(dark.accent, headerBackground(moved))).toBeLessThan(dark.minContrast);
-
-    for (const role of SPAN_ROLES) {
-      const {fg} = headerSpanStyle(moved, {text: 'completed', role});
-      const floor = role === 'separator' ? SUBTLE_FLOOR : minContrast(moved);
-      expect({
-        role,
-        ratio: contrastRatio(fg, headerBackground(moved)) >= floor,
-      }).toEqual({role, ratio: true});
+  it('paints the canvas, so the top line wears no colour of its own', () => {
+    // #574: the header filled `elevatedSurface` while the frame behind it
+    // filled `canvas`, so the top line agreed with the panes and disagreed with
+    // the strip of frame showing around them. The collapse kept the header's
+    // own value and moved `canvas` onto it; this pins that the two names now
+    // mean one colour. The token is gone, so no theme can reintroduce a second
+    // shade, but `headerBackground` is still the single place that chooses the
+    // fill, so the choice is pinned rather than left to the next reader.
+    for (const theme of listThemes()) {
+      expect({theme: theme.name, background: headerBackground(theme)}).toEqual({
+        theme: theme.name,
+        background: theme.canvas,
+      });
     }
   });
 

--- a/clients/tui/src/ui/header.ts
+++ b/clients/tui/src/ui/header.ts
@@ -26,7 +26,7 @@ import {hasRunEnded} from '@vibesys/core-state';
 import {runStatusLabel, type SessionState} from '../session-model.js';
 import {agentKindText, describePhase, phaseText} from './phase-label.js';
 import {displayWidth, truncateToWidth} from './text-width.js';
-import {ensureContrast, SUBTLE_TEXT_MIN_CONTRAST, type Theme} from './theme.js';
+import type {Theme} from './theme.js';
 
 /** Separator between header segments, matching the rest of the interface. */
 const SEPARATOR = ' · ';
@@ -271,17 +271,19 @@ export function renderHeader(state: SessionState, showLog: boolean, width: numbe
  * The surface the header paints, and therefore the surface its text is read
  * against.
  *
- * One definition for both: `app.ts` fills the frame with it and
- * `headerSpanStyle` derives every tone against it. Two independent statements
- * of where the header sits is how the contrast guarantee below comes to be
- * measured against a background nothing draws.
+ * One definition for both: `app.ts` fills the frame with it and the tones below
+ * are held against it. Two independent statements of where the header sits is
+ * how a contrast guarantee comes to be measured against a background nothing
+ * draws.
  *
- * `elevatedSurface` because the header is a pane, and that is the surface every
- * other pane sits on. Which shade that is belongs to the theme: #574 is open on
- * the ladder being inverted, and moving it there moves the header with it.
+ * `canvas`, because that is the only background the theme has (#574). This
+ * returned `elevatedSurface` until then. The cells the header paints have not
+ * changed colour: the collapse kept the value the panes and the header already
+ * used and brought `canvas` down to meet it. What changed is that the header
+ * now matches everything around it and not only the other panes.
  */
 export function headerBackground(theme: Theme): string {
-  return theme.elevatedSurface;
+  return theme.canvas;
 }
 
 /**
@@ -295,40 +297,32 @@ export function headerBackground(theme: Theme): string {
  * metadata and recede to muted. The separators recede further still: dots
  * divide the words without competing with them.
  *
- * Every colour comes from the theme, which holds each of these tokens to
- * `minContrast` against the canvas. The header does not sit on the canvas, so
- * that guarantee is not the one it needs, and each tone is put back through
- * `ensureContrast` against the surface the header actually paints. In all eight
- * built-in themes that is a no-op, because their elevated surface is further
- * from mid grey than their canvas in every case. It is a no-op the header
- * cannot assume: a theme, or #574 moving the ladder, can make the two
- * disagree, and a tone that clears 4.5:1 on a background nothing draws is not
- * a readable header.
+ * Every colour comes from the theme as `buildTheme` made it, which is enough
+ * because the header paints the canvas and `buildTheme` holds each of these
+ * tokens to `minContrast` against exactly that. Each tone used to be put back
+ * through `ensureContrast` here; that pass existed only to cross from the
+ * canvas to a second surface, and since #574 there is no second surface to
+ * cross to.
  *
  * `textSubtle` is the exception the theme itself makes, at a floor of 3 rather
  * than 4.5 or 7, which is why only the punctuation is drawn in it and every
  * word clears the full floor.
  */
 export function headerSpanStyle(theme: Theme, span: HeaderSpan): HeaderSpanStyle {
-  const surface = headerBackground(theme);
-  const readable = (color: string): string => ensureContrast(color, surface, theme.minContrast);
   switch (span.role) {
     case 'brand':
-      return {fg: readable(theme.accent), bold: true};
+      return {fg: theme.accent, bold: true};
     case 'state':
-      return {fg: readable(stateColor(theme, span.text)), bold: true};
+      return {fg: stateColor(theme, span.text), bold: true};
     case 'phase':
     case 'title':
-      return {fg: readable(theme.textPrimary), bold: false};
+      return {fg: theme.textPrimary, bold: false};
     case 'usage':
     case 'selection':
     case 'hint':
-      return {fg: readable(theme.textMuted), bold: false};
+      return {fg: theme.textMuted, bold: false};
     case 'separator':
-      return {
-        fg: ensureContrast(theme.textSubtle, surface, SUBTLE_TEXT_MIN_CONTRAST),
-        bold: false,
-      };
+      return {fg: theme.textSubtle, bold: false};
   }
 }
 

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -85,7 +85,7 @@ export class OverlayView {
       // included, and a fill that reaches the ring needs a square corner.
       borderStyle: 'single',
       borderColor: theme.info,
-      backgroundColor: theme.elevatedSurface,
+      backgroundColor: theme.canvas,
       // Above the chat modal (20), below the theme picker (30): a command ack
       // submitted from the modal chat has to be visible over it.
       zIndex: 25,
@@ -125,7 +125,7 @@ export class OverlayView {
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.output.backgroundColor = theme.elevatedSurface;
+    this.output.backgroundColor = theme.canvas;
     this.scrim.backgroundColor = scrim(theme).color;
     this.scrim.opacity = scrim(theme).strength;
     this.output.borderColor = borderFor(theme, this.#renderedKind ?? 'detail');

--- a/clients/tui/src/ui/theme-picker.ts
+++ b/clients/tui/src/ui/theme-picker.ts
@@ -36,7 +36,7 @@ export class ThemePickerView {
       // included, and a fill that reaches the ring needs a square corner.
       borderStyle: 'single',
       borderColor: theme.info,
-      backgroundColor: theme.elevatedSurface,
+      backgroundColor: theme.canvas,
       title: ' Themes ',
       visible: false,
       zIndex: 30,
@@ -46,7 +46,7 @@ export class ThemePickerView {
   applyTheme(theme: Theme): void {
     this.#theme = theme;
     this.output.borderColor = theme.info;
-    this.output.backgroundColor = theme.elevatedSurface;
+    this.output.backgroundColor = theme.canvas;
     // Rows carry theme colors, so they are rebuilt on the next render.
     this.#renderedSelection = null;
     this.#renderedActive = null;
@@ -78,7 +78,7 @@ export class ThemePickerView {
         new TextRenderable(this.renderer, {
           content: `${marker} ${theme.name.padEnd(NAME_WIDTH)} ${theme.label} (${theme.appearance})${suffix}`,
           fg: selected ? this.#theme.textStrong : this.#theme.textPrimary,
-          bg: selected ? this.#theme.selectedSurface : this.#theme.elevatedSurface,
+          bg: selected ? this.#theme.selectedSurface : this.#theme.canvas,
           width: '100%',
         }),
       );

--- a/clients/tui/src/ui/theme.test.ts
+++ b/clients/tui/src/ui/theme.test.ts
@@ -58,14 +58,23 @@ describe('theme selection', () => {
     expect(dark.conversation.analysis.label).toBe('#b193f8');
   });
 
-  it('keeps the dark baseline pinned to the pre-theme appearance', () => {
+  it('keeps the dark baseline pinned, background excepted', () => {
     const dark = resolveTheme('dark');
-    expect(dark.canvas).toBe('#0f172a');
+    // #574 moved the canvas, and only the canvas: this was the pre-theme
+    // `#0f172a`, and is now the value the panes already painted, so the whole
+    // screen is one shade instead of two. Everything below is unchanged from
+    // the pre-theme palette, which is the point of pinning it here: the token
+    // that was meant to move is the only one that did.
+    expect(dark.canvas).toBe('#020617');
     expect(dark.accent).toBe('#22d3ee');
     expect(dark.border).toBe('#475569');
     expect(dark.conversation.assistant).toEqual({
       border: '#0891b2',
-      background: '#0e283d',
+      // The one knock-on. A card fill is `mix(canvas, roleAccent, cardTint)`,
+      // so it follows the canvas by construction and stays the same 14% step
+      // off it that it was; pinning the old `#0e283d` here would put a lighter
+      // rectangle back on the screen, which is the thing #574 removed.
+      background: '#03192d',
       label: '#5cb6cc',
       content: '#e2e8f0',
     });
@@ -182,6 +191,39 @@ describe('semantic roles', () => {
     expect(contrastRatio(theme.borderFocus, theme.canvas)).toBeGreaterThanOrEqual(
       contrastRatio(theme.border, theme.canvas),
     );
+  });
+
+  it.each(
+    themes.map(theme => [theme.name, theme] as const),
+  )('%s keeps every semantic foreground readable where a pane draws it', (_name, theme: Theme) => {
+    // Panes reuse these tokens raw, with no re-contrast at the call site:
+    // error-banner draws its message and hint in `warning` and its fatal
+    // message in `conversation.failure.content`; overlay borders and bodies its
+    // help/error/detail kinds in `success`/`error`/`info`; experiment-log
+    // colours rows and the active-hypothesis column in
+    // `warning`/`success`/`error`; theme-picker borders itself in `info`;
+    // chat-overlay borders itself in `conversation.analysis.label`; the header
+    // draws the brand in `accent` and the run state in a verdict colour.
+    //
+    // Every one of those fills `canvas` (#574 collapsed the surface ladder
+    // instead of re-ordering it), so `buildTheme`'s guarantee is now made
+    // against the cell the text actually lands on and this asserts it there.
+    // Stricter than `status colors distinguishable` above, which asks only 3:1
+    // and only of three of them: a token retuned below the reading floor, or a
+    // second background token coming back, breaks all of these at once and
+    // without a symptom until someone reads a pane.
+    const minimum = theme.name.startsWith('high-contrast') ? 7 : 4.5;
+    for (const status of [
+      theme.accent,
+      theme.info,
+      theme.success,
+      theme.warning,
+      theme.error,
+      theme.conversation.failure.content,
+      theme.conversation.analysis.label,
+    ] as const) {
+      expect(contrastRatio(status, theme.canvas)).toBeGreaterThanOrEqual(minimum);
+    }
   });
 
   it('orients light and dark themes in opposite luminance directions', () => {

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -75,9 +75,30 @@ export interface Theme {
    */
   minContrast: number;
 
+  /**
+   * The one background the UI paints. Every pane, modal, the header, the error
+   * banner, the composer and the frame behind them all fill with this, so a box
+   * is told from the page by its border and not by a shade of its own.
+   *
+   * There is deliberately no second, raised shade (#574). On a cell grid a
+   * "raised" surface is a flat fill one step off the canvas: at a step small
+   * enough to keep text readable it is not seen as depth, and at a step large
+   * enough to be seen it bleeds a rectangle around content it is not marking.
+   *
+   * Where the two used to disagree this took the pane's value rather than the
+   * frame's, because the panes cover nearly all of the screen. That made the
+   * frame the minority colour, and the strips of it left showing between and
+   * below the panes read as stray bands of light rather than as a background.
+   * The key-help line was the plainest case: it paints no background of its own
+   * and so falls through to the frame, which drew a pale rule across the bottom
+   * of every dark theme.
+   *
+   * The two remaining fills name a state rather than a depth: `selectedSurface`
+   * is what the cursor is on, and `surface` backs a code block, which has no
+   * border to delimit it.
+   */
   canvas: string;
   surface: string;
-  elevatedSurface: string;
   selectedSurface: string;
 
   textPrimary: string;
@@ -231,7 +252,6 @@ interface ThemeSpec {
   appearance: Appearance;
   canvas: string;
   surface: string;
-  elevatedSurface: string;
   selectedSurface: string;
   textPrimary: string;
   textMuted: string;
@@ -328,7 +348,6 @@ function buildTheme(spec: ThemeSpec): Theme {
     minContrast: spec.minContrast,
     canvas: spec.canvas,
     surface: spec.surface,
-    elevatedSurface: spec.elevatedSurface,
     selectedSurface: spec.selectedSurface,
     textPrimary: ensureContrast(spec.textPrimary, spec.canvas, spec.minContrast),
     textMuted: ensureContrast(spec.textMuted, spec.canvas, spec.minContrast),
@@ -353,9 +372,8 @@ const DARK: ThemeSpec = {
   name: 'dark',
   label: 'Dark',
   appearance: 'dark',
-  canvas: '#0f172a',
+  canvas: '#020617',
   surface: '#1e293b',
-  elevatedSurface: '#020617',
   // Distinct from the canvas: a selection painted in the canvas colour is not a
   // selection. Every other theme already differs here.
   selectedSurface: '#1e293b',
@@ -401,9 +419,8 @@ const LIGHT: ThemeSpec = {
   name: 'light',
   label: 'Light',
   appearance: 'light',
-  canvas: '#f8fafc',
+  canvas: '#ffffff',
   surface: '#f1f5f9',
-  elevatedSurface: '#ffffff',
   selectedSurface: '#e2e8f0',
   textPrimary: '#0f172a',
   textMuted: '#475569',
@@ -435,9 +452,8 @@ const SOLARIZED_DARK: ThemeSpec = {
   name: 'solarized-dark',
   label: 'Solarized Dark',
   appearance: 'dark',
-  canvas: '#002b36',
+  canvas: '#001f27',
   surface: '#073642',
-  elevatedSurface: '#001f27',
   selectedSurface: '#073642',
   textPrimary: '#93a1a1',
   textMuted: '#839496',
@@ -469,9 +485,8 @@ const SOLARIZED_LIGHT: ThemeSpec = {
   name: 'solarized-light',
   label: 'Solarized Light',
   appearance: 'light',
-  canvas: '#fdf6e3',
+  canvas: '#fffbf0',
   surface: '#eee8d5',
-  elevatedSurface: '#fffbf0',
   selectedSurface: '#eee8d5',
   textPrimary: '#073642',
   textMuted: '#586e75',
@@ -503,9 +518,8 @@ const CATPPUCCIN_MOCHA: ThemeSpec = {
   name: 'catppuccin-mocha',
   label: 'Catppuccin Mocha',
   appearance: 'dark',
-  canvas: '#1e1e2e',
+  canvas: '#11111b',
   surface: '#181825',
-  elevatedSurface: '#11111b',
   selectedSurface: '#313244',
   textPrimary: '#cdd6f4',
   textMuted: '#a6adc8',
@@ -537,9 +551,8 @@ const CATPPUCCIN_LATTE: ThemeSpec = {
   name: 'catppuccin-latte',
   label: 'Catppuccin Latte',
   appearance: 'light',
-  canvas: '#eff1f5',
+  canvas: '#ffffff',
   surface: '#e6e9ef',
-  elevatedSurface: '#ffffff',
   selectedSurface: '#ccd0da',
   textPrimary: '#4c4f69',
   textMuted: '#6c6f85',
@@ -573,7 +586,6 @@ const HIGH_CONTRAST_DARK: ThemeSpec = {
   appearance: 'dark',
   canvas: '#000000',
   surface: '#0a0a0a',
-  elevatedSurface: '#000000',
   selectedSurface: '#262626',
   textPrimary: '#ffffff',
   textMuted: '#e6e6e6',
@@ -607,7 +619,6 @@ const HIGH_CONTRAST_LIGHT: ThemeSpec = {
   appearance: 'light',
   canvas: '#ffffff',
   surface: '#f2f2f2',
-  elevatedSurface: '#ffffff',
   selectedSurface: '#d9d9d9',
   textPrimary: '#000000',
   textMuted: '#1a1a1a',


### PR DESCRIPTION
## Problem

Closes #574.

The theme carried two backgrounds: `canvas` for the root frame and
`elevatedSurface` for every pane, modal and the header. In the dark themes the
"elevated" surface was the *darker* of the two, so panes read as recesses cut
into the page rather than panels on it, which is what #574 reported.

Two symptoms followed from the same pair, and the second is visible without
comparing panes at all:

- The header calls `headerBackground()`, which returned `elevatedSurface`, so it
  read as a different colour from the frame around it.
- The key-help line sets no background of its own, so it fell through to the
  root's `canvas`. On `main`, against panes painted the darker surface, that left
  a **pale rule across the bottom of the screen**.

**What this PR's own frames show, and what they do not.** By the time this
change applies, #646 moves the pane fills inside their borders rather than
dropping them, so the panes still paint `elevatedSurface` in the base: measured
84.68% of the crop on the 2026-09-10 frames, not the 450 of 6000 cells an
earlier revision of this paragraph claimed. The before frame therefore shows the
pale bottom rule and the pale margins the Problem section describes, rather than
the header alone disagreeing with its surroundings. Both symptoms come from the
same pair of tokens; this removes the pair.

### Before / after

Full window, 150x40, dark. Base is #651.

**Before** — the three header rows are `#020617` while the panes, the frame and the key-help
row are all `#0f172a`, so the header reads as a different colour from everything
around it.

![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr652-onebg-before-0910.png)

**After** — all four sampled points are the single background `#020617`, asserted at cells
`1,60`, `20,10` and `39,60`.

![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr652-onebg-after-0910.png)

## Solution

The ladder is removed rather than re-ordered. `elevatedSurface` is deleted and
`canvas` moves down to the value the panes and header already painted, so there
is exactly one background and nothing left to fall through to that disagrees
with its neighbour.

| theme | canvas before | canvas after |
| --- | --- | --- |
| dark | `#0f172a` | `#020617` |
| light | `#f8fafc` | `#ffffff` |
| solarized-dark | `#002b36` | `#001f27` |
| solarized-light | `#fdf6e3` | `#fffbf0` |
| catppuccin-mocha | `#1e1e2e` | `#11111b` |

The cells the panes and header paint do not change colour; the root comes to
meet them. `selectedSurface` is untouched: selection is state, not a decorative
tint, and it is the one distinction worth keeping.

This supersedes the first attempt on this branch, which raised `elevatedSurface`
above `canvas` and added `ensureStatusContrast` so semantic foregrounds still
cleared 4.5:1 against the raised surface. With one background that second pass
has nothing to guard, but the contrast guarantee it protected is unchanged:
every semantic foreground still clears its theme's `minContrast` against the
single surface, and the regression test a reviewer asked for is kept.

### Stack position

Rebased onto #651 and reopened from #643 (see the note there). It conflicted
with #646 on `chat-pane.ts`, `error-banner.ts`, `experiment-log.ts` and
`app.test.ts`: both PRs decide where fills live. They are two halves of one rule
— #646 says a box may have a rounded border **or** a fill, this says there is
only one fill colour — so they now sit in one line of work instead of colliding
at merge. At the seam, #646 wins on the three rounded panes (their fill is
removed outright, so there is nothing left to recolour) and this PR applies at
the sites #646 kept a fill: the modals, the header and the composer.

## Verification

### Correctness properties

- Exactly one background token exists; nothing renders a second surface.
- The key-help line and the header carry the same background as the panes.
- Every semantic foreground still clears its theme's `minContrast`.
- Selection remains visually distinct via `selectedSurface`.

### Testing

`pnpm check:ts`, `pnpm check:ts-architecture`, `pnpm check:clients` all clean.
`pnpm test:clients`: **722 pass, 0 fail** at this commit; 737 at the top of the
stack.

New assertion: *"gives the key-help line the same background as the chrome above
it"*, checked against the header's own cells rather than a literal, so the
property survives a future palette move rather than needing the number updated.

The scrim assertion in #651 named `theme.elevatedSurface`; it now names
`theme.canvas`. That is the deleted token, not a behaviour change — the modal is
still the one surface the scrim does not paint over.

### Design note

The modal interior is now `theme.canvas` and the scrim tints toward
`theme.canvas`, so separation rests on the modal's single-line border plus the
scrim being translucent. The contrast floor is still asserted, so this is a
visual-separation tradeoff, not a legibility one. Taken deliberately; if it
reads badly in use the fix belongs on the modal edge, not in a revived surface
ladder.




