### PR TITLE
TUI: stream journal attachment with a validated index cache

### DIFF
--- a/scripts/benchmark_event_store_attach.py
+++ b/scripts/benchmark_event_store_attach.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Measure event-journal attach wall time and peak RSS in fresh processes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import resource
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_MIB = 1024 * 1024
+_DEFAULT_SIZES_MIB = (20, 100, 500)
+
+
+@dataclass(frozen=True, slots=True)
+class Measurement:
+    """One isolated attach measurement."""
+
+    wall_seconds: float
+    peak_rss_mib: float
+    records: int
+    parsed_records: int
+    source_bytes: int
+    index_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkTarget:
+    """Stable inputs shared by every mode for one journal size."""
+
+    repeats: int
+    python: Path
+    module_root: Path
+    source: Path
+
+
+def _event_line(sequence: int, payload_bytes: int = 900) -> bytes:
+    event = {
+        "protocol_version": 1,
+        "sequence": sequence,
+        "run_id": "benchmark",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "type": "output",
+        "text": "x" * payload_bytes,
+    }
+    return (json.dumps(event, separators=(",", ":")) + "\n").encode()
+
+
+def _generate_journal(path: Path, target_bytes: int) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    written = 0
+    with path.open("wb") as stream:
+        while written < target_bytes:
+            count += 1
+            line = _event_line(count)
+            stream.write(line)
+            written += len(line)
+    return count
+
+
+def _worker(path: Path) -> None:
+    from server.events import EventStore  # noqa: PLC0415  # implementation selected by PYTHONPATH
+
+    started = time.perf_counter()
+    store = EventStore(path, run_id="benchmark")
+    wall_seconds = time.perf_counter() - started
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    peak_rss_mib = rss / (_MIB if sys.platform == "darwin" else 1024)
+    index_path = path.with_name(f"{path.name}.idx")
+    print(  # benchmark result protocol
+        json.dumps(
+            {
+                "wall_seconds": wall_seconds,
+                "peak_rss_mib": peak_rss_mib,
+                "records": len(store.event_headers()),
+                "parsed_records": store.parsed_record_count,
+                "source_bytes": path.stat().st_size,
+                "index_bytes": index_path.stat().st_size if index_path.exists() else 0,
+            }
+        )
+    )
+
+
+def _measure(python: Path, module_root: Path, source: Path) -> Measurement:
+    environment = dict(os.environ)
+    source_path = str(module_root / "src")
+    environment["PYTHONPATH"] = os.pathsep.join(
+        [source_path, environment["PYTHONPATH"]] if environment.get("PYTHONPATH") else [source_path]
+    )
+    result = subprocess.run(  # noqa: S603  # explicit benchmark interpreter and script
+        [str(python), str(Path(__file__).resolve()), "--worker", str(source)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    return Measurement(**json.loads(result.stdout))
+
+
+def _prepare_warm(python: Path, module_root: Path, source: Path) -> None:
+    _measure(python, module_root, source)
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(percentile * len(ordered)) - 1)]
+
+
+def _summary(measurements: list[Measurement]) -> dict[str, float | int]:
+    walls = [item.wall_seconds for item in measurements]
+    rss = [item.peak_rss_mib for item in measurements]
+    sample = measurements[-1]
+    return {
+        "wall_median_seconds": statistics.median(walls),
+        "wall_p95_seconds": _percentile(walls, 0.95),
+        "peak_rss_median_mib": statistics.median(rss),
+        "peak_rss_p95_mib": _percentile(rss, 0.95),
+        "records": sample.records,
+        "parsed_records": sample.parsed_records,
+        "source_bytes": sample.source_bytes,
+        "index_bytes": sample.index_bytes,
+    }
+
+
+def _run_mode(
+    mode: str,
+    *,
+    target: BenchmarkTarget,
+    next_sequence: int,
+) -> tuple[list[Measurement], int]:
+    index_path = target.source.with_name(f"{target.source.name}.idx")
+    measurements: list[Measurement] = []
+    if mode == "warm":
+        index_path.unlink(missing_ok=True)
+        _prepare_warm(target.python, target.module_root, target.source)
+    for _ in range(target.repeats):
+        if mode == "cold":
+            index_path.unlink(missing_ok=True)
+        elif mode == "changed-source":
+            index_path.unlink(missing_ok=True)
+            _prepare_warm(target.python, target.module_root, target.source)
+            with target.source.open("ab") as stream:
+                stream.write(_event_line(next_sequence))
+            next_sequence += 1
+        measurements.append(_measure(target.python, target.module_root, target.source))
+    return measurements, next_sequence
+
+
+def _render_markdown(results: dict[str, dict[str, dict[str, float | int]]]) -> str:
+    lines = [
+        "| Journal | Mode | Wall median | Wall p95 | Peak RSS median | Peak RSS p95 | Index |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for size, modes in results.items():
+        for mode, values in modes.items():
+            lines.append(
+                f"| {size} MiB | {mode} | {values['wall_median_seconds']:.3f}s | "
+                f"{values['wall_p95_seconds']:.3f}s | {values['peak_rss_median_mib']:.1f} MiB | "
+                f"{values['peak_rss_p95_mib']:.1f} MiB | "
+                f"{values['index_bytes'] / _MIB:.1f} MiB |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    """Generate journals and benchmark isolated cold, warm, and changed attaches."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--worker", type=Path)
+    parser.add_argument("--python", type=Path, default=Path(sys.executable))
+    parser.add_argument("--module-root", type=Path, default=Path.cwd())
+    default_work_dir = Path(tempfile.gettempdir()) / "vibesys-event-attach-bench"
+    parser.add_argument("--work-dir", type=Path, default=default_work_dir)
+    parser.add_argument("--sizes-mib", type=int, nargs="+", default=_DEFAULT_SIZES_MIB)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.worker is not None:
+        _worker(args.worker)
+        return
+    if args.repeats < 1 or any(size < 1 for size in args.sizes_mib):
+        parser.error("sizes and repeats must be positive")
+
+    results: dict[str, dict[str, dict[str, float | int]]] = {}
+    for size_mib in args.sizes_mib:
+        source = args.work_dir / f"events-{size_mib}mib.jsonl"
+        next_sequence = _generate_journal(source, size_mib * _MIB) + 1
+        target = BenchmarkTarget(
+            repeats=args.repeats,
+            python=args.python,
+            module_root=args.module_root,
+            source=source,
+        )
+        modes: dict[str, dict[str, float | int]] = {}
+        for mode in ("cold", "warm", "changed-source"):
+            measurements, next_sequence = _run_mode(
+                mode,
+                target=target,
+                next_sequence=next_sequence,
+            )
+            modes[mode] = _summary(measurements)
+        results[str(size_mib)] = modes
+
+    rendered = _render_markdown(results)
+    print(rendered, end="")  # benchmark report
+    if args.output is not None:
+        args.output.write_text(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/server/event_index.py
+++ b/src/server/event_index.py
@@ -1,0 +1,386 @@
+"""Disposable on-disk index for the authoritative JSONL event journal."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import tempfile
+from contextlib import suppress
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import BinaryIO
+
+_FORMAT = "vibesys-event-index"
+_VERSION = 1
+_FINGERPRINT_BYTES = 64 * 1024
+_RECORD_FIELDS = 7
+_SHA256_HEX_LENGTH = 64
+
+
+class _Digest(Protocol):
+    def update(self, content: bytes, /) -> None:
+        """Add bytes to the digest."""
+
+    def hexdigest(self) -> str:
+        """Return the lowercase hexadecimal digest."""
+
+
+@dataclass(frozen=True, slots=True)
+class EventIndexRecord:
+    """Primitive fields needed to reconstruct one in-memory event record."""
+
+    offset: int
+    length: int
+    raw_sequence: int
+    sequence: int
+    event_type: str
+    execution_id: str | None
+    chat_thread_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedEventIndex:
+    """A fully validated sidecar and its safe source boundary."""
+
+    records: list[EventIndexRecord]
+    boundary: int
+
+
+@dataclass(frozen=True, slots=True)
+class SourceStat:
+    """Source metadata that must remain stable across one streaming scan."""
+
+    device: int
+    inode: int
+    size: int
+    mtime_ns: int
+    ctime_ns: int
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceIdentity:
+    device: int
+    inode: int
+    size: int
+    mtime_ns: int
+    ctime_ns: int
+    head_sha256: str
+    boundary_sha256: str
+
+
+def event_index_path(source: Path) -> Path:
+    """Return the disposable sidecar path adjacent to ``source``."""
+    return source.with_name(f"{source.name}.idx")
+
+
+def load_event_index(source: Path) -> LoadedEventIndex | None:
+    """Load a sidecar only when it exactly matches the current source file."""
+    path = event_index_path(source)
+    try:
+        with path.open("rb") as stream:
+            header_line = stream.readline()
+            decoded_header = _decode_header(header_line)
+            if decoded_header is None:
+                return None
+            boundary, count, expected_source = decoded_header
+            current_source = _source_identity(source, boundary)
+            if current_source != expected_source:
+                return None
+
+            digest = hashlib.sha256(usedforsecurity=False)
+            digest.update(header_line)
+            records = _load_records(stream, count, boundary, digest)
+            if records is None or not _valid_footer(stream, digest):
+                return None
+            if _source_identity(source, boundary) != current_source:
+                return None
+    except (OSError, UnicodeError, ValueError):
+        return None
+    return LoadedEventIndex(records=records, boundary=boundary)
+
+
+def _decode_header(line: bytes) -> tuple[int, int, _SourceIdentity] | None:
+    header = _decode_object(line)
+    expected_keys = {"format", "version", "source", "boundary", "count"}
+    if header is None or set(header) != expected_keys:
+        return None
+    if header["format"] != _FORMAT or header["version"] != _VERSION:
+        return None
+    boundary = _plain_nonnegative_int(header["boundary"])
+    count = _plain_nonnegative_int(header["count"])
+    source = _decode_source_identity(header["source"])
+    if boundary is None or count is None or source is None:
+        return None
+    return boundary, count, source
+
+
+def _load_records(
+    stream: BinaryIO, count: int, boundary: int, digest: _Digest
+) -> list[EventIndexRecord] | None:
+    records: list[EventIndexRecord] = []
+    expected_offset = 0
+    last_sequence = 0
+    for _ in range(count):
+        line = stream.readline()
+        digest.update(line)
+        record = _decode_record(line)
+        if record is None or record.offset != expected_offset or record.length <= 0:
+            return None
+        repaired = record.raw_sequence if record.raw_sequence > last_sequence else last_sequence + 1
+        if record.sequence != repaired:
+            return None
+        records.append(record)
+        expected_offset += record.length
+        last_sequence = record.sequence
+    return records if expected_offset == boundary else None
+
+
+def _valid_footer(stream: BinaryIO, digest: _Digest) -> bool:
+    footer = _decode_object(stream.readline())
+    checksum = None if footer is None else footer.get("sha256")
+    return bool(
+        footer is not None
+        and set(footer) == {"sha256"}
+        and isinstance(checksum, str)
+        and _is_sha256(checksum)
+        and hmac.compare_digest(checksum, digest.hexdigest())
+        and not stream.read(1)
+    )
+
+
+def write_event_index(
+    source: Path,
+    records: Iterable[EventIndexRecord],
+    record_count: int,
+    boundary: int,
+    expected_source: SourceStat,
+) -> bool:
+    """Atomically publish an index, returning false when caching is unavailable."""
+    identity = _source_identity(source, boundary)
+    if identity is None or _identity_stat(identity) != expected_source:
+        return False
+    header = {
+        "format": _FORMAT,
+        "version": _VERSION,
+        "source": asdict(identity),
+        "boundary": boundary,
+        "count": record_count,
+    }
+    path = event_index_path(source)
+    descriptor: int | None = None
+    temporary: Path | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        temporary = Path(temporary_name)
+        temporary.chmod(0o600)
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = None
+            digest = hashlib.sha256(usedforsecurity=False)
+            header_line = _encode(header)
+            stream.write(header_line)
+            digest.update(header_line)
+            written_records = 0
+            for record in records:
+                written_records += 1
+                line = _encode(
+                    [
+                        record.offset,
+                        record.length,
+                        record.raw_sequence,
+                        record.sequence,
+                        record.event_type,
+                        record.execution_id,
+                        record.chat_thread_id,
+                    ]
+                )
+                stream.write(line)
+                digest.update(line)
+            stream.write(_encode({"sha256": digest.hexdigest()}))
+            stream.flush()
+            os.fsync(stream.fileno())
+        if written_records != record_count:
+            return False
+        # A source change only makes this cache stale, but avoid publishing work
+        # already known to be unusable.
+        if _source_identity(source, boundary) != identity:
+            return False
+        os.replace(temporary, path)  # noqa: PTH105  # atomic publication
+        _fsync_directory(path.parent)
+        temporary = None
+    except OSError:
+        return False
+    finally:
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+        if temporary is not None:
+            with suppress(OSError):
+                temporary.unlink(missing_ok=True)
+    return True
+
+
+def source_stat(source: Path) -> SourceStat | None:
+    """Return the exact metadata used to reject changes during a source scan."""
+    try:
+        value = source.stat()
+    except OSError:
+        return None
+    return SourceStat(
+        device=value.st_dev,
+        inode=value.st_ino,
+        size=value.st_size,
+        mtime_ns=value.st_mtime_ns,
+        ctime_ns=value.st_ctime_ns,
+    )
+
+
+def _source_identity(source: Path, boundary: int) -> _SourceIdentity | None:
+    """Capture stable stat fields plus bounded source-content fingerprints."""
+    try:
+        with source.open("rb") as stream:
+            before = os.fstat(stream.fileno())
+            if boundary < 0 or boundary > before.st_size:
+                return None
+            head = stream.read(min(_FINGERPRINT_BYTES, before.st_size))
+            boundary_start = max(0, boundary - _FINGERPRINT_BYTES)
+            stream.seek(boundary_start)
+            boundary_bytes = stream.read(boundary - boundary_start)
+            after = os.fstat(stream.fileno())
+        path_stat = source.stat()
+    except OSError:
+        return None
+    before_fields = _stat_fields(before)
+    if before_fields != _stat_fields(after) or before_fields != _stat_fields(path_stat):
+        return None
+    return _SourceIdentity(
+        device=before.st_dev,
+        inode=before.st_ino,
+        size=before.st_size,
+        mtime_ns=before.st_mtime_ns,
+        ctime_ns=before.st_ctime_ns,
+        head_sha256=_content_digest(head),
+        boundary_sha256=_content_digest(boundary_bytes),
+    )
+
+
+def _stat_fields(value: os.stat_result) -> tuple[int, int, int, int, int]:
+    return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns, value.st_ctime_ns
+
+
+def _identity_stat(identity: _SourceIdentity) -> SourceStat:
+    return SourceStat(
+        device=identity.device,
+        inode=identity.inode,
+        size=identity.size,
+        mtime_ns=identity.mtime_ns,
+        ctime_ns=identity.ctime_ns,
+    )
+
+
+def _content_digest(content: bytes) -> str:
+    return hashlib.sha256(content, usedforsecurity=False).hexdigest()
+
+
+def _encode(value: object) -> bytes:
+    return (json.dumps(value, separators=(",", ":"), sort_keys=True) + "\n").encode()
+
+
+def _decode_object(line: bytes) -> dict[str, Any] | None:
+    try:
+        value = json.loads(line)
+    except (UnicodeError, ValueError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _decode_source_identity(value: object) -> _SourceIdentity | None:
+    if not isinstance(value, dict) or set(value) != {
+        "device",
+        "inode",
+        "size",
+        "mtime_ns",
+        "ctime_ns",
+        "head_sha256",
+        "boundary_sha256",
+    }:
+        return None
+    integers = [value[name] for name in ("device", "inode", "size", "mtime_ns", "ctime_ns")]
+    if any(_plain_nonnegative_int(item) is None for item in integers):
+        return None
+    head = value["head_sha256"]
+    boundary = value["boundary_sha256"]
+    if not _is_sha256(head) or not _is_sha256(boundary):
+        return None
+    return _SourceIdentity(
+        device=integers[0],
+        inode=integers[1],
+        size=integers[2],
+        mtime_ns=integers[3],
+        ctime_ns=integers[4],
+        head_sha256=head,
+        boundary_sha256=boundary,
+    )
+
+
+def _decode_record(line: bytes) -> EventIndexRecord | None:
+    try:
+        value = json.loads(line)
+    except (UnicodeError, ValueError):
+        return None
+    if not isinstance(value, list) or len(value) != _RECORD_FIELDS:
+        return None
+    offset, length, raw_sequence, sequence, event_type, execution_id, chat_thread_id = value
+    if any(
+        _plain_nonnegative_int(item) is None for item in (offset, length, raw_sequence, sequence)
+    ):
+        return None
+    if not isinstance(event_type, str):
+        return None
+    if not _is_optional_str(execution_id) or not _is_optional_str(chat_thread_id):
+        return None
+    return EventIndexRecord(
+        offset=offset,
+        length=length,
+        raw_sequence=raw_sequence,
+        sequence=sequence,
+        event_type=event_type,
+        execution_id=execution_id,
+        chat_thread_id=chat_thread_id,
+    )
+
+
+def _plain_nonnegative_int(value: object) -> int | None:
+    return value if type(value) is int and value >= 0 else None
+
+
+def _is_optional_str(value: object) -> bool:
+    return value is None or isinstance(value, str)
+
+
+def _is_sha256(value: object) -> bool:
+    if not isinstance(value, str) or len(value) != _SHA256_HEX_LENGTH or value != value.lower():
+        return False
+    try:
+        bytes.fromhex(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)

--- a/src/server/events.py
+++ b/src/server/events.py
@@ -14,6 +14,12 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, ValidationError, model_validator
 
 from server.diagnostics import Diagnostic
+from server.event_index import (
+    EventIndexRecord,
+    load_event_index,
+    source_stat,
+    write_event_index,
+)
 from server.run_lifecycle import RunStatus
 
 if TYPE_CHECKING:
@@ -479,12 +485,7 @@ class EventStore:
         self._lock = threading.RLock()
         self._changed = threading.Condition(self._lock)
         self._parsed_records = 0
-        scanned = self._scan_unlocked()
-        if scanned is None:
-            events, self._malformed_tail_offset = self._read_unlocked()
-            self._records = _records_from_events(_repair_legacy_sequences(events))
-        else:
-            self._records, self._malformed_tail_offset = scanned
+        self._records, self._malformed_tail_offset = self._scan_unlocked()
         # A valid final record whose line was never terminated must gain its
         # newline before ``append`` writes anything after it.
         self._missing_tail_newline = self._malformed_tail_offset is None and _ends_without_newline(
@@ -661,36 +662,94 @@ class EventStore:
             event = event.model_copy(update={"sequence": record.header.sequence})
         record.event = event
 
-    def _scan_unlocked(self) -> tuple[list[_StoredRecord], int | None] | None:
-        """Index the log by byte range and header, or return None on any doubt.
+    def _scan_unlocked(self) -> tuple[list[_StoredRecord], int | None]:
+        """Index the log by byte range and header without a full-file allocation.
 
-        ``json.loads`` is a real parser, so the offsets and header fields it
-        yields are exact. Returning None sends construction to the fully eager
-        path, which is the only place a corrupt history is diagnosed.
+        An exact sidecar match restores the record index without parsing the
+        JSONL prefix. Otherwise this streams the source once and atomically
+        publishes a replacement cache. A record the cheap header scan cannot
+        classify is fully validated in place, so strict corruption detection
+        does not require retaining the other event payloads.
         """
         if not self.path.exists():
             return [], None
-        raw = self.path.read_bytes()
-        lines = raw.splitlines(keepends=True)
-        records: list[_StoredRecord] = []
+
+        cached = load_event_index(self.path)
+        if cached is not None:
+            try:
+                records: list[_StoredRecord] = []
+                while cached.records:
+                    records.append(_stored_record_from_index(cached.records.pop()))
+                records.reverse()
+            except ValueError:
+                records = []
+            else:
+                records, malformed_tail_offset, _safe_count, _safe_boundary = (
+                    self._scan_stream_unlocked(records, start=cached.boundary)
+                )
+                self._parse_eager_tail(records, malformed_tail_offset)
+                return records, malformed_tail_offset
+
+        initial_source = source_stat(self.path)
+        records, malformed_tail_offset, safe_count, safe_boundary = self._scan_stream_unlocked(
+            [], start=0
+        )
+        self._parse_eager_tail(records, malformed_tail_offset)
+        if initial_source is not None:
+            write_event_index(
+                self.path,
+                (_index_record_from_stored(records[index]) for index in range(safe_count)),
+                safe_count,
+                safe_boundary,
+                initial_source,
+            )
+        return records, malformed_tail_offset
+
+    def _scan_stream_unlocked(
+        self, records: list[_StoredRecord], *, start: int
+    ) -> tuple[list[_StoredRecord], int | None, int, int]:
+        """Extend ``records`` by streaming source lines beginning at ``start``."""
         malformed_tail_offset: int | None = None
-        offset = 0
-        last_sequence = 0
-        for index, line in enumerate(lines):
-            record_offset = offset
-            offset += len(line)
+        last_sequence = records[-1].header.sequence if records else 0
+        safe_count = len(records)
+        safe_boundary = start
+        for record_offset, line, is_final in _stream_lines(self.path, start=start):
             header_fields = _scan_header_fields(line)
             if header_fields is None:
                 # A final line holding complete JSON the header scan cannot
                 # classify must be judged by full validation, so it falls to
                 # the eager path; only a tail with no complete JSON prefix (a
                 # torn append) is set aside for repair.
-                if index != len(lines) - 1 or _starts_with_complete_json(line):
-                    return None
-                # Preserve access to earlier audit history if a process was
-                # interrupted during its final append.
-                malformed_tail_offset = record_offset
-                break
+                if is_final and not _starts_with_complete_json(line):
+                    # Preserve access to earlier audit history if a process was
+                    # interrupted during its final append.
+                    malformed_tail_offset = record_offset
+                    break
+                try:
+                    self._parsed_records += 1
+                    event = RunEvent.model_validate_json(line)
+                except ValidationError as error:
+                    if not is_final:
+                        raise
+                    raise _complete_invalid_tail_error(self.path, record_offset) from error
+                raw_sequence = event.sequence
+                sequence = raw_sequence if raw_sequence > last_sequence else last_sequence + 1
+                if sequence != raw_sequence:
+                    event = event.model_copy(update={"sequence": sequence})
+                last_sequence = sequence
+                records.append(
+                    _StoredRecord(
+                        header=_header_from_event(event, sequence),
+                        offset=record_offset,
+                        length=len(line),
+                        raw_sequence=raw_sequence,
+                        event=event,
+                    )
+                )
+                if line.endswith(b"\n"):
+                    safe_count = len(records)
+                    safe_boundary = record_offset + len(line)
+                continue
             raw_sequence, event_type, execution_id, chat_thread_id = header_fields
             sequence = raw_sequence if raw_sequence > last_sequence else last_sequence + 1
             last_sequence = sequence
@@ -707,11 +766,13 @@ class EventStore:
                     raw_sequence=raw_sequence,
                 )
             )
-        self._parse_eager_tail(raw, records, malformed_tail_offset)
-        return records, malformed_tail_offset
+            if line.endswith(b"\n"):
+                safe_count = len(records)
+                safe_boundary = record_offset + len(line)
+        return records, malformed_tail_offset, safe_count, safe_boundary
 
     def _parse_eager_tail(
-        self, raw: bytes, records: list[_StoredRecord], malformed_tail_offset: int | None
+        self, records: list[_StoredRecord], malformed_tail_offset: int | None
     ) -> None:
         """Validate the trailing window, raising on any record that fails.
 
@@ -719,11 +780,20 @@ class EventStore:
         never leave behind, so a validation failure on the final record is
         corruption to surface, not an interrupted write to set aside.
         """
-        for position in range(max(0, len(records) - _EAGER_TAIL_RECORDS), len(records)):
-            record = records[position]
+        start = max(0, len(records) - _EAGER_TAIL_RECORDS)
+        tail = records[start:]
+        if not tail:
+            return
+        with self.path.open("rb") as stream:
+            base = tail[0].offset
+            stream.seek(base)
+            raw = stream.read(tail[-1].offset + tail[-1].length - base)
+        for relative_position, record in enumerate(tail):
+            begin = record.offset - base
             try:
-                self._parse_record(record, raw[record.offset : record.offset + record.length])
+                self._parse_record(record, raw[begin : begin + record.length])
             except ValidationError as error:
+                position = start + relative_position
                 if position != len(records) - 1 or malformed_tail_offset is not None:
                     raise
                 raise _complete_invalid_tail_error(self.path, record.offset) from error
@@ -731,18 +801,14 @@ class EventStore:
     def _read_unlocked(self) -> tuple[list[RunEvent], int | None]:
         if not self.path.exists():
             return [], None
-        lines = self.path.read_bytes().splitlines(keepends=True)
         events: list[RunEvent] = []
-        offset = 0
-        for index, line in enumerate(lines):
-            record_offset = offset
-            offset += len(line)
+        for record_offset, line, is_final in _stream_lines(self.path, start=0):
             try:
                 self._parsed_records += 1
                 event = RunEvent.model_validate_json(line)
                 events.append(event)
             except ValidationError as error:
-                if index != len(lines) - 1:
+                if not is_final:
                     raise
                 if _starts_with_complete_json(line):
                     raise _complete_invalid_tail_error(self.path, record_offset) from error
@@ -750,6 +816,47 @@ class EventStore:
                 # interrupted during its final append.
                 return events, record_offset
         return events, None
+
+
+def _stream_lines(path: Path, *, start: int) -> Iterable[tuple[int, bytes, bool]]:
+    """Yield source lines with offsets and final-line identity using bounded memory."""
+    with path.open("rb") as stream:
+        stream.seek(start)
+        offset = start
+        line = stream.readline()
+        while line:
+            following = stream.readline()
+            yield offset, line, not following
+            offset += len(line)
+            line = following
+
+
+def _stored_record_from_index(record: EventIndexRecord) -> _StoredRecord:
+    """Restore a typed in-memory record from primitive validated cache fields."""
+    return _StoredRecord(
+        header=EventHeader(
+            sequence=record.sequence,
+            type=EventType(record.event_type),
+            execution_id=record.execution_id,
+            chat_thread_id=record.chat_thread_id,
+        ),
+        offset=record.offset,
+        length=record.length,
+        raw_sequence=record.raw_sequence,
+    )
+
+
+def _index_record_from_stored(record: _StoredRecord) -> EventIndexRecord:
+    """Project one scanned record into the sidecar's primitive representation."""
+    return EventIndexRecord(
+        offset=record.offset,
+        length=record.length,
+        raw_sequence=record.raw_sequence,
+        sequence=record.header.sequence,
+        event_type=record.header.type.value,
+        execution_id=record.header.execution_id,
+        chat_thread_id=record.header.chat_thread_id,
+    )
 
 
 def _scan_header_fields(line: bytes) -> tuple[int, EventType, str | None, str | None] | None:

--- a/tests/server/test_event_store_index.py
+++ b/tests/server/test_event_store_index.py
@@ -1,0 +1,435 @@
+"""Disposable-index and streaming-attach tests for the event store."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+import server.event_index as event_index_module
+import server.events as events_module
+from server.event_index import event_index_path, load_event_index
+from server.events import EventStore, EventType, RunEvent, make_event
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import BinaryIO
+
+type _ScannedHeader = tuple[int, EventType, str | None, str | None]
+type _SidecarMutation = Callable[[dict[str, object], list[list[object]]], None]
+
+_TIMESTAMP = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _event(sequence: int, text: str) -> RunEvent:
+    return RunEvent(
+        sequence=sequence,
+        run_id="persisted-run",
+        timestamp=_TIMESTAMP,
+        type=EventType.OUTPUT,
+        text=text,
+    )
+
+
+def _write(path: Path, sequences: list[int], *, terminate: bool = True) -> None:
+    content = "\n".join(
+        _event(sequence, f"event-{index}").model_dump_json()
+        for index, sequence in enumerate(sequences)
+    )
+    path.write_text(content + ("\n" if terminate else ""))
+
+
+def _rewrite_sidecar(path: Path, mutate: _SidecarMutation) -> None:
+    lines = path.read_bytes().splitlines(keepends=True)
+    header = json.loads(lines[0])
+    records = [json.loads(line) for line in lines[1:-1]]
+    mutate(header, records)
+    encoded = [
+        (json.dumps(header, separators=(",", ":"), sort_keys=True) + "\n").encode(),
+        *[
+            (json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n").encode()
+            for record in records
+        ],
+    ]
+    digest = hashlib.sha256(b"".join(encoded), usedforsecurity=False).hexdigest()
+    path.write_bytes(b"".join(encoded) + f'{{"sha256":"{digest}"}}\n'.encode())
+
+
+def test_cold_attach_never_reads_the_complete_file_at_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, list(range(1, 1_500)))
+
+    def reject_read_bytes(_path: Path) -> None:
+        raise AssertionError
+
+    monkeypatch.setattr(Path, "read_bytes", reject_read_bytes)
+
+    store = EventStore(path, run_id="active-run")
+
+    assert len(store.event_headers()) == 1_499
+    assert store.last_sequence == 1_499
+
+
+def test_a_valid_record_rejected_by_the_header_scan_is_validated_in_place(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    encoded = _event(1, "coerced").model_dump_json().replace('"sequence":1', '"sequence":"1"')
+    path.write_text(encoded + "\n")
+
+    def reject_read_bytes(_path: Path) -> None:
+        raise AssertionError
+
+    monkeypatch.setattr(Path, "read_bytes", reject_read_bytes)
+
+    store = EventStore(path, run_id="active-run")
+
+    assert [(event.sequence, event.text) for event in store.read()] == [(1, "coerced")]
+    assert load_event_index(path) is not None
+
+
+def test_warm_attach_uses_the_validated_sidecar_without_scanning_jsonl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, list(range(1, 1_500)))
+    EventStore(path, run_id="first")
+    index_path = event_index_path(path)
+    original_index = index_path.read_bytes()
+
+    def reject_header_scan(_line: bytes) -> _ScannedHeader | None:
+        raise AssertionError
+
+    monkeypatch.setattr(events_module, "_scan_header_fields", reject_header_scan)
+
+    store = EventStore(path, run_id="second")
+
+    assert store.last_sequence == 1_499
+    assert index_path.read_bytes() == original_index
+
+
+def test_appended_source_rebuilds_instead_of_trusting_a_stale_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2, 3])
+    EventStore(path, run_id="first")
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(_event(4, "appended").model_dump_json() + "\n")
+    scanned = 0
+    scan_header = events_module._scan_header_fields  # noqa: SLF001
+
+    def count_header_scans(line: bytes) -> _ScannedHeader | None:
+        nonlocal scanned
+        scanned += 1
+        return scan_header(line)
+
+    monkeypatch.setattr(events_module, "_scan_header_fields", count_header_scans)
+
+    store = EventStore(path, run_id="second")
+
+    assert scanned == 4
+    assert [event.text for event in store.read()] == ["event-0", "event-1", "event-2", "appended"]
+
+
+def test_source_change_during_scan_does_not_publish_an_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2])
+    scan_header = events_module._scan_header_fields  # noqa: SLF001
+    changed = False
+
+    def change_during_scan(line: bytes) -> _ScannedHeader | None:
+        nonlocal changed
+        if not changed:
+            changed = True
+            with path.open("a", encoding="utf-8") as stream:
+                stream.write(_event(3, "concurrent").model_dump_json() + "\n")
+        return scan_header(line)
+
+    monkeypatch.setattr(events_module, "_scan_header_fields", change_during_scan)
+
+    store = EventStore(path, run_id="active-run")
+
+    assert store.last_sequence in {2, 3}
+    assert not event_index_path(path).exists()
+
+
+def test_source_change_while_loading_sidecar_rejects_the_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2])
+    EventStore(path, run_id="first")
+    validate_footer = event_index_module._valid_footer  # noqa: SLF001
+    changed = False
+
+    def change_after_validation(stream: BinaryIO, digest: event_index_module._Digest) -> bool:
+        nonlocal changed
+        valid = validate_footer(stream, digest)
+        if not changed:
+            changed = True
+            with path.open("a", encoding="utf-8") as output:
+                output.write(_event(3, "concurrent").model_dump_json() + "\n")
+        return valid
+
+    monkeypatch.setattr(event_index_module, "_valid_footer", change_after_validation)
+
+    assert [event.text for event in EventStore(path, run_id="second").read()] == [
+        "event-0",
+        "event-1",
+        "concurrent",
+    ]
+
+
+def test_boundary_fingerprint_rejects_same_size_source_overwrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2, 3])
+    EventStore(path, run_id="first")
+    index_path = event_index_path(path)
+    original_stat = path.stat()
+    content = path.read_text()
+    path.write_text(content.replace("event-2", "edited2"))
+    os.utime(path, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+    current_stat = path.stat()
+
+    def copy_current_stat(header: dict[str, object], _records: list[list[object]]) -> None:
+        source = header["source"]
+        assert isinstance(source, dict)
+        source["device"] = current_stat.st_dev
+        source["inode"] = current_stat.st_ino
+        source["size"] = current_stat.st_size
+        source["mtime_ns"] = current_stat.st_mtime_ns
+        source["ctime_ns"] = current_stat.st_ctime_ns
+
+    # Make every stat field look current and repair the sidecar checksum. The
+    # stale content fingerprint must still force a source scan.
+    _rewrite_sidecar(index_path, copy_current_stat)
+    scanned = 0
+    scan_header = events_module._scan_header_fields  # noqa: SLF001
+
+    def count_header_scans(line: bytes) -> _ScannedHeader | None:
+        nonlocal scanned
+        scanned += 1
+        return scan_header(line)
+
+    monkeypatch.setattr(events_module, "_scan_header_fields", count_header_scans)
+
+    store = EventStore(path, run_id="second")
+
+    assert scanned == 3
+    assert store.read()[-1].text == "edited2"
+
+
+def test_source_truncated_below_the_cached_boundary_is_rebuilt(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2, 3])
+    EventStore(path, run_id="first")
+    _write(path, [1, 2])
+
+    store = EventStore(path, run_id="second")
+
+    assert [event.sequence for event in store.read()] == [1, 2]
+    loaded = load_event_index(path)
+    assert loaded is not None
+    assert len(loaded.records) == 2
+
+
+@pytest.mark.parametrize("corruption", [b"not-json\n", b""])
+def test_corrupt_or_truncated_sidecar_is_rebuilt(tmp_path: Path, corruption: bytes) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2, 3])
+    EventStore(path, run_id="first")
+    index_path = event_index_path(path)
+    index_path.write_bytes(corruption)
+
+    store = EventStore(path, run_id="second")
+
+    assert [event.sequence for event in store.read()] == [1, 2, 3]
+    assert load_event_index(path) is not None
+
+
+def test_unknown_cached_event_type_is_rebuilt_from_jsonl(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2])
+    EventStore(path, run_id="first")
+    index_path = event_index_path(path)
+
+    def replace_type(_header: dict[str, object], records: list[list[object]]) -> None:
+        records[0][4] = "future_event"
+
+    _rewrite_sidecar(index_path, replace_type)
+
+    store = EventStore(path, run_id="second")
+
+    assert [event.type for event in store.read()] == [EventType.OUTPUT, EventType.OUTPUT]
+    assert load_event_index(path) is not None
+
+
+def test_non_ascii_sidecar_checksum_is_a_cache_miss(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2])
+    EventStore(path, run_id="first")
+    index_path = event_index_path(path)
+    lines = index_path.read_bytes().splitlines(keepends=True)
+    lines[-1] = (json.dumps({"sha256": "é" * 64}) + "\n").encode()
+    index_path.write_bytes(b"".join(lines))
+
+    assert [event.sequence for event in EventStore(path, run_id="second").read()] == [1, 2]
+    assert load_event_index(path) is not None
+
+
+def test_valid_unterminated_record_stays_outside_the_safe_cache_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2], terminate=False)
+    EventStore(path, run_id="first")
+    loaded = load_event_index(path)
+    assert loaded is not None
+    assert len(loaded.records) == 1
+    scanned = 0
+    scan_header = events_module._scan_header_fields  # noqa: SLF001
+
+    def count_header_scans(line: bytes) -> _ScannedHeader | None:
+        nonlocal scanned
+        scanned += 1
+        return scan_header(line)
+
+    monkeypatch.setattr(events_module, "_scan_header_fields", count_header_scans)
+    store = EventStore(path, run_id="second")
+
+    assert scanned == 1
+    store.append(make_event(EventType.OUTPUT, "third"))
+    assert [event.text for event in EventStore(path, run_id="third").read()] == [
+        "event-0",
+        "event-1",
+        "third",
+    ]
+
+
+def test_malformed_tail_stays_repairable_after_warm_attach(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1])
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write('{"protocol_version":1')
+    first = EventStore(path, run_id="first")
+    assert [event.text for event in first.read()] == ["event-0"]
+
+    second = EventStore(path, run_id="second")
+    second.append(make_event(EventType.OUTPUT, "after repair"))
+
+    assert [event.text for event in EventStore(path, run_id="third").read()] == [
+        "event-0",
+        "after repair",
+    ]
+
+
+def test_legacy_sequence_repair_survives_cache_reuse_and_rebuild(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [2, 1, 3])
+
+    assert [event.sequence for event in EventStore(path, run_id="first").read()] == [2, 3, 4]
+    warm = EventStore(path, run_id="second")
+    assert [event.sequence for event in warm.read()] == [2, 3, 4]
+    warm.append(make_event(EventType.OUTPUT, "appended"))
+
+    assert [event.sequence for event in EventStore(path, run_id="third").read()] == [2, 3, 4, 5]
+
+
+def test_sidecar_write_failure_never_fails_attach_or_leaves_a_temporary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2])
+
+    def fail_replace(_source: object, _target: object) -> None:
+        raise OSError
+
+    monkeypatch.setattr(event_index_module.os, "replace", fail_replace)
+
+    store = EventStore(path, run_id="active-run")
+
+    assert [event.sequence for event in store.read()] == [1, 2]
+    assert not event_index_path(path).exists()
+    assert list(tmp_path.glob(".events.jsonl.idx.*")) == []
+
+
+def test_temporary_cleanup_failure_does_not_mask_a_sidecar_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1])
+    real_unlink = Path.unlink
+
+    def fail_replace(_source: object, _target: object) -> None:
+        raise OSError
+
+    def fail_temporary_unlink(target: Path, *, missing_ok: bool = False) -> None:
+        if target.name.startswith(".events.jsonl.idx."):
+            raise OSError
+        return real_unlink(target, missing_ok=missing_ok)
+
+    monkeypatch.setattr(event_index_module.os, "replace", fail_replace)
+    monkeypatch.setattr(Path, "unlink", fail_temporary_unlink)
+
+    assert [event.sequence for event in EventStore(path, run_id="active-run").read()] == [1]
+
+
+def test_failed_replacement_preserves_an_existing_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2])
+    EventStore(path, run_id="first")
+    index_path = event_index_path(path)
+    original = index_path.read_bytes()
+    stat = path.stat()
+    os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+
+    def fail_replace(_source: object, _target: object) -> None:
+        raise OSError
+
+    monkeypatch.setattr(event_index_module.os, "replace", fail_replace)
+
+    store = EventStore(path, run_id="second")
+
+    assert [event.sequence for event in store.read()] == [1, 2]
+    assert index_path.read_bytes() == original
+    assert list(tmp_path.glob(".events.jsonl.idx.*")) == []
+
+
+def test_unreadable_sidecar_is_only_a_cache_miss(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "events.jsonl"
+    _write(path, [1, 2])
+    EventStore(path, run_id="first")
+    index_path = event_index_path(path)
+    real_open = Path.open
+
+    def deny_index_read(  # noqa: PLR0913  # mirrors Path.open for the monkeypatch
+        target: Path,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> object:
+        if target == index_path and mode == "rb":
+            raise PermissionError
+        return real_open(target, mode, buffering, encoding, errors, newline)
+
+    monkeypatch.setattr(Path, "open", deny_index_read)
+
+    assert [event.sequence for event in EventStore(path, run_id="second").read()] == [1, 2]

--- a/tests/server/test_lazy_event_store.py
+++ b/tests/server/test_lazy_event_store.py
@@ -28,6 +28,8 @@ from server.events import (
     RoundFinishedData,
     RunEvent,
     RunStartedData,
+    _records_from_events,
+    _repair_legacy_sequences,
     make_event,
 )
 from server.journal import _canonical_execution_events
@@ -43,7 +45,8 @@ class _EagerEventStore(EventStore):
     """
 
     def _scan_unlocked(self):  # noqa: ANN202
-        return None
+        events, malformed_tail_offset = self._read_unlocked()
+        return _records_from_events(_repair_legacy_sequences(events)), malformed_tail_offset
 
 
 def _write_events(path: Path, events: list[RunEvent]) -> None:


### PR DESCRIPTION
## Problem

Fixes #612.

`EventStore` attached a durable run by calling `read_bytes()` and then `splitlines(keepends=True)`. The complete journal and a second set of line byte objects coexisted during startup, so attach memory grew with the full JSONL payload. Every reopen also parsed every record header even when the source had not changed.

## Solution

Attach now streams the JSONL source one line at a time. The scanner retains only the in-memory record index, two current lines, and the bounded eager-validation tail. If the cheap header scan cannot classify a complete record, that record is fully validated in place, which preserves strict corruption errors without retaining every parsed payload.

A versioned `run-events.jsonl.idx` sidecar caches record offsets and the four header fields used during bootstrap. The journal is append-only, so reuse requires the same device and inode, a source at least as large as when it was indexed, and matching SHA-256 fingerprints of the indexed head (first 64 KiB), seven interior 4 KiB samples, and the 64 KiB window ending at the last safe newline boundary. A source of exactly the indexed size must also have identical modification and change times. `EventJournal.attach` appends `SERVER_STARTED` after building the store, so an exact size/mtime check would reject the sidecar on every real reattach; a grown source instead has only its suffix scanned and the extended index is republished atomically. The sidecar also has a checksum and validates its count, contiguous offsets, field types, and legacy sequence-repair recurrence before use. A shrunken or replaced source, any fingerprint mismatch, or a sidecar of another format version (now 2) performs a full streaming rebuild. The fingerprints do not cover interior bytes outside the sampled windows, which is the accepted residual for an append-only file. The JSONL file remains authoritative.

Sidecars are written to a mode-0600 temporary in the journal directory, flushed, fsynced, and published with `os.replace`. Sidecar read, write, directory-sync, and cleanup failures are cache misses and do not affect a healthy journal.

### Architecture

```mermaid
flowchart TD
    A[EventStore attach] --> B[Capture JSONL identity]
    B --> C{Indexed prefix unchanged?}
    C -->|yes| D[Stream and validate sidecar records]
    D --> S[Scan only the suffix past the boundary]
    S --> F
    S --> I
    C -->|no| E[Stream JSONL records]
    F[Validate bounded event tail]
    E --> G[Validate uncertain records in place]
    G --> F
    F --> H[Expose in-memory record index]
    E --> I[Write temporary sidecar]
    I --> J[Recheck JSONL identity]
    J --> K[Atomic sidecar replacement]
```

`server.events` continues to own JSONL parsing, corruption policy, lazy event validation, and legacy cursor repair. The new leaf `server.event_index` module owns only primitive sidecar serialization, validation, source identity, and atomic cache I/O. No protocol, journal-spine, core-state, or TUI behavior changes.

## Verification

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/AyanBinRafaih/vibe-serve/ee1c830cf194e0d921b1eb9c2cf41dd5608990ba/pr-659/before.png) | ![After](https://raw.githubusercontent.com/AyanBinRafaih/vibe-serve/ee1c830cf194e0d921b1eb9c2cf41dd5608990ba/pr-659/after.png) |

The regression test fails on the merge base by replacing `Path.read_bytes` with an assertion during cold attach. New tests also cover exact warm reuse, suffix-only scanning and index extension after append (asserting scan counts, including that a third attach scans nothing new), the real `EventJournal.attach` path reusing the index despite `SERVER_STARTED`, rejection of head, boundary, and interior edits combined with growth, replaced files, truncation, partial sidecars and other sidecar versions, a same-size overwrite with current stat fields copied into the stale cache, changes during scan and cache load, corrupt and truncated sidecars, invalid event types and non-ASCII checksums, valid unterminated and malformed tails, legacy cursor repair, unreadable sidecars, failed atomic replacement, and cleanup failure.

The checked-in benchmark runs every attach in a fresh subprocess and reports median and p95 wall time and peak RSS for cold, warm, and changed-source cases. The changed-source mode appends one event to a warm journal; since the follow-up fix it measures the suffix-scan path, not a full rebuild, and the table below predates that change.

### Correctness properties

- Attach never reads or splits the complete JSONL file into memory.
- A sidecar is accepted only after structural validation, checksum validation, same-file and no-shrink checks, bounded content fingerprint matching of the indexed prefix, and a second source-identity check after the sidecar read. Any doubt is a full rebuild, never a stale index.
- A source change during a cold scan prevents that scan from publishing an index.
- Only newline-terminated records enter the persistent safe boundary. Valid unterminated records and malformed append tails are rescanned, so append repair behavior remains unchanged.
- Complete invalid records still raise, while only an incomplete final append is ignored and truncated by the next append.
- Duplicate, out-of-order, and reset legacy sequences retain the same strictly increasing cursors across cold attach, warm attach, append, and reopen.
- Failure to read, create, sync, replace, or clean up a sidecar cannot hide or damage the authoritative JSONL journal.

### Testing

- Maintainer follow-up (`d67c2b2e`): `tests/server` passes (382 tests) and Ruff check/format are clean locally; CI on the pushed head is the authority for the rest. The benchmark table and full-suite numbers below were measured before this follow-up.

- Regression reproduced against `ea6f9073`: cold attach fails at `Path.read_bytes`; the branch passes the same invariant.
- `.venv/bin/python -m pytest -n 8 --dist loadgroup --cov-report=xml --cov-report=json --cov-fail-under=75 -q`, 5,738 passed and 28 platform/toolchain skips.
- `.venv/bin/python scripts/check_coverage_floor.py coverage.json`, passed. `.venv/bin/diff-cover coverage.xml --compare-branch=upstream/main --include-untracked --fail-under=80`, passed with 90% patch coverage, including the new module.
- Ruff lint and formatting, `ty check`, `lint-imports`, and Markdown link validation passed.
- Protocol regeneration produced zero diff. `pnpm check:ts`, `pnpm check:clients`, `pnpm check:ts-architecture`, `pnpm test:clients`, and `pnpm build:clients` passed using Node 24.21.0 and Bun 1.3.9. Client tests: 25 backend-client, 98 core-state, 738 TUI, zero failures.

For each module root (merge-base main and this branch), ran `.venv/bin/python scripts/benchmark_event_store_attach.py --module-root ROOT --python /tmp/vibesys-issues-20260910/612/.venv/bin/python --sizes-mib 20 100 500 --repeats 3 --work-dir UNIQUE --output REPORT.md`. Each sample uses a fresh Python 3.12 subprocess. With three repetitions, p95 is the largest observed sample; these are local measurements, not a statistical latency guarantee.

| Journal | Mode | Main median / p95 | Branch median / p95 | Main peak RSS median / p95 | Branch peak RSS median / p95 |
| --- | --- | ---: | ---: | ---: | ---: |
| 20 MiB | cold | 0.225 / 0.243s | 0.328 / 0.343s | 80.6 / 80.6 MiB | 42.7 / 42.7 MiB |
| 20 MiB | warm | 0.230 / 0.233s | 0.177 / 0.181s | 80.6 / 80.6 MiB | 43.1 / 43.2 MiB |
| 20 MiB | changed source | 0.226 / 0.231s | 0.337 / 0.345s | 80.6 / 80.6 MiB | 42.7 / 42.8 MiB |
| 100 MiB | cold | 1.086 / 1.086s | 1.521 / 1.533s | 264.5 / 264.5 MiB | 62.1 / 62.2 MiB |
| 100 MiB | warm | 1.076 / 1.082s | 0.814 / 0.834s | 264.5 / 264.5 MiB | 64.6 / 64.7 MiB |
| 100 MiB | changed source | 1.065 / 1.069s | 1.562 / 1.586s | 264.6 / 264.7 MiB | 62.4 / 62.4 MiB |
| 500 MiB | cold | 5.657 / 10.604s | 7.300 / 7.728s | 1184.8 / 1185.3 MiB | 162.6 / 162.7 MiB |
| 500 MiB | warm | 5.352 / 5.391s | 4.408 / 4.409s | 1184.7 / 1184.8 MiB | 178.3 / 178.3 MiB |
| 500 MiB | changed source | 5.339 / 5.429s | 6.158 / 7.648s | 1184.8 / 1184.9 MiB | 162.6 / 162.6 MiB |

At 500 MiB, cold peak RSS falls 86% and warm attach is 18% faster. Cold and changed-source attach pay extra serialization, checksum, and atomic-publication cost. Index files are 0.9, 4.6, and 24.1 MiB at the three sizes. Index memory still grows with record count; this change removes whole-journal payload allocation, not the record index itself.

- Combined integration of all ten independently based fixes: 5,816 Python tests passed (6 environment/platform skips), 91% patch coverage, 25 backend-client, 123 core-state and 745 TUI tests passed. All repository static checks, stable protocol generation, builds, and packed/deployed TUI self-tests passed.
- Real combined `codex` / `gpt-5.6-sol` queue-rs SPSC run, capped at one round: completed with independent review and official evaluation. The run reported the retained winner `5e621d36bcc4` at 26,412,131.227693 operations/second; the final workspace was clean and differed from the winning tree only in framework state and the final archive. Live chat completed once while optimization streamed; the TUI showed execution label, progress, elapsed time and context usage. Pathological concurrency, large histories and minimizing-objective rankings were exercised separately by the targeted regressions and performance benchmarks for their respective issues.

Closes #612

