### PR TITLE
Drop the unreachable import guard and share the channel publisher

### DIFF
--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -439,6 +439,14 @@ class AgentLogger(BaseCallbackHandler):
     # on the same private ``_emit_*`` helpers, so emitted events and log text
     # are identical regardless of which backend is in use.
 
+    def _publish_channel(self, text: str, channel: AgentOutputChannel) -> None:
+        """Publish ``text`` verbatim on ``channel`` and mirror it to the log."""
+        if not text:
+            return
+        status = self._status()
+        self._publish(text, channel, status=status)
+        self._log_line(f"{format_status_prefix(status)}{text}")
+
     def on_thinking(self, text: str) -> None:
         """Publish agent reasoning on the analysis channel.
 
@@ -446,11 +454,7 @@ class AgentLogger(BaseCallbackHandler):
         ``payload={"channel": "diagnostic"}``, which the observer routes to
         :meth:`on_diagnostic`, so nothing that reaches here is inspected.
         """
-        if not text:
-            return
-        status = self._status()
-        self._publish(text, "analysis", status=status)
-        self._log_line(f"{format_status_prefix(status)}{text}")
+        self._publish_channel(text, "analysis")
 
     def on_diagnostic(self, text: str) -> None:
         """Publish driver plumbing on the diagnostic channel.
@@ -459,11 +463,7 @@ class AgentLogger(BaseCallbackHandler):
         agent reasoning, so nothing here inspects it. The text is published
         verbatim; only the channel differs from :meth:`on_thinking`.
         """
-        if not text:
-            return
-        status = self._status()
-        self._publish(text, "diagnostic", status=status)
-        self._log_line(f"{format_status_prefix(status)}{text}")
+        self._publish_channel(text, "diagnostic")
 
     def on_tool_call(self, tool: str, args: dict[str, Any] | str | None = None) -> None:  # noqa: D102  # tracked: #288
         if isinstance(args, dict):

--- a/src/vibesys/agents/host_resource_declarations.py
+++ b/src/vibesys/agents/host_resource_declarations.py
@@ -15,6 +15,7 @@ import sys
 from collections.abc import Iterable, Mapping  # noqa: TC003  # tracked: #288
 from pathlib import Path
 
+import vibesys
 from vibesys.agents import provider_profiles
 from vs_sandbox import (
     HostResource,
@@ -182,14 +183,9 @@ def _agent_runtime(ctx: HostResourceContext) -> Iterable[HostResource]:
         real_node = Path(node).resolve()
         paths.extend((real_node.parent, real_node.parent.parent))
 
-    try:
-        import vibesys  # noqa: PLC0415  # tracked: #288
-
-        pkg_file = getattr(vibesys, "__file__", None)
-        if pkg_file:
-            paths.append(Path(pkg_file).resolve().parents[1])
-    except Exception:  # pragma: no cover - defensive; import cannot normally fail here  # noqa: BLE001, S110  # tracked: #288
-        pass
+    pkg_file = getattr(vibesys, "__file__", None)
+    if pkg_file:
+        paths.append(Path(pkg_file).resolve().parents[1])
 
     return _resources(paths, purpose="agent and VibeSys runtime")
 

--- a/tests/vibesys/agents/test_callbacks.py
+++ b/tests/vibesys/agents/test_callbacks.py
@@ -150,6 +150,23 @@ class TestOnThinkingChannel:
 
         assert [chunk.channel for chunk in chunks] == ["analysis"] * 2
 
+    def test_empty_text_publishes_nothing_directly(self) -> None:
+        """``on_thinking`` and ``on_diagnostic`` share a no-op-on-empty helper."""
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            AgentLogger().on_thinking("")
+        finally:
+            unsubscribe()
+
+        assert [event.data for event in seen if isinstance(event.data, AgentOutputChunkData)] == []
+
+    def test_writes_to_log_file(self) -> None:
+        log = io.StringIO()
+        AgentLogger(log_file=log).on_thinking("The ring buffer is the hot path.")
+
+        assert "The ring buffer is the hot path." in log.getvalue()
+
 
 class TestOnDiagnostic:
     """The explicit hook a driver-marked event routes to."""
@@ -174,6 +191,12 @@ class TestOnDiagnostic:
 
     def test_empty_text_publishes_nothing(self) -> None:
         assert self._chunks("") == []
+
+    def test_writes_to_log_file(self) -> None:
+        log = io.StringIO()
+        AgentLogger(log_file=log).on_diagnostic("agentshim: restarting the provider process")
+
+        assert "agentshim: restarting the provider process" in log.getvalue()
 
 
 class TestOnToolStart:

--- a/tests/vibesys/agents/test_host_resource_declarations.py
+++ b/tests/vibesys/agents/test_host_resource_declarations.py
@@ -7,8 +7,9 @@ import agentshim
 import pytest
 from tests.support import provider_profiles as fake_profiles
 
+import vibesys
 from vibesys.agents import host_resource_declarations
-from vs_sandbox import HostResource, HostResourceAccess
+from vs_sandbox import HostResource, HostResourceAccess, HostResourceContext
 
 _SHIPPED = ("claude", "codex", "gemini", "opencode")
 
@@ -95,6 +96,29 @@ class TestInterpreterAliasRoots:
         monkeypatch.setattr(host_resource_declarations.sys, "executable", str(real))
 
         assert host_resource_declarations._interpreter_alias_roots() == set()  # noqa: SLF001  # tracked: #288
+
+
+class TestAgentRuntime:
+    """The running VibeSys install must be importable inside confinement.
+
+    ``import vibesys`` cannot fail here: this test module is itself reached
+    through ``vibesys.agents.host_resource_declarations``, so the package is
+    already loaded and ``vibesys/__init__.py`` is a docstring-only module with
+    no re-exports that could raise. The declaration is unconditional.
+    """
+
+    def test_declares_the_running_vibesys_package_root(self) -> None:
+        declarations = tuple(
+            host_resource_declarations._agent_runtime(  # noqa: SLF001  # tracked: #288
+                HostResourceContext(env={})
+            )
+        )
+
+        vibesys_root = Path(vibesys.__file__).resolve().parents[1]
+        matching = [resource for resource in declarations if resource.path == vibesys_root]
+        assert len(matching) == 1
+        assert matching[0].access is HostResourceAccess.READ_ONLY
+        assert matching[0].purpose == "agent and VibeSys runtime"
 
 
 def test_defaults_declare_path_rust_and_shell_resources(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288


### PR DESCRIPTION
## Problem

Two small quality issues found while auditing the agentshim integration (stack on #668, first of four VibeSys follow-ups). `_agent_runtime` in `host_resource_declarations.py` wrapped `import vibesys` in `except Exception: pass`, so if it ever failed the runtime grant would be missing and the failure would surface later as a confusing sandbox violation. `on_thinking` and `on_diagnostic` in `callbacks.py` had identical bodies except for the channel string.

## Solution

The import cannot fail from inside the package, so the guard, its `pragma: no cover`, and its three lint waivers are removed and the import moves to module level. The two channel publishers share one private helper; the public methods and their docstrings stay.

### Architecture

No boundary changes.

## Verification

### Correctness properties

- The running VibeSys package root is always declared read-only under the "agent and VibeSys runtime" purpose.
- Empty text is a no-op on both channels; non-empty text is published on its channel and mirrored to the log with the status prefix.

### Testing

```
uv run ruff check src/vibesys/agents/host_resource_declarations.py src/vibesys/agents/callbacks.py tests/vibesys/agents/test_host_resource_declarations.py tests/vibesys/agents/test_callbacks.py
uv run ruff format --check <same files>
scripts/check_types.sh
uv run pytest -q tests/vibesys/agents/test_host_resource_declarations.py tests/vibesys/agents/test_callbacks.py -n auto   # 111 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
