### PR TITLE
TUI: respect minimizing objectives in evolve selection fallbacks

### DIFF
--- a/src/vibesys/loops/evolve/population.py
+++ b/src/vibesys/loops/evolve/population.py
@@ -209,24 +209,25 @@ class Population:
             front = self.frontier(space)
             if front and rng.random() < frontier_bias:
                 return rng.choice(front)
-        return self._scalar_softmax_parent(rng=rng, temperature=temperature)
+        return self._scalar_softmax_parent(rng=rng, temperature=temperature, space=space)
 
     def _scalar_softmax_parent(
         self,
         *,
         rng: random.Random,
         temperature: float,
+        space: MetricSpace,
     ) -> Individual | None:
         ranked = [i for i in self.passed if i.perf_metric is not None]
         if not ranked:
             return None
         if len(ranked) == 1:
             return ranked[0]
-        perfs = [i.perf_metric for i in ranked if i.perf_metric is not None]
-        lo, hi = min(perfs), max(perfs)
+        scores = [space.signed_primary(i.perf_metric) for i in ranked if i.perf_metric is not None]
+        lo, hi = min(scores), max(scores)
         if hi - lo < 1e-12:  # noqa: PLR2004  # tracked: #288
             return rng.choice(ranked)
-        normed = [(p - lo) / (hi - lo) for p in perfs]
+        normed = [(score - lo) / (hi - lo) for score in scores]
         t = max(temperature, 1e-6)
         logits = [n / t for n in normed]
         m = max(logits)
@@ -282,7 +283,11 @@ class Population:
             if len(top) < k_top:
                 non_front = [i for i in pool if i.id not in front_ids and i.perf_metric is not None]
                 non_front.sort(
-                    key=lambda i: i.perf_metric if i.perf_metric is not None else float("-inf"),
+                    key=lambda i: (
+                        space.signed_primary(i.perf_metric)
+                        if i.perf_metric is not None
+                        else float("-inf")
+                    ),
                     reverse=True,
                 )
                 top.extend(non_front[: k_top - len(top)])

--- a/src/vibesys/loops/evolve/search_policy.py
+++ b/src/vibesys/loops/evolve/search_policy.py
@@ -652,4 +652,8 @@ class OpenEvolveSearchPolicy:
                 # A ranking score for the upstream database, not a comparison:
                 # it must stay monotone in the primary axis.
                 return primary.signed(value)
-        return float(individual.perf_metric or 0.0)
+        if individual.perf_metric is None:
+            return 0.0
+        # The profiler contract defines perf_metric as the configured primary's
+        # headline value when an objective space exists.
+        return space.signed_primary(individual.perf_metric)

--- a/src/vibesys/loops/metrics.py
+++ b/src/vibesys/loops/metrics.py
@@ -113,6 +113,16 @@ class MetricSpace(BaseModel):
             return None
         return next((item for item in self.objectives if item.name == metric), None)
 
+    def signed_primary(self, value: float) -> float:
+        """Orient a headline value so larger ranks better in this space.
+
+        The empty compatibility space keeps the original scalar maximization
+        semantics. A configured space applies its primary axis direction;
+        callers use this only for values representing that headline axis.
+        """
+        primary = self.primary
+        return value if primary is None else primary.signed(value)
+
     def direction(self, measurement: Measurement | None) -> Literal["max", "min"] | None:
         """Resolve which way is better for *measurement*.
 

--- a/src/vibesys/schemas.py
+++ b/src/vibesys/schemas.py
@@ -477,7 +477,12 @@ class ProfilerSummary(BaseModel):
     )
     perf_metric: FiniteFloat | None = Field(
         default=None,
-        description="Primary performance metric collected during profiling (higher is better). None when unavailable.",
+        description=(
+            "Uninverted primary performance metric collected during profiling. "
+            "The configured primary objective determines whether lower or higher is better. "
+            "Without configured objectives, scalar selection assumes higher is better. "
+            "None when unavailable."
+        ),
     )
     perf_unit: str | None = Field(
         default=None,

--- a/tests/vibesys/loops/evolve/test_evolutionary_population.py
+++ b/tests/vibesys/loops/evolve/test_evolutionary_population.py
@@ -26,6 +26,10 @@ _TPUT_LAT = _space(
     Objective(name="tput", direction="max"),
     Objective(name="lat", direction="min"),
 )
+_LAT_QUALITY = _space(
+    Objective(name="lat", direction="min"),
+    Objective(name="quality", direction="max"),
+)
 
 # ---------------------------------------------------------------------------
 # Population: basic accessors
@@ -316,6 +320,30 @@ def test_select_parent_pareto_mode_falls_back_to_scalar_when_bias_zero():  # noq
     assert counts[1] > 90
 
 
+def test_select_parent_scalar_fallback_respects_min_primary() -> None:
+    pop = Population(
+        [
+            _multi(1, {"lat": 10.0, "quality": 80.0}),
+            _multi(2, {"lat": 100.0, "quality": 90.0}),
+        ]
+    )
+    rng = random.Random(0)  # noqa: S311  # deterministic selection test
+
+    counts = Counter(
+        _selected_id(
+            pop.select_parent(
+                rng=rng,
+                space=_LAT_QUALITY,
+                frontier_bias=0.0,
+                temperature=0.01,
+            )
+        )
+        for _ in range(100)
+    )
+
+    assert counts[1] > 90
+
+
 def test_select_parent_falls_back_when_frontier_is_empty():  # noqa: ANN201  # tracked: #288
     """No individual reports both objectives → frontier is empty →
     even with bias=1.0, scalar softmax kicks in so the loop isn't blocked."""
@@ -330,6 +358,30 @@ def test_select_parent_falls_back_when_frontier_is_empty():  # noqa: ANN201  # t
     # We get *some* individual via scalar fallback rather than None.
     assert pick is not None
     assert pick.id in (1, 2)
+
+
+def test_select_parent_empty_frontier_fallback_respects_min_primary() -> None:
+    pop = Population(
+        [
+            _multi(1, {"lat": 10.0}),
+            _multi(2, {"lat": 100.0}),
+        ]
+    )
+    rng = random.Random(0)  # noqa: S311  # deterministic selection test
+
+    counts = Counter(
+        _selected_id(
+            pop.select_parent(
+                rng=rng,
+                space=_LAT_QUALITY,
+                frontier_bias=1.0,
+                temperature=0.01,
+            )
+        )
+        for _ in range(100)
+    )
+
+    assert counts[1] > 90
 
 
 def test_select_inspirations_pareto_mode_pulls_from_frontier_first():  # noqa: ANN201  # tracked: #288
@@ -384,6 +436,27 @@ def test_select_inspirations_backfills_when_frontier_smaller_than_k_top():  # no
     # perf_metric == primary metric (set in _multi). For non-frontier pool
     # {3, 4}, primaries are 70 and 60 → id=3 before id=4.
     assert ids[1:] == [3, 4]
+
+
+def test_select_inspiration_backfill_respects_min_primary() -> None:
+    pop = Population(
+        [
+            _multi(1, {"lat": 10.0, "quality": 100.0}),
+            _multi(2, {"lat": 12.0, "quality": 110.0}),
+            _multi(3, {"lat": 20.0, "quality": 80.0}),
+            _multi(4, {"lat": 30.0, "quality": 70.0}),
+        ]
+    )
+
+    picks = pop.select_inspirations(
+        parent_id=1,
+        k_top=3,
+        k_random=0,
+        rng=random.Random(0),  # noqa: S311  # deterministic selection test
+        space=_LAT_QUALITY,
+    )
+
+    assert [pick.id for pick in picks] == [2, 3, 4]
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])

--- a/tests/vibesys/loops/evolve/test_search_policy.py
+++ b/tests/vibesys/loops/evolve/test_search_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import random
 import shutil
 from collections.abc import Iterable, Iterator  # noqa: TC003  # tracked: #288
@@ -35,7 +36,7 @@ def _individual(
     *,
     parent_id: int | None = None,
     generation: int = 0,
-    perf: float = 10.0,
+    perf: float | None = 10.0,
     metrics: dict[str, float] | None = None,
 ) -> Individual:
     return Individual(
@@ -496,6 +497,37 @@ def test_primary_min_objective_is_signed_for_openevolve_fitness(tmp_path) -> Non
     )
 
     assert policy._database.programs["vibesys-1"].metrics["combined_score"] == -20.0  # noqa: SLF001  # tracked: #288
+
+
+@pytest.mark.parametrize(
+    ("objective", "expected"),
+    [
+        (Objective(name="latency_ms", direction="max"), 20.0),
+        (Objective(name="latency_ms", direction="min"), -20.0),
+    ],
+)
+def test_primary_direction_signs_openevolve_perf_fallback(
+    objective: Objective,
+    expected: float,
+) -> None:
+    space = MetricSpace(objectives=(objective,))
+    individual = _individual(1, perf=20.0)
+
+    assert OpenEvolveSearchPolicy._combined_score(individual, space) == expected  # noqa: SLF001
+
+
+def test_zero_perf_fallback_is_still_oriented_by_min_primary() -> None:
+    space = MetricSpace(objectives=(Objective(name="latency_ms", direction="min"),))
+    individual = _individual(1, perf=0.0)
+
+    score = OpenEvolveSearchPolicy._combined_score(individual, space)  # noqa: SLF001
+    assert math.copysign(1.0, score) == -1.0
+
+
+def test_missing_perf_fallback_stays_neutral() -> None:
+    space = MetricSpace(objectives=(Objective(name="latency_ms", direction="min"),))
+
+    assert OpenEvolveSearchPolicy._combined_score(_individual(1, perf=None), space) == 0.0  # noqa: SLF001
 
 
 @pytest.mark.parametrize(

--- a/tests/vibesys/loops/test_metrics.py
+++ b/tests/vibesys/loops/test_metrics.py
@@ -41,6 +41,15 @@ def test_the_axis_supplies_the_direction_a_reading_omits() -> None:
     assert space.direction(None) is None
 
 
+def test_signed_primary_orients_headline_values_for_ranking() -> None:
+    maximizing = MetricSpace(objectives=(_OPS,))
+    minimizing = MetricSpace(objectives=(_LATENCY,))
+
+    assert maximizing.signed_primary(12.0) == 12.0
+    assert minimizing.signed_primary(12.0) == -12.0
+    assert MetricSpace().signed_primary(12.0) == 12.0
+
+
 @pytest.mark.parametrize("direction", ["max", "min"])
 def test_a_delta_exactly_at_the_tolerance_is_within_noise(
     direction: Literal["max", "min"],


### PR DESCRIPTION
## Problem

Evolve accepts a minimizing primary objective, but several scalar ranking paths still treated raw `perf_metric` as higher-is-better. The native parent softmax therefore favored worse candidates when Pareto selection fell back to scalar fitness, inspiration backfill ranked worse non-frontier candidates first, and OpenEvolve's missing-primary-metric fallback published an inverted combined score. End-of-run best selection was corrected separately in #583.

## Solution

`MetricSpace.signed_primary()` now owns direction normalization for headline ranking values. It preserves legacy maximization when no objective is configured and applies the configured primary direction otherwise. Native softmax weights and inspiration backfill use this normalized score. OpenEvolve uses it only when the primary metric is absent from the metrics row and it must fall back to `perf_metric`; its existing primary-metric path is unchanged.

The `ProfilerSummary.perf_metric` schema now describes the uninverted headline value and configured direction, removing the contradictory blanket claim that higher is better. Without configured objectives, its description explicitly documents the existing scalar maximization behavior.

The ranking paths use `perf_metric` as the configured primary objective's headline value. A missing `perf_metric` remains the neutral OpenEvolve fallback, while a real zero is normalized rather than treated as missing.

### Architecture

```mermaid
flowchart LR
    P[Profiler headline perf_metric] --> M[MetricSpace.signed_primary]
    O[Configured primary direction] --> M
    M --> S[Native parent softmax]
    M --> I[Pareto inspiration backfill]
    M --> F[OpenEvolve fallback score]
    E[Empty objective space] -->|legacy max| M
```

## Verification

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/AyanBinRafaih/vibe-serve/ee1c830cf194e0d921b1eb9c2cf41dd5608990ba/pr-665/before.png) | ![After](https://raw.githubusercontent.com/AyanBinRafaih/vibe-serve/ee1c830cf194e0d921b1eb9c2cf41dd5608990ba/pr-665/after.png) |

The new regressions cover all three remaining raw-ranking paths. With a minimizing latency primary, native parent selection now concentrates on the lower value both when frontier bias is disabled and when the frontier is empty. Inspiration backfill ranks lower-latency candidates first. OpenEvolve fallback scores mirror max/min directions, treat measured zero as a valid value, and use an explicit neutral fallback when `perf_metric` is missing.

### Correctness properties

- Configured primary direction governs every scalar fallback that ranks `perf_metric`.
- An empty objective space keeps the historical higher-is-better scalar behavior.
- OpenEvolve's complete primary-metric score path remains unchanged.
- Missing OpenEvolve fallback fitness stays neutral and is distinct in control flow from a measured zero.
- Pareto dominance, frontier membership, tolerance comparisons, persisted state, and protocol contracts do not change.

### Testing

- Unchanged-main regression: focused new tests, `5 failed, 83 passed`; each failure identified an unsigned min-objective path.
- `VIBESYS_SKYPILOT_CALLER_STATE=/tmp/vibesys-504-evolve uv run pytest -q --no-cov tests/vibesys/loops/test_metrics.py tests/vibesys/loops/evolve`, `153 passed`.
- `uv run ruff check src/vibesys/loops/metrics.py src/vibesys/loops/evolve/population.py src/vibesys/loops/evolve/search_policy.py tests/vibesys/loops/test_metrics.py tests/vibesys/loops/evolve/test_evolutionary_population.py tests/vibesys/loops/evolve/test_search_policy.py`, passed.
- `uv run ruff format --check` on the same files, passed.
- `uv run ty check` on the same files, passed.
- Full Python CI suite: 5,749 passed, 6 environment or platform skips. Global and module coverage gates passed; patch coverage including untracked source was 100%.
- Node 24.21.0 / Bun 1.3.9: 25 backend-client, 98 core-state, and 738 TUI tests passed. Protocol regeneration was stable; all repository formatting, lint, type, architecture, launcher, and client build checks passed.

- After correcting the profiler schema description: schema contracts, protocol schema, and evolve prompt snapshots passed, 44 tests. Ruff, formatting and full typecheck passed; protocol regeneration produced no diff.

- Combined integration of all ten independently based fixes: 5,816 Python tests passed (6 environment/platform skips), 91% patch coverage, 25 backend-client, 123 core-state and 745 TUI tests passed. All repository static checks, stable protocol generation, builds, and packed/deployed TUI self-tests passed.
- Real combined `codex` / `gpt-5.6-sol` queue-rs SPSC run, capped at one round: completed with independent review and official evaluation. The run reported the retained winner `5e621d36bcc4` at 26,412,131.227693 operations/second; the final workspace was clean and differed from the winning tree only in framework state and the final archive. Live chat completed once while optimization streamed; the TUI showed execution label, progress, elapsed time and context usage. Pathological concurrency, large histories and minimizing-objective rankings were exercised separately by the targeted regressions and performance benchmarks for their respective issues.

Closes #504
