### PR TITLE
Server: name the event store a subscription streams from

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -458,6 +458,7 @@ export type Type16 = "event_batch";
 export type Events1 = RunEvent[];
 export type ThroughSequence = number;
 export type ActiveExecutions1 = ActiveAgentExecution[];
+export type StoreId = string;
 export type HistoryAfterSequence = number;
 export type Type17 = "protocol_error";
 export type RequestId16 = string | null;
@@ -1106,6 +1107,7 @@ export interface EventBatchMessage {
   events: Events1;
   through_sequence?: ThroughSequence;
   active_executions?: ActiveExecutions1;
+  store_id?: StoreId;
   history_after_sequence?: HistoryAfterSequence;
 }
 export interface ProtocolErrorMessage {

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -1135,6 +1135,11 @@
           "title": "Active Executions",
           "type": "array"
         },
+        "store_id": {
+          "default": "",
+          "title": "Store Id",
+          "type": "string"
+        },
         "history_after_sequence": {
           "default": 0,
           "minimum": 0,

--- a/clients/tui/dev/mock-server.ts
+++ b/clients/tui/dev/mock-server.ts
@@ -339,6 +339,17 @@ class Replay {
   }
 
   /**
+   * The one sequence space this replay ever serves.
+   *
+   * A real server swaps stores when it attaches a run's durable log, and the
+   * client re-folds when the id changes. The mock replays a finished log from
+   * the start, so its id is constant and no batch ever asks for a re-fold.
+   */
+  get storeId(): string {
+    return `mock-store-${this.runId}`;
+  }
+
+  /**
    * Sequence of the newest event delivered so far, or 0 before any.
    *
    * The cursor is a count, not an index, so a zero cursor means nothing has
@@ -445,6 +456,7 @@ class Replay {
       events: [event],
       through_sequence: event.sequence,
       active_executions: this.activeExecutions,
+      store_id: this.storeId,
     });
     if (this.#options.verbose) {
       process.stderr.write(`mock: seq ${String(event.sequence)} ${String(event.type)}\n`);
@@ -519,6 +531,7 @@ function main(): void {
             events: replay.delivered,
             through_sequence: replay.latestSequence,
             active_executions: replay.activeExecutions,
+            store_id: replay.storeId,
             // 0 means the stream carries its whole history, so the TUI never
             // asks for a backfill it cannot get.
             history_after_sequence: 0,

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -1833,6 +1833,88 @@ describe('a stream that re-bootstraps at a raised floor', () => {
   });
 });
 
+/**
+ * The same late attach, but the run log is shorter than the subscription's
+ * tail, so the re-bootstrap replays it whole and declares floor 0 like the
+ * batch before it. Nothing about the floors distinguishes the two logs; only
+ * the store they name does.
+ */
+describe('a stream that re-bootstraps into a log shorter than the tail', () => {
+  const runLog: RunEvent[] = [
+    {
+      ...event(1, 'run_started'),
+      data: {kind: 'run_started', outer_loop: 'agent', input: '.', max_rounds: 3},
+    },
+    event(2, 'agent_output_chunk', 'two\n'),
+    roundFinished(3, 1),
+    event(4, 'agent_output_chunk', 'four\n'),
+  ];
+  // What the client folded from the server's own log before the attach: the
+  // same sequence numbers, different events.
+  const preAttach = [
+    event(1, 'agent_output_chunk', 'server started\n'),
+    event(2, 'agent_output_chunk', 'server ready\n'),
+  ];
+
+  async function rebootstrapped(transport: HistoryTransport): Promise<SocketSessionController> {
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    transport.emitBatch(preAttach, 0, 'bootstrap-store');
+    transport.emitBatch(runLog, 0, 'run-store');
+    return controller;
+  }
+
+  it('reaches the state a full replay of the run log would have built', async () => {
+    const replayedTransport = new HistoryTransport(runLog);
+    const replayed = new SocketSessionController(replayedTransport);
+    await replayed.start();
+    replayedTransport.emitBatch(runLog, 0, 'run-store');
+
+    const controller = await rebootstrapped(new HistoryTransport(runLog));
+
+    expect(controller.state.core.transcript).toEqual(replayed.state.core.transcript);
+    expect(controller.state.core.rounds).toEqual(replayed.state.core.rounds);
+    expect(controller.state.core.sequence).toBe(replayed.state.core.sequence);
+  });
+
+  it('folds the run log prefix its stale cursor covered', async () => {
+    const controller = await rebootstrapped(new HistoryTransport(runLog));
+
+    // `run_started` is sequence 1 in the attached log and sequence 1 was
+    // already folded from the log it replaces, so the out-of-order guard drops
+    // it unless the batch is recognized as superseding what came before.
+    expect(controller.state.core.maxRounds).toBe(3);
+    expect(controller.state.core.outerLoop).toBe('agent');
+    expect(controller.state.core.rounds.map(round => round.number)).toEqual([1]);
+  });
+
+  it('declares a complete history, so nothing is left to backfill', async () => {
+    const transport = new HistoryTransport(runLog);
+
+    const controller = await rebootstrapped(transport);
+
+    expect(controller.state.core.historyAfterSequence).toBe(0);
+    await expect(controller.loadOlderHistory()).resolves.toBe(false);
+    expect(eventsQueries(transport)).toEqual([]);
+  });
+
+  it('extends rather than re-folds while the store stays the same', async () => {
+    const transport = new HistoryTransport(runLog);
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    transport.emitBatch(runLog.slice(0, 2), 0, 'run-store');
+    transport.emitBatch(runLog.slice(2), 0, 'run-store');
+
+    // A fresh run attaches its (empty) log without renumbering anything, so
+    // its stream keeps one identity and the client must not discard the
+    // events it already folded under it.
+    expect(controller.state.core.maxRounds).toBe(3);
+    expect(controller.state.core.rounds.map(round => round.number)).toEqual([1]);
+    expect(controller.state.core.transcript.map(item => item.content).join('')).toContain('two\n');
+  });
+});
+
 describe('stream reconnect', () => {
   /** Lets the zero-delay reconnect timer and its subscribe settle. */
   const settle = () => new Promise<void>(resolve => setTimeout(resolve, 1));
@@ -2242,11 +2324,14 @@ class HistoryTransport implements ServerTransport {
   }
 
   /** One bootstrap batch: the spine below the floor, then the tail. */
-  emitBatch(events: readonly RunEvent[], historyAfterSequence: number): void {
+  emitBatch(events: readonly RunEvent[], historyAfterSequence: number, storeId?: string): void {
     this.#message?.({
       type: 'event_batch',
       events: [...events],
       history_after_sequence: historyAfterSequence,
+      // Omitted rather than empty when a test does not care, so the default
+      // path stays what a server that reports no store identity sends.
+      ...(storeId === undefined ? {} : {store_id: storeId}),
     });
   }
 

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -227,11 +227,21 @@ export class SocketSessionController implements SessionController {
   /**
    * Highest floor the stream itself has declared, which is not the same as the
    * floor in state: backfill lowers the latter and the stream never sees it.
-   * A later batch declaring more than this is a re-bootstrap; see
-   * `#raiseHistoryFloor`. Null until the first batch, whose floor is the
+   * A later batch declaring more than this is a re-bootstrap within one store,
+   * which is what the server does when a burst outruns the tail bound; see
+   * `#resetHistoryFloor`. Null until the first batch, whose floor is the
    * bootstrap's own and therefore raises nothing.
    */
   #declaredFloor: number | null = null;
+  /**
+   * The event store the folded sequences belong to, as the stream last named
+   * it. Sequences only mean anything within one store, and a run swaps in its
+   * durable log after the client subscribes, so a batch that names a different
+   * store supersedes the fold however the two logs compare in length. Null
+   * until the first batch, and empty against a server that does not report
+   * identity, which leaves `#declaredFloor` as the only signal.
+   */
+  #storeId: string | null = null;
   #streamProtocolError = false;
 
   constructor(
@@ -1036,10 +1046,14 @@ export class SocketSessionController implements SessionController {
         );
       } else {
         const declared = message.history_after_sequence ?? 0;
-        const rebootstrap = this.#declaredFloor !== null && declared > this.#declaredFloor;
+        const store = message.store_id ?? '';
+        const rebootstrap =
+          (this.#storeId !== null && store !== this.#storeId) ||
+          (this.#declaredFloor !== null && declared > this.#declaredFloor);
+        this.#storeId = store;
         this.#declaredFloor = declared;
         const floor = rebootstrap
-          ? this.#raiseHistoryFloor(declared)
+          ? this.#resetHistoryFloor(declared)
           : this.#lowerHistoryFloor(declared);
         const apply = rebootstrap ? applyEventRebootstrap : applyEventBatch;
         this.#setState(
@@ -1081,15 +1095,17 @@ export class SocketSessionController implements SessionController {
   }
 
   /**
-   * Adopts a floor the stream raised, which only a re-bootstrap does.
+   * Takes a re-bootstrapped stream's floor literally, up or down.
    *
    * The run's durable event log is attached after the client subscribes, so a
    * subscription that bootstrapped against the server's own short log is
-   * re-bootstrapped at a tail of the run log. Everything below that tail is
+   * re-bootstrapped against the run log. Everything below the new floor is
    * unread history, whatever the client held before, and the spine set
-   * described a log this one replaces.
+   * described a log this one replaces. Descending is not the backfill's
+   * descent either: a run log shorter than the tail is replayed whole and
+   * declares floor 0, which is the truth about the log now being streamed.
    */
-  #raiseHistoryFloor(floor: number): number {
+  #resetHistoryFloor(floor: number): number {
     this.#historyFloor = floor;
     this.#foldedBelowFloor.clear();
     return floor;

--- a/src/server/api/protocol.py
+++ b/src/server/api/protocol.py
@@ -403,6 +403,13 @@ class EventBatchMessage(ProtocolModel):  # noqa: D101  # tracked: #288
     events: list[RunEvent]
     through_sequence: int = Field(default=0, ge=0)
     active_executions: list[ActiveAgentExecution] = Field(default_factory=list)
+    # Names the event store these sequences number. A run attaches its durable
+    # log after clients subscribe, and sequences are only comparable within one
+    # store, so a batch whose id differs from the previous one supersedes what
+    # the client folded rather than extending it. Empty means the server does
+    # not report store identity, leaving the client on watermark comparison
+    # alone, which is what it had before this field existed.
+    store_id: str = ""
     # "Every event in this stream's history has sequence > this." 0 means the
     # full history was delivered, which is the default and today's behavior.
     # Carried on every batch of the subscription, live ones included.

--- a/src/server/api/service.py
+++ b/src/server/api/service.py
@@ -64,7 +64,23 @@ class SubscriptionBootstrap:
     """One journal state captured atomically for a subscription bootstrap."""
 
     run_id: str
+    store_id: str
     floor: int
+    through_sequence: int
+    events: list[RunEvent]
+    active_executions: list[ActiveAgentExecution]
+
+
+@dataclass(frozen=True)
+class SubscriptionCheckpoint:
+    """One journal state captured atomically for a live subscription batch.
+
+    ``store_id`` names the store the events came from. A subscription compares
+    it against the store it bootstrapped from, so it can never mistake a
+    replaced log's sequences for a continuation of its own.
+    """
+
+    store_id: str
     through_sequence: int
     events: list[RunEvent]
     active_executions: list[ActiveAgentExecution]
@@ -230,14 +246,29 @@ class RunApi:
             )
 
     def subscription_checkpoint(
-        self, after_sequence: int, *, bootstrap_spine: bool = False
-    ) -> tuple[int, list[RunEvent], list[ActiveAgentExecution]]:
-        """Capture events and executions at one subscription sequence boundary."""
+        self, after_sequence: int, *, store_id: str | None = None, bootstrap_spine: bool = False
+    ) -> SubscriptionCheckpoint:
+        """Capture events and executions at one subscription sequence boundary.
+
+        ``store_id`` names the store the caller's cursor belongs to. When the
+        journal has since attached a different one, that cursor numbers a log
+        that is gone, so the checkpoint reports the new identity and reads
+        nothing: the caller must bootstrap against the new store rather than
+        extend a fold with sequences from another log.
+        """
         with self._condition:
+            current = self._journal.store_id_locked()
+            if store_id is not None and current != store_id:
+                return SubscriptionCheckpoint(current, after_sequence, [], [])
             through_sequence, events = self._journal.checkpoint_locked(
                 after_sequence, bootstrap_spine=bootstrap_spine
             )
-            return through_sequence, events, self._executions.active_locked()
+            return SubscriptionCheckpoint(
+                store_id=current,
+                through_sequence=through_sequence,
+                events=events,
+                active_executions=self._executions.active_locked(),
+            )
 
     def subscription_bootstrap(
         self, after_sequence: int, tail: int | None
@@ -256,6 +287,7 @@ class RunApi:
             )
             return SubscriptionBootstrap(
                 run_id=self._journal.run_id_locked(),
+                store_id=self._journal.store_id_locked(),
                 floor=floor,
                 through_sequence=through_sequence,
                 events=events,

--- a/src/server/events.py
+++ b/src/server/events.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import threading
+import uuid
 from bisect import bisect_left, bisect_right
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -476,6 +477,13 @@ class EventStore:
     def __init__(self, path: Path, run_id: str):  # noqa: ANN204, D107  # tracked: #288
         self.path = path
         self.run_id = run_id
+        # Names this store's sequence space. Sequences are only comparable
+        # within one store, and a run replaces its store mid-flight when the
+        # durable log is attached, so a consumer holding folded state needs an
+        # identity to tell "the next events" from "a different log's events".
+        # Neither ``path`` nor ``run_id`` can serve: a retired store can be
+        # reopened at the same path, and ``run_id`` is reassigned in place.
+        self.store_id = uuid.uuid4().hex
         self._lock = threading.RLock()
         self._changed = threading.Condition(self._lock)
         self._parsed_records = 0

--- a/src/server/journal.py
+++ b/src/server/journal.py
@@ -111,6 +111,14 @@ class EventJournal:
             self._index_stored_history(durable)
             pending = previous.read() if previous is not None else self._pending_events
             self._pending_events = []
+            # Migrating into an empty log re-appends the retired store's events
+            # in order, so every sequence keeps its meaning: the new store
+            # continues the same sequence space, and subscriptions that folded
+            # it are still correct. Carrying the identity over says so. A
+            # nonempty log renumbers those events onto its own tail instead,
+            # which is a different space and has to read as one.
+            if previous is not None and durable.last_sequence == 0:
+                durable.store_id = previous.store_id
             for event in pending:
                 self._apply_recorded(durable.append(event))
             self._store = durable
@@ -302,6 +310,13 @@ class EventJournal:
     def run_id_locked(self) -> str:
         """Return the durable run id while the shared lock is held."""
         return self._store.run_id if self._store else ""
+
+    def store_id_locked(self) -> str:
+        """Return the attached store's identity while the shared lock is held.
+
+        Empty before the first attach, when no sequence space exists yet.
+        """
+        return self._store.store_id if self._store else ""
 
     def checkpoint_locked(
         self, after_sequence: int, *, bootstrap_spine: bool = False

--- a/src/server/transport/unix_jsonl.py
+++ b/src/server/transport/unix_jsonl.py
@@ -98,7 +98,7 @@ class _RequestHandler(socketserver.StreamRequestHandler):
                 latest_sequence=bootstrap.through_sequence,
             )
         )
-        cursor, reported_floor = self._write_bootstrap(request, bootstrap)
+        cursor, reported_floor, store_id = self._write_bootstrap(request, bootstrap)
         while True:
             if not api.wait_for_change(cursor, timeout=_DISCONNECT_POLL_SECONDS):
                 if self._client_disconnected():
@@ -106,36 +106,48 @@ class _RequestHandler(socketserver.StreamRequestHandler):
                 time.sleep(0.05)
                 continue
             if request.tail is not None and api.latest_sequence - cursor > request.tail:
-                # The run's durable event store is attached after the client
-                # subscribes, so a subscription that bootstrapped against the
-                # near-empty server store now faces the whole history as if it
-                # were live output. Bootstrap again at a fresh tail rather than
-                # replay a window the tail bound was meant to exclude.
-                cursor, reported_floor = self._write_bootstrap(
-                    request, api.subscription_bootstrap(request.after_sequence, request.tail)
-                )
+                # More live output landed in one wait than the tail bound was
+                # willing to replay. Bootstrap again at a fresh tail rather
+                # than deliver a window the bound was meant to exclude.
+                cursor, reported_floor, store_id = self._rebootstrap(request)
                 continue
             # ``wait_for_change`` only tells us that the stream changed. Take
             # one watermark-consistent snapshot before writing so a resumed
             # run, or a burst of live output, reaches the client as one state
             # transition instead of thousands of repaint-triggering messages.
-            through_sequence, events, active_executions = api.subscription_checkpoint(cursor)
+            checkpoint = api.subscription_checkpoint(cursor, store_id=store_id)
+            if checkpoint.store_id != store_id:
+                # The run's durable event store was attached after this client
+                # subscribed. The cursor numbers the retired store, so nothing
+                # after it is a continuation of what the client folded, however
+                # the two logs compare in length. Bootstrap against the store
+                # that is live now; the client re-folds from the batch's id.
+                cursor, reported_floor, store_id = self._rebootstrap(request)
+                continue
             self._write_message(
                 EventBatchMessage(
-                    events=events,
-                    through_sequence=through_sequence,
-                    active_executions=active_executions,
+                    events=checkpoint.events,
+                    through_sequence=checkpoint.through_sequence,
+                    active_executions=checkpoint.active_executions,
                     history_after_sequence=reported_floor,
+                    store_id=store_id,
                 )
             )
-            cursor = through_sequence
+            cursor = checkpoint.through_sequence
+
+    def _rebootstrap(self, request: SubscribeRequest) -> tuple[int, int, str]:
+        """Restart this subscription's replay against the journal's live state."""
+        api = self.server.api
+        return self._write_bootstrap(
+            request, api.subscription_bootstrap(request.after_sequence, request.tail)
+        )
 
     def _write_bootstrap(
         self,
         request: SubscribeRequest,
         bootstrap: SubscriptionBootstrap,
-    ) -> tuple[int, int]:
-        """Send one tail-bounded replay batch; return the new cursor and floor.
+    ) -> tuple[int, int, str]:
+        """Send one tail-bounded replay batch; return the cursor, floor, and store.
 
         Without ``tail`` the reported floor stays 0: the client asked for
         everything from its own cursor onward, so nothing was withheld and old
@@ -148,9 +160,10 @@ class _RequestHandler(socketserver.StreamRequestHandler):
                 through_sequence=bootstrap.through_sequence,
                 active_executions=bootstrap.active_executions,
                 history_after_sequence=reported_floor,
+                store_id=bootstrap.store_id,
             )
         )
-        return bootstrap.through_sequence, reported_floor
+        return bootstrap.through_sequence, reported_floor, bootstrap.store_id
 
     def _write_stream_error(self, request_id: str, error: Exception) -> None:
         """Report a replay or stream failure without hiding a live connection."""

--- a/tests/server/test_api_transport.py
+++ b/tests/server/test_api_transport.py
@@ -128,8 +128,10 @@ def test_subscription_reports_structured_stream_failure(
     parts = build_server_parts(tmp_path / "logs")
     socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"  # noqa: S108
 
-    def fail_replay(after_sequence: int, *, bootstrap_spine: bool = False):  # noqa: ANN202
-        del after_sequence, bootstrap_spine
+    def fail_replay(  # noqa: ANN202
+        after_sequence: int, *, store_id: str | None = None, bootstrap_spine: bool = False
+    ):
+        del after_sequence, store_id, bootstrap_spine
         raise RuntimeError("event store is unavailable")  # noqa: TRY003
 
     monkeypatch.setattr(parts.api, "subscription_checkpoint", fail_replay)

--- a/tests/server/test_execution_tracker.py
+++ b/tests/server/test_execution_tracker.py
@@ -92,7 +92,7 @@ def test_execution_identity_is_recorded_in_events_and_checkpoints(
     assert (started.data.driver, started.data.provider, started.data.model) == expected
     active = parts.api.snapshot().active_executions
     assert (active[0].driver, active[0].provider, active[0].model) == expected
-    _sequence, _events, checkpointed = parts.api.subscription_checkpoint(0)
+    checkpointed = parts.api.subscription_checkpoint(0).active_executions
     assert (checkpointed[0].driver, checkpointed[0].provider, checkpointed[0].model) == expected
 
 
@@ -173,18 +173,21 @@ def test_checkpoint_watermark_and_active_state_are_consistent(tmp_path):  # noqa
     parts = build_server_parts(tmp_path)
     execution = parts.controller.start_agent_execution("judge", "round-2", "review")
 
-    through_sequence, events, active = parts.api.subscription_checkpoint(0)
-    assert all(event.sequence <= through_sequence for event in events)
+    checkpoint = parts.api.subscription_checkpoint(0)
+    assert all(event.sequence <= checkpoint.through_sequence for event in checkpoint.events)
+    active = checkpoint.active_executions
     assert [item.execution_id for item in active] == [execution.execution_id]
     assert active[0].activity.summary == "Reviewing"
-    started = next(event for event in events if event.type is EventType.AGENT_EXECUTION_STARTED)
+    started = next(
+        event for event in checkpoint.events if event.type is EventType.AGENT_EXECUTION_STARTED
+    )
     assert isinstance(started.data, AgentExecutionStartedData)
     assert started.data.activity == active[0].activity
 
     parts.controller.after_agent("judge", "round-2", execution_id=execution.execution_id)
-    through_sequence, events, active = parts.api.subscription_checkpoint(through_sequence)
-    assert events[-1].sequence == through_sequence
-    assert active == []
+    checkpoint = parts.api.subscription_checkpoint(checkpoint.through_sequence)
+    assert checkpoint.events[-1].sequence == checkpoint.through_sequence
+    assert checkpoint.active_executions == []
 
 
 def test_attach_merges_bootstrap_and_durable_execution_history(tmp_path):  # noqa: ANN001, ANN201
@@ -213,8 +216,9 @@ def test_attach_merges_bootstrap_and_durable_execution_history(tmp_path):  # noq
         "current work", agent_kind="implementer", round_label="round-2-implementer"
     )
 
-    through_sequence, events, _active = parts.api.subscription_checkpoint(0)
-    assert [event.sequence for event in events] == list(range(1, through_sequence + 1))
+    checkpoint = parts.api.subscription_checkpoint(0)
+    events = checkpoint.events
+    assert [event.sequence for event in events] == list(range(1, checkpoint.through_sequence + 1))
     assert any(
         event.type is EventType.AGENT_EXECUTION_STARTED and event.execution_id == execution_id
         for event in events

--- a/tests/server/test_journal.py
+++ b/tests/server/test_journal.py
@@ -57,6 +57,37 @@ def test_bootstrap_events_join_durable_history(tmp_path):  # noqa: ANN001, ANN20
     ]
 
 
+def test_attach_renumbering_bootstrap_events_starts_a_new_sequence_space(tmp_path):  # noqa: ANN001, ANN201
+    durable = build_server_parts(tmp_path / "durable")
+    durable.journal.record(EventType.RUN_FINISHED, status=EventStatus.COMPLETED)
+
+    current = build_server_parts(tmp_path / "bootstrap")
+    bootstrap_store = current.journal.store_id_locked()
+    folded = current.journal.read()
+    current.attach(tmp_path / "durable")
+    attached = current.journal.read()[: len(folded)]
+
+    # The bootstrap events were re-appended onto the durable log's tail, so the
+    # sequences a subscriber already folded now name different events. That is
+    # a different sequence space and the identity has to say so.
+    assert current.journal.store_id_locked() != bootstrap_store
+    assert [event.sequence for event in attached] == [event.sequence for event in folded]
+    assert attached != folded
+
+
+def test_attach_into_an_empty_log_keeps_the_sequence_space(tmp_path):  # noqa: ANN001, ANN201
+    current = build_server_parts(tmp_path / "bootstrap")
+    bootstrap_store = current.journal.store_id_locked()
+    before = [(event.sequence, event.type) for event in current.journal.read()]
+
+    current.attach(tmp_path / "durable")
+
+    # Nothing was renumbered, so every folded sequence still names the same
+    # event and a subscriber has nothing to re-fold.
+    assert current.journal.store_id_locked() == bootstrap_store
+    assert [(event.sequence, event.type) for event in current.journal.read()] == before
+
+
 def test_invocation_and_terminal_failure_share_diagnostic_identity(tmp_path):  # noqa: ANN001, ANN201
     parts = build_server_parts(tmp_path)
     error = RuntimeError("token=super-secret agent process exited")

--- a/tests/server/test_transport_subscription.py
+++ b/tests/server/test_transport_subscription.py
@@ -320,12 +320,12 @@ def test_checkpoint_parses_only_tail_and_spine(tmp_path):  # noqa: ANN001, ANN20
     assert store is not None
     parsed_at_attach = store.parsed_record_count
 
-    through, events, _active = parts.api.subscription_checkpoint(count - 500, bootstrap_spine=True)
+    checkpoint = parts.api.subscription_checkpoint(count - 500, bootstrap_spine=True)
 
     assert store.parsed_record_count <= (parsed_at_attach + 500 + _spine_records(count - 500))
     assert store.parsed_record_count < count
-    assert through >= count
-    assert len(events) < count
+    assert checkpoint.through_sequence >= count
+    assert len(checkpoint.events) < count
 
 
 def test_events_query_is_half_open_and_backfills_without_gaps(tmp_path):  # noqa: ANN001, ANN201
@@ -380,6 +380,81 @@ def test_late_attach_rebootstraps_at_fresh_tail_with_spine(tmp_path):  # noqa: A
         "round_finished" for _ in range(floor // _ROUND_EVERY)
     ]
     assert len(batch["events"]) <= 40 + _spine_records(floor)
+
+
+def test_late_attach_rebootstraps_a_run_log_shorter_than_the_tail(tmp_path):  # noqa: ANN001, ANN201
+    # The watermark check alone cannot see this attach: the whole run log fits
+    # inside the tail, so ``latest_sequence - cursor`` never exceeds it. Without
+    # the store's identity on the batch, the durable events at or below the
+    # client's pre-attach cursor are dropped by its out-of-order guard, and the
+    # floor stays 0, so backfill has no reason to fetch the prefix either.
+    parts = build_server_parts(tmp_path / "server")
+    tail = 1_000
+
+    with _live_subscription(parts.api, SubscribeRequest(after_sequence=0, tail=tail)) as read:
+        assert read()["type"] == "subscribed"
+        bootstrap = read()
+        parts.attach(_write_log(tmp_path / "logs", _round_log(200)))
+        batch = read()
+
+    latest = parts.api.snapshot().sequence
+    assert latest < tail
+    assert batch["store_id"] != bootstrap["store_id"]
+    assert batch["history_after_sequence"] == 0
+    assert batch["through_sequence"] == latest
+    # A whole-log replay, so the client re-folds to exactly what the durable
+    # store holds, starting at the ``run_started`` the stale cursor covered.
+    assert [event["sequence"] for event in batch["events"]] == list(range(1, latest + 1))
+    assert batch["events"][0]["type"] == "run_started"
+
+
+def test_attach_into_an_empty_log_keeps_the_subscription_streaming(tmp_path):  # noqa: ANN001, ANN201
+    # A fresh run's attach re-appends the bootstrap events into an empty log,
+    # which preserves every sequence. The client's fold is still correct, so
+    # the store keeps its identity and the stream stays incremental.
+    parts = build_server_parts(tmp_path / "server")
+
+    with _live_subscription(parts.api, SubscribeRequest(after_sequence=0, tail=40)) as read:
+        assert read()["type"] == "subscribed"
+        bootstrap = read()
+        parts.attach(tmp_path / "logs")
+        parts.journal.publish_output("stdout", "first line of the run")
+        batch = read()
+
+    assert batch["store_id"] == bootstrap["store_id"]
+    assert [event["type"] for event in batch["events"]] == ["output"]
+    assert batch["events"][0]["sequence"] == bootstrap["through_sequence"] + 1
+
+
+def test_live_batches_carry_the_store_they_were_read_from(tmp_path):  # noqa: ANN001, ANN201
+    parts = _attach(tmp_path, _round_log(50))
+
+    with _live_subscription(parts.api, SubscribeRequest(after_sequence=0, tail=40)) as read:
+        read()
+        bootstrap = read()
+        parts.journal.publish_output("stdout", "one more line")
+        batch = read()
+
+    store_id = parts.journal.store_id_locked()
+    assert store_id != ""
+    assert bootstrap["store_id"] == store_id
+    assert batch["store_id"] == store_id
+
+
+def test_checkpoint_reads_nothing_from_a_store_the_cursor_predates(tmp_path):  # noqa: ANN001, ANN201
+    parts = build_server_parts(tmp_path / "server")
+    bootstrap_store = parts.journal.store_id_locked()
+    cursor = parts.api.latest_sequence
+    parts.attach(_write_log(tmp_path / "logs", _round_log(200)))
+
+    stale = parts.api.subscription_checkpoint(cursor, store_id=bootstrap_store)
+    current = parts.api.subscription_checkpoint(cursor)
+
+    assert stale.store_id == parts.journal.store_id_locked() != bootstrap_store
+    assert stale.events == []
+    # Without the guard the same cursor reads the replacement log's suffix,
+    # which is exactly the batch that used to reach the client unannounced.
+    assert current.events != []
 
 
 def test_late_attach_does_not_parse_skipped_history(tmp_path):  # noqa: ANN001, ANN201


### PR DESCRIPTION
## Problem

Fixes #470. A run subscribes clients against a scratch bootstrap event store, then `EventJournal.attach` swaps in the durable log and re-appends the pending bootstrap events. When the durable log is nonempty those pending events are renumbered onto its tail, so the low sequences the client has already folded (`server_started`, `run_status_changed`, `run_started`, and whatever else the spine emitted) now name completely different events. The transport's only defense was PR #468's watermark check, `latest_sequence - cursor > request.tail`, which by construction cannot fire when the durable log is shorter than the tail.

Both halves of the client then fail silently. Durable events at or below the stale cursor are dropped by `foldEvent`'s out-of-order guard, and durable events above it are folded on top of unrelated state as if they continued it. `history_after_sequence` stays at 0 the whole time, so the backfill path is told the history is complete and never asks for the prefix it is missing.

Measured on `main` with a 202-event durable log and the standard `BOOTSTRAP_TAIL` of 1000: after attach the client's next batch begins at sequence 3, durable sequences 1 and 2 are never delivered in any batch, `run_started` never arrives, and the declared floor remains 0. The same run with `tail=40` re-bootstraps correctly, which is the shape of the defect: correctness depends on the accident of whether the resumed log happens to be longer than the tail.

## Solution

Sequences are only meaningful inside one event store, so the protocol now names the store. `EventStore` mints an opaque `store_id` (a `uuid4` hex) at construction, `EventBatchMessage` carries the id of the store each batch was read from, and both the transport and the TUI compare that id instead of inferring a swap from log lengths.

The identity names a *sequence space*, not a file and not a run. `path` cannot serve because a retired store can be reopened at the same path, and `run_id` cannot because it is reassigned in place. The distinction earns its keep at the one place the two diverge: attaching into an *empty* durable log re-appends the bootstrap events with their sequences preserved, so every sequence still names the same event and a subscriber has nothing to re-fold. `attach` therefore hands the retired store's identity to the new one in exactly that case, which is why a fresh run still streams incrementally rather than re-bootstrapping the instant its log is attached. Behavior for fresh runs is unchanged.

On the server, `subscription_checkpoint` takes the caller's `store_id` and reads the journal's current one under the same condition lock that guards the event read, so a swap cannot race a batch: on a mismatch it returns the new identity and reads nothing. The transport re-bootstraps on that mismatch. PR #468's watermark check is kept rather than replaced, now scoped to what it actually detects, a live burst inside one store that outruns the tail bound, so bounded replay still holds.

On the client, `SessionController` tracks the last store it saw and treats "the batch names a different store" and "the declared floor moved up" as two independent triggers for the same re-fold. Either one routes the batch through `applyEventRebootstrap` and resets the history floor instead of lowering it.

`store_id` is deliberately added to `EventBatchMessage` only, not to `SubscribedMessage` as the issue sketches. The bootstrap message's id would have no consumer: the client learns the identity from the first batch, and a field no reader uses is a field that drifts. One known gap is left open on purpose and is not in this issue's scope: a *reconnect* that redials with `resumed` set still resumes from the client cursor, so a store swap across a dropped connection is the same defect class through a different door. The identity now exists to fix it; wiring the resume dial is separate work.

### Architecture

```mermaid
flowchart TD
    A["EventStore.__init__: store_id = uuid4"] --> B["EventJournal.attach: empty durable log inherits the id, nonempty log renumbers and keeps its own"]
    B --> C["FrontendApi.subscription_checkpoint(cursor, store_id): compares under the condition lock, reads nothing on mismatch"]
    C --> D["unix_jsonl._stream: id differs -> _rebootstrap; tail watermark still guards a live burst"]
    D --> E["EventBatchMessage.store_id on the wire"]
    E --> F["SessionController: different store -> applyEventRebootstrap + reset floor; same store -> applyEventBatch + lower floor"]
```

## Verification

The defect is a client/server interaction, so it is pinned from both ends: server-side transport tests drive a real journal through a real attach over the real socket, and TUI tests drive the controller through the batch sequence that attach produces.

### Correctness properties

- A client's folded state after a mid-stream attach equals a full replay of the durable log, for any relative size of the durable log and the subscription tail. The regression test asserts the whole log is replayed from sequence 1 with `run_started` first, on the exact `tail=1000` / 202-event shape the issue reports.
- A store swap is detectable independent of log length. Identity comparison replaces size comparison as the *correctness* signal; the size check remains only as a bounded-replay guard within a single store.
- Attaching into an empty log preserves every sequence, so it preserves the identity, so a fresh run streams incrementally with no spurious re-fold. This is asserted at the journal level (sequences and identity both unchanged) and at the transport level (the post-attach batch starts at exactly `bootstrap.through_sequence + 1`).
- The identity read and the event read are atomic with respect to `attach`: both happen under `FrontendApi._condition`, so no batch can be stamped with one store's id and carry another store's events.
- Backward compatible in both directions. `store_id` defaults to `""`, and the client only treats a change as a swap once it has seen a non-null previous value, so a server that never reports identity leaves the client on exactly its pre-existing watermark behavior.
- After a re-bootstrap the declared floor is reset, not lowered, so the client reports the new store's real floor rather than the retired store's stale one and backfill asks for what is actually missing.

### Testing

- Fail-before: a standalone repro against `main` (real journal, real socket, real attach) showed the post-attach batch starting at sequence 3 with durable sequences 1 and 2 never delivered and `history_after_sequence` stuck at 0. With this branch the same script replays sequences 1 through 202 with `run_started` first and a correct floor.
- The client-side condition is load-bearing, not decorative: reverting only the `SessionController` change and rerunning fails 2 of the 4 new TUI tests ("reaches the state a full replay of the run log would have built" and "folds the run log prefix its stale cursor covered").
- New server tests. `tests/server/test_transport_subscription.py`: the issue's repro (short durable log, `tail=1000`, asserts a changed `store_id`, floor 0, whole-log replay, `run_started` first), the empty-log attach that must *not* re-bootstrap, live batches carrying the store they were read from, and a checkpoint reading nothing from a store the cursor predates. `tests/server/test_journal.py`: renumbering starts a new sequence space, an empty-log attach keeps it.
- New TUI tests: 4 cases under "a stream that re-bootstraps into a log shorter than the tail", covering equivalence with a full replay, folding the prefix the stale cursor covered, declaring a complete history so nothing is left to backfill, and extending rather than re-folding while the store stays the same.
- Full local suite: 5066 passed, 24 skipped, 5 failed, all five in `tests/vibesys/skypilot/test_evaluator_helper.py`. That file's whole import graph (167 modules) contains nothing this branch touches, and the same five fail identically on an unrelated branch in this environment, so they are local infrastructure. Unrelated but worth knowing: the suite parks at interpreter exit waiting on leaked non-daemon `_omnigent_runtime._serve` loop threads after the last test has reported.
- `uv run pytest tests/server`: 312 passed. `uv run pytest tests/architecture`: 248 passed, 22 skipped. `pnpm test:clients`: 25 backend-client, 98 core-state, 742 TUI, 0 failures. `./scripts/check_format.sh`, `./scripts/check_types.sh`, `uv run lint-imports`, `pnpm check:ts`, `pnpm check:ts-architecture`, `pnpm check:clients`, `pnpm build:clients` all pass. `uv run ruff check src/server tests/server` is clean.
- The generated protocol files were regenerated with `pnpm --dir clients/backend-client generate:protocol`, so the CI parity check and `tests/server/test_protocol_schema.py` both agree with `src/server/api/protocol.py`.
- Merges cleanly (`git merge-tree --write-tree`) against the current `main` tip and against 23 of the 25 open sibling branches. The two exceptions, #633 and #467, conflict in `resources/evaluators/microservice/` and `src/vibesys/loops/` respectively, files this branch does not touch, and both conflict with plain `main` the same way.

Closes #470.
