### PR TITLE
TUI: index run-map folding without copying history

### DIFF
--- a/clients/core-state/bench/run-map.ts
+++ b/clients/core-state/bench/run-map.ts
@@ -1,0 +1,260 @@
+import type {RunEvent} from '@vibesys/backend-client';
+import type {CoreState} from '../src/core-state.js';
+import type {RunMapState} from '../src/run-map.js';
+
+const runMapModule =
+  Bun.env.RUN_MAP_BENCH_MODULE ?? new URL('../src/run-map.ts', import.meta.url).pathname;
+const {applyRunMapEvent} = (await import(runMapModule)) as typeof import('../src/run-map.js');
+const coreStateModule =
+  Bun.env.RUN_MAP_BENCH_CORE_MODULE ?? new URL('../src/core-state.ts', import.meta.url).pathname;
+const {initialCoreState, reduceEvent, reduceEventBatch} = (await import(
+  coreStateModule
+)) as typeof import('../src/core-state.js');
+
+const ROLES = ['orchestrator', 'implementer', 'judge', 'profiler'] as const;
+const LIVE_SAMPLES = 5_000;
+
+interface Measurement {
+  readonly kind:
+    | 'run-map replay'
+    | 'core replay'
+    | 'run-map live no-op'
+    | 'run-map phase replacement'
+    | 'core live no-op'
+    | 'core phase replacement';
+  readonly scale: number;
+  readonly phases: number;
+  readonly totalMs: number;
+  readonly microsecondsPerEvent: number;
+}
+
+const measurements: Measurement[] = [];
+
+for (const count of [15_000, 36_000, 72_000]) {
+  const input = replayEvents(count, 280);
+  let state = emptyRunMap();
+  const startedAt = performance.now();
+  for (const event of input) state = applyRunMapEvent(state, event);
+  measurements.push(
+    measurement('run-map replay', count, state, performance.now() - startedAt, count),
+  );
+
+  const coreStartedAt = performance.now();
+  const coreState = reduceEventBatch(initialCoreState(), input);
+  measurements.push(
+    measurement('core replay', count, coreState, performance.now() - coreStartedAt, count),
+  );
+}
+
+const outputCosts: Measurement[] = [];
+const phaseCosts: Measurement[] = [];
+for (const round of [20, 100, 280, 2_000]) {
+  const base = replay(replayEvents(round * 40, round));
+  outputCosts.push(measureLiveOutput(base, round));
+  phaseCosts.push(measureLivePhaseReplacement(base, round));
+}
+measurements.push(...outputCosts, ...phaseCosts);
+
+const coreOutputCosts: Measurement[] = [];
+const corePhaseCosts: Measurement[] = [];
+for (const round of [20, 100, 280, 2_000]) {
+  const base = reduceEventBatch(initialCoreState(), replayEvents(round * 40, round));
+  coreOutputCosts.push(measureCoreNoop(base, round));
+  corePhaseCosts.push(measureCorePhaseReplacement(base, round));
+}
+measurements.push(...coreOutputCosts, ...corePhaseCosts);
+
+console.log('| Path | Events / late round | Phases | Total ms | µs/event |');
+console.log('|---|---:|---:|---:|---:|');
+for (const result of measurements) {
+  console.log(
+    `| ${result.kind} | ${result.scale} | ${result.phases} | ${result.totalMs.toFixed(2)} | ${result.microsecondsPerEvent.toFixed(3)} |`,
+  );
+}
+
+assertNearFlat('live output', outputCosts);
+assertNearFlat('live phase replacement', phaseCosts);
+assertNearFlat('core live no-op', coreOutputCosts);
+assertNearFlat('core phase replacement', corePhaseCosts);
+
+function measureLiveOutput(base: RunMapState, round: number): Measurement {
+  let state = base;
+  const startedAt = performance.now();
+  for (let sample = 0; sample < LIVE_SAMPLES; sample += 1) {
+    state = applyRunMapEvent(
+      state,
+      scopedEvent(100_000 + sample, round, 'implementer', 'agent_output_chunk'),
+    );
+  }
+  return measurement(
+    'run-map live no-op',
+    round,
+    state,
+    performance.now() - startedAt,
+    LIVE_SAMPLES,
+  );
+}
+
+function measureLivePhaseReplacement(base: RunMapState, round: number): Measurement {
+  let state = applyRunMapEvent(base, {
+    ...scopedEvent(90_000, round, 'implementer', 'phase_started'),
+    execution_id: 'live-phase',
+    invocation_id: 'live-phase',
+  });
+  const startedAt = performance.now();
+  for (let sample = 0; sample < LIVE_SAMPLES; sample += 1) {
+    state = applyRunMapEvent(state, {
+      ...scopedEvent(100_000 + sample, round, 'implementer', 'phase_started'),
+      execution_id: 'live-phase',
+      invocation_id: 'live-phase',
+    });
+  }
+  return measurement(
+    'run-map phase replacement',
+    round,
+    state,
+    performance.now() - startedAt,
+    LIVE_SAMPLES,
+  );
+}
+
+function measureCoreNoop(base: CoreState, round: number): Measurement {
+  let state = base;
+  const startedAt = performance.now();
+  for (let sample = 0; sample < LIVE_SAMPLES; sample += 1) {
+    state = reduceEvent(
+      state,
+      scopedEvent(100_000 + sample, round, 'implementer', 'agent_execution_activity_changed'),
+    );
+  }
+  return measurement('core live no-op', round, state, performance.now() - startedAt, LIVE_SAMPLES);
+}
+
+function measureCorePhaseReplacement(base: CoreState, round: number): Measurement {
+  let state = reduceEvent(base, {
+    ...scopedEvent(90_000, round, 'implementer', 'agent_execution_started'),
+    execution_id: 'live-phase',
+    invocation_id: 'live-phase',
+  });
+  const startedAt = performance.now();
+  for (let sample = 0; sample < LIVE_SAMPLES; sample += 1) {
+    state = reduceEvent(state, {
+      ...scopedEvent(100_000 + sample, round, 'implementer', 'agent_execution_started'),
+      execution_id: 'live-phase',
+      invocation_id: 'live-phase',
+    });
+  }
+  return measurement(
+    'core phase replacement',
+    round,
+    state,
+    performance.now() - startedAt,
+    LIVE_SAMPLES,
+  );
+}
+
+function measurement(
+  kind: Measurement['kind'],
+  scale: number,
+  state: RunMapState | CoreState,
+  totalMs: number,
+  events: number,
+): Measurement {
+  return {
+    kind,
+    scale,
+    phases: state.phases.length,
+    totalMs,
+    microsecondsPerEvent: (totalMs * 1_000) / events,
+  };
+}
+
+function assertNearFlat(kind: string, results: readonly Measurement[]): void {
+  const costs = results.map(result => result.microsecondsPerEvent);
+  const ratio = Math.max(...costs) / Math.min(...costs);
+  if (ratio > 2.5) {
+    throw new Error(`${kind} cost grew ${ratio.toFixed(2)}x across late-round scales`);
+  }
+}
+
+function replay(events: readonly RunEvent[]): RunMapState {
+  let state = emptyRunMap();
+  for (const event of events) state = applyRunMapEvent(state, event);
+  return state;
+}
+
+function replayEvents(count: number, rounds: number): RunEvent[] {
+  const events: RunEvent[] = [runStarted(rounds)];
+  const ordinaryEvents = count - 1;
+  const perRound = Math.floor(ordinaryEvents / rounds);
+  let remainder = ordinaryEvents % rounds;
+  let sequence = 2;
+  for (let round = 1; round <= rounds; round += 1) {
+    const eventsThisRound = perRound + (remainder > 0 ? 1 : 0);
+    remainder -= remainder > 0 ? 1 : 0;
+    for (const role of ROLES) {
+      events.push(scopedEvent(sequence, round, role, 'agent_execution_started'));
+      sequence += 1;
+    }
+    const outputCount = Math.max(0, eventsThisRound - ROLES.length * 2);
+    for (let offset = 0; offset < outputCount; offset += 1) {
+      const role = ROLES[offset % ROLES.length] ?? 'implementer';
+      events.push(scopedEvent(sequence, round, role, 'agent_output_chunk'));
+      sequence += 1;
+    }
+    for (const role of ROLES) {
+      events.push(scopedEvent(sequence, round, role, 'agent_execution_finished'));
+      sequence += 1;
+    }
+  }
+  return events.slice(0, count);
+}
+
+function runStarted(rounds: number): RunEvent {
+  return {
+    sequence: 1,
+    timestamp: timestamp(1),
+    type: 'run_started',
+    status: 'active',
+    data: {
+      kind: 'run_started',
+      outer_loop: 'agent',
+      input: '/benchmark',
+      max_rounds: rounds,
+      expected_roles: [...ROLES],
+    },
+  };
+}
+
+function scopedEvent(
+  sequence: number,
+  round: number,
+  role: string,
+  type: RunEvent['type'],
+): RunEvent {
+  const executionId = `${round}-${role}`;
+  return {
+    sequence,
+    timestamp: timestamp(sequence),
+    type,
+    status: type.endsWith('_finished') ? 'completed' : 'active',
+    agent_kind: role,
+    round_label: `round-${round}-${role}`,
+    execution_id: executionId,
+    invocation_id: executionId,
+  };
+}
+
+function timestamp(sequence: number): string {
+  return new Date(1_767_225_600_000 + sequence).toISOString();
+}
+
+function emptyRunMap(): RunMapState {
+  return {
+    outerLoop: null,
+    expectedRoles: null,
+    rounds: [],
+    phases: [],
+    lastEventTimestamp: null,
+  };
+}

--- a/clients/core-state/package.json
+++ b/clients/core-state/package.json
@@ -20,7 +20,8 @@
     "precheck": "pnpm --filter @vibesys/core-state^... build",
     "check": "tsc -p tsconfig.check.json",
     "pretest": "pnpm --filter @vibesys/core-state^... build",
-    "test": "bun test --max-concurrency 1 src"
+    "test": "bun test --max-concurrency 1 src",
+    "bench:run-map": "bun bench/run-map.ts"
   },
   "dependencies": {
     "@vibesys/backend-client": "workspace:*"

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -159,6 +159,32 @@ describe('core state projection', () => {
     expect(replayed.transcript.map(entry => entry.content)).toEqual(['one']);
   });
 
+  it('preserves published run-map arrays through core-state clone paths', () => {
+    const started = reduceEvent(
+      initialCoreState(),
+      executionEvent(1, 'agent_execution_started', 'exec', startedData('Implement')),
+    );
+    const rounds = started.rounds;
+    const phases = started.phases;
+
+    const streamed = reduceEvent(started, outputEvent(2, 'working', 'exec'));
+    const diagnosed = reduceEvent(
+      streamed,
+      diagnosticEvent(3, 'agent_output_chunk', 'warning', 'warning', 'Check output'),
+    );
+    const batched = reduceEventBatch(diagnosed, [outputEvent(4, 'still working', 'exec')]);
+    const chatted = reduceEvent(batched, chatAnswerEvent(5, 'status'));
+
+    expect(streamed.rounds).toBe(rounds);
+    expect(streamed.phases).toBe(phases);
+    expect(diagnosed.rounds).toBe(rounds);
+    expect(diagnosed.phases).toBe(phases);
+    expect(batched.rounds).toBe(rounds);
+    expect(batched.phases).toBe(phases);
+    expect(chatted.rounds).toBe(rounds);
+    expect(chatted.phases).toBe(phases);
+  });
+
   it('applies event batches before reconciling their execution checkpoint', () => {
     const started = executionEvent(1, 'agent_execution_started', 'stale', {
       kind: 'agent_execution_started',

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -1,7 +1,9 @@
 import type {Diagnostic, RunEvent, RunSnapshot, RunStatus} from '@vibesys/backend-client';
 import {
   type AgentPhase,
+  adoptRunMapArrays,
   applyRunMapEvent,
+  indexRunMapArrays,
   mergePhaseLists,
   mergeRoundLists,
   type RoundSummary,
@@ -51,13 +53,7 @@ export interface BenchmarkRecord {
   unit: string;
 }
 
-/**
- * A round as core state carries it: the run map's timing and status summary
- * plus round facts folded outside the run map. `profileSkipped` is set from a
- * `round_finished` event whose round ran no fresh profile (such a round records
- * no perf reading); readers treat an absent flag as false, which also covers
- * events recorded before the field existed.
- */
+/** A round as core state carries the run map's timing, status, and profile result. */
 export interface RoundState extends RoundSummary {
   profileSkipped?: boolean;
 }
@@ -298,13 +294,13 @@ export function reduceSnapshot(state: CoreState, snapshot: RunSnapshot): CoreSta
   // has seen the run end, a snapshot no newer than the fold cannot un-end it;
   // a genuinely newer one (a resumed run) still applies.
   if (hasRunEnded(registered) && snapshot.sequence <= registered.sequence) return registered;
-  return {
-    ...registered,
+  const next = cloneCoreStateWith(registered, {
     status: snapshot.status,
     agentKind: snapshot.agent_kind ?? null,
     roundLabel: snapshot.round_label ?? null,
     activeExecutions: activeExecutionsFromCheckpoint(snapshot.active_executions ?? []),
-  };
+  });
+  return next;
 }
 
 export type ActiveExecutionCheckpoint = NonNullable<RunSnapshot['active_executions']>;
@@ -316,7 +312,10 @@ export function reconcileActiveExecutions(
   throughSequence?: number,
 ): CoreState {
   if (throughSequence !== undefined && throughSequence < state.sequence) return state;
-  return {...state, activeExecutions: activeExecutionsFromCheckpoint(executions)};
+  const next = cloneCoreStateWith(state, {
+    activeExecutions: activeExecutionsFromCheckpoint(executions),
+  });
+  return next;
 }
 
 /**
@@ -342,7 +341,9 @@ export function reduceEventBatch(
   for (const event of events) folded = foldEvent(folded, event, folder);
   const committed = folder.commit(folded);
   const reduced =
-    historyAfterSequence === undefined ? committed : {...committed, historyAfterSequence};
+    historyAfterSequence === undefined
+      ? committed
+      : cloneCoreStateWith(committed, {historyAfterSequence});
   return activeExecutions === undefined
     ? reduced
     : reconcileActiveExecutions(reduced, activeExecutions, throughSequence);
@@ -408,21 +409,19 @@ export function reduceEventPrefix(
       (left, right) => (left.sequence ?? 0) - (right.sequence ?? 0),
     ),
   );
-  const older: CoreState = {
-    ...olderData,
+  const older = cloneCoreStateWith(olderData, {
     outerLoop: runMapReplay.outerLoop,
     expectedRoles: runMapReplay.expectedRoles,
-    rounds: runMapReplay.rounds,
-    phases: runMapReplay.phases,
     lastEventTimestamp: runMapReplay.lastEventTimestamp,
     lastRunMapSequence: runMapReplay.lastRunMapSequence,
     runLifetimeBoundaries: mergeRunLifetimeBoundaries(
       runMapReplay.runLifetimeBoundaries,
       state.runLifetimeBoundaries,
     ),
-  };
+  });
+  adoptRunMapArrays(older, runMapReplay);
   const chatTranscripts = mergeChatTranscriptsPrefix(older.chatTranscripts, state.chatTranscripts);
-  return {
+  const merged: CoreState = {
     sequence: state.sequence,
     // The newer events own run termination.
     status: state.status,
@@ -460,6 +459,8 @@ export function reduceEventPrefix(
     chatTypedToolEvents: mergeTypedToolFlags(older.chatTypedToolEvents, state.chatTypedToolEvents),
     historyAfterSequence,
   };
+  indexRunMapArrays(merged);
+  return merged;
 }
 
 /**
@@ -668,7 +669,8 @@ export function reduceEvent(state: CoreState, event: RunEvent): CoreState {
 function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder | null): CoreState {
   const sequence = event.sequence ?? 0;
   if (sequence > 0 && sequence <= state.sequence) return state;
-  let next: CoreState = {...state, sequence: Math.max(state.sequence, sequence)};
+  let next = cloneCoreState(state);
+  next.sequence = Math.max(state.sequence, sequence);
   next = applyDiagnosticEvent(next, event);
   next = applyAgentExecutionEvent(next, event);
   if (event.agent_kind === 'chat') return applyChatEvent(next, event, folder);
@@ -680,21 +682,10 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
       : isRunLifetimeBoundary(event)
         ? {event, closeout: null}
         : null;
-  const runMap = applyRunMapEvent(
-    {
-      outerLoop: next.outerLoop,
-      expectedRoles: next.expectedRoles,
-      rounds: next.rounds,
-      phases: next.phases,
-      lastEventTimestamp: next.lastEventTimestamp,
-    },
-    event,
-    boundary?.closeout?.timestamp ?? null,
-  );
+  const runMap = applyRunMapEvent(next, event, boundary?.closeout?.timestamp ?? null);
   next.outerLoop = runMap.outerLoop;
   next.expectedRoles = runMap.expectedRoles;
-  next.rounds = runMap.rounds;
-  next.phases = runMap.phases;
+  adoptRunMapArrays(next, runMap);
   next.lastEventTimestamp = runMap.lastEventTimestamp;
   next.lastRunMapSequence = sequence;
   if (boundary !== null) {
@@ -702,15 +693,6 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
   }
 
   const data = event.data;
-  // The run map owns a round's status and timing; the carried-forward flag is
-  // a round fact folded here, like benchmarks, so it lands on the summary the
-  // run map just settled.
-  if (data?.kind === 'round_finished' && data.profile_skipped === true) {
-    const finishedRound = roundNumberFromLabel(event.round_label);
-    next.rounds = next.rounds.map(round =>
-      round.number === finishedRound ? {...round, profileSkipped: true} : round,
-    );
-  }
   if (data?.kind === 'tool_call' || data?.kind === 'tool_result') next.typedToolEvents = true;
   if (data?.kind === 'todo_update') next.todos = updateTodos(next.todos, event);
   if (data?.kind === 'usage_update') {
@@ -759,6 +741,19 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
   return next;
 }
 
+function cloneCoreState(state: CoreState): CoreState {
+  return Object.create(
+    Object.getPrototypeOf(state),
+    Object.getOwnPropertyDescriptors(state),
+  ) as CoreState;
+}
+
+function cloneCoreStateWith(state: CoreState, patch: Partial<CoreState>): CoreState {
+  const next = cloneCoreState(state);
+  Object.assign(next, patch);
+  return next;
+}
+
 /** Returns the one diagnostic added or updated by a reducer transition. */
 export function latestDiagnosticChange(
   previous: CoreState,
@@ -774,11 +769,11 @@ export function latestDiagnosticChange(
 /** Folds one backend-published status, ending the run when that status has. */
 function applyRunStatus(state: CoreState, status: CoreRunStatus): CoreState {
   const ended = endedRunStatus(status);
-  return ended === null ? {...state, status} : terminate(state, ended);
+  return ended === null ? cloneCoreStateWith(state, {status}) : terminate(state, ended);
 }
 
 function terminate(state: CoreState, status: EndedRunStatus): CoreState {
-  return {...state, status, activeExecutions: {}};
+  return cloneCoreStateWith(state, {status, activeExecutions: {}});
 }
 
 function activeExecutionsFromCheckpoint(
@@ -814,8 +809,7 @@ function applyAgentExecutionEvent(state: CoreState, event: RunEvent): CoreState 
   const data = event.data;
   if (executionId == null) return state;
   if (data?.kind === 'agent_execution_started') {
-    return {
-      ...state,
+    return cloneCoreStateWith(state, {
       activeExecutions: {
         ...state.activeExecutions,
         [executionId]: {
@@ -837,13 +831,12 @@ function applyAgentExecutionEvent(state: CoreState, event: RunEvent): CoreState 
           model: data.model ?? null,
         },
       },
-    };
+    });
   }
   if (data?.kind === 'agent_execution_activity_changed') {
     const current = state.activeExecutions[executionId];
     if (current === undefined) return state;
-    return {
-      ...state,
+    return cloneCoreStateWith(state, {
       activeExecutions: {
         ...state.activeExecutions,
         [executionId]: {
@@ -851,11 +844,11 @@ function applyAgentExecutionEvent(state: CoreState, event: RunEvent): CoreState 
           activity: {mode: data.mode, summary: data.summary, tool: data.tool ?? null},
         },
       },
-    };
+    });
   }
   if (data?.kind === 'agent_execution_finished') {
     const {[executionId]: _finished, ...remaining} = state.activeExecutions;
-    return {...state, activeExecutions: remaining};
+    return cloneCoreStateWith(state, {activeExecutions: remaining});
   }
   return state;
 }
@@ -904,7 +897,9 @@ function applyChatEvent(
   let next = state;
   const typed = data?.kind === 'tool_call' || data?.kind === 'tool_result';
   if (typed && next.chatTypedToolEvents[threadId] !== true) {
-    next = {...next, chatTypedToolEvents: {...next.chatTypedToolEvents, [threadId]: true}};
+    next = cloneCoreStateWith(next, {
+      chatTypedToolEvents: {...next.chatTypedToolEvents, [threadId]: true},
+    });
   }
   const legacyToolChunk =
     data?.kind === 'agent_output_chunk' &&
@@ -934,7 +929,7 @@ function upsertChatThread(state: CoreState, thread: ChatThread): CoreState {
     state.chatTranscripts[thread.id] === undefined
       ? {...state.chatTranscripts, [thread.id]: []}
       : state.chatTranscripts;
-  return {...state, chatThreads, chatTranscripts};
+  return cloneCoreStateWith(state, {chatThreads, chatTranscripts});
 }
 
 function setChatThreadTitle(state: CoreState, threadId: string, title: string): CoreState {
@@ -947,12 +942,11 @@ function setChatThreadTitle(state: CoreState, threadId: string, title: string): 
       title,
     );
   }
-  return {
-    ...state,
+  return cloneCoreStateWith(state, {
     chatThreads: state.chatThreads.map(thread =>
       thread.id === threadId ? {...thread, title} : thread,
     ),
-  };
+  });
 }
 
 function appendChatTranscript(
@@ -972,11 +966,10 @@ function appendChatTranscript(
     foldTranscriptEntry(transcript, entry, null);
   }
   const chatTranscripts = {...state.chatTranscripts, [threadId]: transcript};
-  return {
-    ...state,
+  return cloneCoreStateWith(state, {
     chatTranscripts,
     chatTranscript: threadId === DEFAULT_CHAT_THREAD_ID ? transcript : state.chatTranscript,
-  };
+  });
 }
 
 /**
@@ -1003,7 +996,9 @@ function foldChatAnswer(entries: TranscriptEntry[], incoming: TranscriptEntry): 
 function applyDiagnosticEvent(state: CoreState, event: RunEvent): CoreState {
   const diagnostic = diagnosticFromEvent(event);
   if (diagnostic === null) return state;
-  return {...state, diagnostics: upsertDiagnostic(state.diagnostics, diagnostic)};
+  return cloneCoreStateWith(state, {
+    diagnostics: upsertDiagnostic(state.diagnostics, diagnostic),
+  });
 }
 
 /** Merges `incoming` into the diagnostic it identifies, else appends it. */
@@ -1598,16 +1593,15 @@ class TranscriptFolder {
   commit(state: CoreState): CoreState {
     if (this.#buffers.size === 0) return state;
     const run = this.#buffers.get(RUN_TRANSCRIPT);
-    let next = run === undefined ? state : {...state, transcript: run.entries};
+    let next = run === undefined ? state : cloneCoreStateWith(state, {transcript: run.entries});
     const threads = [...this.#buffers].filter(([key]) => key !== RUN_TRANSCRIPT);
     if (threads.length === 0) return next;
     const chatTranscripts = {...next.chatTranscripts};
     for (const [threadId, buffer] of threads) chatTranscripts[threadId] = buffer.entries;
-    next = {
-      ...next,
+    next = cloneCoreStateWith(next, {
       chatTranscripts,
       chatTranscript: chatTranscripts[DEFAULT_CHAT_THREAD_ID] ?? next.chatTranscript,
-    };
+    });
     return next;
   }
 }

--- a/clients/core-state/src/run-map-array.ts
+++ b/clients/core-state/src/run-map-array.ts
@@ -1,0 +1,181 @@
+/**
+ * Persistent storage for the run map's internal arrays.
+ *
+ * A 32-way tree gives indexed reads and immutable replacement in at most a few
+ * node copies for the run sizes we support. The proxy gives the reducer normal
+ * indexed array operations while old folds retain their original tree root.
+ * Public state materializes ordinary arrays at the core-state boundary.
+ */
+
+const BRANCH_FACTOR = 32;
+
+type VectorNode<T> = readonly (VectorNode<T> | T | undefined)[];
+
+interface Vector<T> {
+  readonly root: VectorNode<T>;
+  readonly depth: number;
+  readonly length: number;
+}
+
+const vectors = new WeakMap<readonly unknown[], Vector<unknown>>();
+
+/** Returns one entry without materializing the persistent array. */
+export function runMapArrayAt<T>(values: readonly T[], index: number): T | undefined {
+  const vector = vectorFor(values);
+  return vector === undefined ? values[index] : vectorAt(vector, index);
+}
+
+/** Replaces one entry without copying the complete public array. */
+export function replaceRunMapArrayEntry<T>(values: T[], index: number, value: T): T[] {
+  if (index < 0 || index >= values.length) throw new RangeError(`Invalid run-map index ${index}`);
+  if (runMapArrayAt(values, index) === value) return values;
+  return arrayFor(vectorSet(vectorFor(values) ?? vectorFrom(values), index, value));
+}
+
+/** Appends one entry while preserving insertion order. */
+export function appendRunMapArrayEntry<T>(values: T[], value: T): T[] {
+  const vector = vectorFor(values) ?? vectorFrom(values);
+  return arrayFor(vectorSet(vector, vector.length, value));
+}
+
+/** Sets a possibly sparse internal index entry. Public run-map arrays use dense indexes. */
+export function setRunMapArrayEntry<T>(values: T[], index: number, value: T): T[] {
+  if (!Number.isSafeInteger(index) || index < 0) {
+    throw new RangeError(`Invalid run-map index ${index}`);
+  }
+  const vector = vectorFor(values) ?? vectorFrom(values);
+  return arrayFor(vectorSet(vector, index, value));
+}
+
+/** Builds a persistent array after a whole-collection operation such as closeout. */
+export function runMapArrayFrom<T>(values: readonly T[]): T[] {
+  return arrayFor(vectorFrom(values));
+}
+
+/** Keeps an internal persistent array, or indexes a plain whole-history result once. */
+export function ensureRunMapArray<T>(values: T[]): T[] {
+  return vectorFor(values) === undefined ? runMapArrayFrom(values) : values;
+}
+
+function vectorFor<T>(values: readonly T[]): Vector<T> | undefined {
+  return vectors.get(values) as Vector<T> | undefined;
+}
+
+function vectorFrom<T>(values: readonly T[]): Vector<T> {
+  let vector: Vector<T> = {root: [], depth: 0, length: 0};
+  for (const value of values) vector = vectorSet(vector, vector.length, value);
+  return vector;
+}
+
+function vectorAt<T>(vector: Vector<T>, index: number): T | undefined {
+  if (!Number.isSafeInteger(index) || index < 0 || index >= vector.length) return undefined;
+  let node = vector.root;
+  for (let level = vector.depth; level > 0; level -= 1) {
+    const child = node[slotAt(index, level)];
+    if (!Array.isArray(child)) return undefined;
+    node = child as VectorNode<T>;
+  }
+  return node[slotAt(index, 0)] as T | undefined;
+}
+
+function vectorSet<T>(vector: Vector<T>, index: number, value: T): Vector<T> {
+  let root = vector.root;
+  let depth = vector.depth;
+  while (index >= capacity(depth)) {
+    root = [root];
+    depth += 1;
+  }
+  return {
+    root: setNode(root, depth, index, value),
+    depth,
+    length: Math.max(vector.length, index + 1),
+  };
+}
+
+function setNode<T>(node: VectorNode<T>, level: number, index: number, value: T): VectorNode<T> {
+  const next = [...node];
+  const slot = slotAt(index, level);
+  if (level === 0) {
+    next[slot] = value;
+    return next;
+  }
+  const child = node[slot];
+  next[slot] = setNode(
+    Array.isArray(child) ? (child as VectorNode<T>) : [],
+    level - 1,
+    index,
+    value,
+  );
+  return next;
+}
+
+function capacity(depth: number): number {
+  return BRANCH_FACTOR ** (depth + 1);
+}
+
+function slotAt(index: number, level: number): number {
+  return Math.floor(index / BRANCH_FACTOR ** level) % BRANCH_FACTOR;
+}
+
+function arrayFor<T>(vector: Vector<T>): T[] {
+  // A real target length is required by native array consumers such as Bun's
+  // partial matcher. Defining one accessor first keeps the target in sparse
+  // dictionary form when its length grows; the persistent tree owns the data.
+  const target: T[] = [];
+  if (vector.length > 0) {
+    Object.defineProperty(target, '0', {
+      configurable: true,
+      enumerable: true,
+      get: () => vectorAt(vector, 0),
+    });
+    target.length = vector.length;
+  }
+  const proxy = new Proxy(target, {
+    get(array, property, receiver) {
+      const index = arrayIndex(property);
+      return index === null ? Reflect.get(array, property, receiver) : vectorAt(vector, index);
+    },
+    has(array, property) {
+      const index = arrayIndex(property);
+      return index === null ? Reflect.has(array, property) : index < vector.length;
+    },
+    ownKeys(array) {
+      const keys = Array.from({length: vector.length}, (_, index) => String(index));
+      return [...keys, ...Reflect.ownKeys(array).filter(key => arrayIndex(key) === null)];
+    },
+    getOwnPropertyDescriptor(array, property) {
+      const index = arrayIndex(property);
+      if (index === null) return Reflect.getOwnPropertyDescriptor(array, property);
+      if (index >= vector.length) return undefined;
+      return {
+        configurable: true,
+        enumerable: true,
+        value: vectorAt(vector, index),
+        writable: false,
+      };
+    },
+    set() {
+      throw new TypeError('Run-map arrays are immutable');
+    },
+    defineProperty() {
+      throw new TypeError('Run-map arrays are immutable');
+    },
+    deleteProperty() {
+      throw new TypeError('Run-map arrays are immutable');
+    },
+    preventExtensions() {
+      throw new TypeError('Run-map arrays are immutable');
+    },
+    setPrototypeOf() {
+      throw new TypeError('Run-map arrays are immutable');
+    },
+  });
+  vectors.set(proxy, vector as Vector<unknown>);
+  return proxy;
+}
+
+function arrayIndex(property: string | symbol): number | null {
+  if (typeof property !== 'string' || !/^(0|[1-9]\d*)$/.test(property)) return null;
+  const index = Number(property);
+  return Number.isSafeInteger(index) ? index : null;
+}

--- a/clients/core-state/src/run-map.test.ts
+++ b/clients/core-state/src/run-map.test.ts
@@ -88,6 +88,103 @@ describe('run map projection', () => {
     expect(roundAgentElapsedMs(round, new Date('2026-01-01T00:00:10Z'))).toBe(3000);
     expect(roundAgentElapsedMs(round, new Date('2026-01-01T00:10:00Z'))).toBe(3000);
   });
+
+  it('publishes ordinary array behavior from persistent run-map storage', () => {
+    let state = applyRunMapEvent(initialRunMap(), runStarted('agent'));
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_started', 'a'));
+    state = applyRunMapEvent(state, execution(3, 'agent_execution_finished', 'a'));
+
+    expect(Array.isArray(state.rounds)).toBe(true);
+    expect(Array.isArray(state.phases)).toBe(true);
+    expect(state.rounds).toMatchObject([{number: 1, status: 'active'}]);
+    expect([...state.rounds]).toEqual(state.rounds);
+    expect(state.phases.map(phase => phase.kind)).toEqual([
+      'orchestrator',
+      'implementer',
+      'judge',
+      'profiler',
+    ]);
+    expect(state.phases.findIndex(phase => phase.executionId === 'a')).toBe(1);
+    expect(state.phases.slice(1, 3)).toEqual(
+      state.phases.filter((_, index) => index === 1 || index === 2),
+    );
+    expect(state.phases.at(-1)?.kind).toBe('profiler');
+    expect(state.phases.concat([])).toEqual(state.phases);
+    expect(Object.keys(state.phases)).toEqual(['0', '1', '2', '3']);
+    expect(Object.getOwnPropertyDescriptor(state.phases, 'length')?.value).toBe(4);
+    expect(JSON.parse(JSON.stringify(state.phases))).toEqual(state.phases);
+  });
+
+  it('keeps older public snapshots unchanged across indexed replacement and branching', () => {
+    const started = applyRunMapEvent(
+      applyRunMapEvent(initialRunMap(), runStarted('agent')),
+      execution(2, 'agent_execution_started', 'a'),
+    );
+    const finished = applyRunMapEvent(started, execution(3, 'agent_execution_finished', 'a'));
+    const branched = applyRunMapEvent(started, execution(4, 'agent_execution_started', 'b'));
+
+    expect(started.phases[1]).toMatchObject({executionId: 'a', status: 'active'});
+    expect(finished.phases[1]).toMatchObject({executionId: 'a', status: 'completed'});
+    expect(branched.phases.filter(phase => phase.kind === 'implementer')).toMatchObject([
+      {executionId: 'a', status: 'active'},
+      {executionId: 'b', status: 'active'},
+    ]);
+    expect(started.rounds[0]?.activeAgentStarts).toEqual({
+      'implementer:a': '2026-01-01T00:00:02Z',
+    });
+  });
+
+  it('reuses public arrays when an event changes no round or phase fact', () => {
+    const started = applyRunMapEvent(
+      applyRunMapEvent(initialRunMap(), runStarted('agent')),
+      execution(2, 'agent_execution_started', 'a'),
+    );
+    const output = applyRunMapEvent(started, execution(3, 'agent_output_chunk', 'a'));
+
+    expect(output.rounds).toBe(started.rounds);
+    expect(output.phases).toBe(started.phases);
+    expect(output.lastEventTimestamp).toBe('2026-01-01T00:00:03Z');
+  });
+
+  it('preserves legacy finish precedence across concurrent same-role executions', () => {
+    let state = applyRunMapEvent(emptyRunMap(), execution(1, 'agent_execution_started', 'a'));
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_started', 'b'));
+    state = applyRunMapEvent(state, {
+      sequence: 3,
+      timestamp: '2026-01-01T00:00:03Z',
+      type: 'phase_finished',
+      status: 'completed',
+      agent_kind: 'implementer',
+      round_label: 'round-1-implementer',
+      data: {kind: 'phase', phase: 'implementer', attempt: null},
+    });
+
+    expect(state.phases.filter(phase => phase.kind === 'implementer')).toMatchObject([
+      {executionId: 'a', status: 'completed'},
+      {executionId: 'b', status: 'active'},
+    ]);
+  });
+
+  it('keeps native array length and indexed endpoints across tree depths', () => {
+    let state = emptyRunMap();
+    for (let round = 1; round <= 1_100; round += 1) {
+      state = applyRunMapEvent(
+        state,
+        execution(round, 'agent_execution_started', `exec-${round}`, round),
+      );
+    }
+
+    expect(state.rounds).toHaveLength(1_100);
+    expect(state.rounds[0]?.number).toBe(1);
+    expect(state.rounds.at(-1)?.number).toBe(1_100);
+    expect(state.phases).toHaveLength(4_400);
+    expect(state.phases[0]?.kind).toBe('orchestrator');
+    expect(state.phases.at(-1)).toMatchObject({
+      kind: 'profiler',
+      roundNumber: 1_100,
+      status: 'pending',
+    });
+  });
 });
 
 describe('run-level closeout', () => {

--- a/clients/core-state/src/run-map.ts
+++ b/clients/core-state/src/run-map.ts
@@ -7,6 +7,14 @@ import {
   type RoundTimingState,
   startAgentTiming,
 } from './round-timing.js';
+import {
+  appendRunMapArrayEntry,
+  ensureRunMapArray,
+  replaceRunMapArrayEntry,
+  runMapArrayAt,
+  runMapArrayFrom,
+  setRunMapArrayEntry,
+} from './run-map-array.js';
 
 export type AgentPhaseStatus =
   | 'pending'
@@ -26,6 +34,8 @@ export interface RoundSummary extends RoundTimingState {
   closedByRunBoundary?: true;
   /** An explicit round_finished event may supersede a prior inferred endpoint. */
   closedByRoundFinished?: true;
+  /** The round completed without a fresh profile measurement. */
+  profileSkipped?: boolean;
 }
 
 export interface AgentPhase {
@@ -64,12 +74,53 @@ export interface RunMapState {
   lastEventTimestamp: string | null;
 }
 
+interface PhaseSlot {
+  readonly indices: readonly number[];
+  readonly placeholderIndex: number | null;
+  readonly activeIndices: readonly number[];
+  readonly executions: ReadonlyMap<string, number>;
+}
+
+type PhaseRoleIndex = ReadonlyMap<string, PhaseSlot>;
+
+interface PhaseIndex {
+  readonly rounds: Array<PhaseRoleIndex | undefined>;
+  readonly unscoped: PhaseRoleIndex;
+}
+
+const phaseIndexes = new WeakMap<AgentPhase[], PhaseIndex>();
+const publishedArrays = new WeakMap<readonly unknown[], unknown[]>();
+const publishedInternals = new WeakMap<readonly unknown[], unknown[]>();
+const RUN_MAP_INTERNAL = Symbol('runMapInternal');
+
+interface RunMapInternal {
+  readonly rounds: RoundSummary[];
+  readonly phases: AgentPhase[];
+}
+
+type IndexedRunMapState = RunMapState & {[RUN_MAP_INTERNAL]?: RunMapInternal};
+
 export function applyRunMapEvent(
   state: RunMapState,
   event: RunEvent,
   abandonedAt: string | null = null,
 ): RunMapState {
-  const seen: RunMapState = {...state, lastEventTimestamp: event.timestamp};
+  return publishRunMapState(applyIndexedRunMapEvent(state, event, abandonedAt));
+}
+
+function applyIndexedRunMapEvent(
+  state: RunMapState,
+  event: RunEvent,
+  abandonedAt: string | null,
+): RunMapState {
+  const internal = runMapInternal(state);
+  const seen: RunMapState = {
+    outerLoop: state.outerLoop,
+    expectedRoles: state.expectedRoles,
+    rounds: internal.rounds,
+    phases: internal.phases,
+    lastEventTimestamp: event.timestamp,
+  };
   // Run-scoped terminal events say the run ended, not which agent ended it, so
   // they carry no `agent_kind` and no `round_label`. Every projection below is
   // keyed by that scope and would drop them, which is why the closeout runs
@@ -92,7 +143,89 @@ export function applyRunMapEvent(
       : base.expectedRoles;
   const rounds = applyRoundEvent(base.rounds, base.phases, event);
   const phases = applyPhaseEvent({...base, outerLoop, expectedRoles, rounds}, event);
-  return {outerLoop, expectedRoles, rounds, phases, lastEventTimestamp: event.timestamp};
+  return {
+    outerLoop,
+    expectedRoles,
+    rounds,
+    phases,
+    lastEventTimestamp: event.timestamp,
+  };
+}
+
+/** Copies lazy run-map array publication from `source` onto a folded core state. */
+export function adoptRunMapArrays(target: RunMapState, source: RunMapState): void {
+  for (const property of ['rounds', 'phases'] as const) {
+    const descriptor = Object.getOwnPropertyDescriptor(source, property);
+    if (descriptor !== undefined) Object.defineProperty(target, property, descriptor);
+  }
+  const internal = (source as IndexedRunMapState)[RUN_MAP_INTERNAL];
+  if (internal !== undefined) {
+    Object.defineProperty(target, RUN_MAP_INTERNAL, {configurable: true, value: internal});
+  }
+}
+
+/** Indexes arrays produced by a whole-history operation and publishes them lazily. */
+export function indexRunMapArrays(state: RunMapState): void {
+  const publishedRounds = state.rounds;
+  const publishedPhases = state.phases;
+  const rounds = runMapArrayFrom(publishedRounds);
+  const phases = runMapArrayFrom(publishedPhases);
+  phaseIndexes.set(phases, buildPhaseIndex(phases));
+  publishedArrays.set(rounds, publishedRounds);
+  publishedArrays.set(phases, publishedPhases);
+  publishedInternals.set(publishedRounds, rounds);
+  publishedInternals.set(publishedPhases, phases);
+  adoptRunMapArrays(state, publishRunMapState({...state, rounds, phases}));
+}
+
+function runMapInternal(state: RunMapState): RunMapInternal {
+  const existing = (state as IndexedRunMapState)[RUN_MAP_INTERNAL];
+  if (existing !== undefined) return existing;
+  const rounds = internalRunMapArray(state.rounds);
+  const phases = internalRunMapArray(state.phases);
+  if (!phaseIndexes.has(phases)) phaseIndexes.set(phases, buildPhaseIndex(phases));
+  return {rounds, phases};
+}
+
+function internalRunMapArray<T>(published: T[]): T[] {
+  return (publishedInternals.get(published) as T[] | undefined) ?? runMapArrayFrom(published);
+}
+
+function publishRunMapState(state: RunMapState): RunMapState {
+  let publishedRounds: RoundSummary[] | undefined;
+  let publishedPhases: AgentPhase[] | undefined;
+  const rounds = ensureRunMapArray(state.rounds);
+  const phases = ensureRunMapArray(state.phases);
+  if (!phaseIndexes.has(phases)) phaseIndexes.set(phases, buildPhaseIndex(phases));
+  const internal: RunMapInternal = {rounds, phases};
+  const published = {
+    outerLoop: state.outerLoop,
+    expectedRoles: state.expectedRoles,
+    lastEventTimestamp: state.lastEventTimestamp,
+  } as RunMapState;
+  Object.defineProperties(published, {
+    rounds: {
+      configurable: true,
+      enumerable: true,
+      get: () => (publishedRounds ??= materializeRunMapArray(internal.rounds)),
+    },
+    phases: {
+      configurable: true,
+      enumerable: true,
+      get: () => (publishedPhases ??= materializeRunMapArray(internal.phases)),
+    },
+    [RUN_MAP_INTERNAL]: {configurable: true, value: internal},
+  });
+  return published;
+}
+
+function materializeRunMapArray<T>(internal: T[]): T[] {
+  const existing = publishedArrays.get(internal) as T[] | undefined;
+  if (existing !== undefined) return existing;
+  const published = [...internal];
+  publishedArrays.set(internal, published);
+  publishedInternals.set(published, internal);
+  return published;
 }
 
 /**
@@ -228,18 +361,22 @@ export function mergePhaseLists(
   older: readonly AgentPhase[],
   newer: readonly AgentPhase[],
 ): AgentPhase[] {
-  const merged = [...older];
+  let merged = runMapArrayFrom(older);
+  phaseIndexes.set(merged, buildPhaseIndex(merged));
   for (const phase of newer) {
     const target = prefixPhaseTarget(merged, phase);
-    const existing = merged[target];
+    const existing = runMapArrayAt(merged, target);
     if (existing !== undefined) {
-      merged[target] = mergePhase(existing, phase);
+      merged = replacePhase(merged, target, mergePhase(existing, phase));
       continue;
     }
-    if (phase.executionId === undefined && merged.some(candidate => sameSlot(candidate, phase))) {
+    if (
+      phase.executionId === undefined &&
+      phaseSlotFor(phaseIndexFor(merged), phase) !== undefined
+    ) {
       continue;
     }
-    merged.push(phase);
+    merged = appendPhase(merged, phase);
   }
   return merged;
 }
@@ -275,22 +412,97 @@ function mergeRoundPrefix(older: RoundSummary, newer: RoundSummary): RoundSummar
   };
 }
 
-function sameSlot(phase: AgentPhase, patch: AgentPhase): boolean {
-  return phase.kind === patch.kind && phase.roundNumber === patch.roundNumber;
+/** Where `patch` lands in `phases` under a prefix merge, or -1 to append. */
+function prefixPhaseTarget(phases: AgentPhase[], patch: AgentPhase): number {
+  if (patch.executionId === undefined) return -1;
+  const slot = phaseSlotFor(phaseIndexFor(phases), patch);
+  return (
+    slot?.executions.get(patch.executionId) ??
+    slot?.placeholderIndex ??
+    slot?.activeIndices[0] ??
+    -1
+  );
 }
 
-/** Where `patch` lands in `phases` under a prefix merge, or -1 to append. */
-function prefixPhaseTarget(phases: readonly AgentPhase[], patch: AgentPhase): number {
-  if (patch.executionId === undefined) return -1;
-  const byExecution = phases.findIndex(
-    phase => sameSlot(phase, patch) && phase.executionId === patch.executionId,
-  );
-  if (byExecution !== -1) return byExecution;
-  const seeded = phases.findIndex(
-    phase => sameSlot(phase, patch) && phase.executionId === undefined,
-  );
-  if (seeded !== -1) return seeded;
-  return phases.findIndex(phase => sameSlot(phase, patch) && phase.status === 'active');
+function phaseIndexFor(phases: AgentPhase[]): PhaseIndex {
+  const existing = phaseIndexes.get(phases);
+  if (existing !== undefined) return existing;
+  const built = buildPhaseIndex(phases);
+  phaseIndexes.set(phases, built);
+  return built;
+}
+
+function buildPhaseIndex(phases: AgentPhase[]): PhaseIndex {
+  let index: PhaseIndex = {rounds: [], unscoped: new Map()};
+  for (let position = 0; position < phases.length; position += 1) {
+    index = updatePhaseSlot(index, phases, position, true);
+  }
+  return index;
+}
+
+function phaseSlotFor(
+  index: PhaseIndex,
+  phase: Pick<AgentPhase, 'kind' | 'roundNumber'>,
+): PhaseSlot | undefined {
+  const roles =
+    phase.roundNumber === null ? index.unscoped : runMapArrayAt(index.rounds, phase.roundNumber);
+  return roles?.get(phase.kind);
+}
+
+function appendPhase(phases: AgentPhase[], phase: AgentPhase): AgentPhase[] {
+  const next = appendRunMapArrayEntry(phases, phase);
+  phaseIndexes.set(next, updatePhaseSlot(phaseIndexFor(phases), next, phases.length, true));
+  return next;
+}
+
+function replacePhase(phases: AgentPhase[], position: number, phase: AgentPhase): AgentPhase[] {
+  const previous = runMapArrayAt(phases, position);
+  if (
+    previous === undefined ||
+    previous.kind !== phase.kind ||
+    previous.roundNumber !== phase.roundNumber
+  ) {
+    throw new Error(`Run-map phase replacement changed slot at index ${position}`);
+  }
+  const next = replaceRunMapArrayEntry(phases, position, phase);
+  phaseIndexes.set(next, updatePhaseSlot(phaseIndexFor(phases), next, position, false));
+  return next;
+}
+
+function updatePhaseSlot(
+  index: PhaseIndex,
+  phases: AgentPhase[],
+  position: number,
+  append: boolean,
+): PhaseIndex {
+  const phase = runMapArrayAt(phases, position);
+  if (phase === undefined) return index;
+  const current = phaseSlotFor(index, phase);
+  const indices = append
+    ? [...(current?.indices ?? []), position]
+    : (current?.indices ?? [position]);
+  const slot = summarizePhaseSlot(phases, indices);
+  const roles =
+    phase.roundNumber === null
+      ? new Map(index.unscoped)
+      : new Map(runMapArrayAt(index.rounds, phase.roundNumber) ?? []);
+  roles.set(phase.kind, slot);
+  if (phase.roundNumber === null) return {...index, unscoped: roles};
+  return {...index, rounds: setRunMapArrayEntry(index.rounds, phase.roundNumber, roles)};
+}
+
+function summarizePhaseSlot(phases: AgentPhase[], indices: readonly number[]): PhaseSlot {
+  let placeholderIndex: number | null = null;
+  const activeIndices: number[] = [];
+  const executions = new Map<string, number>();
+  for (const position of indices) {
+    const phase = runMapArrayAt(phases, position);
+    if (phase === undefined) continue;
+    if (phase.executionId === undefined) placeholderIndex ??= position;
+    else if (!executions.has(phase.executionId)) executions.set(phase.executionId, position);
+    if (phase.status === 'active') activeIndices.push(position);
+  }
+  return {indices, placeholderIndex, activeIndices, executions};
 }
 
 export function roundAgentElapsedMs(round: RoundSummary, now: Date): number {
@@ -340,7 +552,8 @@ function applyRoundEvent(
 ): RoundSummary[] {
   const number = roundNumberFromLabel(event.round_label);
   if (number === null || event.type === 'run_finished') return rounds;
-  const existing = rounds.find(round => round.number === number);
+  const existingIndex = roundIndex(rounds, number);
+  const existing = runMapArrayAt(rounds, existingIndex);
   // Run-scoped terminal events never reach here: `applyRunMapEvent` closes every
   // round for them, because the round a label names is not the only one open.
   const status =
@@ -358,9 +571,14 @@ function applyRoundEvent(
     ...(terminal
       ? {finishedAt: event.timestamp, closedByRoundFinished: true as const}
       : {startedAt: event.timestamp}),
+    ...(terminal && event.data?.kind === 'round_finished' && event.data.profile_skipped === true
+      ? {profileSkipped: true}
+      : {}),
   };
   const round = existing ? mergeRound(existing, patch) : patch;
-  return replaceRound(rounds, updateRoundAgentElapsed(round, phases, event));
+  const updated = updateRoundAgentElapsed(round, phases, event);
+  if (existing !== undefined && shallowEqual(existing, updated)) return rounds;
+  return replaceRound(rounds, existingIndex, updated);
 }
 
 function seedExpectedPhases(
@@ -403,29 +621,26 @@ function legacyExpectedRoles(outerLoop: string): readonly string[] | null {
 }
 
 function ensurePhase(phases: AgentPhase[], kind: string, roundNumber: number | null): AgentPhase[] {
-  if (phases.some(phase => phase.kind === kind && phase.roundNumber === roundNumber)) return phases;
-  return [...phases, {kind, status: 'pending', roundNumber, roundLabel: null}];
+  const patch: AgentPhase = {kind, status: 'pending', roundNumber, roundLabel: null};
+  if (phaseSlotFor(phaseIndexFor(phases), patch) !== undefined) return phases;
+  return appendPhase(phases, patch);
 }
 
 function upsertPhase(phases: AgentPhase[], patch: AgentPhase): AgentPhase[] {
-  const sameRoleAndRound = (phase: AgentPhase): boolean =>
-    phase.kind === patch.kind && phase.roundNumber === patch.roundNumber;
+  const slot = phaseSlotFor(phaseIndexFor(phases), patch);
   let existing =
-    patch.executionId === undefined
-      ? -1
-      : phases.findIndex(
-          phase => sameRoleAndRound(phase) && phase.executionId === patch.executionId,
-        );
+    patch.executionId === undefined ? -1 : (slot?.executions.get(patch.executionId) ?? -1);
   if (existing === -1 && patch.status === 'active') {
-    existing = phases.findIndex(
-      phase => sameRoleAndRound(phase) && phase.executionId === undefined,
-    );
+    existing = slot?.placeholderIndex ?? -1;
   }
   if (existing === -1 && patch.status !== 'active') {
-    existing = phases.findIndex(phase => sameRoleAndRound(phase) && phase.status === 'active');
+    existing = slot?.activeIndices[0] ?? -1;
   }
-  if (existing === -1) return [...phases, patch];
-  return phases.map((phase, index) => (index === existing ? mergePhase(phase, patch) : phase));
+  if (existing === -1) return appendPhase(phases, patch);
+  const phase = runMapArrayAt(phases, existing);
+  return phase === undefined
+    ? appendPhase(phases, patch)
+    : replacePhase(phases, existing, mergePhase(phase, patch));
 }
 
 /** Applies `patch` to `phase`, keeping the identity and endpoints it already has. */
@@ -445,10 +660,39 @@ function mergePhase(phase: AgentPhase, patch: AgentPhase): AgentPhase {
   };
 }
 
-function replaceRound(rounds: RoundSummary[], round: RoundSummary): RoundSummary[] {
-  const existing = rounds.findIndex(item => item.number === round.number);
-  if (existing === -1) return [...rounds, round].sort((left, right) => left.number - right.number);
-  return rounds.map((item, index) => (index === existing ? round : item));
+function replaceRound(
+  rounds: RoundSummary[],
+  existing: number,
+  round: RoundSummary,
+): RoundSummary[] {
+  if (existing !== -1) return replaceRunMapArrayEntry(rounds, existing, round);
+  const last = runMapArrayAt(rounds, rounds.length - 1);
+  if (last === undefined || last.number < round.number)
+    return appendRunMapArrayEntry(rounds, round);
+  return runMapArrayFrom([...rounds, round].sort((left, right) => left.number - right.number));
+}
+
+/** Returns the round's stable sorted position, or -1 when it has not been observed. */
+function roundIndex(rounds: RoundSummary[], number: number): number {
+  let low = 0;
+  let high = rounds.length - 1;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const candidate = runMapArrayAt(rounds, middle);
+    if (candidate === undefined) return -1;
+    if (candidate.number === number) return middle;
+    if (candidate.number < number) low = middle + 1;
+    else high = middle - 1;
+  }
+  return -1;
+}
+
+function shallowEqual(left: RoundSummary, right: RoundSummary): boolean {
+  const leftKeys = Object.keys(left) as Array<keyof RoundSummary>;
+  const rightKeys = Object.keys(right);
+  return (
+    leftKeys.length === rightKeys.length && leftKeys.every(key => Object.is(left[key], right[key]))
+  );
 }
 
 function mergeRound(round: RoundSummary, patch: RoundSummary): RoundSummary {
@@ -491,13 +735,12 @@ function updateRoundAgentElapsed(
   }
   if (event.type === 'phase_started' || event.type === 'phase_finished') {
     const executionId = event.execution_id ?? event.invocation_id;
-    const existing = phases.find(
-      phase =>
-        executionId != null &&
-        phase.executionId === executionId &&
-        phase.kind === event.agent_kind &&
-        phase.roundNumber === roundNumberFromLabel(event.round_label),
-    );
+    const slot = phaseSlotFor(phaseIndexFor(phases), {
+      kind: event.agent_kind ?? '',
+      roundNumber: roundNumberFromLabel(event.round_label),
+    });
+    const existingIndex = executionId == null ? undefined : slot?.executions.get(executionId);
+    const existing = existingIndex === undefined ? undefined : runMapArrayAt(phases, existingIndex);
     if (
       (started && existing?.status === 'active') ||
       (finished && existing !== undefined && existing.status !== 'active')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "agentshim>=0.5.0",
+    "agentshim>=0.5.0,<0.6.0",
     "cbor2<6",
     "cryptography<50",
     "deepagents",


### PR DESCRIPTION
## Problem

Fixes #613. Every late run-map event searched the complete round and phase histories, and lifecycle events then copied those complete arrays to replace one entry. Tail bootstrap reduces startup exposure but leaves live delivery, full replay, tests, and prefix backfill with cost proportional to retained history.

## Solution

Index round lookup with binary search over its already sorted public order, and index phases by round, role, execution identity, seeded placeholder, and ordered active executions. The phase index preserves the existing exact-execution, placeholder, then first-active precedence for modern and legacy lifecycle events. Index metadata is derived inside `@vibesys/core-state`, held in `WeakMap`s, and rebuilt lazily when an older plain-array state enters the reducer.

Back immutable replacement with a 32-way persistent tree held entirely inside the reducer. Public getters lazily materialize and cache ordinary arrays for consumers, so `Array.isArray`, indexed access, iteration, `map`, `findIndex`, `slice`, `at`, concatenation, own keys, descriptors, JSON serialization, and native test matchers retain their current behavior. The first public array access is intentionally linear; later accesses return that cached native array. Internal `CoreState` clones preserve the non-enumerable tree roots without invoking the getters, and a reverse cache recovers the roots if an external caller spreads an already published state. Replacing one entry copies only the short tree path, old states keep their prior roots, and events that change no round or phase fact reuse both public arrays by identity. Run-wide closeout remains linear because it intentionally changes every open item.

The carried-forward `profileSkipped` fact now lands in the run-map's indexed `round_finished` update instead of performing a second full round-array map in `core-state.ts`. Ordering, prefix merge rules, rebootstrap behavior, and the backend protocol are unchanged.

### Architecture

The backend client continues to supply typed events to the pure core-state fold. `run-map.ts` owns semantic round and phase projection, its private index selects the stable entry, and `run-map-array.ts` updates persistent storage. The core-state publication boundary materializes ordinary arrays only when a consumer reads them. The TUI continues to consume only the public `CoreState` arrays and knows nothing about indexes or storage.

```mermaid
flowchart LR
    Event[Typed backend event] --> Fold[core-state fold]
    Fold --> Map[run-map semantic reducer]
    Map --> Index[private round and phase indexes]
    Index --> Tree[private 32-way persistent storage]
    Tree --> State[lazy ordinary CoreState arrays]
    State --> TUI[TUI selectors and renderers]
```

## Verification

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/AyanBinRafaih/vibe-serve/ee1c830cf194e0d921b1eb9c2cf41dd5608990ba/pr-658/before.png) | ![After](https://raw.githubusercontent.com/AyanBinRafaih/vibe-serve/ee1c830cf194e0d921b1eb9c2cf41dd5608990ba/pr-658/after.png) |

The focused core-state suite covers concurrent same-role executions, compatibility lifecycle duplicates, legacy missing execution identities, expected-role placeholders, failures, run closeout, full and batched replay, rebootstrap, and prefix backfill. New regressions verify ordinary array reads, immutable old snapshots and branches, legacy first-active finish precedence, identity reuse for events that change no map fact, and root preservation through transcript, diagnostic, chat, and batch clone paths.

The checked-in benchmark reports isolated run-map and full core-state replay cost at 15,000, 36,000, and 72,000 events. It also measures direct `reduceEvent` calls for no-op map delivery and actual lifecycle replacement at rounds 20, 100, 280, and 2,000. Its near-flat assertions cover both the isolated reducer and full fold. On the same Bun 1.3.9 harness, the full-fold costs were:

| Path | Scale | Main µs/event | Branch µs/event |
|---|---:|---:|---:|
| core replay | 15,000 events | 19.262 | 16.275 |
| core replay | 36,000 events | 14.363 | 15.108 |
| core replay | 72,000 events | 16.987 | 12.791 |
| core live no-op | round 20 | 6.264 | 12.783 |
| core live no-op | round 100 | 14.737 | 13.627 |
| core live no-op | round 280 | 31.423 | 13.128 |
| core live no-op | round 2,000 | 219.817 | 13.800 |
| core phase replacement | round 20 | 7.779 | 20.829 |
| core phase replacement | round 100 | 19.286 | 20.025 |
| core phase replacement | round 280 | 45.077 | 21.553 |
| core phase replacement | round 2,000 | 304.806 | 21.822 |

The round-280 versus round-20 cost ratio falls from 5.02x to 1.03x for no-op map delivery and from 5.79x to 1.03x for actual phase replacement. At round 2,000 (8,000 retained phases), branch costs remain within 1.08x and 1.05x of their round-20 values. The immutable publication strategy adds fixed overhead at small sizes; full-array reads by consumers remain linear.

### Correctness properties

- Round lookup is logarithmic in the sorted round count and preserves ascending public order.
- Phase lookup is keyed by round, role, and execution identity, with existing placeholder and first-active legacy precedence unchanged.
- Expected-role seeding performs indexed slot checks instead of scanning phase history once per role.
- One phase or round replacement copies a bounded persistent-tree path, not the complete retained history.
- `rounds` and `phases` remain deterministic ordinary arrays for consumers and native matchers, and older `CoreState` snapshots remain unchanged after later folds or branches.
- Full replay, one-event folding, batched folding, rebootstrap, and prefix backfill retain the established equivalence properties.
- Run-wide terminal events still close every open phase, round, and timing interval.
- The backend protocol and TUI ownership boundaries do not change.

### Testing

- `PATH=/tmp/vibesys-issues-tools:$PATH pnpm --filter @vibesys/core-state test`, 104 passed, 0 failed.
- `pnpm --filter @vibesys/core-state check`, passed.
- `pnpm exec biome check clients/core-state/src/run-map-array.ts clients/core-state/src/run-map.ts clients/core-state/src/core-state.ts clients/core-state/src/run-map.test.ts clients/core-state/bench/run-map.ts clients/core-state/package.json`, passed.
- `PATH=/tmp/vibesys-issues-tools:$PATH pnpm --filter @vibesys/core-state bench:run-map`, passed at all required replay and live scales.
- The same full-fold benchmark against merge-base main reproduced linear late-round growth: 5.02x for no-op delivery and 5.79x for actual phase replacement over rounds 20 through 280.

- Independent main regression: the no-op public-array identity assertion fails on `ea6f9073`; the branch passes it.
- Full Python CI suite: `.venv/bin/python -m pytest -n 8 --dist loadgroup --cov-report=xml --cov-report=json --cov-fail-under=75 -q`, 5,719 passed and 28 platform/toolchain skips. Coverage floors, Ruff lint/format, `ty`, import boundaries, Markdown links, and launcher help passed.
- With Node 24.21.0 and Bun 1.3.9: protocol regeneration preserved checked-in bindings; `pnpm check:ts`, `pnpm check:ts-architecture`, `pnpm check:clients`, `pnpm test:clients`, and `pnpm build:clients` passed. Client tests: 25 backend-client, 104 core-state, 738 TUI, zero failures.

- `pnpm --dir clients/tui pack`, offline installation of the resulting package, and its Bun self-test passed. `pnpm --config.node-linker=hoisted --filter @vibesys/tui deploy --prod` and the deployed Bun self-test also passed.

The existing `scratch removal outwaits a straggler` harness test failed once on this host during the final client rerun. It passed in isolation and the complete client test suite then passed; no test or cleanup implementation was changed for that transient failure.

- Combined integration of all ten independently based fixes: 5,816 Python tests passed (6 environment/platform skips), 91% patch coverage, 25 backend-client, 123 core-state and 745 TUI tests passed. All repository static checks, stable protocol generation, builds, and packed/deployed TUI self-tests passed.
- Real combined `codex` / `gpt-5.6-sol` queue-rs SPSC run, capped at one round: completed with independent review and official evaluation. The run reported the retained winner `5e621d36bcc4` at 26,412,131.227693 operations/second; the final workspace was clean and differed from the winning tree only in framework state and the final archive. Live chat completed once while optimization streamed; the TUI showed execution label, progress, elapsed time and context usage. Pathological concurrency, large histories and minimizing-objective rankings were exercised separately by the targeted regressions and performance benchmarks for their respective issues.

Closes #613
