### PR TITLE
TUI: serialize chat restoration and resource teardown

### DIFF
--- a/src/server/chat/factory.py
+++ b/src/server/chat/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from contextlib import ExitStack
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
@@ -205,13 +206,18 @@ class ExperimentChatFactory:
         self._attachment = attachment
         self._build_agent = build_agent
         self._fallback = fallback
+        self._lock = threading.Lock()
+        self._closed = False
         self._sessions: list[ExperimentChatSession] = []
         self._default_retained = False
 
     def start(self) -> None:
         """Install the default session and per-thread factory on the manager."""
-        self._manager.set_run_settings(self._defaults)
-        self._manager.set_thread_factory(self._create_thread)
+        with self._lock:
+            if self._closed:
+                raise _factory_closed_error()
+            self._manager.set_run_settings(self._defaults)
+            self._manager.set_thread_factory(self._create_thread)
         default = self._build_session(
             None,
             AgentSelection(
@@ -220,20 +226,28 @@ class ExperimentChatFactory:
                 model=self._defaults.model,
             ),
         )
-        self._default_retained = self._manager.retain_terminal_resource(
-            TerminalChatResource(handler=default.ask, close=default.close)
-        )
-        if self._default_retained:
-            self._sessions.remove(default)
-        else:
-            self._manager.install_default_handler(default.ask)
+        with self._lock:
+            if self._closed:
+                raise _factory_closed_error()
+            self._default_retained = self._manager.retain_terminal_resource(
+                TerminalChatResource(handler=default.ask, close=default.close)
+            )
+            if self._default_retained:
+                self._sessions.remove(default)
+            else:
+                self._manager.install_default_handler(default.ask)
 
     def close(self) -> None:
         """Drain chat calls and close every factory-owned session."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
         self._manager.clear_threads_and_drain()
         if not self._default_retained:
             self._manager.clear_default_handler_and_drain()
-        sessions, self._sessions = self._sessions, []
+        with self._lock:
+            sessions, self._sessions = self._sessions, []
         first_error: BaseException | None = None
         for session in sessions:
             try:
@@ -265,11 +279,15 @@ class ExperimentChatFactory:
                 created_at=datetime.now(UTC),
             ),
             handler=session.ask,
+            close=session.close,
         )
 
     def _build_session(
         self, thread_id: str | None, selection: AgentSelection
     ) -> ExperimentChatSession:
+        with self._lock:
+            if self._closed:
+                raise _factory_closed_error()
         shared_state_dir = self._project.state.local_namespace(
             self._run_id, "server"
         ).external_directory("chat")
@@ -291,34 +309,50 @@ class ExperimentChatFactory:
             log=resources.log,
             flush_logs=resources.flush_logs,
         )
-        session = ExperimentChatSession(
-            ExperimentChatDependencies(
-                controller=self._controller,
-                executions=self._executions,
-                agent_client=resources.client,
-                # One conversation per thread. The run's default chat has no
-                # thread ID of its own, so it names the identifier the threads
-                # cannot collide with.
-                session_key=AgentSessionKey(
-                    SessionScope.CHAT, DEFAULT_CHAT_THREAD if thread_id is None else thread_id
+        try:
+            session = ExperimentChatSession(
+                ExperimentChatDependencies(
+                    controller=self._controller,
+                    executions=self._executions,
+                    agent_client=resources.client,
+                    # One conversation per thread. The run's default chat has no
+                    # thread ID of its own, so it names the identifier the threads
+                    # cannot collide with.
+                    session_key=AgentSessionKey(
+                        SessionScope.CHAT,
+                        DEFAULT_CHAT_THREAD if thread_id is None else thread_id,
+                    ),
+                    workspace=self._workspace,
+                    state_dir=state_dir,
+                    agent_shared_state_dir=resources.agent_shared_state_dir,
+                    agent_state_dir=agent_state_dir,
+                    evidence=evidence,
+                    log=resources.log,
+                    environment=resources.environment,
+                    progress=resources.progress,
+                    driver=selection.driver,
+                    provider=selection.provider,
+                    model=selection.model,
+                    fallback=self._fallback,
                 ),
-                workspace=self._workspace,
-                state_dir=state_dir,
-                agent_shared_state_dir=resources.agent_shared_state_dir,
-                agent_state_dir=agent_state_dir,
-                evidence=evidence,
-                log=resources.log,
-                environment=resources.environment,
-                progress=resources.progress,
-                driver=selection.driver,
-                provider=selection.provider,
-                model=selection.model,
-                fallback=self._fallback,
-            ),
-            _CloseCallback(resources.close),
-        )
-        self._sessions.append(session)
-        return session
+                _CloseCallback(resources.close),
+            )
+        except BaseException as construction_error:
+            try:
+                resources.close()
+            except BaseException as cleanup_error:  # noqa: BLE001
+                construction_error.add_note(
+                    "Additional error while cleaning up chat-session construction: "
+                    f"{type(cleanup_error).__name__}: {cleanup_error}"
+                )
+            raise
+
+        with self._lock:
+            if not self._closed:
+                self._sessions.append(session)
+                return session
+        session.close()
+        raise _factory_closed_error()
 
 
 class _CloseCallback:
@@ -334,3 +368,7 @@ class _CloseCallback:
 
 def _noop() -> None:
     pass
+
+
+def _factory_closed_error() -> RuntimeError:
+    return RuntimeError("Experiment chat factory is closed")

--- a/src/server/chat/manager.py
+++ b/src/server/chat/manager.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import threading
 import time
 import uuid
 from collections.abc import Callable
+from concurrent.futures import Future
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from server.events import (
     ChatData,
@@ -18,14 +20,16 @@ from server.events import (
 )
 
 if TYPE_CHECKING:
-    import threading
-
     from server.chat.options import ChatRunSettings
     from server.journal import EventJournal
     from server.run_lifecycle import RunStatus
 
 _CHAT_DRAIN_TIMEOUT_SECONDS = 5.0
 _CHAT_THREAD_TITLE_MAX_CHARS = 40
+
+
+def _noop_thread_close() -> None:
+    """Provide a compatibility close callback for stateless test handlers."""
 
 
 @dataclass(frozen=True)
@@ -42,9 +46,37 @@ class ChatThreadHandle:
 
     spec: ChatThreadCreatedData
     handler: Callable[[str], str]
+    close: Callable[[], None] = _noop_thread_close
 
 
 ChatThreadFactory = Callable[[str, str | None, str | None, str | None], ChatThreadHandle]
+
+
+@dataclass(frozen=True)
+class _ThreadRoute:
+    """One installed handler and the lock serializing its turns."""
+
+    handler: Callable[[str], str]
+    turn_lock: threading.Lock
+
+
+@dataclass(frozen=True)
+class _ThreadLease:
+    """A callable route whose turn lock and teardown lease are held."""
+
+    handler: Callable[[str], str]
+    turn_lock: threading.Lock
+
+    def __call__(self, text: str) -> str:
+        """Invoke the leased route."""
+        return self.handler(text)
+
+
+_ThreadRestoration: TypeAlias = Future[_ThreadRoute]
+
+
+class _ThreadsDrainingError(RuntimeError):
+    """Signal that a completed restoration cannot be published."""
 
 
 class ChatManager:
@@ -64,7 +96,8 @@ class ChatManager:
         self._fallback_answer: Callable[[str], str] | None = None
         self._default_handler: Callable[[str], str] | None = None
         self._thread_factory: ChatThreadFactory | None = None
-        self._thread_handlers: dict[str, Callable[[str], str]] = {}
+        self._thread_handlers: dict[str, _ThreadRoute] = {}
+        self._thread_restorations: dict[str, _ThreadRestoration] = {}
         self._thread_specs: dict[str, ChatThreadCreatedData] = {}
         self._run_settings: ChatRunSettings | None = None
         self._active_default_calls = 0
@@ -154,26 +187,38 @@ class ChatManager:
         """Create, register, and record a chat thread with resolved settings."""
         with self._condition:
             factory = self._thread_factory
+            if factory is not None:
+                self._active_thread_calls += 1
         if factory is None:
             raise RuntimeError(  # noqa: TRY003  # Report current run availability.
                 "Experiment chat threads are not available for this run "
                 f"({self._unavailable_reason()})"
             )
-        handle = factory(uuid.uuid4().hex, driver, provider, model)
-        spec = handle.spec
-        if title is not None and title.strip():
-            spec = spec.model_copy(update={"title": title.strip()})
-        with self._condition:
-            self._thread_specs[spec.thread_id] = spec
-            self._thread_handlers[spec.thread_id] = handle.handler
-        self._journal.record(
-            EventType.CHAT_THREAD_CREATED,
-            agent_kind="chat",
-            round_label="experiment-chat",
-            chat_thread_id=spec.thread_id,
-            data=spec,
-        )
-        return spec
+        try:
+            handle = factory(uuid.uuid4().hex, driver, provider, model)
+            spec = handle.spec
+            if title is not None and title.strip():
+                spec = spec.model_copy(update={"title": title.strip()})
+            with self._condition:
+                accepting = self._thread_factory is factory
+                if accepting:
+                    self._thread_specs[spec.thread_id] = spec
+                    self._thread_handlers[spec.thread_id] = _ThreadRoute(
+                        handle.handler, threading.Lock()
+                    )
+            if not accepting:
+                handle.close()
+                raise _ThreadsDrainingError(self._thread_unavailable_message())
+            self._journal.record(
+                EventType.CHAT_THREAD_CREATED,
+                agent_kind="chat",
+                round_label="experiment-chat",
+                chat_thread_id=spec.thread_id,
+                data=spec,
+            )
+            return spec
+        finally:
+            self._release_thread_call()
 
     def threads_locked(self) -> list[ChatThreadCreatedData]:
         """Return known thread metadata while the caller holds the condition."""
@@ -216,9 +261,7 @@ class ChatManager:
         with self._condition:
             self._thread_factory = None
             self._thread_handlers.clear()
-            self._wait_locked(
-                lambda: self._active_thread_calls > 0, timeout=_CHAT_DRAIN_TIMEOUT_SECONDS
-            )
+            self._wait_locked(lambda: self._active_thread_calls > 0, timeout=None)
 
     def enable_terminal_retention(self) -> None:
         """Request that the next default resource survive run teardown."""
@@ -261,11 +304,9 @@ class ChatManager:
             resource.close()
 
     def _thread_chat(self, text: str, thread_id: str) -> str:
-        handler = self._resolve_thread_handler(thread_id)
+        handler = self._acquire_thread_handler(thread_id)
         if isinstance(handler, str):
             return handler
-        with self._condition:
-            self._active_thread_calls += 1
         try:
             answer = handler(text)
             thread_title = self._title_thread_if_needed(thread_id, text)
@@ -280,36 +321,119 @@ class ChatManager:
             )
             return answer
         finally:
-            with self._condition:
-                self._active_thread_calls -= 1
-                self._condition.notify_all()
+            handler.turn_lock.release()
+            self._release_thread_call()
 
-    def _resolve_thread_handler(self, thread_id: str) -> Callable[[str], str] | str:
+    def _acquire_thread_handler(self, thread_id: str) -> _ThreadLease | str:
         with self._condition:
-            handler = self._thread_handlers.get(thread_id)
+            route = self._thread_handlers.get(thread_id)
             spec = self._thread_specs.get(thread_id)
             factory = self._thread_factory
-        if handler is not None:
-            return handler
-        if spec is None:
-            return (
-                f"Unknown experiment chat thread {thread_id!r}. Create one with "
-                "/new-chat, or omit the thread to use the default experiment chat."
-            )
-        if factory is None:
-            return (
-                f"Experiment chat thread {thread_id!r} cannot answer right now "
-                f"({self._unavailable_reason()})."
-            )
+            if route is not None:
+                self._active_thread_calls += 1
+            elif spec is None:
+                return (
+                    f"Unknown experiment chat thread {thread_id!r}. Create one with "
+                    "/new-chat, or omit the thread to use the default experiment chat."
+                )
+            elif factory is None:
+                return self._thread_unavailable_message(thread_id)
+            else:
+                restoration = self._thread_restorations.get(thread_id)
+                restore = restoration is None
+                if restoration is None:
+                    restoration = Future()
+                    self._thread_restorations[thread_id] = restoration
+                self._active_thread_calls += 1
+        if route is not None:
+            return self._lease_thread_route(route)
+        assert spec is not None  # noqa: S101  # Narrowed above.
+        assert factory is not None  # noqa: S101  # Narrowed above.
+        if restore:
+            self._restore_thread(thread_id, spec, factory, restoration)
         try:
-            handle = factory(thread_id, spec.driver, spec.provider, spec.model)
+            route = restoration.result()
+        except _ThreadsDrainingError:
+            self._release_thread_call()
+            return self._thread_unavailable_message(thread_id)
         except Exception as exc:  # noqa: BLE001
+            self._release_thread_call()
             return (
                 f"Could not restore experiment chat thread {thread_id!r}: "
                 f"{type(exc).__name__}: {exc}"
             )
+        except BaseException:
+            self._release_thread_call()
+            raise
+        return self._lease_thread_route(route)
+
+    def _lease_thread_route(self, route: _ThreadRoute) -> _ThreadLease:
+        try:
+            route.turn_lock.acquire()
+        except BaseException:
+            self._release_thread_call()
+            raise
+        return _ThreadLease(route.handler, route.turn_lock)
+
+    def _restore_thread(
+        self,
+        thread_id: str,
+        spec: ChatThreadCreatedData,
+        factory: ChatThreadFactory,
+        restoration: _ThreadRestoration,
+    ) -> None:
         with self._condition:
-            return self._thread_handlers.setdefault(thread_id, handle.handler)
+            assert self._thread_restorations.get(thread_id) is restoration  # noqa: S101
+        try:
+            handle = factory(thread_id, spec.driver, spec.provider, spec.model)
+        except BaseException as exc:  # noqa: BLE001  # Wake waiters on cancellation too.
+            self._finish_thread_restoration(thread_id, restoration, error=exc)
+            return
+
+        route = _ThreadRoute(handle.handler, threading.Lock())
+        with self._condition:
+            if self._thread_factory is factory:
+                self._thread_handlers[thread_id] = route
+                self._thread_restorations.pop(thread_id, None)
+                restoration.set_result(route)
+                self._condition.notify_all()
+                return
+
+        error = _ThreadsDrainingError(self._thread_unavailable_message(thread_id))
+        try:
+            handle.close()
+        except BaseException as cleanup_error:  # noqa: BLE001
+            error.add_note(
+                "Additional error while cleaning up chat-thread restoration: "
+                f"{type(cleanup_error).__name__}: {cleanup_error}"
+            )
+        self._finish_thread_restoration(thread_id, restoration, error=error)
+
+    def _finish_thread_restoration(
+        self,
+        thread_id: str,
+        restoration: _ThreadRestoration,
+        *,
+        error: BaseException,
+    ) -> None:
+        with self._condition:
+            if self._thread_restorations.get(thread_id) is restoration:
+                self._thread_restorations.pop(thread_id)
+            restoration.set_exception(error)
+            self._condition.notify_all()
+
+    def _release_thread_call(self) -> None:
+        with self._condition:
+            self._active_thread_calls -= 1
+            self._condition.notify_all()
+
+    def _thread_unavailable_message(self, thread_id: str | None = None) -> str:
+        subject = (
+            "Experiment chat threads"
+            if thread_id is None
+            else f"Experiment chat thread {thread_id!r}"
+        )
+        return f"{subject} cannot answer right now ({self._unavailable_reason()})."
 
     def _title_thread_if_needed(self, thread_id: str, question: str) -> str | None:
         with self._condition:

--- a/tests/server/test_chat_thread_lifecycle.py
+++ b/tests/server/test_chat_thread_lifecycle.py
@@ -1,0 +1,420 @@
+"""Concurrent experiment-chat thread restoration and teardown tests."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from tests.server.support import ServerParts, build_server_parts
+
+from server.chat.factory import ChatAgentResources, ExperimentChatFactory
+from server.chat.manager import ChatThreadHandle
+from server.chat.options import ChatRunSettings
+from server.events import ChatThreadCreatedData, EventType, make_event
+from vibesys.run.integration import AgentSelection
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from vibesys.run.integration import RunAttachment
+
+
+def _remember_thread(parts: ServerParts, thread_id: str = "thread-1") -> ChatThreadCreatedData:
+    spec = ChatThreadCreatedData(
+        thread_id=thread_id,
+        driver="agentshim",
+        provider="codex",
+        model="gpt-test",
+        created_at=datetime.now(UTC),
+    )
+    parts.chat.apply_replayed_event(
+        make_event(
+            EventType.CHAT_THREAD_CREATED,
+            chat_thread_id=thread_id,
+            agent_kind="chat",
+            data=spec,
+        )
+    )
+    return spec
+
+
+def _wait_for_active_calls(parts: ServerParts, count: int) -> None:
+    with parts.condition:
+        assert parts.condition.wait_for(
+            lambda: vars(parts.chat)["_active_thread_calls"] == count,
+            timeout=2,
+        )
+
+
+def test_concurrent_restore_is_single_flight(tmp_path: Path) -> None:
+    parts = build_server_parts(tmp_path)
+    spec = _remember_thread(parts)
+    construction_started = threading.Event()
+    release_construction = threading.Event()
+    calls: list[str] = []
+
+    def factory(
+        thread_id: str,
+        _driver: str | None,
+        _provider: str | None,
+        _model: str | None,
+    ) -> ChatThreadHandle:
+        calls.append(thread_id)
+        construction_started.set()
+        assert release_construction.wait(timeout=2)
+        return ChatThreadHandle(spec=spec, handler=lambda question: f"answer: {question}")
+
+    parts.chat.set_thread_factory(factory)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(parts.chat.chat, "first", spec.thread_id)
+        assert construction_started.wait(timeout=2)
+        second = pool.submit(parts.chat.chat, "second", spec.thread_id)
+        _wait_for_active_calls(parts, 2)
+        release_construction.set()
+
+        assert first.result(timeout=2) == "answer: first"
+        assert second.result(timeout=2) == "answer: second"
+
+    assert calls == [spec.thread_id]
+
+
+class _RestoreFailureError(ValueError):
+    """Stable construction failure used by the shared-result test."""
+
+    def __init__(self) -> None:
+        super().__init__("restore failed")
+
+
+def test_concurrent_restore_shares_factory_failure(tmp_path: Path) -> None:
+    parts = build_server_parts(tmp_path)
+    spec = _remember_thread(parts)
+    construction_started = threading.Event()
+    release_construction = threading.Event()
+    calls = 0
+
+    def factory(
+        _thread_id: str,
+        _driver: str | None,
+        _provider: str | None,
+        _model: str | None,
+    ) -> ChatThreadHandle:
+        nonlocal calls
+        calls += 1
+        construction_started.set()
+        assert release_construction.wait(timeout=2)
+        raise _RestoreFailureError
+
+    parts.chat.set_thread_factory(factory)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(parts.chat.chat, "first", spec.thread_id)
+        assert construction_started.wait(timeout=2)
+        second = pool.submit(parts.chat.chat, "second", spec.thread_id)
+        _wait_for_active_calls(parts, 2)
+        release_construction.set()
+        first_answer = first.result(timeout=2)
+        second_answer = second.result(timeout=2)
+
+    assert first_answer == second_answer
+    assert "_RestoreFailureError: restore failed" in first_answer
+    assert calls == 1
+
+
+class _RestoreCancelled(BaseException):
+    """Deterministic stand-in for cancellation during construction."""
+
+
+def test_restore_cancellation_wakes_every_waiter(tmp_path: Path) -> None:
+    parts = build_server_parts(tmp_path)
+    spec = _remember_thread(parts)
+    construction_started = threading.Event()
+    release_construction = threading.Event()
+    calls = 0
+
+    def factory(
+        _thread_id: str,
+        _driver: str | None,
+        _provider: str | None,
+        _model: str | None,
+    ) -> ChatThreadHandle:
+        nonlocal calls
+        calls += 1
+        construction_started.set()
+        assert release_construction.wait(timeout=2)
+        raise _RestoreCancelled
+
+    parts.chat.set_thread_factory(factory)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(parts.chat.chat, "first", spec.thread_id)
+        assert construction_started.wait(timeout=2)
+        second = pool.submit(parts.chat.chat, "second", spec.thread_id)
+        _wait_for_active_calls(parts, 2)
+        release_construction.set()
+        with pytest.raises(_RestoreCancelled):
+            first.result(timeout=2)
+        with pytest.raises(_RestoreCancelled):
+            second.result(timeout=2)
+
+    _wait_for_active_calls(parts, 0)
+    assert calls == 1
+
+
+def test_thread_turns_serialize_and_shutdown_drains_queued_borrowers(tmp_path: Path) -> None:
+    parts = build_server_parts(tmp_path)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    resource_closed = threading.Event()
+    invocations: list[str] = []
+
+    def handler(question: str) -> str:
+        assert not resource_closed.is_set()
+        invocations.append(question)
+        if question == "first":
+            first_started.set()
+            assert release_first.wait(timeout=2)
+        assert not resource_closed.is_set()
+        return f"answer: {question}"
+
+    def factory(
+        thread_id: str,
+        driver: str | None,
+        provider: str | None,
+        model: str | None,
+    ) -> ChatThreadHandle:
+        return ChatThreadHandle(
+            spec=ChatThreadCreatedData(
+                thread_id=thread_id,
+                driver=driver or "agentshim",
+                provider=provider or "codex",
+                model=model or "gpt-test",
+                created_at=datetime.now(UTC),
+            ),
+            handler=handler,
+            close=resource_closed.set,
+        )
+
+    parts.chat.set_thread_factory(factory)
+    spec = parts.chat.create_thread()
+
+    def shutdown() -> None:
+        parts.chat.clear_threads_and_drain()
+        resource_closed.set()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+        first = pool.submit(parts.chat.chat, "first", spec.thread_id)
+        assert first_started.wait(timeout=2)
+        second = pool.submit(parts.chat.chat, "second", spec.thread_id)
+        _wait_for_active_calls(parts, 2)
+        closing = pool.submit(shutdown)
+
+        assert invocations == ["first"]
+        assert not resource_closed.wait(timeout=0.05)
+        assert not closing.done()
+        release_first.set()
+
+        assert first.result(timeout=2) == "answer: first"
+        assert second.result(timeout=2) == "answer: second"
+        closing.result(timeout=2)
+
+    assert invocations == ["first", "second"]
+    assert resource_closed.is_set()
+
+
+def test_restoration_finishing_during_shutdown_is_closed_without_invocation(
+    tmp_path: Path,
+) -> None:
+    parts = build_server_parts(tmp_path)
+    spec = _remember_thread(parts)
+    construction_started = threading.Event()
+    release_construction = threading.Event()
+    resource_closed = 0
+    invocations = 0
+
+    def close() -> None:
+        nonlocal resource_closed
+        resource_closed += 1
+
+    def handler(_question: str) -> str:
+        nonlocal invocations
+        invocations += 1
+        return "should not run"
+
+    def factory(
+        _thread_id: str,
+        _driver: str | None,
+        _provider: str | None,
+        _model: str | None,
+    ) -> ChatThreadHandle:
+        construction_started.set()
+        assert release_construction.wait(timeout=2)
+        return ChatThreadHandle(spec=spec, handler=handler, close=close)
+
+    parts.chat.set_thread_factory(factory)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        answer = pool.submit(parts.chat.chat, "question", spec.thread_id)
+        assert construction_started.wait(timeout=2)
+        closing = pool.submit(parts.chat.clear_threads_and_drain)
+        with parts.condition:
+            assert parts.condition.wait_for(
+                lambda: vars(parts.chat)["_thread_factory"] is None,
+                timeout=2,
+            )
+        release_construction.set()
+
+        assert "cannot answer right now" in answer.result(timeout=2)
+        closing.result(timeout=2)
+
+    assert invocations == 0
+    assert resource_closed == 1
+
+
+def test_thread_creation_finishing_during_shutdown_is_closed_without_publish(
+    tmp_path: Path,
+) -> None:
+    parts = build_server_parts(tmp_path)
+    construction_started = threading.Event()
+    release_construction = threading.Event()
+    resource_closed = 0
+
+    def close() -> None:
+        nonlocal resource_closed
+        resource_closed += 1
+
+    def factory(
+        thread_id: str,
+        driver: str | None,
+        provider: str | None,
+        model: str | None,
+    ) -> ChatThreadHandle:
+        construction_started.set()
+        assert release_construction.wait(timeout=2)
+        return ChatThreadHandle(
+            spec=ChatThreadCreatedData(
+                thread_id=thread_id,
+                driver=driver or "agentshim",
+                provider=provider or "codex",
+                model=model or "gpt-test",
+                created_at=datetime.now(UTC),
+            ),
+            handler=lambda _question: "unused",
+            close=close,
+        )
+
+    parts.chat.set_thread_factory(factory)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        creation = pool.submit(parts.chat.create_thread)
+        assert construction_started.wait(timeout=2)
+        closing = pool.submit(parts.chat.clear_threads_and_drain)
+        with parts.condition:
+            assert parts.condition.wait_for(
+                lambda: vars(parts.chat)["_thread_factory"] is None,
+                timeout=2,
+            )
+        release_construction.set()
+
+        with pytest.raises(RuntimeError, match="cannot answer right now"):
+            creation.result(timeout=2)
+        closing.result(timeout=2)
+
+    assert parts.chat.threads() == []
+    assert resource_closed == 1
+
+
+@dataclass(frozen=True)
+class _ExternalDirectory:
+    path: Path
+
+    def external_directory(self, _name: str) -> Path:
+        return self.path
+
+
+@dataclass(frozen=True)
+class _ProjectState:
+    path: Path
+
+    def local_namespace(self, _run_id: str, _owner: str) -> _ExternalDirectory:
+        return _ExternalDirectory(self.path)
+
+
+@dataclass(frozen=True)
+class _Project:
+    state: _ProjectState
+
+
+def _factory_for_test(
+    parts: ServerParts,
+    tmp_path: Path,
+    build_agent: Callable[[RunAttachment, AgentSelection, str | None, Path], ChatAgentResources],
+) -> ExperimentChatFactory:
+    defaults = ChatRunSettings(driver="agentshim", provider="codex", model="gpt-test")
+
+    def resolve_selection(
+        *, driver: str | None, provider: str | None, model: str | None
+    ) -> AgentSelection:
+        return AgentSelection(
+            driver=driver or defaults.driver,
+            provider=provider or defaults.provider,
+            model=model or defaults.model,
+        )
+
+    return ExperimentChatFactory(
+        manager=parts.chat,
+        controller=cast("Any", object()),
+        executions=cast("Any", object()),
+        project=cast("Any", _Project(_ProjectState(tmp_path / "chat"))),
+        run_id="run-1",
+        workspace=tmp_path,
+        log_dir=tmp_path,
+        defaults=defaults,
+        resolve_selection=resolve_selection,
+        attachment=cast("Any", object()),
+        build_agent=build_agent,
+        fallback=lambda _question: "fallback",
+    )
+
+
+def test_factory_closes_session_finishing_after_close_once(tmp_path: Path) -> None:
+    parts = build_server_parts(tmp_path)
+    construction_started = threading.Event()
+    release_construction = threading.Event()
+    close_calls = 0
+
+    def close() -> None:
+        nonlocal close_calls
+        close_calls += 1
+
+    def build_agent(
+        _attachment: RunAttachment,
+        _selection: AgentSelection,
+        _thread_id: str | None,
+        shared_state_dir: Path,
+    ) -> ChatAgentResources:
+        construction_started.set()
+        assert release_construction.wait(timeout=2)
+        return ChatAgentResources(
+            client=object(),
+            close=close,
+            log=lambda _message: None,
+            flush_logs=lambda: None,
+            environment=dict,
+            progress=lambda: None,
+            agent_shared_state_dir=str(shared_state_dir),
+        )
+
+    factory = _factory_for_test(parts, tmp_path, build_agent)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        construction = pool.submit(factory.start)
+        assert construction_started.wait(timeout=2)
+        pool.submit(factory.close).result(timeout=2)
+        release_construction.set()
+        with pytest.raises(RuntimeError, match="factory is closed"):
+            construction.result(timeout=2)
+
+    factory.close()
+    with pytest.raises(RuntimeError, match="factory is closed"):
+        factory.start()
+    assert close_calls == 1


### PR DESCRIPTION
## Problem

Fixes #609. Concurrent requests for one replayed chat thread could each construct an agent session. Only one handler survived `setdefault`, and the discarded session was never closed. Handler lookup also happened before the active-call lease, which allowed teardown to close a session before the request invoked it. A session constructor finishing after `ExperimentChatFactory.close()` could append to the already-cleared ownership list and leak.

## Solution

Chat restoration is now single-flight per thread. The manager publishes one shared `Future` under its condition, and every caller acquires an active lease before constructing or waiting. Successful restoration installs one route; failure and cancellation are delivered to all callers that joined that attempt. Each installed route has a turn lock, so same-thread questions remain serialized while different threads can proceed independently.

Thread creation uses the same active-call accounting. Teardown removes the factory and routes under the condition, then waits for executing, queued, and constructing borrowers to finish. A handle that completes after draining starts is rejected and closed.

The experiment-chat factory now marks itself closed before manager draining begins. Session construction checks the closed state before allocation and again before publishing ownership. A session completed during shutdown is closed immediately, and `ChatThreadHandle.close` gives the manager an explicit cleanup path for rejected construction.

### Architecture

`server.chat.manager` owns thread routing, shared restoration, turn serialization, and active leases. `server.chat.factory` owns the resources retained by each constructed session. The shared condition protects routing and leases; factory resource ownership has its own lock, and provider construction and teardown run outside those locks. The protocol and TUI continue to use the same chat requests and answers.

```mermaid
sequenceDiagram
    participant Request
    participant Manager
    participant SharedRestore as Shared restoration Future
    participant Factory
    participant Session

    Request->>Manager: acquire thread lease
    Manager->>Manager: increment active borrowers
    alt route is missing
        Manager->>SharedRestore: create or join by thread ID
        SharedRestore->>Factory: one constructor call
        Factory->>Session: build resources
        alt factory still accepting
            Factory-->>Manager: handle with close callback
            Manager->>Manager: install serialized route
            Manager-->>Request: leased route
        else draining started
            Factory->>Session: close late session
            SharedRestore-->>Request: unavailable
        end
    else route exists
        Manager-->>Request: leased route
    end
    Request->>Session: invoke under per-thread turn lock
    Request->>Manager: release lease
```

## Verification

The seven barrier regressions fail on unchanged main and pass with this change. Existing chat behavior and the complete server test suite also pass.

### Correctness properties

- At most one restoration factory call is active for a thread ID, and concurrent callers observe the same success, exception, or cancellation.
- A request increments the teardown lease in the same critical section that obtains an installed route or joins restoration.
- Shutdown prevents new construction before it waits, and it waits for constructing, executing, and queued same-thread calls.
- A restoration or new-thread handle rejected during shutdown runs its close callback exactly once.
- A factory session is either published into the owned session list or closed after construction. It cannot append after `close()` detaches that list.
- Turns on one thread are serialized. Separate thread routes keep independent locks.

### Testing

- Unchanged-main regression: copied `tests/server/test_chat_thread_lifecycle.py`, `7 failed`.
- Baseline existing chat regression: `uv run pytest -q tests/server/test_chat_manager.py tests/server/test_chat_resources.py tests/server/test_chat_factory.py tests/server/test_chat_session.py`, `30 passed`.
- Focused head regression: `uv run pytest -q tests/server/test_chat_thread_lifecycle.py tests/server/test_chat_manager.py tests/server/test_chat_resources.py tests/server/test_chat_factory.py tests/server/test_chat_session.py`, `37 passed`; focused coverage reported `server.chat.manager` 94% and `server.chat.factory` 76%.
- Barrier-only rerun: `uv run pytest -q --no-cov tests/server/test_chat_thread_lifecycle.py`, `7 passed`.
- Server regression: `uv run pytest -q --no-cov tests/server`, `313 passed`.
- `uv run ruff check src/server/chat/manager.py src/server/chat/factory.py tests/server/test_chat_thread_lifecycle.py`, passed.
- `uv run ruff format --check src/server/chat/manager.py src/server/chat/factory.py tests/server/test_chat_thread_lifecycle.py`, passed.
- `uv run ty check src/server/chat/manager.py src/server/chat/factory.py tests/server/test_chat_thread_lifecycle.py`, passed.
- `uv run lint-imports`, 2 contracts kept, 0 broken.
- `git diff --check`, passed.
- Full Python CI suite: 5,748 passed, 6 environment or platform skips. Global and module coverage gates passed; patch coverage including untracked source was 90%.
- Node 24.21.0 / Bun 1.3.9: 25 backend-client, 98 core-state, and 738 TUI tests passed. Protocol regeneration was stable; all formatting, lint, type, architecture, launcher, and client build checks passed.

- Combined integration of all ten independently based fixes: 5,816 Python tests passed (6 environment/platform skips), 91% patch coverage, 25 backend-client, 123 core-state and 745 TUI tests passed. All repository static checks, stable protocol generation, builds, and packed/deployed TUI self-tests passed.
- Real combined `codex` / `gpt-5.6-sol` queue-rs SPSC run, capped at one round: completed with independent review and official evaluation. The run reported the retained winner `5e621d36bcc4` at 26,412,131.227693 operations/second; the final workspace was clean and differed from the winning tree only in framework state and the final archive. Live chat completed once while optimization streamed; the TUI showed execution label, progress, elapsed time and context usage. Pathological concurrency, large histories and minimizing-objective rankings were exercised separately by the targeted regressions and performance benchmarks for their respective issues.

Closes #609
