### PR TITLE
TUI: materialize the agent loop's final trusted result

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -345,10 +345,38 @@ def _format_metric_row(metrics: dict[str, float], objectives: Sequence[Objective
 def _pareto_archive_summary(records: list[RoundRecord], space: MetricSpace) -> str:
     """Render trusted frontier parents and any measured points awaiting review."""
     objectives = space.objectives
+    latest = max(records, key=lambda record: record.round_number, default=None)
+    latest_metrics = (
+        _format_metric_row(latest.metrics, objectives)
+        if latest is not None
+        and latest.official_evaluation
+        and trusted_perf_provenance(latest.perf_provenance)
+        and objectives
+        and space.complete(latest.metrics)
+        else (
+            f"{latest.perf_metric:.6g} {latest.perf_unit or ''}".strip()
+            if latest is not None
+            and latest.official_evaluation
+            and trusted_perf_provenance(latest.perf_provenance)
+            and latest.perf_metric is not None
+            else "(none)"
+        )
+    )
+    latest_line = (
+        "Latest completed round: none."
+        if latest is None
+        else (
+            f"Latest completed round: round {latest.round_number}, "
+            f"commit {(latest.commit or '(missing)')[:12]}, "
+            f"official metrics: {latest_metrics}; "
+            f"retained: {_record_candidate_retained(latest)}."
+        )
+    )
     if not objectives:
         return (
             "No objective axes are configured. Use objectives.toml to enable "
-            "multi-objective checkpoint retention; official scalar tracking remains active."
+            "multi-objective checkpoint retention; official scalar tracking remains active.\n"
+            f"{latest_line}"
         )
 
     lines = [
@@ -359,6 +387,7 @@ def _pareto_archive_summary(records: list[RoundRecord], space: MetricSpace) -> s
             f"within {space.relative_noise:.0%} on every axis and better by more than "
             f"{space.relative_noise:.0%} on at least one."
         ),
+        latest_line,
     ]
     frontier = _pareto_frontier_records(records, space)
     if frontier:
@@ -410,6 +439,118 @@ def _pareto_archive_summary(records: list[RoundRecord], space: MetricSpace) -> s
                 f"reason: {record.candidate_retention_reason or '(unspecified)'}"
             )
     return "\n".join(lines)
+
+
+def _headline_measurement(record: RoundRecord) -> Measurement | None:
+    """Return a record's scalar headline as a typed measurement."""
+    if record.perf_metric is None or record.perf_unit is None:
+        return None
+    return Measurement(
+        metric=record.perf_unit,
+        value=record.perf_metric,
+        direction=record.perf_direction,
+    )
+
+
+def _trusted_final_records(records: list[RoundRecord], space: MetricSpace) -> list[RoundRecord]:
+    """Return retained records with canonical framework-owned measurements."""
+    return [
+        record
+        for record in records
+        if record.commit
+        and record.passed
+        and record.reviewed
+        and record.official_evaluation
+        and trusted_perf_provenance(record.perf_provenance)
+        and _record_candidate_retained(record) is True
+        and (
+            space.complete(record.metrics)
+            if space.objectives
+            else space.direction(_headline_measurement(record)) is not None
+        )
+    ]
+
+
+def _select_final_candidate(records: list[RoundRecord], space: MetricSpace) -> RoundRecord | None:
+    """Select the latest noise-aware winner from trusted retained records."""
+    newest_first = sorted(
+        _trusted_final_records(records, space),
+        key=lambda record: record.round_number,
+        reverse=True,
+    )
+    if space.primary is not None:
+        frontier_rounds = {
+            record.round_number for record in _pareto_frontier_records(newest_first, space)
+        }
+        candidates = [record for record in newest_first if record.round_number in frontier_rounds]
+        primary = space.primary
+
+        def primary_measurement(record: RoundRecord) -> Measurement:
+            return Measurement(
+                metric=primary.name,
+                value=record.metrics[primary.name],
+                direction=primary.direction,
+            )
+
+        return space.best(candidates, primary_measurement)
+    return space.best(newest_first, _headline_measurement)
+
+
+def _finalize_agent_run(
+    ctx: LoopContext,
+    *,
+    records: list[RoundRecord],
+    space: MetricSpace,
+    progress_path: Path,
+) -> None:
+    """Persist the final archive, report trusted results, and restore the winner."""
+    issue_board.write_pareto_archive(progress_path, _pareto_archive_summary(records, space))
+    if space.objectives:
+        frontier = _pareto_frontier_records(records, space)
+        ctx.lprint(f"\nFinal Pareto frontier ({len(frontier)} rounds):")
+        for record in frontier:
+            ctx.lprint(
+                f"  round {record.round_number}: "
+                f"{_format_metric_row(_record_candidate_metrics(record), space.objectives)} "
+                f"(commit {(record.commit or 'n/a')[:12]})"
+            )
+
+    winner = _select_final_candidate(records, space)
+    relative_memory = tuple(
+        str(path.relative_to(ctx.workspace))
+        for path in issue_board.framework_memory_paths(ctx.workspace)
+    )
+    if winner is None:
+        baseline = ctx.git.trusted_input_baseline
+        if baseline is None:
+            raise RuntimeError(  # noqa: TRY003
+                "no trusted retained candidate or trusted input baseline is available"
+            )
+        if not ctx.git.checkout_tree(baseline, clean=True, preserve_paths=relative_memory):
+            raise RuntimeError(  # noqa: TRY003
+                f"could not restore trusted input baseline at {baseline}"
+            )
+        ctx.snapshot_workspace("agent: restore trusted input baseline")
+        ctx.lprint(
+            f"\nNo evaluated winner was retained. Restored trusted input baseline {baseline[:12]}."
+        )
+        return
+    assert winner.commit is not None  # noqa: S101  # selected records require a commit
+    ctx.git.retain_candidate(f"selected-round-{winner.round_number:04d}", winner.commit)
+    if not ctx.git.checkout_tree(winner.commit, clean=True, preserve_paths=relative_memory):
+        raise RuntimeError(  # noqa: TRY003
+            f"could not materialize selected round {winner.round_number} at {winner.commit}"
+        )
+    ctx.snapshot_workspace(f"agent: select round {winner.round_number}")
+    metrics = (
+        _format_metric_row(_record_candidate_metrics(winner), space.objectives)
+        if space.objectives
+        else f"{winner.perf_metric:.6g} {winner.perf_unit or ''}"
+    )
+    ctx.lprint(
+        f"\nFinal selected candidate: round {winner.round_number}, "
+        f"commit {winner.commit[:12]}, official metrics: {metrics.strip()}"
+    )
 
 
 def _pareto_archive_conflict(
@@ -2316,10 +2457,25 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     carry = _CarryOver(regression_info=_terminal_workspace_notice(records))
     round_number = start_round if start_round is not None else len(records) + 1
     if round_number > max_rounds:
-        raise ValueError(  # noqa: TRY003  # tracked: #288
-            f"This run has completed {round_number - 1} rounds; max_rounds={max_rounds} "
-            "is a total limit. Increase --max-rounds to continue."
-        )
+        try:
+            if existing and records:
+                ctx.lprint(
+                    f"This run already completed {len(records)} rounds; "
+                    "finalizing its retained result."
+                )
+                _finalize_agent_run(
+                    ctx,
+                    records=records,
+                    space=agent_run_state.metrics,
+                    progress_path=progress_path,
+                )
+                return True
+            raise ValueError(  # noqa: TRY003  # tracked: #288
+                f"This run has completed {round_number - 1} rounds; max_rounds={max_rounds} "
+                "is a total limit. Increase --max-rounds to continue."
+            )
+        finally:
+            ctx.close()
 
     # When inner_loop == "single-agent", we don't run a separate
     # pre-round decision or profiler invocation. We thread the previous
@@ -3484,6 +3640,12 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 round_number += 1
 
         ctx.lprint(f"Reached max_rounds={max_rounds}. Stopping.")
+        _finalize_agent_run(
+            ctx,
+            records=records,
+            space=agent_run_state.metrics,
+            progress_path=progress_path,
+        )
         return True
     finally:
         ctx.close()

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -24,6 +24,7 @@ from vibesys.loops.agent.loop import (
     FrameworkBenchmarkOutcome,
     _backfill_revert_commit,
     _candidate_evidence_is_fresh,
+    _finalize_agent_run,
     _invoke_read_only_role,
     _missing_implementer_response,
     _official_evaluation_reason,
@@ -33,6 +34,7 @@ from vibesys.loops.agent.loop import (
     _provisional_candidates_since_official,
     _review_due,
     _run_framework_validation_gate,
+    _select_final_candidate,
     _terminal_workspace_notice,
     _trusted_candidate_records,
     run_agent_loop,
@@ -1082,12 +1084,188 @@ def test_implementer_report_cannot_seed_archive_or_dominate_candidates():  # noq
     # Trusted Pareto-parent selection is gated on framework provenance.
     assert _trusted_candidate_records([implementer], space) == []
     assert _trusted_candidate_records([framework], space) == [framework]
-
     # A weaker later candidate is only dominated by the trusted framework row,
     # never by the untrusted implementer self-report.
     weaker = {"accuracy": 0.80}
     assert _pareto_archive_dominators(weaker, [implementer], space) == []
     assert _pareto_archive_dominators(weaker, [framework], space) == [framework]
+
+
+def _official_record(  # noqa: PLR0913  # test record builder
+    round_number: int,
+    commit: str,
+    perf: float,
+    *,
+    retained: bool = True,
+    passed: bool = True,
+    provenance: Literal["framework", "implementer"] = "framework",
+    metrics: dict[str, float] | None = None,
+) -> RoundRecord:
+    """Build one reviewed record eligible for final selection when trusted."""
+    return RoundRecord(
+        round_number,
+        commit,
+        perf,
+        "throughput",
+        passed,
+        reviewed=True,
+        judge_verdict="pass" if passed else "fail",
+        metrics=metrics or {},
+        official_evaluation=True,
+        candidate_retained=retained,
+        perf_direction="max",
+        perf_provenance=provenance,
+    )
+
+
+def test_final_candidate_is_noise_aware_and_rejects_untrusted_records():  # noqa: ANN201  # tracked: #288
+    space = MetricSpace(relative_noise=0.05)
+    older = _official_record(1, "a" * 40, 100.0)
+    newer_within_noise = _official_record(2, "b" * 40, 103.0)
+    self_reported = _official_record(3, "c" * 40, 500.0, provenance="implementer")
+    rejected = _official_record(4, "d" * 40, 600.0, retained=False)
+    failed = _official_record(5, "e" * 40, 700.0, passed=False)
+
+    assert (
+        _select_final_candidate([older, newer_within_noise, self_reported, rejected, failed], space)
+        is newer_within_noise
+    )
+
+
+def test_final_pareto_candidate_requires_canonical_official_metrics():  # noqa: ANN201  # tracked: #288
+    official = _official_record(
+        1,
+        "a" * 40,
+        100.0,
+        metrics={"throughput": 100.0, "latency": 10.0},
+    )
+    provisional = RoundRecord(
+        2,
+        "b" * 40,
+        None,
+        None,
+        True,  # noqa: FBT003  # tracked: #288
+        reviewed=True,
+        judge_verdict="pass",
+        candidate_metrics={"throughput": 200.0, "latency": 5.0},
+        candidate_retained=True,
+    )
+
+    assert _select_final_candidate([official, provisional], _THROUGHPUT_LATENCY) is official
+
+
+def test_finalize_restores_winner_after_failed_last_round_and_updates_archive(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    candidate = workspace / "candidate.txt"
+    candidate.write_text("baseline\n")
+    tracker = GitTracker(workspace, run_id="test-run", log=lambda _message: None)
+    tracker.init(existing=False)
+
+    candidate.write_text("winner\n")
+    tracker.snapshot("round 1 winner")
+    winner_commit = tracker.current_sha()
+    assert winner_commit is not None
+    candidate.write_text("failed final attempt\n")
+    tracker.snapshot("round 2 failed")
+    failed_commit = tracker.current_sha()
+    assert failed_commit is not None
+
+    progress_path = workspace / "progress.md"
+    issue_board.ensure_progress_file(progress_path)
+    logs: list[str] = []
+    ctx = SimpleNamespace(
+        workspace=workspace,
+        git=tracker,
+        snapshot_workspace=tracker.snapshot,
+        lprint=logs.append,
+    )
+    winner = _official_record(1, winner_commit, 125.0)
+    failed = _official_record(2, failed_commit, 250.0, retained=False, passed=False)
+
+    _finalize_agent_run(
+        cast("LoopContext", ctx),
+        records=[winner, failed],
+        space=MetricSpace(),
+        progress_path=progress_path,
+    )
+
+    assert candidate.read_text() == "winner\n"
+    selected_ref = (
+        tracker.run(["git", "rev-parse", "refs/vibesys/test-run/candidates/selected-round-0001"])
+        .stdout.decode()
+        .strip()
+    )
+    assert selected_ref == winner_commit
+    archive = issue_board.pareto_archive_path(progress_path).read_text()
+    assert "Latest completed round: round 2" in archive
+    assert failed_commit[:12] in archive
+    report = "\n".join(logs)
+    assert "Final selected candidate: round 1" in report
+    assert winner_commit[:12] in report
+    assert "official metrics: 125 throughput" in report
+
+
+def test_finalize_with_no_eligible_candidate_restores_trusted_baseline(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    candidate = workspace / "candidate.txt"
+    candidate.write_text("trusted input\n")
+    tracker = GitTracker(workspace, run_id="test-run", log=lambda _message: None)
+    tracker.init(existing=False)
+    baseline = tracker.trusted_input_baseline
+    assert baseline is not None
+    candidate.write_text("failed candidate\n")
+    tracker.snapshot("failed round")
+    failed_commit = tracker.current_sha()
+    assert failed_commit is not None
+
+    progress_path = workspace / "progress.md"
+    logs: list[str] = []
+    ctx = SimpleNamespace(
+        workspace=workspace,
+        git=tracker,
+        snapshot_workspace=tracker.snapshot,
+        lprint=logs.append,
+    )
+    untrusted = _official_record(1, failed_commit, 999.0, provenance="implementer")
+
+    _finalize_agent_run(
+        cast("LoopContext", ctx),
+        records=[untrusted],
+        space=MetricSpace(),
+        progress_path=progress_path,
+    )
+
+    assert candidate.read_text() == "trusted input\n"
+    assert tracker.pending_changes() == []
+    assert "No evaluated winner was retained" in "\n".join(logs)
+    assert baseline[:12] in "\n".join(logs)
+    assert (
+        "Latest completed round: round 1"
+        in issue_board.pareto_archive_path(progress_path).read_text()
+    )
+
+
+def test_finalize_fails_when_neither_winner_nor_baseline_exists(tmp_path: Path) -> None:
+    ctx = MagicMock()
+    ctx.workspace = tmp_path
+    ctx.git.trusted_input_baseline = None
+
+    with pytest.raises(RuntimeError, match="no trusted retained candidate"):
+        _finalize_agent_run(
+            ctx,
+            records=[],
+            space=MetricSpace(),
+            progress_path=tmp_path / "progress.md",
+        )
+
+    ctx.git.checkout_tree.assert_not_called()
+    ctx.snapshot_workspace.assert_not_called()
 
 
 def test_official_evaluation_cadence_resets_at_verified_checkpoint():  # noqa: ANN201  # tracked: #288
@@ -2331,6 +2509,38 @@ def test_loop_round_one_no_profile_runs_one_round(tmp_path, ref_file):  # noqa: 
     assert runner.counters["orch_plan"] == 1
     assert runner.counters["impl"] == 1
     assert runner.counters["judge"] == 1
+
+
+def test_resume_at_completed_limit_finalizes_without_replaying_agents(
+    tmp_path: Path,
+    ref_file: str,
+) -> None:
+    first_runner = _make_orchestrate_runner()
+    assert _invoke_orchestrate(tmp_path, ref_file, first_runner, max_rounds=1) is True
+
+    project_path = _created_project(tmp_path)
+    run_id = _run_id(project_path)
+    resumed_runner = _make_orchestrate_runner()
+    assert (
+        _invoke_orchestrate(
+            tmp_path,
+            str(project_path / "resume-input"),
+            resumed_runner,
+            exp_name=run_id,
+            existing=True,
+            start_round=2,
+            max_rounds=1,
+        )
+        is True
+    )
+
+    assert resumed_runner.counters == {
+        "impl": 0,
+        "judge": 0,
+        "orch_pre": 0,
+        "orch_plan": 0,
+        "prof": 0,
+    }
 
 
 def test_continuing_hypothesis_uses_unified_run_state(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
@@ -3628,12 +3838,13 @@ def test_hypothesis_revert_is_applied_once_across_continuation_rounds(tmp_path, 
             judge_every=10,
         )
 
-    assert checkout_tree.call_count == 1
-    checkout_tree.assert_called_once_with(
-        ANY,
-        clean=True,
-        preserve_paths=("roadmap.md", "progress.md", "pareto-frontier.md"),
-    )
+    assert checkout_tree.call_count == 2
+    assert checkout_tree.call_args_list[0].args == (ANY,)
+    assert checkout_tree.call_args_list[0].kwargs == {
+        "clean": True,
+        "preserve_paths": ("roadmap.md", "progress.md", "pareto-frontier.md"),
+    }
+    assert "progress-artifacts" in checkout_tree.call_args_list[1].kwargs["preserve_paths"]
     repair_calls = [
         call
         for call in runner.invoke.call_args_list
@@ -3714,7 +3925,7 @@ def test_failed_hypothesis_revert_is_retried_and_not_claimed_as_applied(tmp_path
 
     with patch(
         "vibesys.run.git_tracker.GitTracker.checkout_tree",
-        side_effect=[False, True],
+        side_effect=[False, True, True],
     ) as checkout_tree:
         _invoke_orchestrate(
             tmp_path,
@@ -3724,7 +3935,7 @@ def test_failed_hypothesis_revert_is_retried_and_not_claimed_as_applied(tmp_path
             judge_every=10,
         )
 
-    assert checkout_tree.call_count == 2
+    assert checkout_tree.call_count == 3
     retry_calls = [
         call
         for call in runner.invoke.call_args_list


### PR DESCRIPTION
## Problem

The agent loop stopped at its round limit without naming or materializing the best retained candidate. A terminal failed round could therefore leave rejected code in the workspace, and the Pareto archive was written before the last round completed.

## Solution

Finalize the run from its persisted `RoundRecord` history. Selection accepts only candidates that passed independent review, carry official framework measurements, remain retained, and have a commit. `MetricSpace` owns direction, relative-noise comparison, Pareto membership, and the latest-round tie break.

The finalizer rewrites the archive after the last completed round, retains the selected commit under a stable VibeSys ref, restores its tree while preserving framework memory, snapshots the resulting workspace, then reports the selected round, commit, and official metrics. If no measured candidate is eligible, it restores the trusted input baseline and reports that no evaluated winner was retained. It fails when neither a winner nor a trusted baseline can be restored.

A resumed run that has already exhausted its total round limit executes the same finalizer without invoking another agent.

### Architecture

```mermaid
flowchart TD
    A[Persisted completed rounds] --> B[Filter reviewed, passing, retained, official framework results]
    B --> C{Canonical MetricSpace has objectives?}
    C -->|Yes| D[Noise-aware Pareto frontier]
    D --> E[Primary-axis best, latest tie break]
    C -->|No| F[Noise-aware scalar best, latest tie break]
    E --> G{Winner exists?}
    F --> G
    G -->|Yes| H[Retain ref and restore winner tree]
    G -->|No| I[Restore trusted input baseline]
    H --> J[Preserve memory, snapshot, report]
    I --> J
    A --> K[Rewrite final Pareto archive with latest completed round]
```

The agent loop owns orchestration and final selection. `MetricSpace` remains the single comparison authority, `GitTracker` owns materialization and retained refs, and `issue_board` owns framework memory paths and the archive document.

## Verification

Focused tests cover scalar and Pareto selection, framework provenance, noise tolerance, failed final rounds, baseline fallback, missing-baseline failure, final archive freshness, artifact preservation, and completed-run resume behavior.

### Correctness properties

- Only reviewed, passing, retained candidates with official framework-owned measurements can be selected.
- Scalar and multi-objective ranking use the run's persisted `MetricSpace` direction and relative-noise tolerance.
- A failed or untrusted last round cannot replace an earlier eligible winner.
- The final archive names the latest completed round even when that round is absent from the retained frontier.
- Candidate or baseline restoration preserves both memory layouts and structured progress artifacts.
- The success report is emitted only after checkout and snapshot succeed.
- A run with no eligible candidate restores its trusted input baseline. A missing or unrestorable baseline fails finalization.
- Resuming an already completed round budget performs finalization without replaying paid agent work.

### Testing

- `PYTHONPATH=/tmp/vibesys-issue-audit/tests/vibesys/loops/agent VIBESYS_STATE_HOME=/tmp/vibesys-506-before-state VIBESYS_SKYPILOT_CALLER_STATE=/tmp/vibesys-506-before-skypilot /tmp/vibesys-issue-audit/.venv312/bin/pytest -q --no-cov -c /tmp/vibesys-issue-audit/pyproject.toml /tmp/vibesys-506-before.py` on unchanged `ea6f9073` (failed as expected: completed-run resume raised `ValueError` instead of finalizing)
- `UV_CACHE_DIR=/tmp/vibesys-506-uv-cache uv run ruff check src/vibesys/loops/agent/loop.py tests/vibesys/loops/agent/test_orchestrate.py` (passed)
- `UV_CACHE_DIR=/tmp/vibesys-506-uv-cache uv run ty check` (passed)
- `UV_CACHE_DIR=/tmp/vibesys-506-uv-cache VIBESYS_SKYPILOT_CALLER_STATE=/tmp/vibesys-506-skypilot-focused uv run pytest -q --no-cov tests/vibesys/loops/agent/test_orchestrate.py -k 'final_candidate or finalize_restores or finalize_with_no_eligible or finalize_fails or resume_at_completed_limit or reused_hypothesis_id or implementer_skill_updates_survive or timed_out_implementer_persists or hypothesis_revert_is_applied or failed_hypothesis_revert or judge_audited_implementer_metrics'` (12 passed, 145 deselected)
- `UV_CACHE_DIR=/tmp/vibesys-506-uv-cache VIBESYS_SKYPILOT_CALLER_STATE=/tmp/vibesys-506-agentmodule-final uv run pytest -q --no-cov tests/vibesys/loops/agent/test_orchestrate.py` (157 passed)
- Full Python CI suite: 5,747 passed, 6 environment or platform skips. Global and module coverage gates passed; patch coverage including untracked source was 92%.
- Node 24.21.0 / Bun 1.3.9: 25 backend-client, 98 core-state, and 738 TUI tests passed. Protocol regeneration was stable; all repository formatting, lint, type, architecture, launcher, and client build checks passed.

- Combined integration of all ten independently based fixes: 5,816 Python tests passed (6 environment/platform skips), 91% patch coverage, 25 backend-client, 123 core-state and 745 TUI tests passed. All repository static checks, stable protocol generation, builds, and packed/deployed TUI self-tests passed.
- Real combined `codex` / `gpt-5.6-sol` queue-rs SPSC run, capped at one round: completed with independent review and official evaluation. The run reported the retained winner `5e621d36bcc4` at 26,412,131.227693 operations/second; the final workspace was clean and differed from the winning tree only in framework state and the final archive. Live chat completed once while optimization streamed; the TUI showed execution label, progress, elapsed time and context usage. Pathological concurrency, large histories and minimizing-objective rankings were exercised separately by the targeted regressions and performance benchmarks for their respective issues.

Closes #506
