### PR TITLE
TUI: project and render structured execution status

### DIFF
--- a/clients/backend-client/src/index.ts
+++ b/clients/backend-client/src/index.ts
@@ -13,6 +13,7 @@ export {
   type StreamTransport,
 } from './persistent-event-stream.js';
 export type {
+  AgentStatusData,
   ChatModelOption,
   ChatOptions,
   ChatProviderOptions,

--- a/clients/backend-client/src/protocol.ts
+++ b/clients/backend-client/src/protocol.ts
@@ -3,6 +3,10 @@ import type {ProtocolDocument} from './generated/protocol.generated.js';
 export type ProtocolRequest = ProtocolDocument['request'];
 export type ProtocolResponse = ProtocolDocument['response'];
 export type RunEvent = ProtocolDocument['event'];
+/** Structured status carried by streamed agent output and tool calls. */
+export type AgentStatusData = NonNullable<
+  Extract<NonNullable<RunEvent['data']>, {channel: unknown}>['status']
+>;
 export type RunSnapshot = ProtocolDocument['snapshot'];
 /** Run lifecycle statuses the backend reports. Source: `RunStatus` in `src/server/run_lifecycle.py`. */
 export type RunStatus = RunSnapshot['status'];

--- a/clients/core-state/src/core-state-prefix.test.ts
+++ b/clients/core-state/src/core-state-prefix.test.ts
@@ -101,6 +101,239 @@ describe('prefix backfill equivalence', () => {
 });
 
 describe('prefix merges across the chunk boundary', () => {
+  it('keeps the newest per-execution status across tail replay and prefix backfill', () => {
+    const events = [
+      executionStartedEvent(1, 'active'),
+      executionStatusEvent(2, 'active', 'agent_output_chunk', {
+        progress: 'Inspecting',
+        agent_label: 'Implementer',
+        elapsed_seconds: 2,
+        input_tokens: 4_000,
+        context_window: 200_000,
+      }),
+      executionStatusEvent(3, 'active', 'tool_call', {input_tokens: 9_000}),
+    ];
+    const checkpoint = [
+      {
+        execution_id: 'active',
+        agent_kind: 'implementer',
+        round_label: 'round-1-implementer',
+        stage: 'implementation',
+        attempt: 1,
+        assignment: 'Implement',
+        started_at: timestamp(1),
+        activity: {
+          kind: 'agent_execution_activity_changed' as const,
+          mode: 'thinking' as const,
+          summary: 'Working',
+          tool: null,
+        },
+      },
+    ];
+    const full = reduceEventBatch(initialCoreState(), events, checkpoint, 3);
+    const tail = reduceEventBatch(initialCoreState(), events.slice(2), checkpoint, 3, 2);
+    const merged = reduceEventPrefix(tail, events.slice(0, 2), 0);
+
+    expect(merged.executionStatuses).toEqual(full.executionStatuses);
+    expect(merged.executionStatuses['active']).toMatchObject({
+      sequence: 3,
+      progress: 'Inspecting',
+      agentLabel: 'Implementer',
+      inputTokens: 9_000,
+      contextWindow: 200_000,
+    });
+    expect(merged.usage).toEqual(full.usage);
+    expect(merged.usage).toEqual({inputTokens: 9_000, contextWindow: 200_000, model: null});
+  });
+
+  it('does not fill a restarted execution from an older generation with the same id', () => {
+    const older = [
+      executionStartedEvent(1, 'reused'),
+      executionStatusEvent(2, 'reused', 'agent_output_chunk', {
+        progress: 'Old work',
+        agent_label: 'Old implementer',
+        context_window: 200_000,
+      }),
+    ];
+    const tail = [
+      executionStartedEvent(4, 'reused'),
+      executionStatusEvent(5, 'reused', 'tool_call', {input_tokens: 7_000}),
+    ];
+    const full = reduceEventBatch(initialCoreState(), [
+      ...older,
+      executionFinishedEvent(3, 'reused'),
+      ...tail,
+    ]);
+    const merged = reduceEventPrefix(reduceEventBatch(initialCoreState(), tail), older, 0);
+
+    expect(merged.executionStatuses).toEqual(full.executionStatuses);
+    expect(merged.executionStatuses['reused']).toMatchObject({
+      sequence: 5,
+      progress: null,
+      agentLabel: null,
+      inputTokens: 7_000,
+      contextWindow: null,
+    });
+  });
+
+  it('does not fill terminal usage from an older generation with the same id', () => {
+    const older = [
+      executionStartedEvent(1, 'reused'),
+      executionStatusEvent(2, 'reused', 'agent_output_chunk', {
+        input_tokens: 4_000,
+        context_window: 200_000,
+      }),
+    ];
+    const tail = [
+      executionStartedEvent(4, 'reused'),
+      executionStatusEvent(5, 'reused', 'tool_call', {input_tokens: 7_000}),
+      executionFinishedEvent(6, 'reused'),
+    ];
+    const full = reduceEventBatch(initialCoreState(), [
+      ...older,
+      executionFinishedEvent(3, 'reused'),
+      ...tail,
+    ]);
+    const merged = reduceEventPrefix(reduceEventBatch(initialCoreState(), tail), older, 0);
+
+    expect(merged.executionStatuses).toEqual({});
+    expect(merged.usage).toEqual(full.usage);
+    expect(merged.usage).toEqual({inputTokens: 7_000, contextWindow: null, model: null});
+  });
+
+  for (const ending of ['execution finish', 'run failure'] as const) {
+    it(`restores status-derived usage across prefix backfill after ${ending}`, () => {
+      const older = [
+        executionStartedEvent(1, 'active'),
+        executionStatusEvent(2, 'active', 'agent_output_chunk', {
+          progress: 'Inspecting',
+          agent_label: 'Implementer',
+          input_tokens: 4_000,
+          context_window: 200_000,
+        }),
+      ];
+      const terminal =
+        ending === 'execution finish'
+          ? executionFinishedEvent(4, 'active')
+          : ({
+              ...baseEvent(4, 'run_failed'),
+              agent_kind: null,
+              round_label: null,
+              status: 'failed',
+            } satisfies RunEvent);
+      const tail = [
+        executionStatusEvent(3, 'active', 'tool_call', {input_tokens: 9_000}),
+        terminal,
+      ];
+      const full = reduceEventBatch(initialCoreState(), [...older, ...tail]);
+      const merged = reduceEventPrefix(reduceEventBatch(initialCoreState(), tail), older, 0);
+
+      expect(merged.executionStatuses).toEqual({});
+      expect(merged.usage).toEqual(full.usage);
+      expect(merged.usage).toEqual({inputTokens: 9_000, contextWindow: 200_000, model: null});
+    });
+  }
+
+  it('retains an earlier usage model when a later status owns terminal usage', () => {
+    const events: RunEvent[] = [
+      executionStartedEvent(1, 'active'),
+      {
+        ...baseEvent(2, 'usage_update'),
+        execution_id: 'active',
+        data: {
+          kind: 'usage_update',
+          input_tokens: 4_000,
+          context_window: 200_000,
+          model: 'gpt-5.6-sol',
+        },
+      },
+      executionStatusEvent(3, 'active', 'agent_output_chunk', {
+        input_tokens: 9_000,
+        context_window: 200_000,
+      }),
+      executionFinishedEvent(4, 'active'),
+      {
+        ...baseEvent(5, 'run_finished'),
+        agent_kind: null,
+        round_label: null,
+        status: 'completed',
+      },
+    ];
+    const full = reduceEventBatch(initialCoreState(), events, [], 5);
+    const merged = backfill(events, 1, 1);
+
+    expect(merged.executionStatuses).toEqual({});
+    expect(merged.usage).toEqual(full.usage);
+    expect(merged.usage).toEqual({
+      inputTokens: 9_000,
+      contextWindow: 200_000,
+      model: 'gpt-5.6-sol',
+    });
+  });
+
+  it('keeps an explicit null model from the newest preceding usage update', () => {
+    const events: RunEvent[] = [
+      executionStartedEvent(1, 'active'),
+      {
+        ...baseEvent(2, 'usage_update'),
+        execution_id: 'active',
+        data: {
+          kind: 'usage_update',
+          input_tokens: 4_000,
+          context_window: 200_000,
+          model: 'older-model',
+        },
+      },
+      {
+        ...baseEvent(3, 'usage_update'),
+        execution_id: 'active',
+        data: {
+          kind: 'usage_update',
+          input_tokens: 5_000,
+          context_window: 200_000,
+          model: null,
+        },
+      },
+      executionStatusEvent(4, 'active', 'agent_output_chunk', {
+        input_tokens: 9_000,
+        context_window: 200_000,
+      }),
+      executionFinishedEvent(5, 'active'),
+      {
+        ...baseEvent(6, 'run_finished'),
+        agent_kind: null,
+        round_label: null,
+        status: 'completed',
+      },
+    ];
+    const full = reduceEventBatch(initialCoreState(), events, [], 6);
+    const merged = backfill(events, 1, 1);
+
+    expect(merged.usage).toEqual(full.usage);
+    expect(merged.usage).toEqual({inputTokens: 9_000, contextWindow: 200_000, model: null});
+  });
+
+  it('does not mutate status provenance shared by divergent prefix forks', () => {
+    const tailEvents = [
+      executionStatusEvent(4, 'active', 'agent_output_chunk', {input_tokens: 9_000}),
+    ];
+    const tail = reduceEventBatch(initialCoreState(), tailEvents, undefined, undefined, 3);
+    const pristineTail = reduceEventBatch(initialCoreState(), tailEvents, undefined, undefined, 3);
+
+    reduceEventPrefix(tail, [executionStartedEvent(3, 'active')], 2);
+    const olderStatus = [
+      executionStatusEvent(2, 'active', 'agent_output_chunk', {
+        input_tokens: 4_000,
+        context_window: 200_000,
+      }),
+    ];
+    const forked = reduceEventPrefix(tail, olderStatus, 1);
+    const pristine = reduceEventPrefix(pristineTail, olderStatus, 1);
+
+    expect(forked.usage).toEqual(pristine.usage);
+    expect(forked.usage?.contextWindow).toBe(200_000);
+  });
+
   it('replays a resumed lifetime when backfill follows the server spine', () => {
     const events = [
       runStartedEvent(1),
@@ -886,6 +1119,29 @@ function chunkEvent(sequence: number, content = `entry ${sequence}`): RunEvent {
     ...baseEvent(sequence, 'agent_output_chunk'),
     invocation_id: 'turn',
     data: {kind: 'agent_output_chunk', channel: 'assistant', content},
+  };
+}
+
+function executionStatusEvent(
+  sequence: number,
+  executionId: string,
+  kind: 'agent_output_chunk' | 'tool_call',
+  status: {
+    progress?: string;
+    agent_label?: string;
+    elapsed_seconds?: number;
+    input_tokens?: number;
+    context_window?: number;
+  },
+): RunEvent {
+  return {
+    ...baseEvent(sequence, kind),
+    execution_id: executionId,
+    invocation_id: executionId,
+    data:
+      kind === 'agent_output_chunk'
+        ? {kind, channel: 'analysis', content: status.progress ?? '', status}
+        : {kind, tool: 'Bash', call_id: `call-${sequence}`, args: {}, status},
   };
 }
 

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -13,6 +13,7 @@ import {
   reduceEventRebootstrap,
   reduceSnapshot,
 } from './core-state.js';
+import {executionStatusFor} from './execution-status.js';
 
 describe('core state projection', () => {
   it('projects snapshots without changing event-derived history', () => {
@@ -220,6 +221,153 @@ describe('core state projection', () => {
       summary: 'Running tests',
       tool: 'Bash',
     });
+  });
+
+  it('tracks structured output and tool status independently per execution', () => {
+    let state = initialCoreState();
+    state = reduceEvent(
+      state,
+      executionEvent(1, 'agent_execution_started', 'first', startedData('First')),
+    );
+    state = reduceEvent(
+      state,
+      executionEvent(2, 'agent_execution_started', 'second', startedData('Second')),
+    );
+    state = reduceEvent(
+      state,
+      statusEvent(3, 'first', 'agent_output_chunk', {
+        progress: 'Round 1/3',
+        agent_label: 'Implementer',
+        elapsed_seconds: 12.5,
+        input_tokens: 8_000,
+        context_window: 200_000,
+      }),
+    );
+    state = reduceEvent(
+      state,
+      statusEvent(4, 'second', 'tool_call', {
+        progress: 'Reviewing',
+        agent_label: 'Judge',
+        elapsed_seconds: 3,
+        input_tokens: 2_000,
+        context_window: 100_000,
+      }),
+    );
+
+    expect(state.executionStatuses).toEqual({
+      first: {
+        executionId: 'first',
+        sequence: 3,
+        observedAt: '2026-01-01T00:00:03Z',
+        progress: 'Round 1/3',
+        agentLabel: 'Implementer',
+        elapsedSeconds: 12.5,
+        inputTokens: 8_000,
+        contextWindow: 200_000,
+      },
+      second: {
+        executionId: 'second',
+        sequence: 4,
+        observedAt: '2026-01-01T00:00:04Z',
+        progress: 'Reviewing',
+        agentLabel: 'Judge',
+        elapsedSeconds: 3,
+        inputTokens: 2_000,
+        contextWindow: 100_000,
+      },
+    });
+    expect(state.usage).toEqual({inputTokens: 2_000, contextWindow: 100_000, model: null});
+
+    state = reduceEvent(
+      state,
+      statusEvent(5, 'first', 'agent_output_chunk', {input_tokens: 9_000}),
+    );
+    expect(state.executionStatuses['first']).toMatchObject({
+      sequence: 5,
+      inputTokens: 9_000,
+      contextWindow: 200_000,
+    });
+    expect(state.usage).toEqual({inputTokens: 9_000, contextWindow: 200_000, model: null});
+  });
+
+  it('reconciles status through checkpoints and clears only the execution that finishes', () => {
+    let state = reduceEvent(initialCoreState(), statusEvent(1, 'first', 'agent_output_chunk'));
+    state = reduceEvent(state, statusEvent(2, 'second', 'tool_call'));
+    state = reconcileActiveExecutions(state, [checkpoint('first'), checkpoint('second')], 2);
+
+    expect(Object.keys(state.executionStatuses)).toEqual(['first', 'second']);
+
+    state = reduceEvent(
+      state,
+      executionEvent(3, 'agent_execution_finished', 'first', {
+        kind: 'agent_execution_finished',
+        error: null,
+      }),
+    );
+    expect(Object.keys(state.executionStatuses)).toEqual(['second']);
+
+    state = reconcileActiveExecutions(
+      state,
+      [checkpoint('second', {started_at: '2026-01-01T00:00:05Z'})],
+      3,
+    );
+    const restarted = state.activeExecutions['second'];
+    if (restarted === undefined) throw new Error('checkpoint dropped its active execution');
+    expect(executionStatusFor(state.executionStatuses, restarted)).toBeUndefined();
+
+    state = reduceEvent(state, outputEvent(4, 'legacy after checkpoint', 'second'));
+    expect(state.executionStatuses).toEqual({});
+  });
+
+  it('leaves legacy output without structured status unchanged', () => {
+    const started = reduceEvent(
+      initialCoreState(),
+      executionEvent(1, 'agent_execution_started', 'first', startedData('First')),
+    );
+    const projected = reduceEvent(started, outputEvent(2, 'legacy', 'first'));
+
+    expect(projected.executionStatuses).toBe(started.executionStatuses);
+    expect(projected.usage).toBeNull();
+  });
+
+  it('advances repeated unsequenced status without replacing sequenced status', () => {
+    let state = reduceEvent(initialCoreState(), statusEvent(0, 'first', 'agent_output_chunk'));
+    state = reduceEvent(
+      state,
+      statusEvent(0, 'first', 'tool_call', {progress: 'second unsequenced'}),
+    );
+    expect(state.executionStatuses['first']?.progress).toBe('second unsequenced');
+
+    state = reduceEvent(
+      state,
+      statusEvent(2, 'first', 'agent_output_chunk', {
+        progress: 'sequenced',
+        input_tokens: 7_000,
+        context_window: 20_000,
+      }),
+    );
+    state = reduceEvent(
+      state,
+      statusEvent(0, 'first', 'agent_output_chunk', {
+        progress: 'stale unsequenced',
+        input_tokens: 1,
+        context_window: 2,
+      }),
+    );
+    expect(state.executionStatuses['first']?.progress).toBe('sequenced');
+    expect(state.executionStatuses['first']?.sequence).toBe(2);
+    expect(state.usage).toEqual({inputTokens: 7_000, contextWindow: 20_000, model: null});
+  });
+
+  it('clears pending status when the run terminates before a checkpoint arrives', () => {
+    const pending = reduceEvent(initialCoreState(), statusEvent(1, 'first', 'agent_output_chunk'));
+    const ended = reduceEvent(pending, {
+      ...baseEvent(2, 'run_failed'),
+      agent_kind: null,
+      round_label: null,
+    });
+
+    expect(ended.executionStatuses).toEqual({});
   });
 
   it('captures runtime identity from agent_execution_started when present', () => {
@@ -1089,6 +1237,29 @@ function executionEvent(
   data: NonNullable<RunEvent['data']>,
 ): RunEvent {
   return {...baseEvent(sequence, type), execution_id: executionId, data};
+}
+
+function statusEvent(
+  sequence: number,
+  executionId: string,
+  kind: 'agent_output_chunk' | 'tool_call',
+  status: {
+    progress?: string;
+    agent_label?: string;
+    elapsed_seconds?: number;
+    input_tokens?: number;
+    context_window?: number;
+  } = {progress: `step ${sequence}`},
+): RunEvent {
+  return {
+    ...baseEvent(sequence, kind),
+    execution_id: executionId,
+    invocation_id: executionId,
+    data:
+      kind === 'agent_output_chunk'
+        ? {kind, channel: 'analysis', content: '', status}
+        : {kind, tool: 'Bash', call_id: `call-${sequence}`, args: {}, status},
+  };
 }
 
 function startedData(assignment: string): NonNullable<RunEvent['data']> {

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -1,5 +1,14 @@
 import type {Diagnostic, RunEvent, RunSnapshot, RunStatus} from '@vibesys/backend-client';
 import {
+  applyExecutionStatus,
+  applyExecutionStatusUsage,
+  type ExecutionStatus,
+  mergeExecutionStatusesPrefix,
+  mergeExecutionStatusUsagePrefix,
+  reconcileExecutionStatuses,
+  removeExecutionStatus,
+} from './execution-status.js';
+import {
   type AgentPhase,
   applyRunMapEvent,
   mergePhaseLists,
@@ -179,6 +188,8 @@ export interface CoreState {
   /** Run lifetime boundaries retained from the replayed event stream. */
   runLifetimeBoundaries: readonly RunLifetimeBoundary[];
   activeExecutions: Record<string, ActiveAgentExecution>;
+  /** Freshest structured status for each active or not-yet-checkpointed execution. */
+  executionStatuses: Record<string, ExecutionStatus>;
   transcript: TranscriptEntry[];
   /** The default thread's transcript; equals `chatTranscripts[DEFAULT_CHAT_THREAD_ID]`. */
   chatTranscript: TranscriptEntry[];
@@ -220,6 +231,7 @@ export function initialCoreState(): CoreState {
     lastRunMapSequence: 0,
     runLifetimeBoundaries: [],
     activeExecutions: {},
+    executionStatuses: {},
     transcript: [],
     chatTranscript: [],
     chatTranscripts: {[DEFAULT_CHAT_THREAD_ID]: []},
@@ -298,13 +310,13 @@ export function reduceSnapshot(state: CoreState, snapshot: RunSnapshot): CoreSta
   // has seen the run end, a snapshot no newer than the fold cannot un-end it;
   // a genuinely newer one (a resumed run) still applies.
   if (hasRunEnded(registered) && snapshot.sequence <= registered.sequence) return registered;
-  return {
-    ...registered,
+  const next = cloneCoreStateWith(registered, {
     status: snapshot.status,
     agentKind: snapshot.agent_kind ?? null,
     roundLabel: snapshot.round_label ?? null,
     activeExecutions: activeExecutionsFromCheckpoint(snapshot.active_executions ?? []),
-  };
+  });
+  return next;
 }
 
 export type ActiveExecutionCheckpoint = NonNullable<RunSnapshot['active_executions']>;
@@ -316,7 +328,10 @@ export function reconcileActiveExecutions(
   throughSequence?: number,
 ): CoreState {
   if (throughSequence !== undefined && throughSequence < state.sequence) return state;
-  return {...state, activeExecutions: activeExecutionsFromCheckpoint(executions)};
+  const next = cloneCoreStateWith(state, {
+    activeExecutions: activeExecutionsFromCheckpoint(executions),
+  });
+  return next;
 }
 
 /**
@@ -443,12 +458,27 @@ export function reduceEventPrefix(
     ),
     // Liveness comes from the backend checkpoint, never from replayed history.
     activeExecutions: state.activeExecutions,
+    executionStatuses: mergeExecutionStatusesPrefix(
+      older.executionStatuses,
+      state.executionStatuses,
+      state.activeExecutions,
+    ),
     transcript: mergeTranscriptPrefix(older.transcript, state.transcript),
     chatTranscripts,
     chatTranscript: chatTranscripts[DEFAULT_CHAT_THREAD_ID] ?? [],
     chatThreads: mergeChatThreadsPrefix(older.chatThreads, state.chatThreads),
     todos: mergeTodosPrefix(older.todos, state.todos),
-    usage: state.usage ?? older.usage,
+    usage: mergeExecutionStatusUsagePrefix(
+      state.usage ?? older.usage,
+      mergeExecutionStatusesPrefix(
+        older.executionStatuses,
+        state.executionStatuses,
+        state.activeExecutions,
+      ),
+      older.executionStatuses,
+      events,
+      older.usage,
+    ),
     // Sorted rather than concatenated for the same reason the transcript is
     // merged: a tail batch can carry events from below its own floor.
     benchmarks: [...older.benchmarks, ...state.benchmarks].sort(
@@ -671,6 +701,7 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
   let next: CoreState = {...state, sequence: Math.max(state.sequence, sequence)};
   next = applyDiagnosticEvent(next, event);
   next = applyAgentExecutionEvent(next, event);
+  next = applyAgentStatusEvent(next, event);
   if (event.agent_kind === 'chat') return applyChatEvent(next, event, folder);
   if (event.agent_kind) next.agentKind = event.agent_kind;
   if (event.round_label) next.roundLabel = event.round_label;
@@ -756,6 +787,19 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
   if (event.type === 'run_failed' || event.type === 'run_interrupted') {
     return terminate(next, 'failed');
   }
+  return next;
+}
+
+function cloneCoreState(state: CoreState): CoreState {
+  return Object.create(
+    Object.getPrototypeOf(state),
+    Object.getOwnPropertyDescriptors(state),
+  ) as CoreState;
+}
+
+function cloneCoreStateWith(state: CoreState, patch: Partial<CoreState>): CoreState {
+  const next = cloneCoreState(state);
+  Object.assign(next, patch);
   return next;
 }
 
@@ -858,6 +902,37 @@ function applyAgentExecutionEvent(state: CoreState, event: RunEvent): CoreState 
     return {...state, activeExecutions: remaining};
   }
   return state;
+}
+
+function applyAgentStatusEvent(state: CoreState, event: RunEvent): CoreState {
+  const data = event.data;
+  const executionId = event.execution_id;
+  let executionStatuses =
+    Object.keys(state.activeExecutions).length === 0
+      ? state.executionStatuses
+      : reconcileExecutionStatuses(state.executionStatuses, state.activeExecutions);
+  if (data?.kind === 'agent_execution_started') {
+    executionStatuses = reconcileExecutionStatuses(executionStatuses, state.activeExecutions);
+  } else if (data?.kind === 'agent_execution_finished' && executionId != null) {
+    executionStatuses = removeExecutionStatus(executionStatuses, executionId);
+  } else if (
+    event.type === 'run_finished' ||
+    event.type === 'run_failed' ||
+    event.type === 'run_interrupted'
+  ) {
+    executionStatuses = {};
+  } else {
+    executionStatuses = applyExecutionStatus(executionStatuses, event);
+  }
+  const usage = applyExecutionStatusUsage(
+    state.usage,
+    state.executionStatuses,
+    executionStatuses,
+    state.activeExecutions,
+    event,
+  );
+  if (executionStatuses === state.executionStatuses && usage === state.usage) return state;
+  return cloneCoreStateWith(state, {executionStatuses, usage});
 }
 
 function updateTodos(previous: ExecutionTodos[], event: RunEvent): ExecutionTodos[] {

--- a/clients/core-state/src/execution-status.ts
+++ b/clients/core-state/src/execution-status.ts
@@ -1,0 +1,259 @@
+import type {AgentStatusData, RunEvent} from '@vibesys/backend-client';
+
+export interface ExecutionStatus {
+  executionId: string;
+  sequence: number;
+  observedAt: string;
+  progress: string | null;
+  agentLabel: string | null;
+  elapsedSeconds: number | null;
+  inputTokens: number | null;
+  contextWindow: number | null;
+}
+
+type StatusMap = Record<string, ExecutionStatus>;
+type ActiveExecutionMap = Record<string, {startedAt: string}>;
+
+interface ExecutionUsage {
+  inputTokens: number;
+  contextWindow: number | null;
+  model: string | null;
+}
+
+interface StatusUsageSource {
+  executionId: string;
+  sequence: number;
+  generationStartedAt: string | null;
+  status: ExecutionStatus;
+}
+
+const statusUsageSources = new WeakMap<object, StatusUsageSource>();
+const unresolvedStatusUsageModels = new WeakSet<object>();
+
+/** Returns status only when it belongs to the active execution generation. */
+export function executionStatusFor(
+  statuses: StatusMap,
+  execution: {executionId: string; startedAt: string},
+): ExecutionStatus | undefined {
+  const status = statuses[execution.executionId];
+  if (status === undefined) return undefined;
+  return Date.parse(status.observedAt) >= Date.parse(execution.startedAt) ? status : undefined;
+}
+
+/** Applies one status-bearing presentation event to its execution. */
+export function applyExecutionStatus(statuses: StatusMap, event: RunEvent): StatusMap {
+  const executionId = executionIdentity(event);
+  const data = event.data;
+  const status =
+    data?.kind === 'agent_output_chunk' || data?.kind === 'tool_call' ? data.status : null;
+  if (executionId == null || status == null) return statuses;
+  const sequence = event.sequence ?? 0;
+  const current = statuses[executionId];
+  if (
+    current !== undefined &&
+    (current.sequence > sequence ||
+      (sequence === 0 ? current.sequence > 0 : current.sequence === sequence))
+  ) {
+    return statuses;
+  }
+  return {
+    ...statuses,
+    [executionId]: {
+      executionId,
+      sequence,
+      observedAt: event.timestamp,
+      progress: status.progress ?? current?.progress ?? null,
+      agentLabel: status.agent_label ?? current?.agentLabel ?? null,
+      elapsedSeconds: status.elapsed_seconds ?? current?.elapsedSeconds ?? null,
+      inputTokens: status.input_tokens ?? current?.inputTokens ?? null,
+      contextWindow: status.context_window ?? current?.contextWindow ?? null,
+    },
+  };
+}
+
+/** Updates global usage only from the status update accepted for this execution. */
+export function applyExecutionStatusUsage(
+  current: ExecutionUsage | null,
+  previousStatuses: StatusMap,
+  nextStatuses: StatusMap,
+  active: ActiveExecutionMap,
+  event: RunEvent,
+): ExecutionUsage | null {
+  const raw = executionStatusData(event);
+  if (raw?.input_tokens == null) return current;
+  const executionId = executionIdentity(event);
+  if (executionId === null) {
+    const usage: ExecutionUsage = {
+      inputTokens: raw.input_tokens,
+      contextWindow: raw.context_window ?? current?.contextWindow ?? null,
+      model: current?.model ?? null,
+    };
+    if (needsModelBackfill(current)) unresolvedStatusUsageModels.add(usage);
+    return usage;
+  }
+  const status = nextStatuses[executionId];
+  if (
+    status === undefined ||
+    status === previousStatuses[executionId] ||
+    status.inputTokens === null
+  ) {
+    return current;
+  }
+  const usage: ExecutionUsage = {
+    inputTokens: status.inputTokens,
+    contextWindow: status.contextWindow,
+    model: current?.model ?? null,
+  };
+  statusUsageSources.set(usage, {
+    executionId,
+    sequence: status.sequence,
+    generationStartedAt: active[executionId]?.startedAt ?? null,
+    status,
+  });
+  if (needsModelBackfill(current)) unresolvedStatusUsageModels.add(usage);
+  return usage;
+}
+
+/** Restores fields supplied by an older status when a partial tail status owns usage. */
+export function mergeExecutionStatusUsagePrefix(
+  usage: ExecutionUsage | null,
+  statuses: StatusMap,
+  olderStatuses: StatusMap,
+  prefixEvents: readonly RunEvent[],
+  olderUsage: ExecutionUsage | null = null,
+): ExecutionUsage | null {
+  if (usage === null) return null;
+  const olderUsageCandidate = olderUsage === usage ? null : olderUsage;
+  const source = statusUsageSources.get(usage);
+  if (source === undefined) {
+    if (!unresolvedStatusUsageModels.has(usage) || olderUsageCandidate === null) return usage;
+    const merged = {...usage, model: olderUsageCandidate.model};
+    if (merged.model === null && unresolvedStatusUsageModels.has(olderUsageCandidate)) {
+      unresolvedStatusUsageModels.add(merged);
+    }
+    return merged;
+  }
+  const generationStartedAt =
+    source.generationStartedAt ??
+    latestExecutionStart(prefixEvents, source.executionId, source.sequence);
+  const older = olderStatuses[source.executionId];
+  const eligibleOlder =
+    older !== undefined &&
+    (generationStartedAt === null ||
+      Date.parse(older.observedAt) >= Date.parse(generationStartedAt))
+      ? older
+      : undefined;
+  const projected = statuses[source.executionId];
+  const status =
+    projected !== undefined && projected.sequence === source.sequence
+      ? projected
+      : mergeStatus(eligibleOlder, source.status);
+  if (status.inputTokens === null) return usage;
+  let model = usage.model;
+  let modelNeedsBackfill = unresolvedStatusUsageModels.has(usage);
+  if (modelNeedsBackfill && olderUsageCandidate !== null) {
+    model = olderUsageCandidate.model;
+    modelNeedsBackfill = model === null && unresolvedStatusUsageModels.has(olderUsageCandidate);
+  }
+  const merged: ExecutionUsage = {
+    inputTokens: status.inputTokens,
+    contextWindow: status.contextWindow,
+    model,
+  };
+  statusUsageSources.set(merged, {...source, generationStartedAt, status});
+  if (modelNeedsBackfill) unresolvedStatusUsageModels.add(merged);
+  return merged;
+}
+
+function needsModelBackfill(current: ExecutionUsage | null): boolean {
+  return current === null || unresolvedStatusUsageModels.has(current);
+}
+
+/** Drops status for an execution that is no longer active. */
+export function removeExecutionStatus(statuses: StatusMap, executionId: string): StatusMap {
+  if (statuses[executionId] === undefined) return statuses;
+  const {[executionId]: _finished, ...remaining} = statuses;
+  return remaining;
+}
+
+/** Reconciles status with the backend's authoritative active-execution checkpoint. */
+export function reconcileExecutionStatuses(
+  statuses: StatusMap,
+  active: ActiveExecutionMap,
+): StatusMap {
+  const entries = Object.entries(statuses);
+  const retained = entries.filter(([executionId, status]) => {
+    const execution = active[executionId];
+    return (
+      execution !== undefined && Date.parse(status.observedAt) >= Date.parse(execution.startedAt)
+    );
+  });
+  return retained.length === entries.length ? statuses : Object.fromEntries(retained);
+}
+
+/** Merges an older prefix under a newer suffix, retaining each execution's latest status. */
+export function mergeExecutionStatusesPrefix(
+  older: StatusMap,
+  newer: StatusMap,
+  active: ActiveExecutionMap,
+): StatusMap {
+  const eligibleOlder = reconcileExecutionStatuses(older, active);
+  const eligibleNewer = reconcileExecutionStatuses(newer, active);
+  const merged = {...eligibleOlder};
+  for (const [executionId, status] of Object.entries(eligibleNewer)) {
+    const previous = merged[executionId];
+    if (
+      previous === undefined ||
+      status.sequence > previous.sequence ||
+      (status.sequence === 0 && previous.sequence === 0)
+    ) {
+      merged[executionId] = mergeStatus(previous, status);
+    }
+  }
+  return merged;
+}
+
+function mergeStatus(older: ExecutionStatus | undefined, newer: ExecutionStatus): ExecutionStatus {
+  if (older === undefined) return newer;
+  return {
+    ...newer,
+    progress: newer.progress ?? older.progress,
+    agentLabel: newer.agentLabel ?? older.agentLabel,
+    elapsedSeconds: newer.elapsedSeconds ?? older.elapsedSeconds,
+    inputTokens: newer.inputTokens ?? older.inputTokens,
+    contextWindow: newer.contextWindow ?? older.contextWindow,
+  };
+}
+
+/** Reads structured status from the two protocol events that carry it. */
+export function executionStatusData(event: RunEvent): AgentStatusData | null {
+  const data = event.data;
+  return data?.kind === 'agent_output_chunk' || data?.kind === 'tool_call'
+    ? (data.status ?? null)
+    : null;
+}
+
+function executionIdentity(event: RunEvent): string | null {
+  return event.execution_id ?? event.invocation_id ?? null;
+}
+
+function latestExecutionStart(
+  events: readonly RunEvent[],
+  executionId: string,
+  throughSequence: number,
+): string | null {
+  let startedAt: string | null = null;
+  let latestSequence = -1;
+  for (const event of events) {
+    if (event.execution_id !== executionId || event.data?.kind !== 'agent_execution_started') {
+      continue;
+    }
+    const sequence = event.sequence ?? 0;
+    if (throughSequence > 0 && sequence > throughSequence) continue;
+    if (sequence >= latestSequence) {
+      latestSequence = sequence;
+      startedAt = event.timestamp;
+    }
+  }
+  return startedAt;
+}

--- a/clients/core-state/src/index.ts
+++ b/clients/core-state/src/index.ts
@@ -1,3 +1,4 @@
 export * from './core-state.js';
+export * from './execution-status.js';
 export * from './round-timing.js';
 export * from './run-map.js';

--- a/clients/tui/src/ui/activity-bar.test.ts
+++ b/clients/tui/src/ui/activity-bar.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'bun:test';
-import type {ActiveAgentExecution} from '@vibesys/core-state';
-import {activitySummary, runtimeSuffix} from './activity-bar.js';
+import type {ActiveAgentExecution, ExecutionStatus} from '@vibesys/core-state';
+import {activityLine, activitySummary, runtimeSuffix, statusSuffix} from './activity-bar.js';
 
 const STARTED_AT = '2026-08-25T12:00:00.000Z';
 function execution(
@@ -36,6 +36,29 @@ describe('activity summary', () => {
       'Working',
     );
   });
+
+  it('uses structured backend progress when available', () => {
+    expect(activitySummary(execution({mode: 'thinking', summary: ''}), status())).toBe('Round 1/3');
+  });
+});
+
+describe('structured execution status', () => {
+  it('renders label, backend elapsed time, tokens, and textual context pressure', () => {
+    expect(activityLine(execution({mode: 'thinking', summary: ''}), status(), Date.now())).toBe(
+      'Implementer 2 · Round 1/3 · 1m 12s · 180k/200k context high 90%',
+    );
+    expect(statusSuffix(status({inputTokens: 198_000}))).toBe(' · 198k/200k context critical 99%');
+  });
+
+  it('falls back to the legacy line when status is absent', () => {
+    expect(
+      activityLine(
+        execution({mode: 'thinking', summary: ''}),
+        undefined,
+        Date.parse(STARTED_AT) + 5_000,
+      ),
+    ).toBe('Implementer · Working · 5s');
+  });
 });
 
 describe('runtime suffix', () => {
@@ -51,3 +74,17 @@ describe('runtime suffix', () => {
     expect(runtimeSuffix(execution({mode: 'thinking', summary: ''}))).toBe('');
   });
 });
+
+function status(overrides: Partial<ExecutionStatus> = {}): ExecutionStatus {
+  return {
+    executionId: 'execution-1',
+    sequence: 3,
+    observedAt: '2026-08-25T12:01:12.000Z',
+    progress: 'Round 1/3',
+    agentLabel: 'Implementer 2',
+    elapsedSeconds: 72.9,
+    inputTokens: 180_000,
+    contextWindow: 200_000,
+    ...overrides,
+  };
+}

--- a/clients/tui/src/ui/activity-bar.ts
+++ b/clients/tui/src/ui/activity-bar.ts
@@ -1,5 +1,9 @@
 import {type CliRenderer, TextRenderable} from '@opentui/core';
-import type {ActiveAgentExecution} from '@vibesys/core-state';
+import {
+  type ActiveAgentExecution,
+  type ExecutionStatus,
+  executionStatusFor,
+} from '@vibesys/core-state';
 import type {SessionState} from '../session-model.js';
 import {visibleActiveExecutions} from '../session-model.js';
 import {agentRuntimeLabel} from './agent-runtime-label.js';
@@ -11,7 +15,7 @@ export const SPINNER_INTERVAL_MS = 120;
 /** Status for executions visible in the selected agent conversation. */
 export class ActivityBarView {
   readonly output: TextRenderable;
-  #executions: ActiveAgentExecution[] = [];
+  #executions: VisibleExecution[] = [];
   #frame = 0;
   #timer: ReturnType<typeof setInterval> | null = null;
 
@@ -29,7 +33,12 @@ export class ActivityBarView {
   }
 
   render(state: SessionState, visible = true): void {
-    this.#executions = visible ? visibleActiveExecutions(state) : [];
+    this.#executions = visible
+      ? visibleActiveExecutions(state).map(execution => ({
+          execution,
+          status: executionStatusFor(state.core.executionStatuses, execution),
+        }))
+      : [];
     this.output.visible = this.#executions.length > 0;
     this.#refresh();
     this.#syncTimer();
@@ -61,17 +70,17 @@ export class ActivityBarView {
     const spinner = SPINNER_FRAMES[this.#frame] ?? SPINNER_FRAMES[0];
     const nowMs = Date.now();
     if (this.#executions.length === 1) {
-      const execution = this.#executions[0];
-      if (execution === undefined) return;
-      const runtime = runtimeSuffix(execution);
-      this.output.content = `${spinner} ${roleLabel(execution.agentKind)} · ${activitySummary(execution)}${runtime} · ${elapsed(execution.startedAt, nowMs)}`;
+      const visible = this.#executions[0];
+      if (visible === undefined) return;
+      const {execution, status} = visible;
+      this.output.content = `${spinner} ${activityLine(execution, status, nowMs)}`;
       return;
     }
     const summaries = this.#executions
       .slice(0, 3)
       .map(
-        execution =>
-          `${roleLabel(execution.agentKind)}: ${activitySummary(execution)}${runtimeSuffix(execution)}`,
+        ({execution, status}) =>
+          `${status?.agentLabel || roleLabel(execution.agentKind)}: ${activitySummary(execution, status)}${statusSuffix(status)}${runtimeSuffix(execution)}`,
       )
       .join(' · ');
     const remainder = this.#executions.length > 3 ? ` · +${this.#executions.length - 3} more` : '';
@@ -79,13 +88,35 @@ export class ActivityBarView {
   }
 }
 
-export function activitySummary(_execution: ActiveAgentExecution): string {
-  return 'Working';
+interface VisibleExecution {
+  execution: ActiveAgentExecution;
+  status: ExecutionStatus | undefined;
+}
+
+export function activitySummary(
+  _execution: ActiveAgentExecution,
+  status?: ExecutionStatus,
+): string {
+  return status?.progress || 'Working';
 }
 
 export function runtimeSuffix(execution: ActiveAgentExecution): string {
   const label = agentRuntimeLabel(execution.provider, execution.model);
   return label === null ? '' : ` · ${label}`;
+}
+
+/** Formats the selected active execution's complete status line. */
+export function activityLine(
+  execution: ActiveAgentExecution,
+  status: ExecutionStatus | undefined,
+  nowMs: number,
+): string {
+  const label = status?.agentLabel || roleLabel(execution.agentKind);
+  const timing =
+    status?.elapsedSeconds === null || status?.elapsedSeconds === undefined
+      ? elapsed(execution.startedAt, nowMs)
+      : elapsedSeconds(status.elapsedSeconds);
+  return `${label} · ${activitySummary(execution, status)}${runtimeSuffix(execution)} · ${timing}${statusSuffix(status)}`;
 }
 
 function roleLabel(role: string): string {
@@ -99,4 +130,26 @@ function elapsed(startedAt: string, nowMs: number): string {
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
   return `${minutes}m ${seconds % 60}s`;
+}
+
+function elapsedSeconds(value: number): string {
+  const seconds = Math.max(0, Math.floor(value));
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+export function statusSuffix(status: ExecutionStatus | undefined): string {
+  if (status?.inputTokens === null || status?.inputTokens === undefined) return '';
+  const used = formatTokenCount(status.inputTokens);
+  const window = status.contextWindow;
+  if (window === null || window <= 0) return ` · ${used} tokens`;
+  const percent = Math.floor((status.inputTokens / window) * 100);
+  const pressure = percent >= 95 ? 'critical ' : percent >= 80 ? 'high ' : '';
+  return ` · ${used}/${formatTokenCount(window)} context ${pressure}${percent}%`;
+}
+
+function formatTokenCount(value: number): string {
+  if (value < 1_000) return String(value);
+  if (value < 1_000_000) return `${Math.floor(value / 1_000)}k`;
+  return `${(value / 1_000_000).toFixed(1)}M`;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "agentshim>=0.5.0",
+    "agentshim>=0.5.0,<0.6.0",
     "cbor2<6",
     "cryptography<50",
     "deepagents",


### PR DESCRIPTION
## Problem

The backend already sends structured progress, agent label, elapsed time, input tokens, and context-window size on `agent_output_chunk.status` and `tool_call.status`. Core state discarded that payload, so the activity bar could only render a generic `Working` label and a client-side timer. The global token meter also waited for a later `usage_update` event.

## Solution

Export the generated status payload through the backend-client protocol facade, then fold it into a typed `executionStatuses` map keyed by execution identity. Each record carries its source sequence and timestamp. Later partial payloads retain fields from earlier payloads for the same execution, while a positive-sequence record cannot be replaced by an older or unsequenced event. Repeated legacy events with no sequence still advance in fold order.

Prefix backfill first filters each side against the active execution generation, then merges each execution field by field. This prevents a reused id from inheriting an earlier generation's label or context. The global usage projection comes from the accepted per-execution record. Private `WeakMap` provenance retains that status snapshot and its known generation even after the execution or run finishes, so an older prefix can restore a context window omitted by a newer token-only suffix without exposing replay metadata in `CoreState`. Concurrent agents never donate context-window fields to each other.

The activity bar uses the status belonging to the active execution generation. It renders the backend agent label, progress, elapsed snapshot, and tokens versus context. Context pressure includes `high` or `critical` text at 80% and 95%, so color is not required. Events without structured status retain the existing role label, `Working`, and live elapsed timer.

### Architecture

```mermaid
flowchart LR
  E[output chunk or tool call] --> P[backend-client generated status type]
  P --> F[core-state execution status fold]
  F --> X[status by execution id]
  X --> M[fieldwise prefix merge]
  X --> U[global usage from accepted execution]
  M --> U
  X --> G[generation-safe active selector]
  G --> A[TUI activity bar]
  U --> H[existing header usage meter]
```

Pending statuses are retained while a tail batch waits for its authoritative execution checkpoint. `executionStatusFor` rejects a record older than the checkpoint's `startedAt`, so a reused execution id cannot surface stale status. A subsequent active fold prunes the stale record. Execution-finished and run-terminal events remove their status immediately.

## Verification

The regression fixture `/tmp/vibesys-614-before.test.ts` fails against base `ea6f9073`: the status payload folds to `undefined` (`0 pass, 1 fail`).

### Correctness properties

- Status is isolated by execution identity and ordered by sequence.
- Partial updates inherit fields only from the same execution.
- Reused execution ids never inherit fields from a prior generation.
- A positive-sequence status is not replaced by an unsequenced replay event.
- Prefix backfill produces the same per-execution status and global usage as a full replay, including after execution or run termination.
- Checkpoint generation timestamps prevent a reused id from exposing stale status.
- Finishing one execution preserves concurrent executions; run termination clears all pending status.
- Missing legacy status preserves the prior activity-bar behavior and does not create usage.
- Context pressure is conveyed by text as well as a percentage.
- The #611 timing and #613 run-map changes merge without conflict; their combined core suite passes.

### Testing

- `pnpm --filter @vibesys/backend-client check`
- `pnpm --filter @vibesys/core-state check`
- `pnpm --filter @vibesys/core-state test` (`111 pass, 0 fail`)
- `pnpm --filter @vibesys/tui check`
- `bun test --max-concurrency 1 src/ui/activity-bar.test.ts` (`6 pass, 0 fail`)
- Combined #611 + #613 + #614: direct core TypeScript check and core tests (`123 pass, 0 fail`)

- Full Python CI suite: 5,741 passed, 6 environment or platform skips; global and module coverage gates passed.
- Final Node 24.21.0 / Bun 1.3.9 client checks: 25 backend-client, 111 core-state and 741 TUI tests passed. Protocol generation was stable; formatting, lint, type, architecture, launcher and build checks passed with the required Unix socket access.

- Combined integration of all ten independently based fixes: 5,816 Python tests passed (6 environment/platform skips), 91% patch coverage, 25 backend-client, 123 core-state and 745 TUI tests passed. All repository static checks, stable protocol generation, builds, and packed/deployed TUI self-tests passed.
- Real combined `codex` / `gpt-5.6-sol` queue-rs SPSC run, capped at one round: completed with independent review and official evaluation. The run reported the retained winner `5e621d36bcc4` at 26,412,131.227693 operations/second; the final workspace was clean and differed from the winning tree only in framework state and the final archive. Live chat completed once while optimization streamed; the TUI showed execution label, progress, elapsed time and context usage. Pathological concurrency, large histories and minimizing-objective rankings were exercised separately by the targeted regressions and performance benchmarks for their respective issues.

- Real completed-journal replay across nine chunk decompositions preserves exact round timing, terminal execution status, usage (including model identity), and all 133 transcript entries. Added regressions preserve explicit nullable model resets and keep private usage provenance independent across immutable state forks. Pre-existing phase-order/identity differences match unchanged main and are outside this change.

Closes #614
