### PR TITLE
Make the Codex watchdog's timing and matching explicit and testable

### DIFF
--- a/src/vibesys/agents/docker_executor.py
+++ b/src/vibesys/agents/docker_executor.py
@@ -20,6 +20,7 @@ Three pieces live here:
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import re
@@ -174,10 +175,42 @@ class _CodexRolloutCompletion:
     message: str
 
 
-_CODEX_RESUME_TERMINATION_SCRIPT = r"""
-import os
-import signal
-import sys
+# The container-side process argv is exactly the request.argv the host built
+# (``DockerCommandExecutor`` only prepends ``docker exec ... <container>``), so
+# this script's match criteria are written to agree with the host-side
+# ``_is_codex_json_command``/``_codex_resume_thread_id`` predicate: the binary
+# basename is ``codex``, ``exec`` and ``--json`` are both present, and the
+# thread ID sits immediately after ``resume``. That precision is required here
+# and not in ``_codex_process_alive`` because a container can carry more than
+# one stale resumed Codex process at a time (that is the situation this
+# watchdog exists to clean up), so termination must single out the exact
+# thread instead of matching any Codex process in the container.
+def _codex_resume_argv_matches(argv: list[str], thread_id: str) -> bool:
+    """Return whether *argv* is the resumed Codex JSON run for *thread_id*.
+
+    Shared verbatim with the container-side termination script (its source is
+    embedded below), so the host and the container agree on what a resumed
+    Codex process looks like. Inside a container the CLI is a node script, so
+    the process argv reads ``node /usr/local/bin/codex exec resume ...`` while
+    its native child reads ``.../codex exec resume ...``; both must match.
+    """
+    if len(argv) > 1 and os.path.basename(argv[0]) != "codex":  # noqa: PTH119  # tracked: #288
+        argv = argv[1:]
+    if not argv or os.path.basename(argv[0]) != "codex":  # noqa: PTH119  # tracked: #288
+        return False
+    if "exec" not in argv or "--json" not in argv:
+        return False
+    try:
+        resume_index = argv.index("resume")
+    except ValueError:
+        return False
+    return argv[resume_index + 1 : resume_index + 2] == [thread_id]
+
+
+_CODEX_RESUME_TERMINATION_SCRIPT = (
+    "from __future__ import annotations\n\nimport os\nimport signal\nimport sys\n\n"
+    + inspect.getsource(_codex_resume_argv_matches)
+    + r"""
 
 thread_id = sys.argv[1]
 own_pid = os.getpid()
@@ -189,15 +222,14 @@ for entry in os.listdir("/proc"):
     except (FileNotFoundError, PermissionError, ProcessLookupError):
         continue
     argv = [part.decode("utf-8", errors="replace") for part in raw.split(b"\0") if part]
-    if "exec" not in argv or "resume" not in argv or thread_id not in argv:
-        continue
-    if not any(os.path.basename(part) == "codex" for part in argv):
+    if not _codex_resume_argv_matches(argv, thread_id):
         continue
     try:
         os.kill(int(entry), signal.SIGTERM)
     except ProcessLookupError:
         pass
 """
+)
 
 
 class _WatchdogState:
@@ -296,27 +328,44 @@ class CodexRolloutWatchdogExecutor:
     after ``run`` returns, so the replay still reaches it.
     """
 
-    #: Seconds between liveness checks while a Codex JSON run is in flight.
-    tick_seconds = 5.0
-    #: Seconds between rollout-file reads.
-    rollout_poll_seconds = 15.0
-    #: How long a terminal rollout state must hold before it is trusted.
-    completion_grace_seconds = 30.0
-    #: How long to wait for the run to end after the in-container SIGTERM.
-    termination_grace_seconds = 5.0
-
-    def __init__(
+    # Each keyword argument is an independent documented timing knob; folding
+    # them into a config object would break the constructors already calling
+    # this with the current keyword spellings.
+    def __init__(  # noqa: PLR0913
         self,
         inner: CommandExecutor,
         container_id_resolver: Callable[[], str],
         *,
         log: Callable[[str], None] = _discard,
+        tick_seconds: float = 5.0,
+        rollout_poll_seconds: float = 15.0,
+        completion_grace_seconds: float = 30.0,
+        termination_grace_seconds: float = 5.0,
     ) -> None:
-        """Wrap *inner*, watching containers named by *container_id_resolver*."""
+        """Wrap *inner*, watching containers named by *container_id_resolver*.
+
+        Args:
+            inner: The transport a Codex JSON command ultimately runs through.
+            container_id_resolver: Names the container to poll, read each time
+                a Codex run needs it.
+            log: Sink for the watchdog's own progress lines; dropped by
+                default.
+            tick_seconds: Seconds between liveness checks while a Codex JSON
+                run is in flight.
+            rollout_poll_seconds: Seconds between rollout-file reads.
+            completion_grace_seconds: How long a terminal rollout state must
+                hold before it is trusted.
+            termination_grace_seconds: How long to wait for the run to end
+                after the in-container SIGTERM.
+        """
         self._inner = inner
         self._container_id_resolver = container_id_resolver
         self._log = log
         self._codex_rollout_paths: dict[str, str] = {}
+        self.tick_seconds = tick_seconds
+        self.rollout_poll_seconds = rollout_poll_seconds
+        self.completion_grace_seconds = completion_grace_seconds
+        self.termination_grace_seconds = termination_grace_seconds
 
     def find_binary(self, name: str, env: Mapping[str, str]) -> str:
         """Delegate binary lookup to the wrapped executor."""
@@ -450,7 +499,15 @@ class CodexRolloutWatchdogExecutor:
                 return
 
     def _codex_process_alive(self, container_id: str, child_binary: str) -> bool:
-        """Return whether the CLI this ``docker exec`` fronts is still running."""
+        """Return whether the CLI this ``docker exec`` fronts is still running.
+
+        This deliberately matches by binary name alone, unlike the thread-exact
+        predicate ``_CODEX_RESUME_TERMINATION_SCRIPT`` uses: this call answers
+        only "has this ``docker exec``'s CLI stopped running", where a false
+        positive (some other Codex process still alive) merely means the poll
+        loop keeps waiting one more tick, which is cheap. Terminating the wrong
+        process would not be.
+        """
         try:
             check = subprocess.run(  # noqa: S603  # tracked: #288
                 ["docker", "exec", container_id, "pgrep", "-f", child_binary],  # noqa: S607  # tracked: #288
@@ -464,38 +521,56 @@ class CodexRolloutWatchdogExecutor:
             return True
         return check.returncode == 0
 
-    def _read_codex_rollout_completion(  # noqa: C901, PLR0912  # tracked: #288
+    def _read_codex_rollout_completion(
         self,
         container_id: str,
         thread_id: str,
     ) -> _CodexRolloutCompletion | None:
         """Read stable terminal evidence from a resumed Codex rollout, if any."""
-        rollout_path = self._codex_rollout_paths.get(thread_id)
+        rollout_path = self._locate_codex_rollout(container_id, thread_id)
         if rollout_path is None:
-            located = subprocess.run(  # noqa: S603  # tracked: #288
-                [  # noqa: S607  # tracked: #288
-                    "docker",
-                    "exec",
-                    container_id,
-                    "find",
-                    "/root/.codex/sessions",
-                    "-type",
-                    "f",
-                    "-name",
-                    f"rollout-*-{thread_id}.jsonl",
-                    "-print",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=_DOCKER_QUERY_TIMEOUT_S,
-                check=False,
-            )
-            paths = [line for line in located.stdout.splitlines() if line]
-            if located.returncode != 0 or not paths:
-                return None
-            rollout_path = max(paths)
-            self._codex_rollout_paths[thread_id] = rollout_path
+            return None
+        events = self._tail_codex_rollout_events(container_id, rollout_path)
+        if events is None:
+            return None
+        return _scan_codex_rollout_completion(events)
 
+    def _locate_codex_rollout(self, container_id: str, thread_id: str) -> str | None:
+        """Find, and cache, the rollout file a resumed thread is writing to."""
+        cached = self._codex_rollout_paths.get(thread_id)
+        if cached is not None:
+            return cached
+        located = subprocess.run(  # noqa: S603  # tracked: #288
+            [  # noqa: S607  # tracked: #288
+                "docker",
+                "exec",
+                container_id,
+                "find",
+                "/root/.codex/sessions",
+                "-type",
+                "f",
+                "-name",
+                f"rollout-*-{thread_id}.jsonl",
+                "-print",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_DOCKER_QUERY_TIMEOUT_S,
+            check=False,
+        )
+        paths = [line for line in located.stdout.splitlines() if line]
+        if located.returncode != 0 or not paths:
+            return None
+        rollout_path = max(paths)
+        self._codex_rollout_paths[thread_id] = rollout_path
+        return rollout_path
+
+    def _tail_codex_rollout_events(
+        self,
+        container_id: str,
+        rollout_path: str,
+    ) -> list[dict[str, Any]] | None:
+        """Read the tail of one rollout file and parse its JSON lines."""
         result = subprocess.run(  # noqa: S603  # tracked: #288
             ["docker", "exec", container_id, "tail", "-n", "512", rollout_path],  # noqa: S607  # tracked: #288
             capture_output=True,
@@ -514,40 +589,63 @@ class CodexRolloutWatchdogExecutor:
                 continue
             if isinstance(event, dict):
                 events.append(event)
+        return events
 
-        last_lifecycle_index = -1
-        last_lifecycle_type: str | None = None
-        for index, event in enumerate(events):
-            if event.get("type") != "event_msg":
-                continue
-            payload = event.get("payload")
-            if not isinstance(payload, dict):
-                continue
-            payload_type = payload.get("type")
-            if payload_type in {"task_started", "task_complete"}:
-                last_lifecycle_index = index
-                last_lifecycle_type = cast("str", payload_type)
-        if last_lifecycle_type != "task_complete":
-            return None
 
-        message: str | None = None
-        for event in reversed(events[: last_lifecycle_index + 1]):
-            if event.get("type") != "event_msg":
-                continue
-            payload = event.get("payload")
-            if not isinstance(payload, dict) or payload.get("type") != "agent_message":
-                continue
-            candidate_message = payload.get("message")
-            if isinstance(candidate_message, str) and candidate_message:
-                message = candidate_message
-                break
-        if message is None:
-            return None
+def _scan_codex_rollout_completion(
+    events: Sequence[dict[str, Any]],
+) -> _CodexRolloutCompletion | None:
+    """Scan already-parsed rollout events for a stable terminal state.
 
-        fingerprint = events[last_lifecycle_index].get("timestamp")
-        if not isinstance(fingerprint, str) or not fingerprint:
-            return None
-        return _CodexRolloutCompletion(fingerprint=fingerprint, message=message)
+    The last lifecycle event has to be ``task_complete``: a rollout still
+    running, or one whose most recent turn merely started, is not evidence.
+    From there the completion carries the last ``agent_message`` written
+    before that lifecycle event, and the lifecycle event's own timestamp as
+    the fingerprint the watchdog waits to see hold steady across two polls.
+    """
+    last_lifecycle_index, last_lifecycle_type = _last_codex_lifecycle_event(events)
+    if last_lifecycle_type != "task_complete":
+        return None
+
+    message = _last_codex_agent_message(events[: last_lifecycle_index + 1])
+    if message is None:
+        return None
+
+    fingerprint = events[last_lifecycle_index].get("timestamp")
+    if not isinstance(fingerprint, str) or not fingerprint:
+        return None
+    return _CodexRolloutCompletion(fingerprint=fingerprint, message=message)
+
+
+def _last_codex_lifecycle_event(events: Sequence[dict[str, Any]]) -> tuple[int, str | None]:
+    """Return the index and type of the last ``task_started``/``task_complete`` event."""
+    last_index = -1
+    last_type: str | None = None
+    for index, event in enumerate(events):
+        if event.get("type") != "event_msg":
+            continue
+        payload = event.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        payload_type = payload.get("type")
+        if payload_type in {"task_started", "task_complete"}:
+            last_index = index
+            last_type = cast("str", payload_type)
+    return last_index, last_type
+
+
+def _last_codex_agent_message(events: Sequence[dict[str, Any]]) -> str | None:
+    """Return the last non-empty ``agent_message`` text among *events*, if any."""
+    for event in reversed(events):
+        if event.get("type") != "event_msg":
+            continue
+        payload = event.get("payload")
+        if not isinstance(payload, dict) or payload.get("type") != "agent_message":
+            continue
+        candidate_message = payload.get("message")
+        if isinstance(candidate_message, str) and candidate_message:
+            return candidate_message
+    return None
 
 
 def _is_codex_json_command(cmd: Sequence[str]) -> bool:
@@ -567,6 +665,8 @@ def _codex_resume_thread_id(cmd: Sequence[str]) -> str | None:
     except (ValueError, IndexError):
         return None
     if not re.fullmatch(r"[0-9a-fA-F-]{32,64}", thread_id):
+        return None
+    if not _codex_resume_argv_matches(list(cmd), thread_id):
         return None
     return thread_id
 

--- a/tests/e2e/test_agentshim_driver_e2e.py
+++ b/tests/e2e/test_agentshim_driver_e2e.py
@@ -35,6 +35,7 @@ from vibesys.agents.contracts import (
     MCPServerSpec,
     SessionDisposition,
 )
+from vibesys.agents.docker_executor import DockerCommandExecutor
 from vibesys.agents.drivers import agentshim as agentshim_driver
 from vibesys.agents.drivers.agentshim import AgentShimDriver
 from vs_sandbox import HostResource, HostResourceAccess
@@ -327,3 +328,100 @@ def test_a_session_mcp_server_is_reachable_from_inside_confinement(
         _report(f"{provider} mcp", text=result.text, tools=calls, usage=result.usage)
         assert any(_is_add_call(call) for call in calls), calls
         assert "1563554" in result.text.replace(",", "")
+
+
+#: How long the "upstream still broken" probe allows a resumed turn before
+#: concluding it did not exit on its own. The prompts are tiny, so this only
+#: needs to be generous enough to absorb normal CLI startup and model latency.
+_UPSTREAM_PROBE_TIMEOUT_S = 90.0
+
+#: A running container with a working, authenticated ``codex`` install, for
+#: the container variant of the same probe. Unset by default: this is a
+#: separate opt-in from ``VIBESYS_E2E_AGENTS`` because it also requires a
+#: container prepared outside this test run.
+_CODEX_CONTAINER_ENV = "VIBESYS_E2E_CODEX_CONTAINER"
+
+
+def _codex_container_id() -> str | None:
+    return os.environ.get(_CODEX_CONTAINER_ENV)
+
+
+@requires_cli("codex")
+@pytest.mark.usefixtures("agent_env")
+def test_upstream_codex_resume_exit_bug_probe_on_the_host(workspace: Path) -> None:
+    """Whether the resumed-turn-never-exits bug is container-specific.
+
+    ``CodexRolloutWatchdogExecutor`` in ``vibesys.agents.docker_executor``
+    exists because a resumed ``codex exec resume <id> --json`` finishes its
+    turn but never exits *inside a container*. This drives the identical
+    resumed-turn shape through plain ``agentshim.CliAgent`` on the host --
+    no container, no ``DockerCommandExecutor``, no watchdog -- to check
+    whether the same failure to exit also shows up there.
+
+    A PASS here is expected: the bug as documented is container-specific, so
+    the host path should resume and exit normally on its own. A FAILURE
+    (the second turn hangs until ``timeout`` kills it, raising
+    ``agentshim.CliTimeoutError``) means the bug reproduces on the host too,
+    which the watchdog's docstring does not currently account for.
+    """
+    agent = agentshim.CliAgent("codex")
+    first = agent.start_session(cwd=str(workspace)).turn(
+        agentshim.TurnRequest(
+            prompt="Remember the word 'juniper'. Reply with exactly: ok",
+            timeout=_UPSTREAM_PROBE_TIMEOUT_S,
+        )
+    )
+    resumed = agent.start_session(cwd=str(workspace), session_id=first.session_id)
+
+    second = resumed.turn(
+        agentshim.TurnRequest(
+            prompt="What word did I ask you to remember? Reply with just that word.",
+            timeout=_UPSTREAM_PROBE_TIMEOUT_S,
+        )
+    )
+
+    _report("codex host upstream probe", text=second.text, duration_ms=second.duration_ms)
+    assert "juniper" in second.text.lower()
+
+
+@pytest.mark.skipif(
+    not _enabled() or not _codex_container_id(),
+    reason=f"set {ENABLE_ENV}=1 and {_CODEX_CONTAINER_ENV} to a running container with codex",
+)
+@pytest.mark.usefixtures("agent_env")
+def test_watchdog_retire_signal_resumed_codex_turn_exits_on_its_own_in_a_container() -> None:
+    """The real retire signal for ``CodexRolloutWatchdogExecutor``.
+
+    The watchdog (``vibesys.agents.docker_executor.CodexRolloutWatchdogExecutor``)
+    exists only because this does not happen today: a resumed
+    ``codex exec --json`` run inside a container finishes its turn but never
+    exits, so the ``docker exec`` fronting it blocks until the turn budget is
+    spent. This drives that exact shape -- a resumed turn inside a real
+    container, through the plain ``DockerCommandExecutor`` transport, with no
+    watchdog in front of it.
+
+    A PASS means the upstream bug is fixed and the watchdog can be deleted.
+    It is expected to FAIL (the second turn hangs until ``timeout`` kills it)
+    for as long as the bug is present.
+    """
+    container_id = _codex_container_id()
+    assert container_id
+    executor = DockerCommandExecutor(lambda: container_id)
+    agent = agentshim.CliAgent("codex", executor=executor)
+    first = agent.start_session().turn(
+        agentshim.TurnRequest(
+            prompt="Remember the word 'juniper'. Reply with exactly: ok",
+            timeout=TURN_TIMEOUT_S,
+        )
+    )
+    resumed = agent.start_session(session_id=first.session_id)
+
+    second = resumed.turn(
+        agentshim.TurnRequest(
+            prompt="What word did I ask you to remember? Reply with just that word.",
+            timeout=TURN_TIMEOUT_S,
+        )
+    )
+
+    _report("codex container retire-signal", text=second.text, duration_ms=second.duration_ms)
+    assert "juniper" in second.text.lower()

--- a/tests/vibesys/agents/test_docker_executor.py
+++ b/tests/vibesys/agents/test_docker_executor.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 import threading
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from agentshim import (
@@ -17,18 +17,22 @@ from agentshim import (
 from agentshim.testing import FakeExecutor, FakeRun, scripted_turn
 
 from vibesys.agents.docker_executor import (
+    _CODEX_RESUME_TERMINATION_SCRIPT,
     CodexRolloutWatchdogExecutor,
     DockerCommandExecutor,
+    _codex_resume_argv_matches,
     _codex_resume_thread_id,
     _codex_started_thread_id,
     _CodexRolloutCompletion,
+    _discard,
+    _scan_codex_rollout_completion,
     repair_workspace_ownership,
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
-    from agentshim import CommandStreamSink
+    from agentshim import CommandExecutor, CommandStreamSink
 
 THREAD_ID = "019fc654-87f2-7702-8bf2-05b6f4f006dc"
 
@@ -299,13 +303,22 @@ class _StalledExecutor:
         )
 
 
-def _impatient(executor: CodexRolloutWatchdogExecutor) -> CodexRolloutWatchdogExecutor:
-    """Collapse the watchdog's real-time budgets so a test can drive it."""
-    executor.tick_seconds = 0.001
-    executor.rollout_poll_seconds = 0.0
-    executor.completion_grace_seconds = 0.0
-    executor.termination_grace_seconds = 1.0
-    return executor
+def _impatient(
+    inner: CommandExecutor,
+    container_id_resolver: Callable[[], str],
+    *,
+    log: Callable[[str], None] = _discard,
+) -> CodexRolloutWatchdogExecutor:
+    """Build a watchdog with its real-time budgets collapsed so a test can drive it."""
+    return CodexRolloutWatchdogExecutor(
+        inner,
+        container_id_resolver,
+        log=log,
+        tick_seconds=0.001,
+        rollout_poll_seconds=0.0,
+        completion_grace_seconds=0.0,
+        termination_grace_seconds=1.0,
+    )
 
 
 class TestCodexRolloutWatchdog:
@@ -333,6 +346,21 @@ class TestCodexRolloutWatchdog:
 
         assert result.returncode == 7
 
+    def test_default_timing_budgets_are_the_documented_production_values(self) -> None:
+        """A change to these defaults should be deliberate, not incidental.
+
+        Every other test in this module overrides the budgets through
+        ``_impatient`` so it can drive the watchdog without real waits; this
+        is the one test that constructs the executor with no overrides at all
+        and pins what production actually runs with.
+        """
+        executor = CodexRolloutWatchdogExecutor(FakeExecutor(FakeRun()), lambda: "container-123")
+
+        assert executor.tick_seconds == 5.0
+        assert executor.rollout_poll_seconds == 15.0
+        assert executor.completion_grace_seconds == 30.0
+        assert executor.termination_grace_seconds == 5.0
+
     def test_delegates_binary_lookup_and_the_health_check(self) -> None:
         inner = FakeExecutor(FakeRun())
         executor = CodexRolloutWatchdogExecutor(inner, lambda: "container-123")
@@ -357,9 +385,7 @@ class TestCodexRolloutWatchdog:
         )
         inner = _StalledExecutor(stdout=[])
         logs: list[str] = []
-        executor = _impatient(
-            CodexRolloutWatchdogExecutor(inner, lambda: "container-123", log=logs.append)
-        )
+        executor = _impatient(inner, lambda: "container-123", log=logs.append)
         docker_calls: list[list[str]] = []
 
         def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -393,7 +419,7 @@ class TestCodexRolloutWatchdog:
         completion = _CodexRolloutCompletion(fingerprint="ts", message="done")
         # The provider's real stream format, from the library that owns it.
         inner = _StalledExecutor(stdout=list(scripted_turn("codex", session_id=THREAD_ID).stdout))
-        executor = _impatient(CodexRolloutWatchdogExecutor(inner, lambda: "container-123"))
+        executor = _impatient(inner, lambda: "container-123")
         seen_threads: list[str] = []
 
         monkeypatch.setattr(
@@ -419,9 +445,7 @@ class TestCodexRolloutWatchdog:
         """The watchdog killed the run, so the signal it caused is not the answer."""
         inner = _StalledExecutor(stdout=[])
         logs: list[str] = []
-        executor = _impatient(
-            CodexRolloutWatchdogExecutor(inner, lambda: "container-123", log=logs.append)
-        )
+        executor = _impatient(inner, lambda: "container-123", log=logs.append)
 
         monkeypatch.setattr(
             "vibesys.agents.docker_executor.subprocess.run",
@@ -457,9 +481,7 @@ class TestCodexRolloutWatchdog:
         """
         inner = _StalledExecutor(stdout=[], returncode=2)
         logs: list[str] = []
-        executor = _impatient(
-            CodexRolloutWatchdogExecutor(inner, lambda: "container-123", log=logs.append)
-        )
+        executor = _impatient(inner, lambda: "container-123", log=logs.append)
         monkeypatch.setattr(
             executor,
             "_read_codex_rollout_completion",
@@ -493,7 +515,7 @@ class TestCodexRolloutWatchdog:
         """The rollout proves the turn finished, whatever signal stopped the shell."""
         completion = _CodexRolloutCompletion(fingerprint="ts", message="done")
         inner = _StalledExecutor(stdout=[], returncode=-15)
-        executor = _impatient(CodexRolloutWatchdogExecutor(inner, lambda: "container-123"))
+        executor = _impatient(inner, lambda: "container-123")
 
         monkeypatch.setattr(
             "vibesys.agents.docker_executor.subprocess.run",
@@ -653,6 +675,56 @@ class TestCodexRolloutReading:
         assert after.message == "two"
 
 
+def _rollout_event(payload_type: str, timestamp: str, **payload: object) -> dict[str, object]:
+    """One already-parsed ``event_msg`` event, the shape the scanner consumes."""
+    return json.loads(_rollout_line(payload_type, timestamp, **payload))
+
+
+class TestScanCodexRolloutCompletion:
+    """The pure scan over already-parsed rollout events.
+
+    This is the seam the ``_read_codex_rollout_completion`` split created: the
+    docker-exec plumbing (finding the file, tailing it, parsing JSON lines) is
+    exercised through ``TestCodexRolloutReading`` above, and this class drives
+    the terminal-state logic directly on plain event dicts, with no
+    ``subprocess.run`` mocking at all.
+    """
+
+    def test_no_events_is_no_evidence(self) -> None:
+        assert _scan_codex_rollout_completion([]) is None
+
+    def test_a_rollout_still_running_is_no_evidence(self) -> None:
+        events = [
+            _rollout_event("task_started", "2026-08-03T10:00:00.000Z"),
+            _rollout_event("agent_message", "2026-08-03T10:00:01.000Z", message="earlier"),
+        ]
+
+        assert _scan_codex_rollout_completion(events) is None
+
+    def test_a_completed_rollout_reports_its_last_message_and_timestamp(self) -> None:
+        events = [
+            _rollout_event("task_started", "2026-08-03T10:00:00.000Z"),
+            _rollout_event("agent_message", "2026-08-03T10:00:01.000Z", message="first"),
+            _rollout_event("agent_message", "2026-08-03T10:00:02.000Z", message="final"),
+            _rollout_event("task_complete", "2026-08-03T10:00:03.000Z"),
+            # Written after the turn finished, so it is not this turn's answer.
+            _rollout_event("agent_message", "2026-08-03T10:00:04.000Z", message="later"),
+        ]
+
+        assert _scan_codex_rollout_completion(events) == _CodexRolloutCompletion(
+            fingerprint="2026-08-03T10:00:03.000Z",
+            message="final",
+        )
+
+    def test_a_completion_with_no_preceding_message_is_no_evidence(self) -> None:
+        events = [
+            _rollout_event("task_started", "2026-08-03T10:00:00.000Z"),
+            _rollout_event("task_complete", "2026-08-03T10:00:03.000Z"),
+        ]
+
+        assert _scan_codex_rollout_completion(events) is None
+
+
 class TestCodexArgvRecognition:
     """Only a machine-readable Codex exec run is watched."""
 
@@ -678,3 +750,30 @@ class TestCodexArgvRecognition:
             )
             is None
         )
+
+
+class TestCodexResumeArgvMatches:
+    """The one predicate the host and the container termination script share."""
+
+    def test_matches_the_native_binary_and_the_node_wrapper(self) -> None:
+        tail = ["exec", "resume", THREAD_ID, "-", "--json"]
+        assert _codex_resume_argv_matches(["/opt/codex/vendor/codex", *tail], THREAD_ID)
+        assert _codex_resume_argv_matches(["node", "/usr/local/bin/codex", *tail], THREAD_ID)
+
+    def test_rejects_other_shapes(self) -> None:
+        assert not _codex_resume_argv_matches(["codex", "exec", "-", "--json"], THREAD_ID)
+        assert not _codex_resume_argv_matches(
+            ["codex", "exec", "resume", "other", "--json"], THREAD_ID
+        )
+        assert not _codex_resume_argv_matches(["codex", "exec", "resume", THREAD_ID], THREAD_ID)
+        assert not _codex_resume_argv_matches(["bash", "-c", "codex exec resume"], THREAD_ID)
+        assert not _codex_resume_argv_matches([], THREAD_ID)
+
+    def test_the_termination_script_embeds_the_same_predicate(self) -> None:
+        namespace: dict[str, object] = {}
+        header = _CODEX_RESUME_TERMINATION_SCRIPT.split("\nthread_id = ")[0]
+        exec(header, namespace)  # noqa: S102
+        embedded = cast("Callable[[list[str], str], bool]", namespace["_codex_resume_argv_matches"])
+        argv = ["node", "/usr/local/bin/codex", "exec", "resume", THREAD_ID, "-", "--json"]
+        assert embedded(argv, THREAD_ID) is True
+        assert embedded(argv[:-1], THREAD_ID) is False


### PR DESCRIPTION
## Problem

`CodexRolloutWatchdogExecutor` (the documented stopgap for a resumed `codex exec --json` run that finishes inside a container but never exits) had three hygiene problems found in the integration audit. Its four timing budgets were class attributes that tests mutated after construction, so no test ever constructed the executor with production values. `_read_codex_rollout_completion` carried a `C901, PLR0912` waiver. Process matching was implemented twice, and the container-side termination script matched looser than the host-side predicate. Nothing signalled when the upstream bug is fixed, so the watchdog would never be retired. Second PR in the stack on #668, based on #669.

## Solution

- Timing budgets are keyword-only constructor parameters with the documented defaults; a test pins the defaults so a change is deliberate.
- The rollout reader is split into locate, tail, and a pure scan over parsed events, with unit tests on the pure seam; the waiver is gone.
- One predicate, `_codex_resume_argv_matches`, decides what a resumed Codex process looks like. The termination script embeds its source verbatim, so host and container cannot drift, and it tolerates the `node /usr/local/bin/codex ...` wrapper a container really runs (the Docker headless round showed both the wrapper and the native child). `pgrep -f` stays for the coarse liveness check, with a comment on why the precision differs.
- Two opt-in e2e probes in `tests/e2e/test_agentshim_driver_e2e.py` drive a resumed Codex turn with no watchdog: on the host (expected to pass) and in a container named by `VIBESYS_E2E_CODEX_CONTAINER` (expected to fail while the bug persists; a pass means the watchdog can be deleted).

### Architecture

No boundary changes. The watchdog stays in VibeSys as provider-behaviour compensation, per "Container execution" in `docs/contributing/agent-drivers.md`.

## Verification

### Correctness properties

- Default timing budgets are 5 s tick, 15 s rollout poll, 30 s completion grace, 5 s termination grace.
- A resumed Codex process is matched only when the binary basename is `codex` (after an optional interpreter), `exec` and `--json` are present, and the thread id immediately follows `resume`; the native binary and the node wrapper both match.
- The scan reports a terminal state only after `task_complete` with a stable last agent message.

### Testing

```
uv run ruff check src/vibesys/agents/docker_executor.py tests/vibesys/agents/test_docker_executor.py tests/e2e/test_agentshim_driver_e2e.py
uv run ruff format --check <same files>
scripts/check_types.sh
uv run pytest -q tests/vibesys/agents/test_docker_executor.py tests/vibesys/agents/drivers -n auto   # 258 passed, 3 skipped
```

The e2e probes were collected, not run; they are opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
