### PR TITLE
fix(agent): make the omitted-claims notice agree with its own count

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -395,10 +395,17 @@ def _pareto_archive_summary(records: list[RoundRecord], space: MetricSpace) -> s
         )
         omitted = pending[:-_PARETO_ARCHIVE_PENDING_CLAIM_LIMIT]
         if omitted:
+            # This line is read by a model, so it agrees with itself: one
+            # omitted claim says "1 older untrusted claim", and a single
+            # omitted round says "round 4" rather than the degenerate
+            # "rounds 4-4".
+            claims = "claim" if len(omitted) == 1 else "claims"
+            first = omitted[0].round_number
+            last = omitted[-1].round_number
+            rounds = f"round {first}" if first == last else f"rounds {first}-{last}"
             lines.append(
-                f"- {len(omitted)} older untrusted claims omitted from this context "
-                f"(rounds {omitted[0].round_number}-{omitted[-1].round_number}); do not "
-                "treat any omitted claim as a trusted parent."
+                f"- {len(omitted)} older untrusted {claims} omitted from this context "
+                f"({rounds}); do not treat any omitted claim as a trusted parent."
             )
         for record in pending[-_PARETO_ARCHIVE_PENDING_CLAIM_LIMIT:]:
             assert record.commit is not None  # noqa: S101  # tracked: #288

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -1009,6 +1009,40 @@ def test_pareto_archive_summary_bounds_pending_claims_with_an_omission_notice():
     assert "do not treat any omitted claim as a trusted parent" in summary
 
 
+def test_pareto_archive_summary_omission_notice_agrees_with_its_own_count():  # noqa: ANN201  # tracked: #288
+    """One omitted claim reads as singular, and one omitted round is not a range.
+
+    The notice goes into prompt context a model reads, so "1 older untrusted
+    claims ... (rounds 3-3)" is not merely untidy: it invites the reader to
+    infer a plural set and a span where neither exists.
+    """
+    pending_records = [
+        RoundRecord(
+            round_number,
+            chr(ord("a") + round_number) * 40,
+            None,
+            None,
+            False,  # noqa: FBT003  # tracked: #288
+            reviewed=False,
+            candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
+            candidate_metrics={
+                "throughput": 6000.0 + round_number,
+                "latency": 3000.0 + round_number,
+            },
+            candidate_evaluation_artifact=f"h{round_number}.json",
+            candidate_operating_point="concurrency=192",
+            candidate_retention_reason="higher-throughput tradeoff",
+        )
+        # Nine records against a limit of eight omits exactly one.
+        for round_number in range(1, 10)
+    ]
+
+    summary = _pareto_archive_summary(pending_records, _THROUGHPUT_LATENCY)
+    assert "1 older untrusted claim omitted from this context (round 1)" in summary
+    assert "claims omitted" not in summary
+    assert "rounds 1-1" not in summary
+
+
 def test_pareto_archive_summary_lists_all_pending_claims_within_the_limit():  # noqa: ANN201  # tracked: #288
     """A short pending list needs no omission notice."""
     pending_records = [


### PR DESCRIPTION
## Problem

The pareto archive's omitted-claims notice is assembled from fixed strings, so a
single omitted claim renders as:

```
- 1 older untrusted claims omitted from this context (rounds 3-3); do not treat
  any omitted claim as a trusted parent.
```

Both halves disagree with the number beside them: a count of one against a plural
noun, and a range whose ends are the same round.

This is prompt context a model reads, not a log line. A reader shown `1 ... claims`
and `rounds 3-3` can reasonably infer a plural set and a span, and the entire
purpose of the notice is to state precisely what it cannot see. An imprecise
disclosure is a weaker disclosure.

Introduced with the notice itself in #621; #547 is closed and this does not reopen
it.

## Solution

Pick the noun from the count, and collapse a single-round span to `round N`.

```
- 1 older untrusted claim omitted from this context (round 3); do not treat any
  omitted claim as a trusted parent.
```

No change to which claims are shown or omitted, and none to the multi-claim
wording.

## Verification

### Correctness properties

- The notice's noun agrees with its count.
- A single omitted round is named, not expressed as a degenerate range.
- The multi-claim rendering is unchanged.

### Testing

- `uv run pytest tests/vibesys/loops/agent/test_orchestrate.py` — **152 passed**
- `uv run ruff check` / `ruff format --check` on both files — clean
- `./scripts/check_types.sh` — all checks passed

The new test uses **nine** pending records against a limit of eight, so exactly
one is omitted. That boundary is not covered today: the existing test uses ten
records and omits two, which is why the plural path was the only one exercised.
Verified failing against `main` and passing with the change.
