### PR TITLE
State VibeSys's provider decisions in one module and guard it

### DIFF
--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
 from vibesys import boot_trace
+from vibesys.agents.provider_policy import SHIPPED_PROVIDERS
 from vibesys.config import Config, load_config
 from vibesys.constants import (
     KNOWN_COMPUTE_BACKENDS,
@@ -620,7 +621,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--cli-provider",
-        choices=["claude", "gemini", "codex", "opencode"],
+        choices=list(SHIPPED_PROVIDERS),
         default=None,
         help=(
             "Which CLI tool to drive when --agent-backend=cli. Overrides "

--- a/src/vibesys/agents/cli_common.py
+++ b/src/vibesys/agents/cli_common.py
@@ -17,19 +17,16 @@ from typing import TextIO
 from pydantic import BaseModel  # noqa: TC002  # tracked: #288
 
 from vibesys.agent_runner import log_and_print
+from vibesys.agents.provider_policy import cli_skill_dirs
 from vibesys.constants import ComputeBackend  # noqa: TC001  # tracked: #288
 from vibesys.skills import foreign_platform_names, is_platforms_parent
 
 # Per-provider CLI skill-discovery paths, matching upstream
-# vibesys-skills install.sh conventions. Each CLI tool auto-loads
-# skills from a flat directory of `<skill-name>/SKILL.md`.
-CLI_SKILL_DIRS: tuple[str, ...] = (
-    ".claude/skills",
-    ".agents/skills",
-    ".gemini/skills",
-    ".cursor/skills",
-    ".opencode/skills",
-)
+# vibesys-skills install.sh conventions. Each CLI tool auto-loads skills from
+# a flat directory of `<skill-name>/SKILL.md`. Derived from the shipped
+# providers' agentshim profiles (plus the VibeSys-only Cursor addition) so a
+# new shipped provider's convention is not hand-copied here.
+CLI_SKILL_DIRS: tuple[str, ...] = cli_skill_dirs()
 
 
 def agent_label(kind: str) -> str:
@@ -77,13 +74,12 @@ def materialize_skills(  # noqa: C901  # tracked: #288
 
     Walks each ``skill_dirs`` entry for ``SKILL.md`` files and flattens each
     parent directory into the workspace root and every path under
-    :data:`CLI_SKILL_DIRS` (one per CLI convention: ``.claude/skills``,
-    ``.agents/skills``, ``.gemini/skills``, ``.cursor/skills``,
-    ``.opencode/skills``). The root copy preserves the documented
-    ``<skill-name>/references/...`` paths used by prompts and agents, while the
-    hidden copies support native CLI discovery. When a compute backend is set,
-    foreign ``references/platforms/<backend>/`` directories are omitted from
-    every materialized copy.
+    :data:`CLI_SKILL_DIRS` (one per shipped provider's skill-discovery
+    convention, plus the VibeSys-only ``.cursor/skills``). The root copy
+    preserves the documented ``<skill-name>/references/...`` paths used by
+    prompts and agents, while the hidden copies support native CLI discovery.
+    When a compute backend is set, foreign ``references/platforms/<backend>/``
+    directories are omitted from every materialized copy.
 
     Existing destinations are replaced on every invocation so skill edits are
     picked up across iterations and after candidate checkpoint rollback. Errors

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -2,10 +2,12 @@
 
 Provider facts come from ``agentshim``'s ``ProviderProfile`` at call time:
 state directories, auth environment variables, and the CLI's own container
-install recipe. What stays here is VibeSys policy: the environment a VibeSys
-container needs, the toolchain a candidate repository needs, which leaf files
-inside a provider state directory carry credentials, and the overrides VibeSys
-applies to a library recipe.
+install recipe. What stays here is VibeSys policy that is not itself a
+provider *decision*: which leaf files inside a provider state directory carry
+credentials, the toolchain a candidate repository needs, and the overrides
+VibeSys applies to a library recipe. The container environment table and the
+Codex CLI version pin are provider decisions and live in
+:mod:`vibesys.agents.provider_policy`; this module imports them.
 """
 
 from __future__ import annotations
@@ -17,31 +19,16 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from vibesys.agents import provider_profiles
+from vibesys.agents.provider_policy import (
+    CODEX_DOCKER_CLI_VERSION,
+    DOCKER_PROVIDER_ENV,
+)
 
-# Per-provider environment variables to set inside the container.  Used as
-# the canonical "supported with --docker" registry — providers absent from
-# this dict are rejected up front in ``build_agent_client``.
-#
-# Claude Code refuses ``--dangerously-skip-permissions`` when running as
-# root unless ``IS_SANDBOX=1`` is set, so we set it here.  We run everything
-# as root inside the container (the default) to avoid uv/pip permission
-# errors when the agent installs packages.
-# Every provider also gets ``PYTHONPATH=/opt/vibesys`` so the in-container
-# CLI can spawn ``python -m vs_issue_board.mcp`` against the
-# bind-mounted project root (added in ``DockerSandbox.start`` for all four
-# CLI providers). Without this the MCP server module wouldn't be importable
-# inside the container.
-DOCKER_PROVIDER_ENV: dict[str, dict[str, str]] = {
-    "claude": {"IS_SANDBOX": "1", "PYTHONPATH": "/opt/vibesys"},
-    "gemini": {"PYTHONPATH": "/opt/vibesys"},
-    "codex": {"PYTHONPATH": "/opt/vibesys"},
-    "opencode": {"PYTHONPATH": "/opt/vibesys"},
-}
-
-
-# Keep the editor container aligned with the verified host CLI feature set.
-# Luna and its Max reasoning level require a newer CLI than the old 0.125 pin.
-CODEX_DOCKER_CLI_VERSION = "0.144.4"
+# Re-exported for existing importers (``vibesys.agents.factory``,
+# ``vibesys.sandbox.run_environment``, and this module's own tests reach them
+# as ``cli_docker.DOCKER_PROVIDER_ENV`` / ``cli_docker.CODEX_DOCKER_CLI_VERSION``);
+# the values themselves live in ``provider_policy`` now.
+__all__ = ["CODEX_DOCKER_CLI_VERSION", "DOCKER_PROVIDER_ENV"]
 
 # Native implementations are valid candidate designs across domains, so the
 # editor container must be able to build and test them before paid target work.

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -32,6 +32,7 @@ from vibesys.agents.contracts import (
     SessionDisposition,
     session_spec_fingerprint,
 )
+from vibesys.agents.provider_policy import DEFAULT_CLI_PROVIDER
 from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.agents.session_store import NullSessionStore, SessionStore
 from vibesys.run.events import CommandResultPayload, JsonResultPayload
@@ -227,7 +228,7 @@ class AgentClient:
     @property
     def provider(self) -> str | None:
         """Return the configured CLI provider (``"codex"``, ``"claude"``, ...)."""
-        return self._provider or "codex"
+        return self._provider or DEFAULT_CLI_PROVIDER
 
     def model_for_kind(self, kind: str) -> str | None:
         """Return the effective model for ``kind``, honoring role overrides."""
@@ -364,7 +365,7 @@ class AgentClient:
         reasoning_effort = self._role_reasoning_efforts.get(kind, self._default_reasoning_effort)
         spec = AgentSessionSpec(
             role=kind,
-            provider=self._provider or "codex",
+            provider=self._provider or DEFAULT_CLI_PROVIDER,
             workspace=workspace,
             policy=self._policy,
             model=model,

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -35,6 +35,7 @@ from vibesys.agents.contracts import (
     SessionDisposition,
 )
 from vibesys.agents.host_resource_declarations import declare_agent_host_resources
+from vibesys.agents.provider_policy import SHIPPED_PROVIDERS, is_codex
 from vibesys.run.events import CommandResultPayload
 from vs_sandbox import build_host_sandbox
 
@@ -57,13 +58,6 @@ AGENTSHIM_CAPABILITIES = AgentCapabilities(
 
 ``provider_session_resume`` is narrowed per provider from
 :attr:`agentshim.ProviderProfile.supports_resume` when the driver is built.
-"""
-
-_SHIPPED_PROVIDERS: tuple[str, ...] = ("claude", "codex", "gemini", "opencode")
-"""The CLI providers VibeSys ships.
-
-The library also carries ``copilot``, which VibeSys has neither host-resource
-declarations nor a container install recipe for, so it is not offered here.
 """
 
 _PYTHON_MCP_COMMANDS = frozenset({"python", "python3"})
@@ -90,7 +84,7 @@ _MAX_CODEX_SESSION_DURATION_MS = 600_000
 
 def supported_providers() -> list[str]:
     """Return the sorted provider names the AgentShim driver can run."""
-    return sorted(_SHIPPED_PROVIDERS)
+    return sorted(SHIPPED_PROVIDERS)
 
 
 def _ignore_log(_message: str) -> None:
@@ -557,7 +551,7 @@ class AgentShimSession:
         usage of the turn that just finished and the caller learns about the
         restart from that turn's result instead of discovering it on the next.
         """
-        if self._profile.name != "codex":
+        if not is_codex(self._profile.name):
             return False
         reason = (
             f"{_MAX_CODEX_SESSION_TURNS} successful turns"
@@ -646,7 +640,7 @@ class AgentShimDriver:
         mode's budget: a container check crosses a ``docker exec`` and is given
         four times as long as a host one.
         """
-        if provider not in _SHIPPED_PROVIDERS:
+        if provider not in SHIPPED_PROVIDERS:
             raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"unknown AgentShim provider {provider!r}; expected one of: {supported_providers()}"
             )
@@ -798,7 +792,7 @@ class AgentShimDriver:
         executor: agentshim.CommandExecutor = DockerCommandExecutor(
             resolve, forward_env=forward_env
         )
-        if self._provider == "codex":
+        if is_codex(self._provider):
             # A resumed containerized `codex exec --json` regularly finishes
             # its work and then never exits; the watchdog recovers the answer
             # from the rollout file and stops the process. Provider-behaviour

--- a/src/vibesys/agents/factory.py
+++ b/src/vibesys/agents/factory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from vibesys.agents.client import AgentClient, AgentDiagnosticLog
+from vibesys.agents.provider_policy import DEFAULT_CLI_PROVIDER
 from vibesys.constants import DEFAULT_AGENT_BACKEND
 
 if TYPE_CHECKING:
@@ -148,7 +149,7 @@ def build_agent_client(  # noqa: C901, PLR0912, PLR0913
         raise SystemExit(f"unknown agent backend: {backend!r}")  # noqa: TRY003  # tracked: #288
 
     driver_name = resolve_agent_driver(config)
-    provider = cli_provider or agent_cfg.cli_provider or "codex"
+    provider = cli_provider or agent_cfg.cli_provider or DEFAULT_CLI_PROVIDER
     timeout = agent_cfg.cli_timeout
     driver_log = AgentDiagnosticLog(run_log_file)
 

--- a/src/vibesys/agents/host_resource_declarations.py
+++ b/src/vibesys/agents/host_resource_declarations.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import vibesys
 from vibesys.agents import provider_profiles
+from vibesys.agents.provider_policy import is_codex
 from vs_sandbox import (
     HostResource,
     HostResourceAccess,
@@ -215,7 +216,7 @@ _NARROWED_STATE_DIRS: dict[str, tuple[str, ...]] = {
 
 
 def _state_root(state_dir: str, *, home: Path, ctx: HostResourceContext) -> Path:
-    if state_dir == _CODEX_DEFAULT_HOME and ctx.provider == "codex":
+    if state_dir == _CODEX_DEFAULT_HOME and is_codex(ctx.provider):
         return Path(ctx.env.get("CODEX_HOME", home / _CODEX_DEFAULT_HOME)).expanduser()
     return home / state_dir
 

--- a/src/vibesys/agents/provider_policy.py
+++ b/src/vibesys/agents/provider_policy.py
@@ -1,0 +1,105 @@
+"""VibeSys's own provider decisions.
+
+``agentshim`` (read through :mod:`vibesys.agents.provider_profiles`) owns what
+a provider *is*: its binary, state directories, auth environment variables,
+skill-discovery paths, and container install recipe. This module owns what
+VibeSys *decides* to do with that: which providers it ships, what a shipped
+provider's container environment needs, which CLI version its container image
+pins, and which VibeSys behaviors are scoped to a single provider.
+
+Before this module existed, several of these decisions were copied by hand
+into the modules that needed them (a shipped-provider tuple in the AgentShim
+driver, a ``--cli-provider`` choices list in the headless entrypoint, a
+container-env table in ``cli_docker``). Every module that would otherwise
+repeat one of those decisions as a literal imports it from here instead, so a
+new decision (or a change to an existing one) has one place to make it.
+"""
+
+from __future__ import annotations
+
+from vibesys.agents import provider_profiles
+
+SHIPPED_PROVIDERS: tuple[str, ...] = ("claude", "codex", "gemini", "opencode")
+"""The CLI providers VibeSys ships.
+
+agentshim also registers ``copilot``, which VibeSys has neither host-resource
+declarations nor a container install recipe for, so it is not offered here.
+"""
+
+DEFAULT_CLI_PROVIDER = "codex"
+"""The CLI provider selected when neither a flag nor config names one."""
+
+
+def is_codex(provider: str | None) -> bool:
+    """Whether *provider* is Codex (``None``, an unset provider, is not).
+
+    A few VibeSys behaviors are deliberately scoped to Codex alone: its
+    session turn/token/duration budget (``AgentShimSession`` retires the
+    thread rather than letting it run unbounded) and the containerized
+    rollout watchdog that compensates for a resumed ``codex exec --json``
+    that finishes its work but never exits. Naming the check here means a
+    driver branches on a documented VibeSys decision instead of repeating the
+    provider's literal name at each call site.
+    """
+    return provider == "codex"
+
+
+# --- Docker container environment -------------------------------------------
+
+_COMMON_DOCKER_ENV: dict[str, str] = {"PYTHONPATH": "/opt/vibesys"}
+"""Every shipped provider's container CLI needs this so it can spawn
+``python -m vs_issue_board.mcp`` against the bind-mounted project root (added
+in ``DockerSandbox.start`` for all four CLI providers). Without it the MCP
+server module would not be importable inside the container."""
+
+# Claude Code refuses ``--dangerously-skip-permissions`` when running as root
+# unless ``IS_SANDBOX=1`` is set, and VibeSys runs every container provider as
+# root (the default) to avoid uv/pip permission errors when the agent installs
+# packages. A later agentshim release is expected to set this itself; keeping
+# it in its own constant means dropping it later is a one-line change instead
+# of a hunt through ``DOCKER_PROVIDER_ENV``.
+_CLAUDE_CONTAINER_SANDBOX_ENV: dict[str, str] = {"IS_SANDBOX": "1"}
+
+DOCKER_PROVIDER_ENV: dict[str, dict[str, str]] = {
+    "claude": {**_COMMON_DOCKER_ENV, **_CLAUDE_CONTAINER_SANDBOX_ENV},
+    "gemini": dict(_COMMON_DOCKER_ENV),
+    "codex": dict(_COMMON_DOCKER_ENV),
+    "opencode": dict(_COMMON_DOCKER_ENV),
+}
+"""Per-provider environment variables to set inside the container.
+
+Used as the canonical "supported with --docker" registry: providers absent
+from this dict are rejected up front in ``build_agent_client``.
+"""
+
+CODEX_DOCKER_CLI_VERSION = "0.144.4"
+"""Keep the editor container aligned with the verified host CLI feature set.
+
+Luna and its Max reasoning level require a newer CLI than the old 0.125 pin.
+"""
+
+
+# --- Skill discovery ---------------------------------------------------------
+
+_CURSOR_SKILL_DIR = ".cursor/skills"
+"""VibeSys-only addition: agentshim registers no Cursor provider (Cursor's
+agent mode is not a CLI VibeSys drives), but Cursor discovers skills from the
+same flat ``<name>/SKILL.md`` convention the shipped CLIs use, so VibeSys
+mirrors skills there too."""
+
+
+def cli_skill_dirs() -> tuple[str, ...]:
+    """Return every CLI skill-discovery path VibeSys mirrors skills into.
+
+    The union of each shipped provider's ``ProviderProfile.skill_dirs``, in
+    :data:`SHIPPED_PROVIDERS` order, plus :data:`_CURSOR_SKILL_DIR`. Resolved
+    at call time (through :mod:`vibesys.agents.provider_profiles`) so a
+    library upgrade that adds or moves a provider's skill directory changes
+    VibeSys behavior without an edit here.
+    """
+    seen: dict[str, None] = {}
+    for provider in SHIPPED_PROVIDERS:
+        for skill_dir in provider_profiles.provider_profile(provider).skill_dirs:
+            seen.setdefault(skill_dir, None)
+    seen.setdefault(_CURSOR_SKILL_DIR, None)
+    return tuple(seen)

--- a/src/vibesys/run/workspace.py
+++ b/src/vibesys/run/workspace.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from vibesys.agents.provider_policy import cli_skill_dirs
 from vibesys.input_manifest import WorkspaceSource
 from vibesys.input_project import materialize_input_project
 from vibesys.skills import foreign_platform_names, is_platforms_parent
@@ -51,14 +52,9 @@ EXCLUDED_WORKSPACE_DIRS: frozenset[str] = frozenset(
     }
 )
 
-# Skill destinations mirrored by materialize_skills in agents.cli_common.
-_CLI_SKILL_DIRS: tuple[str, ...] = (
-    ".agents/skills",
-    ".claude/skills",
-    ".gemini/skills",
-    ".cursor/skills",
-    ".opencode/skills",
-)
+# Skill destinations mirrored by materialize_skills in agents.cli_common; both
+# derive from the same vibesys.agents.provider_policy.cli_skill_dirs union.
+_CLI_SKILL_DIRS: tuple[str, ...] = cli_skill_dirs()
 
 
 @dataclass(frozen=True)

--- a/tests/vibesys/agents/test_provider_policy.py
+++ b/tests/vibesys/agents/test_provider_policy.py
@@ -1,0 +1,111 @@
+"""Guard against re-scattering VibeSys's provider decisions.
+
+``vibesys.agents.provider_policy`` is the one place VibeSys states which CLI
+providers it ships and what it decides to do with them. Before it existed,
+the same provider-name literals were hand-copied across the AgentShim driver,
+``cli_docker``, and the headless entrypoint's ``--cli-provider`` flag, and
+those copies could silently drift from each other. This test scans the
+source for a shipped-provider literal appearing anywhere it should instead be
+a reference to ``provider_policy`` (or, for the omnigent integration, to
+Omnigent's own provider registry), so a future edit that reintroduces one of
+these literals fails here instead of drifting quietly again.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+
+import agentshim
+
+from vibesys.agents.provider_policy import SHIPPED_PROVIDERS
+from vibesys.constants import PROJECT_ROOT
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_PROVIDER_LITERALS = frozenset({"claude", "codex", "gemini", "opencode", "copilot"})
+
+_SCAN_ROOTS = (
+    PROJECT_ROOT / "src" / "vibesys" / "agents",
+    PROJECT_ROOT / "src" / "entrypoints",
+)
+
+# Files (or directories) exempt from the "no bare provider literal" rule, and
+# why. Each entry maps a path (relative to the repository root, POSIX-style)
+# to either ``None`` (every occurrence in the file is exempt) or a frozenset
+# of the specific literals that are exempt there; any other literal in that
+# file still fails.
+_ALLOWED_LITERALS_BY_PATH: dict[str, frozenset[str] | None] = {
+    # The seam that reads agentshim's own provider facts, and the module this
+    # test is guarding, both are expected to name providers directly.
+    "src/vibesys/agents/provider_policy.py": None,
+    "src/vibesys/agents/provider_profiles.py": None,
+    # Omnigent 0.10 supports exactly claude and codex and exposes no
+    # provider-name abstraction of its own; this driver and its package
+    # branch on Omnigent's own per-provider attributes (its executor
+    # registry, its MCP translation), not on a VibeSys provider decision, so
+    # routing them through vibesys.agents.provider_policy would misstate
+    # ownership.
+    "src/vibesys/agents/drivers/omnigent.py": None,
+    # docker_executor.py: the Codex rollout watchdog recognizes a resumed
+    # `codex exec --json` process and rollout file by name. It is documented
+    # provider-behaviour compensation that "stays in VibeSys until the
+    # behaviour is verified fixed upstream" (docs/contributing/agent-drivers.md).
+    "src/vibesys/agents/docker_executor.py": frozenset({"codex"}),
+}
+
+_ALLOWED_DIR_PREFIXES = ("src/vibesys/agents/omnigent/",)
+
+
+def _relative_posix(path: Path) -> str:
+    return path.relative_to(PROJECT_ROOT).as_posix()
+
+
+def _iter_python_files() -> list[Path]:
+    files: list[Path] = []
+    for root in _SCAN_ROOTS:
+        files.extend(sorted(root.rglob("*.py")))
+    return files
+
+
+def _string_constants(tree: ast.AST) -> list[tuple[int, str]]:
+    return [
+        (node.lineno, node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    ]
+
+
+def _violations() -> list[str]:
+    problems: list[str] = []
+    for path in _iter_python_files():
+        rel = _relative_posix(path)
+        if any(rel.startswith(prefix) for prefix in _ALLOWED_DIR_PREFIXES):
+            continue
+        allowed = _ALLOWED_LITERALS_BY_PATH.get(rel, frozenset())
+        if allowed is None:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for lineno, value in _string_constants(tree):
+            if value not in _PROVIDER_LITERALS:
+                continue
+            if value in allowed:
+                continue
+            problems.append(f"{rel}:{lineno}: bare provider literal {value!r}")
+    return problems
+
+
+def test_no_bare_provider_literals_outside_the_allowlist() -> None:
+    """Every shipped-provider string outside the allowlist must route through
+    ``provider_policy`` (a constant, a predicate, or a profile lookup)."""
+    violations = _violations()
+    assert not violations, (
+        "found provider-name literal(s) that should route through "
+        "vibesys.agents.provider_policy instead:\n" + "\n".join(violations)
+    )
+
+
+def test_shipped_providers_are_registered_with_agentshim() -> None:
+    """VibeSys cannot ship a provider the library does not know about."""
+    assert set(SHIPPED_PROVIDERS) <= set(agentshim.provider_names())


### PR DESCRIPTION
## Problem

VibeSys's own provider decisions were scattered as literals: the shipped-provider list lived in the AgentShim driver, the `--cli-provider` choices in the headless entrypoint, and the container env table in `cli_docker.py`, with the Codex version pin next to it. Skill directories were hand-copied in `cli_common.py` and `run/workspace.py` even though agentshim's `ProviderProfile.skill_dirs` already provides them. Nothing failed when a new copy appeared, which is how the old `_agent_cli` fork grew. Third PR in the stack on #668, based on #670.

## Solution

- New `src/vibesys/agents/provider_policy.py`: `SHIPPED_PROVIDERS`, `DEFAULT_CLI_PROVIDER`, `is_codex()`, `DOCKER_PROVIDER_ENV` (the common `PYTHONPATH` plus Claude's `IS_SANDBOX=1` in its own constant, so it is a one-line deletion once agentshim carries it), `CODEX_DOCKER_CLI_VERSION`, and `cli_skill_dirs()`, the union of the shipped profiles' skill dirs plus `.cursor/skills`.
- `provider_profiles.py` stays the read-only seam for library facts; the two are not merged.
- Consumers import from the policy module: the driver, `cli_docker.py` (re-exports the two names its callers use), `factory.py`, `client.py`, `headless.py`, `cli_common.py`, `run/workspace.py`, and `host_resource_declarations.py` (`is_codex`).
- Guard test `tests/vibesys/agents/test_provider_policy.py` walks every module under `src/vibesys/agents` and `src/entrypoints` with `ast` and fails on a bare provider literal outside the allowlist: the policy module, the profile seam, the omnigent driver and package (they branch on omnigent's own registry), and `docker_executor.py` for `"codex"` only (the documented watchdog stopgap). It also asserts the shipped set is a subset of `agentshim.provider_names()`.

No behaviour change: the shipped set, env values, version pin, and skill directory set are identical before and after (checked by assertion during the change).

### Architecture

Ownership stays as documented in "Where agentshim lives": agentshim owns what a provider is, VibeSys owns what it decides to do with it. This PR gives the second half one home and a test that keeps it there.

## Verification

### Correctness properties

- Every provider literal in the agents package and entrypoints is either in the policy module or on the allowlist with a stated reason.
- `cli_skill_dirs()` contains each shipped profile's skill dirs and `.cursor/skills`, in stable order, with no duplicates.
- `is_codex(None)` is false, so an unset provider never triggers Codex-only behaviour.

### Testing

```
uv run ruff check <changed files>          # All checks passed
uv run ruff format --check <changed files> # already formatted
scripts/check_types.sh                     # All checks passed
uv run lint-imports                        # Contracts: 2 kept, 0 broken
uv run pytest -q tests/vibesys/agents tests/vibesys/run tests/entrypoints -n auto   # 849 passed, 4 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
