### PR TITLE
TUI: reconcile agent timing across history backfill

### DIFF
--- a/clients/core-state/src/core-state-prefix.test.ts
+++ b/clients/core-state/src/core-state-prefix.test.ts
@@ -7,7 +7,6 @@ import {
   reduceEventBatch,
   reduceEventPrefix,
 } from './core-state.js';
-import type {RoundSummary} from './run-map.js';
 
 /**
  * Equivalence harness for the tail bootstrap.
@@ -16,14 +15,7 @@ import type {RoundSummary} from './run-map.js';
  * the same `CoreState` as folding its tail and then backfilling the preceding
  * chunks through `reduceEventPrefix`.
  *
- * One exception is scoped out of the comparison, see `mergeRoundLists`: an agent
- * execution whose `agent_execution_started` falls in a backfilled chunk and
- * whose `agent_execution_finished` falls after the boundary loses its timing
- * interval, because the newer fold saw a finish with no start and dropped the
- * timestamp. `withoutRoundTiming` scopes exactly that, and the round-aligned
- * case below asserts full equality including timing.
- *
- * Two further divergences are inherent to folding a bare suffix, and each has a
+ * Two divergences are inherent to folding a bare suffix, and each has a
  * test of its own below rather than a normalization here:
  * - `status` and the expected-phase seeding both need `run_started`, which a
  *   suffix does not carry.
@@ -44,7 +36,7 @@ describe('prefix backfill equivalence', () => {
           const bootstrapped = backfill(events, tail, 97);
 
           expect(bootstrapped.historyAfterSequence).toBe(0);
-          expect(withoutRoundTiming(bootstrapped)).toEqual(withoutRoundTiming(full));
+          expect(bootstrapped).toEqual(full);
         }
       });
     }
@@ -416,10 +408,7 @@ describe('prefix merges across the chunk boundary', () => {
     ]);
   });
 
-  // Documents the one field the merge cannot reconstruct. The chunk holds an
-  // open start, the tail holds a finish with nothing to close, and the finish
-  // timestamp is gone by the time the two states meet.
-  it('loses the timing interval of an execution split across the boundary', () => {
+  it('reconciles the timing interval of an execution split across the boundary', () => {
     const events = [
       executionStartedEvent(1, 'exec-a'),
       executionFinishedEvent(2, 'exec-a'),
@@ -429,12 +418,85 @@ describe('prefix merges across the chunk boundary', () => {
 
     const merged = foldAsPrefix(events, 1);
 
-    expect(withoutRoundTiming(merged)).toEqual(withoutRoundTiming(full));
+    expect(merged).toEqual(full);
     expect(full.rounds[0]?.agentIntervals).toEqual([
       {startedAt: timestamp(1), finishedAt: timestamp(2)},
     ]);
-    expect(merged.rounds[0]?.agentIntervals).toEqual([]);
-    expect(merged.rounds[0]?.activeAgentStarts).toEqual({'implementer:exec-a': timestamp(1)});
+    expect(merged.rounds[0]?.agentIntervals).toEqual([
+      {startedAt: timestamp(1), finishedAt: timestamp(2)},
+    ]);
+    expect(merged.rounds[0]?.activeAgentStarts).toEqual({});
+  });
+
+  for (const terminal of ['round_finished', 'run_failed', 'run_interrupted'] as const) {
+    it(`closes a backfilled active timing at a tail ${terminal}`, () => {
+      const terminalEvent: RunEvent =
+        terminal === 'round_finished'
+          ? roundFinishedEvent(2)
+          : {sequence: 2, timestamp: timestamp(2), type: terminal};
+      const events = [executionStartedEvent(1, 'exec-a'), terminalEvent];
+
+      const merged = foldAsPrefix(events, 1);
+      const full = reduceEventBatch(initialCoreState(), events);
+
+      expect({...merged, activeExecutions: {}}).toEqual({...full, activeExecutions: {}});
+      expect(merged.rounds[0]?.agentIntervals).toEqual([
+        {startedAt: timestamp(1), finishedAt: timestamp(2)},
+      ]);
+      expect(merged.rounds[0]?.activeAgentStarts).toEqual({});
+    });
+  }
+
+  it('deduplicates modern and compatibility finishes split across chunks', () => {
+    const events = [
+      executionStartedEvent(1, 'exec-a'),
+      executionFinishedEvent(2, 'exec-a'),
+      phaseFinishedEvent(3, 'exec-a'),
+      roundFinishedEvent(4),
+    ];
+
+    const merged = backfillAt(events, [1, 2, 3]);
+    const full = reduceEventBatch(initialCoreState(), events);
+
+    expect(merged.rounds).toEqual(full.rounds);
+    expect(merged.rounds[0]?.agentIntervals).toEqual([
+      {startedAt: timestamp(1), finishedAt: timestamp(2)},
+    ]);
+  });
+
+  it('reconciles a reused legacy key across more than two prefix chunks', () => {
+    const sharedTimestamp = timestamp(9);
+    const events = [
+      {...legacyExecutionEvent(1, 'agent_execution_started'), timestamp: sharedTimestamp},
+      {...legacyExecutionEvent(2, 'agent_execution_finished'), timestamp: sharedTimestamp},
+      {...legacyExecutionEvent(3, 'agent_execution_started'), timestamp: sharedTimestamp},
+    ];
+
+    const merged = backfillAt(events, [1, 2]);
+    const full = reduceEventBatch(initialCoreState(), events);
+
+    expect(merged.rounds).toEqual(full.rounds);
+    expect(merged.rounds[0]?.agentIntervals).toEqual([
+      {startedAt: sharedTimestamp, finishedAt: sharedTimestamp},
+    ]);
+    expect(merged.rounds[0]?.activeAgentStarts).toEqual({'implementer:': sharedTimestamp});
+  });
+
+  it('retains timing provenance when profileSkipped copies the round', () => {
+    const events = [
+      executionStartedEvent(1, 'exec-a'),
+      roundFinishedEvent(2, {profile_skipped: true}),
+    ];
+
+    const merged = foldAsPrefix(events, 1);
+
+    const full = reduceEventBatch(initialCoreState(), events);
+    expect({...merged, activeExecutions: {}}).toEqual({...full, activeExecutions: {}});
+    expect(merged.rounds[0]).toMatchObject({
+      profileSkipped: true,
+      agentIntervals: [{startedAt: timestamp(1), finishedAt: timestamp(2)}],
+      activeAgentStarts: {},
+    });
   });
 
   // A bare suffix has no `run_started`, so the tail fold has no run status and
@@ -549,18 +611,6 @@ function foldWithSpineBackfill(
 
 function sequenceAt(events: readonly RunEvent[], index: number): number {
   return index < 0 ? 0 : (events[index]?.sequence ?? 0);
-}
-
-/** The state minus the round timing fields a split execution cannot recover. */
-function withoutRoundTiming(state: CoreState): CoreState {
-  return {
-    ...state,
-    rounds: state.rounds.map(
-      ({agentIntervals: _intervals, activeAgentStarts: _starts, ...rest}) => {
-        return rest as RoundSummary;
-      },
-    ),
-  };
 }
 
 // A deterministic 32-bit generator, so a failing seed is reproducible.
@@ -971,6 +1021,28 @@ function executionFinishedEvent(sequence: number, executionId: string): RunEvent
     status: 'completed',
     data: {kind: 'agent_execution_finished', error: null},
   };
+}
+
+function phaseFinishedEvent(sequence: number, executionId: string): RunEvent {
+  return {
+    ...baseEvent(sequence, 'phase_finished'),
+    round_label: 'round-1',
+    execution_id: executionId,
+    status: 'completed',
+    data: {kind: 'phase', phase: 'implementer', attempt: null},
+  };
+}
+
+function legacyExecutionEvent(
+  sequence: number,
+  type: 'agent_execution_started' | 'agent_execution_finished',
+): RunEvent {
+  const event =
+    type === 'agent_execution_started'
+      ? executionStartedEvent(sequence, 'discarded')
+      : executionFinishedEvent(sequence, 'discarded');
+  const {execution_id: _discarded, ...legacy} = event;
+  return legacy;
 }
 
 function threadCreatedEvent(sequence: number, threadId: string): RunEvent {

--- a/clients/core-state/src/round-timing.ts
+++ b/clients/core-state/src/round-timing.ts
@@ -3,6 +3,42 @@ export interface AgentTimingInterval {
   finishedAt: string;
 }
 
+interface TimingFinish {
+  key: string;
+  agentKind: string;
+  finishedAt: string;
+  sequence: number | null;
+  compatibility: boolean;
+}
+
+interface TimingCloseout {
+  finishedAt: string;
+  sequence: number | null;
+}
+
+interface TimingIntervalProvenance {
+  startKey: string;
+  startSequence: number | null;
+  startCompatibility: boolean;
+  finishKey: string;
+  agentKind: string;
+  finishSequence: number | null;
+  finishCompatibility: boolean;
+}
+
+/** Internal replay provenance used to join timing facts across prefix boundaries. */
+interface AgentTimingProvenance {
+  activeStarts: Record<string, TimingStartProvenance>;
+  intervals: Array<TimingIntervalProvenance | null>;
+  unmatchedFinishes: TimingFinish[];
+  closeouts: TimingCloseout[];
+}
+
+interface TimingStartProvenance {
+  sequence: number | null;
+  compatibility: boolean;
+}
+
 export interface RoundTimingState {
   agentIntervals?: AgentTimingInterval[];
   activeAgentStarts?: Record<string, string>;
@@ -13,15 +49,31 @@ export interface AgentTimingEvent {
   invocation_id?: string | null;
   execution_id?: string | null;
   timestamp: string;
+  sequence?: number;
+  type?: string;
 }
+
+const timingProvenances = new WeakMap<object, AgentTimingProvenance>();
 
 export function startAgentTiming<T extends RoundTimingState>(state: T, event: AgentTimingEvent): T {
   const key = timingKey(event);
   if (key === null) return state;
-  return {
+  const provenance = timingProvenance(state);
+  const next = {
     ...state,
     activeAgentStarts: {...(state.activeAgentStarts ?? {}), [key]: event.timestamp},
   };
+  recordTimingProvenance(next, {
+    ...provenance,
+    activeStarts: {
+      ...provenance.activeStarts,
+      [key]: {
+        sequence: event.sequence ?? null,
+        compatibility: event.type === 'phase_started',
+      },
+    },
+  });
+  return next;
 }
 
 export function finishAgentTiming<T extends RoundTimingState>(
@@ -29,12 +81,19 @@ export function finishAgentTiming<T extends RoundTimingState>(
   event: AgentTimingEvent,
 ): T {
   const exactKey = timingKey(event);
-  if (exactKey === null) return state;
+  const agentKind = event.agent_kind;
+  if (exactKey === null || !agentKind) return state;
+  const provenance = timingProvenance(state);
   const activeAgentStarts = {...(state.activeAgentStarts ?? {})};
   const activeKey = findActiveTimingKey(activeAgentStarts, event, exactKey);
   const startedAt = activeKey === null ? undefined : activeAgentStarts[activeKey];
-  if (activeKey !== null) delete activeAgentStarts[activeKey];
-  return {
+  const activeStarts = {...provenance.activeStarts};
+  const startProvenance = activeKey === null ? undefined : activeStarts[activeKey];
+  if (activeKey !== null) {
+    delete activeAgentStarts[activeKey];
+    delete activeStarts[activeKey];
+  }
+  const next = {
     ...state,
     ...(startedAt === undefined
       ? {}
@@ -46,21 +105,166 @@ export function finishAgentTiming<T extends RoundTimingState>(
         }),
     activeAgentStarts,
   };
+  recordTimingProvenance(next, {
+    activeStarts,
+    intervals:
+      startedAt === undefined
+        ? provenance.intervals
+        : [
+            ...provenance.intervals,
+            {
+              startKey: activeKey as string,
+              startSequence: startProvenance?.sequence ?? null,
+              startCompatibility: startProvenance?.compatibility ?? false,
+              finishKey: exactKey,
+              agentKind,
+              finishSequence: event.sequence ?? null,
+              finishCompatibility: event.type === 'phase_finished',
+            },
+          ],
+    unmatchedFinishes:
+      startedAt === undefined
+        ? [
+            ...provenance.unmatchedFinishes,
+            {
+              key: exactKey,
+              agentKind,
+              finishedAt: event.timestamp,
+              sequence: event.sequence ?? null,
+              compatibility: event.type === 'phase_finished',
+            },
+          ]
+        : provenance.unmatchedFinishes,
+    closeouts: provenance.closeouts,
+  });
+  return next;
 }
 
 export function closeActiveAgentTimings<T extends RoundTimingState>(
   state: T,
   timestamp: string,
+  sequence: number | null = null,
 ): T {
-  const activeIntervals = Object.values(state.activeAgentStarts ?? {}).map(startedAt => ({
+  const activeEntries = Object.entries(state.activeAgentStarts ?? {});
+  const activeIntervals = activeEntries.map(([, startedAt]) => ({
     startedAt,
     finishedAt: timestamp,
   }));
-  return {
+  const provenance = timingProvenance(state);
+  const next = {
     ...state,
     agentIntervals: [...(state.agentIntervals ?? []), ...activeIntervals],
     activeAgentStarts: {},
   };
+  recordTimingProvenance(next, {
+    activeStarts: {},
+    intervals: [
+      ...provenance.intervals,
+      ...activeEntries.map(([key]) => ({
+        startKey: key,
+        startSequence: provenance.activeStarts[key]?.sequence ?? null,
+        startCompatibility: provenance.activeStarts[key]?.compatibility ?? false,
+        finishKey: key,
+        agentKind: agentKindFromKey(key),
+        finishSequence: sequence,
+        finishCompatibility: false,
+      })),
+    ],
+    unmatchedFinishes: provenance.unmatchedFinishes,
+    closeouts: [...provenance.closeouts, {finishedAt: timestamp, sequence}],
+  });
+  return next;
+}
+
+/** Merges timing facts from an older prefix under a newer suffix. */
+export function mergeAgentTimingPrefix(
+  older: RoundTimingState,
+  newer: RoundTimingState,
+): RoundTimingState {
+  const taggedIntervals: TaggedInterval[] = [];
+  const operations: TimingOperation[] = [];
+  collectTimingFacts(older, timingProvenance(older), taggedIntervals, operations);
+  collectTimingFacts(newer, timingProvenance(newer), taggedIntervals, operations);
+  operations.sort(compareTimingOperations);
+
+  const active = new Map<string, TimingStart>();
+  const completed = new Set<string>();
+  const unmatchedFinishes: TimingFinish[] = [];
+  for (const operation of operations) {
+    if (operation.kind === 'start') {
+      if (operation.start.compatibility && active.has(operation.start.key)) continue;
+      active.set(operation.start.key, operation.start);
+      completed.delete(operation.start.key);
+      continue;
+    }
+    if (operation.kind === 'closeout') {
+      for (const [startKey, start] of active) {
+        taggedIntervals.push({
+          interval: {startedAt: start.startedAt, finishedAt: operation.closeout.finishedAt},
+          provenance: {
+            startKey,
+            startSequence: start.sequence,
+            startCompatibility: start.compatibility,
+            finishKey: startKey,
+            agentKind: start.agentKind,
+            finishSequence: operation.closeout.sequence,
+            finishCompatibility: false,
+          },
+        });
+      }
+      active.clear();
+      continue;
+    }
+    const finish = operation.finish;
+    if (finish.compatibility && completed.has(finish.key)) continue;
+    const startKey = findReplayTimingKey(active, finish);
+    if (startKey === null) {
+      unmatchedFinishes.push(finish);
+      completed.add(finish.key);
+      continue;
+    }
+    const start = active.get(startKey) as TimingStart;
+    active.delete(startKey);
+    taggedIntervals.push({
+      interval: {startedAt: start.startedAt, finishedAt: finish.finishedAt},
+      provenance: {
+        startKey,
+        startSequence: start.sequence,
+        startCompatibility: start.compatibility,
+        finishKey: finish.key,
+        agentKind: finish.agentKind,
+        finishSequence: finish.sequence,
+        finishCompatibility: finish.compatibility,
+      },
+    });
+    completed.add(finish.key);
+  }
+
+  taggedIntervals.sort(compareTaggedIntervals);
+  const activeAgentStarts = Object.fromEntries(
+    [...active].map(([key, start]) => [key, start.startedAt]),
+  );
+  const activeStarts = Object.fromEntries(
+    [...active].map(([key, start]) => [
+      key,
+      {sequence: start.sequence, compatibility: start.compatibility},
+    ]),
+  );
+  const hadIntervals = older.agentIntervals !== undefined || newer.agentIntervals !== undefined;
+  const hadStarts = older.activeAgentStarts !== undefined || newer.activeAgentStarts !== undefined;
+  const merged: RoundTimingState = {
+    ...(hadIntervals || taggedIntervals.length > 0
+      ? {agentIntervals: taggedIntervals.map(tagged => tagged.interval)}
+      : {}),
+    ...(hadStarts || active.size > 0 ? {activeAgentStarts} : {}),
+  };
+  recordTimingProvenance(merged, {
+    activeStarts,
+    intervals: taggedIntervals.map(tagged => tagged.provenance),
+    unmatchedFinishes,
+    closeouts: mergeCloseouts(timingProvenance(older).closeouts, timingProvenance(newer).closeouts),
+  });
+  return merged;
 }
 
 /** The caller supplies time so this selector stays deterministic. */
@@ -77,9 +281,161 @@ export function hasActiveAgentTiming(state: RoundTimingState): boolean {
   return Object.keys(state.activeAgentStarts ?? {}).length > 0;
 }
 
+interface TaggedInterval {
+  interval: AgentTimingInterval;
+  provenance: TimingIntervalProvenance | null;
+}
+
+interface TimingStart {
+  key: string;
+  agentKind: string;
+  startedAt: string;
+  sequence: number | null;
+  compatibility: boolean;
+}
+
+type TimingOperation =
+  | {kind: 'start'; start: TimingStart}
+  | {kind: 'finish'; finish: TimingFinish}
+  | {kind: 'closeout'; closeout: TimingCloseout};
+
+function timingProvenance(state: RoundTimingState): AgentTimingProvenance {
+  const provenance =
+    (state.activeAgentStarts === undefined
+      ? undefined
+      : timingProvenances.get(state.activeAgentStarts)) ??
+    (state.agentIntervals === undefined ? undefined : timingProvenances.get(state.agentIntervals));
+  return {
+    activeStarts: provenance?.activeStarts ?? {},
+    intervals: provenance?.intervals ?? (state.agentIntervals ?? []).map(() => null),
+    unmatchedFinishes: provenance?.unmatchedFinishes ?? [],
+    closeouts: provenance?.closeouts ?? [],
+  };
+}
+
+function recordTimingProvenance(state: RoundTimingState, provenance: AgentTimingProvenance): void {
+  if (state.activeAgentStarts !== undefined) {
+    timingProvenances.set(state.activeAgentStarts, provenance);
+  }
+  if (state.agentIntervals !== undefined) timingProvenances.set(state.agentIntervals, provenance);
+}
+
+function collectTimingFacts(
+  state: RoundTimingState,
+  provenance: AgentTimingProvenance,
+  fixed: TaggedInterval[],
+  operations: TimingOperation[],
+): void {
+  for (const [index, interval] of (state.agentIntervals ?? []).entries()) {
+    const endpoints = provenance.intervals[index] ?? null;
+    if (endpoints === null) {
+      fixed.push({interval, provenance: null});
+      continue;
+    }
+    operations.push({
+      kind: 'start',
+      start: {
+        key: endpoints.startKey,
+        agentKind: agentKindFromKey(endpoints.startKey),
+        startedAt: interval.startedAt,
+        sequence: endpoints.startSequence,
+        compatibility: endpoints.startCompatibility,
+      },
+    });
+    operations.push({
+      kind: 'finish',
+      finish: {
+        key: endpoints.finishKey,
+        agentKind: endpoints.agentKind,
+        finishedAt: interval.finishedAt,
+        sequence: endpoints.finishSequence,
+        compatibility: endpoints.finishCompatibility,
+      },
+    });
+  }
+  for (const [key, startedAt] of Object.entries(state.activeAgentStarts ?? {})) {
+    operations.push({
+      kind: 'start',
+      start: {
+        key,
+        agentKind: agentKindFromKey(key),
+        startedAt,
+        sequence: provenance.activeStarts[key]?.sequence ?? null,
+        compatibility: provenance.activeStarts[key]?.compatibility ?? false,
+      },
+    });
+  }
+  for (const finish of provenance.unmatchedFinishes) operations.push({kind: 'finish', finish});
+  for (const closeout of provenance.closeouts) operations.push({kind: 'closeout', closeout});
+}
+
+function compareTimingOperations(left: TimingOperation, right: TimingOperation): number {
+  const leftSequence = operationSequence(left);
+  const rightSequence = operationSequence(right);
+  if (leftSequence !== null && rightSequence !== null) return leftSequence - rightSequence;
+  return operationTimestamp(left) - operationTimestamp(right);
+}
+
+function operationSequence(operation: TimingOperation): number | null {
+  if (operation.kind === 'start') return operation.start.sequence;
+  return operation.kind === 'finish' ? operation.finish.sequence : operation.closeout.sequence;
+}
+
+function operationTimestamp(operation: TimingOperation): number {
+  const timestamp =
+    operation.kind === 'start'
+      ? operation.start.startedAt
+      : operation.kind === 'finish'
+        ? operation.finish.finishedAt
+        : operation.closeout.finishedAt;
+  return new Date(timestamp).getTime();
+}
+
+function mergeCloseouts(
+  older: readonly TimingCloseout[],
+  newer: readonly TimingCloseout[],
+): TimingCloseout[] {
+  return [...older, ...newer].sort((left, right) => {
+    if (left.sequence !== null && right.sequence !== null) return left.sequence - right.sequence;
+    return new Date(left.finishedAt).getTime() - new Date(right.finishedAt).getTime();
+  });
+}
+
+function findReplayTimingKey(
+  active: ReadonlyMap<string, TimingStart>,
+  finish: TimingFinish,
+): string | null {
+  if (active.has(finish.key)) return finish.key;
+  let first: TimingStart | null = null;
+  for (const start of active.values()) {
+    if (start.agentKind !== finish.agentKind) continue;
+    if (
+      first === null ||
+      new Date(start.startedAt).getTime() < new Date(first.startedAt).getTime()
+    ) {
+      first = start;
+    }
+  }
+  return first?.key ?? null;
+}
+
+function compareTaggedIntervals(left: TaggedInterval, right: TaggedInterval): number {
+  const leftSequence = left.provenance?.finishSequence ?? null;
+  const rightSequence = right.provenance?.finishSequence ?? null;
+  if (leftSequence !== null && rightSequence !== null) return leftSequence - rightSequence;
+  return (
+    new Date(left.interval.finishedAt).getTime() - new Date(right.interval.finishedAt).getTime()
+  );
+}
+
 function timingKey(event: AgentTimingEvent): string | null {
   if (!event.agent_kind) return null;
   return `${event.agent_kind}:${event.execution_id ?? event.invocation_id ?? ''}`;
+}
+
+function agentKindFromKey(key: string): string {
+  const separator = key.indexOf(':');
+  return separator === -1 ? key : key.slice(0, separator);
 }
 
 function findActiveTimingKey(

--- a/clients/core-state/src/run-map.ts
+++ b/clients/core-state/src/run-map.ts
@@ -4,6 +4,7 @@ import {
   closeActiveAgentTimings,
   finishAgentTiming,
   hasActiveAgentTiming,
+  mergeAgentTimingPrefix,
   type RoundTimingState,
   startAgentTiming,
 } from './round-timing.js';
@@ -75,9 +76,11 @@ export function applyRunMapEvent(
   // keyed by that scope and would drop them, which is why the closeout runs
   // first and returns: one owner for "the run ended", sweeping the whole map
   // rather than the one round a label happened to name.
-  if (event.type === 'run_failed') return closeOpenRunState(seen, 'failed', event.timestamp);
+  if (event.type === 'run_failed') {
+    return closeOpenRunState(seen, 'failed', event.timestamp, event.sequence ?? null);
+  }
   if (event.type === 'run_interrupted') {
-    return closeOpenRunState(seen, 'interrupted', event.timestamp);
+    return closeOpenRunState(seen, 'interrupted', event.timestamp, event.sequence ?? null);
   }
   const base =
     event.type === 'run_started'
@@ -113,10 +116,11 @@ function closeOpenRunState(
   state: RunMapState,
   activeStatus: Extract<AgentPhaseStatus, 'failed' | 'interrupted'>,
   timestamp: string,
+  sequence: number | null = null,
 ): RunMapState {
   return {
     ...state,
-    rounds: state.rounds.map(round => closeRound(round, timestamp)),
+    rounds: state.rounds.map(round => closeRound(round, timestamp, sequence)),
     phases: state.phases.map(phase => closePhase(phase, activeStatus, timestamp)),
   };
 }
@@ -150,7 +154,7 @@ function isRoundClosed(status: RoundStatus): boolean {
   return status === 'completed' || status === 'failed';
 }
 
-function closeRound(round: RoundSummary, timestamp: string): RoundSummary {
+function closeRound(round: RoundSummary, timestamp: string, sequence: number | null): RoundSummary {
   const closed = isRoundClosed(round.status)
     ? round
     : {
@@ -159,7 +163,9 @@ function closeRound(round: RoundSummary, timestamp: string): RoundSummary {
         finishedAt: round.finishedAt ?? timestamp,
         closedByRunBoundary: true as const,
       };
-  return hasActiveAgentTiming(closed) ? closeActiveAgentTimings(closed, timestamp) : closed;
+  return hasActiveAgentTiming(closed)
+    ? closeActiveAgentTimings(closed, timestamp, sequence)
+    : closed;
 }
 
 function closePhase(
@@ -195,10 +201,8 @@ export function phasesForRound(phases: AgentPhase[], roundNumber: number | null)
  * Intervals recorded on either side are both real, so they concatenate instead
  * of last-write-wins, and open starts union.
  *
- * Known boundary: an agent execution whose start is in `older` and whose finish
- * is in `newer` loses its interval. The newer fold saw a finish with no start
- * and dropped it, and the finish timestamp is not recoverable from the merged
- * state. Rounds that do not straddle the boundary are exact.
+ * Unmatched finishes retained in the newer suffix reconcile with starts in the
+ * older prefix by event sequence, so a chunk boundary does not lose intervals.
  */
 export function mergeRoundLists(
   older: readonly RoundSummary[],
@@ -246,14 +250,7 @@ export function mergePhaseLists(
 
 function mergeRoundPrefix(older: RoundSummary, newer: RoundSummary): RoundSummary {
   const round = mergeRound(older, newer);
-  const agentIntervals =
-    older.agentIntervals === undefined && newer.agentIntervals === undefined
-      ? undefined
-      : [...(older.agentIntervals ?? []), ...(newer.agentIntervals ?? [])];
-  const activeAgentStarts =
-    older.activeAgentStarts === undefined && newer.activeAgentStarts === undefined
-      ? undefined
-      : {...older.activeAgentStarts, ...newer.activeAgentStarts};
+  const timing = mergeAgentTimingPrefix(older, newer);
   const preserveRunBoundary =
     older.closedByRunBoundary === true && newer.closedByRoundFinished !== true;
   return {
@@ -270,8 +267,7 @@ function mergeRoundPrefix(older: RoundSummary, newer: RoundSummary): RoundSummar
       : isRoundClosed(older.status) && !isRoundClosed(newer.status)
         ? {status: older.status}
         : {}),
-    ...(agentIntervals === undefined ? {} : {agentIntervals}),
-    ...(activeAgentStarts === undefined ? {} : {activeAgentStarts}),
+    ...timing,
   };
 }
 
@@ -487,7 +483,7 @@ function updateRoundAgentElapsed(
   const finished = event.type === 'agent_execution_finished' || event.type === 'phase_finished';
   if (!started && !finished) {
     if (event.type !== 'round_finished') return round;
-    return closeActiveAgentTimings(round, event.timestamp);
+    return closeActiveAgentTimings(round, event.timestamp, event.sequence ?? null);
   }
   if (event.type === 'phase_started' || event.type === 'phase_finished') {
     const executionId = event.execution_id ?? event.invocation_id;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "agentshim>=0.5.0",
+    "agentshim>=0.5.0,<0.6.0",
     "cbor2<6",
     "cryptography<50",
     "deepagents",


### PR DESCRIPTION
## Problem

Fixes #611. Tail bootstrap folds the newest suffix first. When that suffix contains an agent finish whose start is still in an older chunk, the timing reducer previously discarded the finish timestamp. Prefix merge then retained the older start forever and could not reproduce the interval from a full chronological replay.

## Solution

Retain timing lifecycle facts as private `WeakMap` provenance attached to the round's immutable timing collections. Starts, finishes, compatibility events, and round or run closeouts carry their sequence into that provenance while the public `RoundSummary` shape remains unchanged. Prefix merge combines the older and newer facts by sequence and replays the timing state machine, including exact execution identity, first-active same-role fallback for legacy events, modern and compatibility event deduplication, reused keys, and close-all terminal events.

Round copies in run-map merge, run closeout, and the carried-forward `profileSkipped` projection retain those collection references until the timing facts change, so they retain the private provenance without coupling other reducers to timing internals. This keeps later prefix chunks reconcilable without mutating older snapshots or exposing internal fields through JSON serialization.

### Architecture

```mermaid
flowchart LR
    Tail[Tail events] --> TailFold[Suffix fold]
    Prefix[Older chunk] --> PrefixFold[Prefix fold]
    TailFold --> Facts[Private timing facts]
    PrefixFold --> Facts
    Facts --> Replay[Sequence-ordered timing replay]
    Replay --> Round[Public round intervals and active starts]
```

## Verification

The randomized prefix harness now compares complete `CoreState` values for every arbitrary chunking. The old normalization that removed `agentIntervals` and `activeAgentStarts` is gone. Focused regressions cover the reported start/finish split, terminal closeout in the suffix, compatibility finish duplication across chunks, reused legacy keys across three chunks, identical timestamps ordered by sequence, and provenance carried through a `profileSkipped` round copy.

The reported regression was run against merge-base main by redirecting the modified test fixture to the base `core-state.ts`. It failed with zero completed intervals and `implementer:exec-a` left active. The branch produces the same completed interval as a full replay.

### Correctness properties

- Full replay, tail bootstrap, and repeated prefix backfill produce identical public timing intervals and active starts.
- Event sequence orders reconciliation even when timestamps are equal or misleading.
- Exact execution identity wins; missing legacy identity closes the earliest active execution of the same role.
- Compatibility phase events do not replace earlier modern starts or double-close modern finishes when a chunk boundary separates them.
- Round and run terminal events close starts supplied later by prefix backfill.
- Timing provenance is private, immutable across snapshots, and absent from the public `RoundSummary` contract.

### Testing

- `PATH=/tmp/vibesys-issues-tools:$PATH pnpm --filter @vibesys/core-state test`, 104 passed, 0 failed.
- `pnpm --filter @vibesys/core-state check`, passed.
- `pnpm exec biome check clients/core-state/src/round-timing.ts clients/core-state/src/run-map.ts clients/core-state/src/core-state.ts clients/core-state/src/core-state-prefix.test.ts`, passed.
- Merge-base regression: `PATH=/tmp/vibesys-issues-tools:$PATH /tmp/vibesys-issues-tools/bun test /tmp/vibesys-611-before.test.ts -t 'reconciles the timing interval of an execution split across the boundary'`, 0 passed, 1 failed.

- Full Python CI suite with Go and Rust enabled: 5,741 passed, six platform/hardware skips. Coverage floors, Python format/lint/type/import checks, Markdown links, and launcher help passed.
- Node 24.21.0 and Bun 1.3.9: protocol regeneration was stable; `pnpm check:ts`, `pnpm check:ts-architecture`, `pnpm check:clients`, `pnpm test:clients`, and `pnpm build:clients` passed.
- The independent #611 and #613 changes merge without content conflicts. Their combined core-state suite passed 110 tests.

- Combined integration of all ten independently based fixes: 5,816 Python tests passed (6 environment/platform skips), 91% patch coverage, 25 backend-client, 123 core-state and 745 TUI tests passed. All repository static checks, stable protocol generation, builds, and packed/deployed TUI self-tests passed.
- Real combined `codex` / `gpt-5.6-sol` queue-rs SPSC run, capped at one round: completed with independent review and official evaluation. The run reported the retained winner `5e621d36bcc4` at 26,412,131.227693 operations/second; the final workspace was clean and differed from the winning tree only in framework state and the final archive. Live chat completed once while optimization streamed; the TUI showed execution label, progress, elapsed time and context usage. Pathological concurrency, large histories and minimizing-objective rankings were exercised separately by the targeted regressions and performance benchmarks for their respective issues.

Closes #611
