### PR TITLE
TUI: bound chat responses to their own exchange

### DIFF
--- a/src/server/api/service.py
+++ b/src/server/api/service.py
@@ -164,12 +164,11 @@ class RunApi:
         return Response(request_id=request.request_id, ack=ack)
 
     def _execute_chat(self, request: ChatQuery) -> Response:
-        sequence = self._journal.latest_sequence
-        answer = self._chat.chat(request.text, thread_id=request.thread_id)
+        answer, event = self._chat.chat_with_event(request.text, thread_id=request.thread_id)
         return Response(
             request_id=request.request_id,
             chat=ChatResult(question=request.text, answer=answer, thread_id=request.thread_id),
-            events=self._journal.read(sequence),
+            events=[] if event is None else [event],
         )
 
     def _execute_chat_thread_create(self, request: ChatThreadCreateQuery) -> Response:

--- a/src/server/chat/manager.py
+++ b/src/server/chat/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 import uuid
 from collections.abc import Callable
@@ -18,8 +19,6 @@ from server.events import (
 )
 
 if TYPE_CHECKING:
-    import threading
-
     from server.chat.options import ChatRunSettings
     from server.journal import EventJournal
     from server.run_lifecycle import RunStatus
@@ -61,6 +60,7 @@ class ChatManager:
         self._condition = condition
         self._journal = journal
         self._run_status = run_status
+        self._chat_response_local = _ChatResponseLocal()
         self._fallback_answer: Callable[[str], str] | None = None
         self._default_handler: Callable[[str], str] | None = None
         self._thread_factory: ChatThreadFactory | None = None
@@ -82,6 +82,9 @@ class ChatManager:
 
     def apply_replayed_event(self, event: RunEvent) -> None:
         """Fold chat metadata from a live append or resumed journal."""
+        captures = self._chat_response_local.captures
+        if event.type is EventType.CHAT and captures:
+            captures[-1] = event
         if event.type is EventType.CHAT_THREAD_CREATED and isinstance(
             event.data, ChatThreadCreatedData
         ):
@@ -142,6 +145,18 @@ class ChatManager:
         finally:
             if handler is not None:
                 self._release_default_call()
+
+    def chat_with_event(
+        self, text: str, thread_id: str | None = None
+    ) -> tuple[str, RunEvent | None]:
+        """Answer a question and return its synchronously folded terminal event."""
+        captures = self._chat_response_local.captures
+        captures.append(None)
+        try:
+            answer = self.chat(text, thread_id)
+            return answer, captures[-1]
+        finally:
+            captures.pop()
 
     def create_thread(
         self,
@@ -365,3 +380,10 @@ def _chat_thread_title(question: str) -> str:
     cut = line[:_CHAT_THREAD_TITLE_MAX_CHARS]
     head, separator, _rest = cut.rpartition(" ")
     return f"{head.rstrip() if separator else cut}…"
+
+
+class _ChatResponseLocal(threading.local):
+    """Active request scopes awaiting a terminal chat event on this thread."""
+
+    def __init__(self) -> None:
+        self.captures: list[RunEvent | None] = []

--- a/tests/server/test_chat_response_bound.py
+++ b/tests/server/test_chat_response_bound.py
@@ -1,0 +1,91 @@
+"""Bounded chat response tests under concurrent journal traffic."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.server.support import build_server_parts
+
+from server.api.protocol import ChatQuery
+from server.events import EventType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_chat_response_excludes_concurrent_run_events(tmp_path: Path) -> None:
+    parts = build_server_parts(tmp_path)
+    handler_started = threading.Event()
+    release_handler = threading.Event()
+
+    def handler(_question: str) -> str:
+        handler_started.set()
+        assert release_handler.wait(timeout=2)
+        return "bounded answer"
+
+    parts.chat.install_default_handler(handler)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        pending = pool.submit(parts.api.execute, ChatQuery(text="what changed?"))
+        assert handler_started.wait(timeout=2)
+        for index in range(1_000):
+            parts.journal.publish_output("stdout", f"optimizer output {index}\n")
+        release_handler.set()
+        response = pending.result(timeout=2)
+
+    assert response.chat is not None
+    assert response.chat.answer == "bounded answer"
+    assert len(response.events) == 1
+    assert response.events[0].type is EventType.CHAT
+    assert response.events[0].text == "what changed?"
+
+    history = parts.journal.read()
+    assert sum(event.type is EventType.OUTPUT for event in history) == 1_000
+    assert history[-1] == response.events[0]
+    assert len(response.model_dump_json()) < 1_000
+
+
+def test_unknown_thread_chat_response_has_no_events(tmp_path: Path) -> None:
+    parts = build_server_parts(tmp_path)
+
+    response = parts.api.execute(ChatQuery(text="hello?", thread_id="missing"))
+
+    assert response.chat is not None
+    assert "Unknown experiment chat thread 'missing'" in response.chat.answer
+    assert response.events == []
+
+
+def test_chat_event_capture_is_cleared_after_handler_error(tmp_path: Path) -> None:
+    parts = build_server_parts(tmp_path)
+
+    def fail(_question: str) -> str:
+        raise RuntimeError
+
+    parts.chat.install_default_handler(fail)
+    with pytest.raises(RuntimeError):
+        parts.chat.chat_with_event("will fail")
+
+    assert parts.chat._chat_response_local.captures == []  # noqa: SLF001
+
+
+def test_nested_chat_captures_keep_each_terminal_event_separate(tmp_path: Path) -> None:
+    parts = build_server_parts(tmp_path)
+    nested_event_text: list[str] = []
+
+    def handler(question: str) -> str:
+        if question == "outer":
+            _answer, nested_event = parts.chat.chat_with_event("inner")
+            assert nested_event is not None
+            nested_event_text.append(nested_event.text)
+        return f"answer to {question}"
+
+    parts.chat.install_default_handler(handler)
+    answer, event = parts.chat.chat_with_event("outer")
+
+    assert answer == "answer to outer"
+    assert event is not None
+    assert event.text == "outer"
+    assert nested_event_text == ["inner"]
+    assert parts.chat._chat_response_local.captures == []  # noqa: SLF001


### PR DESCRIPTION
## Problem

`RunApi._execute_chat()` captured a journal sequence before invoking the chat agent and returned the complete suffix afterward. A slow chat therefore copied every optimizer event emitted during the request onto the dedicated chat socket, even though the primary subscription already delivered those events. Response size and parsing work grew with unrelated run activity and delayed the chat result.

## Solution

`ChatManager.chat_with_event()` now scopes a terminal-event capture to the current request and returns the answer together with the exact chat event folded synchronously by the journal listener. A stack in thread-local storage keeps concurrent and nested chat requests isolated, and `finally` cleanup prevents events from being retained by reused worker threads. Unknown or unavailable thread routes that do not record an event return no event. `RunApi` uses that causal result directly instead of reading a concurrent journal suffix.

The terminal chat event remains in the response because the TUI uses it to reconcile streamed chat output, update thread titles, and avoid synthesizing a duplicate answer. All events, including concurrent optimizer traffic and the terminal chat event, remain in the journal and continue through the normal subscription.

### Architecture

```mermaid
sequenceDiagram
    participant Subscription
    participant Optimizer
    participant ChatRPC as Chat RPC
    participant ChatManager
    participant Journal

    ChatRPC->>ChatManager: question
    loop concurrent run activity
        Optimizer->>Journal: append run event
        Journal-->>Subscription: stream run event
    end
    ChatManager->>Journal: append terminal chat event
    Journal-->>Subscription: stream terminal chat event
    ChatManager-->>ChatRPC: answer + exact chat event
    ChatRPC-->>ChatRPC: response.events = [chat event]
```

## Verification

A barrier test holds the chat handler while 1,000 optimizer output events are appended. On unchanged main, the response contains all 1,001 events. With this change, the response contains only the terminal chat event and encodes below 1 KB, while journal history retains all 1,000 output events plus the chat event.

### Correctness properties

- A successful chat response includes the same terminal chat event recorded for that request and no concurrent run events.
- A chat path that records no event returns an empty event list while preserving its `ChatResult` answer.
- Request capture is active only during `chat_with_event`; nested calls remain isolated and success or failure clears the scope.
- The primary journal and subscription retain the complete live event stream.
- The TUI continues receiving the terminal event needed to fold streamed chunks and apply authoritative thread titles.
- The protocol schema and generated client types do not change.

### Testing

- Unchanged-main regression: copied `tests/server/test_chat_response_bound.py`, `1 failed, 1 passed`; the failure observed 1,001 response events.
- Focused regression: `uv run pytest -q --no-cov tests/server/test_chat_response_bound.py tests/server/test_api_transport.py tests/server/test_chat_manager.py tests/server/test_integration.py`, `31 passed`.
- Server regression: `uv run pytest -q --no-cov tests/server`, `308 passed`.
- `uv run ruff check src/server/chat/manager.py src/server/api/service.py tests/server/test_chat_response_bound.py tests/server/test_api_transport.py tests/server/test_chat_manager.py`, passed.
- `uv run ruff format --check src/server/chat/manager.py src/server/api/service.py tests/server/test_chat_response_bound.py`, passed.
- `uv run ty check src/server/chat/manager.py src/server/api/service.py tests/server/test_chat_response_bound.py`, passed.
- `uv run lint-imports`, 2 contracts kept, 0 broken.
- `git diff --check`, passed.
- Compatibility check with #609: `git merge-file` merged both `server.chat.manager` changes without conflict, and the combined focused chat suite passed, `47 passed`.

- Full Python CI suite: 5,745 passed, 6 environment or platform skips. Global and module coverage gates passed; patch coverage including untracked source was 100%.
- Node 24.21.0 / Bun 1.3.9: 25 backend-client, 98 core-state, and 738 TUI tests passed. Protocol regeneration was stable; all repository formatting, lint, type, architecture, launcher, and client build checks passed.

- Combined integration of all ten independently based fixes: 5,816 Python tests passed (6 environment/platform skips), 91% patch coverage, 25 backend-client, 123 core-state and 745 TUI tests passed. All repository static checks, stable protocol generation, builds, and packed/deployed TUI self-tests passed.
- Real combined `codex` / `gpt-5.6-sol` queue-rs SPSC run, capped at one round: completed with independent review and official evaluation. The run reported the retained winner `5e621d36bcc4` at 26,412,131.227693 operations/second; the final workspace was clean and differed from the winning tree only in framework state and the final archive. Live chat completed once while optimization streamed; the TUI showed execution label, progress, elapsed time and context usage. Pathological concurrency, large histories and minimizing-objective rankings were exercised separately by the targeted regressions and performance benchmarks for their respective issues.

Closes #608
