### PR TITLE
Consume agentshim 0.6.1 and delete the provider tables it replaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "agentshim>=0.6.0,<0.7",
+    "agentshim>=0.6.1,<0.7",
     "cbor2<6",
     "cryptography<50",
     "deepagents",

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -1,13 +1,13 @@
 """Docker configuration for CLI agent providers.
 
 Provider facts come from ``agentshim``'s ``ProviderProfile`` at call time:
-state directories, auth environment variables, and the CLI's own container
-install recipe. What stays here is VibeSys policy that is not itself a
-provider *decision*: which leaf files inside a provider state directory carry
-credentials, the toolchain a candidate repository needs, and the overrides
-VibeSys applies to a library recipe. The container environment table and the
-Codex CLI version pin are provider decisions and live in
-:mod:`vibesys.agents.provider_policy`; this module imports them.
+state directories, auth environment variables, which files carry credentials,
+and the CLI's own container install recipe. What stays here is VibeSys policy
+that is not itself a provider *decision*: the toolchain a candidate
+repository needs, and the overrides VibeSys applies to a library recipe. The
+container environment table and the Codex CLI version pin are provider
+decisions and live in :mod:`vibesys.agents.provider_policy`; this module
+imports them.
 """
 
 from __future__ import annotations
@@ -167,58 +167,26 @@ class DockerAuthPath:
     container_path: str
 
 
-# Which leaf files VibeSys stages out of each provider state directory named by
-# ``ProviderProfile.state_dirs``.
-#
-# The profile names directories; those directories also hold caches,
-# worktrees, session history, package installations, and databases that are
-# neither required for authentication nor appropriate to duplicate for every
-# sandbox. ``None`` marks a state entry that is itself a single file and is
-# staged as-is. A state directory with no entry here stages nothing.
-#
-# This is the one piece of per-provider knowledge that did not move to the
-# library: ``ProviderProfile`` carries no "which files hold credentials" field.
-# An ``auth_files`` tuple per state directory would let this table go away.
-_AUTH_LEAF_FILES: dict[str, tuple[str, ...] | None] = {
-    ".claude": (".credentials.json", "settings.json", "settings.local.json"),
-    ".claude.json": None,
-    ".gemini": ("oauth_creds.json", "google_accounts.json", "settings.json", ".env"),
-    ".codex": ("auth.json", "config.toml"),
-    ".local/share/opencode": ("auth.json",),
-    ".config/opencode": (
-        "opencode.json",
-        "opencode.jsonc",
-        # Older OpenCode releases used config.json/config.jsonc.
-        "config.json",
-        "config.jsonc",
-        ".env",
-    ),
-}
-
-
 def auth_paths(provider: str) -> list[DockerAuthPath]:
     """Return the provider state files to stage into a container, in order.
 
     Authentication and user configuration are mounted read-only under
     ``/opt/vibesys-auth`` and copied into the container's ephemeral writable
-    layer before the CLI starts.
+    layer before the CLI starts. Which home-relative paths those are comes
+    straight from ``ProviderProfile.auth_files`` (agentshim 0.6.1+): each
+    entry is either a state directory's leaf file or a state entry that is
+    itself a single file, and is staged at the same relative path under
+    ``/root``. A state directory the profile does not list a leaf for
+    contributes nothing.
 
     Raises:
         ValueError: if agentshim does not register *provider*.
     """
     home = Path.home()
-    paths: list[DockerAuthPath] = []
-    for state_dir in provider_profiles.provider_profile(provider).state_dirs:
-        if state_dir not in _AUTH_LEAF_FILES:
-            continue
-        leaves = _AUTH_LEAF_FILES[state_dir]
-        if leaves is None:
-            paths.append(DockerAuthPath(home / state_dir, f"/root/{state_dir}"))
-            continue
-        paths.extend(
-            DockerAuthPath(home / state_dir / leaf, f"/root/{state_dir}/{leaf}") for leaf in leaves
-        )
-    return paths
+    return [
+        DockerAuthPath(home / auth_file, f"/root/{auth_file}")
+        for auth_file in provider_profiles.provider_profile(provider).auth_files
+    ]
 
 
 def auth_env_vars(provider: str) -> tuple[str, ...]:

--- a/src/vibesys/agents/host_resource_declarations.py
+++ b/src/vibesys/agents/host_resource_declarations.py
@@ -14,10 +14,10 @@ import subprocess
 import sys
 from collections.abc import Iterable, Mapping  # noqa: TC003  # tracked: #288
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import vibesys
 from vibesys.agents import provider_profiles
-from vibesys.agents.provider_policy import is_codex
 from vs_sandbox import (
     HostResource,
     HostResourceAccess,
@@ -25,6 +25,9 @@ from vs_sandbox import (
     HostResourceDeclarer,
     declare_resources,
 )
+
+if TYPE_CHECKING:
+    from agentshim import ProviderProfile
 
 ALLOW_ENV = "VIBESYS_AGENT_SANDBOX_ALLOW"
 
@@ -191,19 +194,21 @@ def _agent_runtime(ctx: HostResourceContext) -> Iterable[HostResource]:
     return _resources(paths, purpose="agent and VibeSys runtime")
 
 
-#: Codex relocates its whole state tree when ``CODEX_HOME`` is set. The profile
-#: names the default location; VibeSys knows which environment variable moves
-#: it, because ``ProviderProfile`` carries no "state root variable" field.
-_CODEX_DEFAULT_HOME = ".codex"
-
 #: State directories granted as named leaves rather than whole.
 #:
-#: A Codex checkout may itself live under ``$CODEX_HOME/worktrees``: granting
-#: the directory would expose sibling tasks to the agent, while dropping it
-#: makes the CLI appear logged out inside confinement (#185). Bubblewrap
-#: creates the ephemeral parent directory these leaf mounts need. Every other
-#: state directory is granted whole, because a CLI writes session history and
-#: caches there and needs them back on resume.
+#: This is VibeSys sandbox policy, not a provider fact: a Codex checkout may
+#: itself live under the CLI's own state root (``$CODEX_HOME/worktrees`` by
+#: default), so granting the directory would expose sibling tasks to the
+#: agent, while dropping it makes the CLI appear logged out inside
+#: confinement (#185). Bubblewrap creates the ephemeral parent directory
+#: these leaf mounts need. Every other state directory is granted whole,
+#: because a CLI writes session history and caches there and needs them back
+#: on resume.
+#:
+#: Keyed on the profile's *default* directory name, ``.codex``, regardless of
+#: where ``CODEX_HOME`` relocates it at runtime: :func:`_state_root` resolves
+#: the actual root, and this table only says which leaves of Codex's state
+#: directory are narrowed once that root is known.
 #:
 #: ``sessions`` is that session history for Codex. Without it the rollout a
 #: turn writes lands in the sandbox's ephemeral view of ``$CODEX_HOME`` and is
@@ -211,13 +216,29 @@ _CODEX_DEFAULT_HOME = ".codex"
 #: thread, the driver restarts the conversation, and a confined run silently
 #: loses continuity it was told it had.
 _NARROWED_STATE_DIRS: dict[str, tuple[str, ...]] = {
-    _CODEX_DEFAULT_HOME: ("auth.json", "config.toml", "sessions"),
+    ".codex": ("auth.json", "config.toml", "sessions"),
 }
 
 
-def _state_root(state_dir: str, *, home: Path, ctx: HostResourceContext) -> Path:
-    if state_dir == _CODEX_DEFAULT_HOME and is_codex(ctx.provider):
-        return Path(ctx.env.get("CODEX_HOME", home / _CODEX_DEFAULT_HOME)).expanduser()
+def _state_root(
+    state_dir: str, *, home: Path, ctx: HostResourceContext, profile: ProviderProfile
+) -> Path:
+    """Return where *state_dir* actually lives, honoring the CLI's own relocation variable.
+
+    ``ProviderProfile.state_root_env`` (agentshim 0.6.1+) names the
+    environment variable a CLI documents for relocating its primary state
+    directory, ``state_dirs[0]`` (``CLAUDE_CONFIG_DIR`` for Claude,
+    ``CODEX_HOME`` for Codex; ``None`` for a provider that documents none).
+    Only that first directory can move this way, and only when the run
+    environment actually sets the variable; every other state directory, and
+    every provider with no such variable, stays under ``home``.
+    """
+    if (
+        profile.state_root_env
+        and state_dir == profile.state_dirs[0]
+        and profile.state_root_env in ctx.env
+    ):
+        return Path(ctx.env[profile.state_root_env]).expanduser()
     return home / state_dir
 
 
@@ -238,7 +259,7 @@ def _provider_state(ctx: HostResourceContext) -> Iterable[HostResource]:
 
     paths: list[Path] = []
     for state_dir in state_dirs:
-        root = _state_root(state_dir, home=Path(home), ctx=ctx)
+        root = _state_root(state_dir, home=Path(home), ctx=ctx, profile=profile)
         leaves = _NARROWED_STATE_DIRS.get(state_dir)
         if leaves is None:
             paths.append(root)

--- a/src/vibesys/agents/provider_policy.py
+++ b/src/vibesys/agents/provider_policy.py
@@ -55,16 +55,16 @@ server module would not be importable inside the container."""
 # Claude Code refuses ``--dangerously-skip-permissions`` when running as root
 # unless ``IS_SANDBOX=1`` is set, and VibeSys runs every container provider as
 # root (the default) to avoid uv/pip permission errors when the agent installs
-# packages. A later agentshim release is expected to set this itself; keeping
-# it in its own constant means dropping it later is a one-line change instead
-# of a hunt through ``DOCKER_PROVIDER_ENV``.
-_CLAUDE_CONTAINER_SANDBOX_ENV: dict[str, str] = {"IS_SANDBOX": "1"}
-
+# packages. agentshim 0.6.1 declares this on ``ProviderProfile.container_env``
+# for every provider that needs container-only environment beyond auth
+# (Claude Code today), so VibeSys folds each shipped profile's answer into the
+# common table rather than pinning Claude's requirement by hand.
 DOCKER_PROVIDER_ENV: dict[str, dict[str, str]] = {
-    "claude": {**_COMMON_DOCKER_ENV, **_CLAUDE_CONTAINER_SANDBOX_ENV},
-    "gemini": dict(_COMMON_DOCKER_ENV),
-    "codex": dict(_COMMON_DOCKER_ENV),
-    "opencode": dict(_COMMON_DOCKER_ENV),
+    provider: {
+        **_COMMON_DOCKER_ENV,
+        **provider_profiles.provider_profile(provider).container_env,
+    }
+    for provider in SHIPPED_PROVIDERS
 }
 """Per-provider environment variables to set inside the container.
 

--- a/tests/support/provider_profiles.py
+++ b/tests/support/provider_profiles.py
@@ -17,6 +17,8 @@ from agentshim import McpMechanism, OutputSchemaStyle, ProviderProfile, SchemaDi
 from vibesys.agents import provider_profiles
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import pytest
 
 
@@ -33,6 +35,10 @@ def profile(  # noqa: PLR0913
     auth_env_vars: tuple[str, ...] = (),
     skill_dirs: tuple[str, ...] = (),
     container_install: tuple[str, ...] = (),
+    container_env: Mapping[str, str] | None = None,
+    state_root_env: str | None = None,
+    auth_files: tuple[str, ...] = (),
+    mcp_config_file: str | None = None,
 ) -> ProviderProfile:
     """Build a profile for *name*, defaulting every field a test ignores.
 
@@ -54,6 +60,10 @@ def profile(  # noqa: PLR0913
         auth_env_vars=auth_env_vars,
         skill_dirs=skill_dirs,
         container_install=container_install,
+        container_env=container_env if container_env is not None else {},
+        state_root_env=state_root_env,
+        auth_files=auth_files,
+        mcp_config_file=mcp_config_file,
     )
 
 

--- a/tests/vibesys/agents/drivers/test_agentshim_driver.py
+++ b/tests/vibesys/agents/drivers/test_agentshim_driver.py
@@ -23,7 +23,14 @@ from typing import TYPE_CHECKING, Any
 
 import agentshim
 import pytest
-from agentshim.testing import FakeExecutor, FakeRun, TokenUsage, scripted_turn
+from agentshim.testing import (
+    FakeExecutor,
+    FakeRun,
+    TokenUsage,
+    installed_mcp_servers,
+    scripted_resume_failure,
+    scripted_turn,
+)
 
 from vibesys.agents import docker_executor
 from vibesys.agents.contracts import (
@@ -63,17 +70,6 @@ Codex and Gemini print one cached-token total, so no scripted turn can carry a
 separate cache-write count through them. The neutral usage contract keeps the
 two fields distinct regardless; these are the providers that can fill both.
 """
-
-RESUME_FAILURE_STDERR = {
-    "claude": "no conversation found\n",
-    "codex": "thread/resume failed: no rollout found for thread id thread-1\n",
-    # Gemini and opencode print nothing that separates a refused resume from
-    # any other startup failure, which is why agentshim applies the Claude
-    # rule to them: any nonzero exit of a resumed turn is a lost conversation.
-    "gemini": "fatal: failed to start\n",
-    "opencode": "error: failed to start\n",
-}
-"""How each provider's CLI reports a resume it will not honour."""
 
 
 @dataclass
@@ -469,13 +465,14 @@ def test_declared_host_resources_reach_the_sandbox(
 def test_mcp_servers_are_installed_for_the_turn_and_removed_after(tmp_path: Path) -> None:
     """The config exists only while the provider process is running.
 
-    Claude discovers MCP servers from ``<workspace>/.mcp.json``, so the file is
-    read from inside the scripted run: that is the only moment it exists.
+    Claude discovers MCP servers from a workspace config file, so it is read
+    with ``installed_mcp_servers`` from inside the scripted run: that is the
+    only moment it exists.
     """
-    observed: list[dict[str, Any]] = []
+    installed: list[dict[str, dict[str, Any]]] = []
 
-    def run(_request: agentshim.CommandRequest) -> FakeRun:
-        observed.append(json.loads((tmp_path / ".mcp.json").read_text()))
+    def run(request: agentshim.CommandRequest) -> FakeRun:
+        installed.append(installed_mcp_servers("claude", request, tmp_path))
         return scripted_turn("claude", text="ok")
 
     driver, _fake = _driver("claude", run)
@@ -488,20 +485,20 @@ def test_mcp_servers_are_installed_for_the_turn_and_removed_after(tmp_path: Path
 
     session.run_turn(AgentTurnRequest(message="review"))
 
-    entry = observed[0]["mcpServers"]["issues"]
+    entry = installed[0]["issues"]
     # A host run pins the interpreter that VibeSys itself is running under: a
     # login shell's bare ``python`` may not have the MCP dependencies.
     assert entry["command"] == subject.sys.executable
     assert entry["args"] == ["-m", "issues"]
-    assert not (tmp_path / ".mcp.json").exists()
+    assert _workspace_files(tmp_path) == {}
 
 
 @pytest.mark.usefixtures("sandbox_builds")
 def test_a_non_python_mcp_command_is_left_alone(tmp_path: Path) -> None:
-    observed: list[dict[str, Any]] = []
+    installed: list[dict[str, dict[str, Any]]] = []
 
-    def run(_request: agentshim.CommandRequest) -> FakeRun:
-        observed.append(json.loads((tmp_path / ".mcp.json").read_text()))
+    def run(request: agentshim.CommandRequest) -> FakeRun:
+        installed.append(installed_mcp_servers("claude", request, tmp_path))
         return scripted_turn("claude", text="ok")
 
     driver, _fake = _driver("claude", run)
@@ -514,7 +511,7 @@ def test_a_non_python_mcp_command_is_left_alone(tmp_path: Path) -> None:
 
     session.run_turn(AgentTurnRequest(message="review"))
 
-    assert observed[0]["mcpServers"]["other"]["command"] == "node"
+    assert installed[0]["other"]["command"] == "node"
 
 
 # ---------------------------------------------------------------------------
@@ -803,33 +800,33 @@ def test_container_session_mcp_servers_are_installed_on_the_host_workspace(
     """
     server = MCPServerSpec(name="issues", command="python", args=("-m", "issues"))
     during: list[dict[str, str]] = []
+    installed: list[dict[str, dict[str, Any]]] = []
 
-    def run(_request: agentshim.CommandRequest) -> FakeRun:
+    def run(request: agentshim.CommandRequest) -> FakeRun:
         # Every container command is scripted, the provider health check
         # included, so the turn is the last snapshot rather than the only one.
         during.append(_workspace_files(tmp_path))
+        installed.append(installed_mcp_servers(provider, request, tmp_path))
         return scripted_turn(provider, text="ok")
 
-    driver, fake, _repairs = _container_driver(monkeypatch, provider, run)
+    driver, _fake, _repairs = _container_driver(monkeypatch, provider, run)
     session = driver.create_session(_container_spec(tmp_path, provider, mcp_servers=(server,)))
 
     session.run_turn(AgentTurnRequest(message="review"))
 
-    if agentshim.get_provider(provider).profile.mcp is not agentshim.McpMechanism.CONFIG_FILE:
-        # Codex passes its servers as `--config` flags, so nothing is written
-        # to the workspace in either execution mode.
-        assert during[-1] == {}
-        assert 'mcp_servers.issues.command="python"' in fake.requests[-1].argv
-        return
-
-    written = during[-1]
-    assert written, f"{provider} wrote no MCP config on the host workspace"
-    config = "".join(written.values())
-    assert "issues" in config
+    entry = installed[-1]["issues"]
     # The container image resolves its own interpreter: the host substitution
-    # would name a path that does not exist inside it.
-    assert subject.sys.executable not in config
-    assert '"python"' in config
+    # would name a path that does not exist inside it, so the command must
+    # reach the CLI unsubstituted.
+    assert entry["command"] == "python"
+    assert entry["args"] == ["-m", "issues"]
+
+    if agentshim.get_provider(provider).profile.mcp is not agentshim.McpMechanism.CONFIG_FILE:
+        # Codex passes its servers as flags, so nothing is written to the
+        # workspace in either execution mode.
+        assert during[-1] == {}
+    else:
+        assert during[-1], f"{provider} wrote no MCP config on the host workspace"
     assert _workspace_files(tmp_path) == {}, "the MCP config outlived the turn"
 
 
@@ -1098,14 +1095,13 @@ def test_a_failed_resume_retries_once_from_a_fresh_conversation(
     del sandbox_builds
 
     attempts: list[int] = []
-    refusal = RESUME_FAILURE_STDERR[provider]
 
     def run(request: agentshim.CommandRequest) -> FakeRun:
         attempts.append(len(attempts))
         if not attempts[:-1]:
             return scripted_turn(provider, text="ok", session_id="session-1")
         if "session-1" in request.argv:
-            return FakeRun(returncode=1, stderr=[refusal])
+            return scripted_resume_failure(provider, session_id="session-1")
         return scripted_turn(provider, text="recovered", session_id="session-2")
 
     session, fake = _session(tmp_path, provider, run)
@@ -1136,7 +1132,7 @@ def test_a_second_failure_after_a_resume_retry_propagates(
         attempts.append(len(attempts))
         if not attempts[:-1]:
             return scripted_turn(provider, text="ok", session_id="session-1")
-        return FakeRun(returncode=1, stderr=[RESUME_FAILURE_STDERR[provider]])
+        return scripted_resume_failure(provider, session_id="session-1")
 
     session, fake = _session(tmp_path, provider, run)
     session.run_turn(AgentTurnRequest(message="one"))

--- a/tests/vibesys/agents/test_cli_docker.py
+++ b/tests/vibesys/agents/test_cli_docker.py
@@ -26,6 +26,12 @@ _FAKE_PROFILES = {
             "ANTHROPIC_BASE_URL",
             "ANTHROPIC_CUSTOM_HEADERS",
         ),
+        auth_files=(
+            ".claude/.credentials.json",
+            ".claude/settings.json",
+            ".claude/settings.local.json",
+            ".claude.json",
+        ),
         container_install=(
             "apt-get update && apt-get install -y --no-install-recommends curl ca-certificates",
             "curl -fsSL https://claude.ai/install.sh | bash",
@@ -36,6 +42,7 @@ _FAKE_PROFILES = {
         "codex",
         state_dirs=(".codex", ".config/codex"),
         auth_env_vars=("OPENAI_API_KEY", "OPENAI_BASE_URL"),
+        auth_files=(".codex/auth.json", ".codex/config.toml"),
         container_install=(
             "curl -fsSL https://nodejs.org/install | bash",
             "npm install -g @openai/codex",
@@ -45,12 +52,26 @@ _FAKE_PROFILES = {
         "gemini",
         state_dirs=(".gemini", ".config/gemini"),
         auth_env_vars=("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        auth_files=(
+            ".gemini/oauth_creds.json",
+            ".gemini/google_accounts.json",
+            ".gemini/settings.json",
+            ".gemini/.env",
+        ),
         container_install=("npm install -g @google/gemini-cli",),
     ),
     "opencode": fake_profiles.profile(
         "opencode",
         state_dirs=(".local/share/opencode", ".config/opencode"),
         auth_env_vars=(),
+        auth_files=(
+            ".local/share/opencode/auth.json",
+            ".config/opencode/opencode.json",
+            ".config/opencode/opencode.jsonc",
+            ".config/opencode/config.json",
+            ".config/opencode/config.jsonc",
+            ".config/opencode/.env",
+        ),
         container_install=("curl -fsSL https://opencode.ai/install | bash",),
     ),
 }
@@ -65,46 +86,28 @@ def fake_profiles_installed(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestAuthPaths:
     """Which provider state files are staged into an editor container."""
 
-    def test_stages_the_credential_leaves_of_each_profile_state_directory(
+    def test_stages_exactly_the_profiles_declared_auth_files(
         self,
         fake_profiles_installed: None,
     ) -> None:
+        """``auth_paths`` derives entirely from ``ProviderProfile.auth_files``.
+
+        Expectations come from the fake profile itself, not a second
+        hand-typed list, so this fails only when the derivation rule changes.
+        """
         del fake_profiles_installed
         home = Path.home()
-        staged = {
-            provider: [
+
+        for provider in _SHIPPED:
+            expected = [
+                (auth_file, f"/root/{auth_file}")
+                for auth_file in _FAKE_PROFILES[provider].auth_files
+            ]
+            staged = [
                 (spec.host_path.relative_to(home).as_posix(), spec.container_path)
                 for spec in cli_docker.auth_paths(provider)
             ]
-            for provider in _SHIPPED
-        }
-
-        assert staged == {
-            "claude": [
-                (".claude/.credentials.json", "/root/.claude/.credentials.json"),
-                (".claude/settings.json", "/root/.claude/settings.json"),
-                (".claude/settings.local.json", "/root/.claude/settings.local.json"),
-                (".claude.json", "/root/.claude.json"),
-            ],
-            "gemini": [
-                (".gemini/oauth_creds.json", "/root/.gemini/oauth_creds.json"),
-                (".gemini/google_accounts.json", "/root/.gemini/google_accounts.json"),
-                (".gemini/settings.json", "/root/.gemini/settings.json"),
-                (".gemini/.env", "/root/.gemini/.env"),
-            ],
-            "codex": [
-                (".codex/auth.json", "/root/.codex/auth.json"),
-                (".codex/config.toml", "/root/.codex/config.toml"),
-            ],
-            "opencode": [
-                (".local/share/opencode/auth.json", "/root/.local/share/opencode/auth.json"),
-                (".config/opencode/opencode.json", "/root/.config/opencode/opencode.json"),
-                (".config/opencode/opencode.jsonc", "/root/.config/opencode/opencode.jsonc"),
-                (".config/opencode/config.json", "/root/.config/opencode/config.json"),
-                (".config/opencode/config.jsonc", "/root/.config/opencode/config.jsonc"),
-                (".config/opencode/.env", "/root/.config/opencode/.env"),
-            ],
-        }
+            assert staged == expected
 
     def test_never_stages_a_bulk_runtime_root(self, fake_profiles_installed: None) -> None:
         del fake_profiles_installed
@@ -122,7 +125,7 @@ class TestAuthPaths:
             }
         )
 
-    def test_skips_a_state_directory_with_no_declared_credential_leaves(
+    def test_stages_nothing_when_the_profile_declares_no_auth_files(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -158,6 +161,7 @@ class TestAuthImport:
                 "fixture": fake_profiles.profile(
                     "fixture",
                     state_dirs=(".codex", ".claude.json"),
+                    auth_files=(".codex/auth.json", ".codex/config.toml", ".claude.json"),
                 )
             },
         )
@@ -184,7 +188,13 @@ class TestAuthImport:
         monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
         fake_profiles.install(
             monkeypatch,
-            {"fixture": fake_profiles.profile("fixture", state_dirs=(".codex",))},
+            {
+                "fixture": fake_profiles.profile(
+                    "fixture",
+                    state_dirs=(".codex",),
+                    auth_files=(".codex/auth.json", ".codex/config.toml"),
+                )
+            },
         )
 
         # The mount index is the position in the full list, so a missing
@@ -382,36 +392,24 @@ class TestShippedProfileAssumptions:
     """
 
     @pytest.mark.parametrize("provider", _SHIPPED)
-    def test_every_named_state_directory_stages_at_least_one_leaf(self, provider: str) -> None:
+    def test_auth_paths_mirrors_the_profiles_own_auth_files(self, provider: str) -> None:
         profile = agentshim.get_provider(provider).profile
         home = Path.home()
-        staged = [
-            spec.host_path.relative_to(home).as_posix() for spec in cli_docker.auth_paths(provider)
-        ]
-        named = [
-            state_dir
-            for state_dir in profile.state_dirs
-            if state_dir in cli_docker._AUTH_LEAF_FILES  # noqa: SLF001
-        ]
 
-        # A state directory with no leaf table entry stages nothing, which is
-        # fine, but a provider that stages nothing at all starts its container
-        # CLI logged out.
-        assert staged
-        for state_dir in named:
-            assert any(path == state_dir or path.startswith(f"{state_dir}/") for path in staged), (
-                state_dir
-            )
-
-    def test_no_leaf_table_entry_names_a_directory_no_profile_declares(self) -> None:
-        declared = {
-            state_dir
-            for provider in _SHIPPED
-            for state_dir in agentshim.get_provider(provider).profile.state_dirs
-        }
-
-        # A stale key stages nothing and reads as coverage that is not there.
-        assert set(cli_docker._AUTH_LEAF_FILES) <= declared  # noqa: SLF001
+        assert [
+            (spec.host_path, spec.container_path) for spec in cli_docker.auth_paths(provider)
+        ] == [(home / auth_file, f"/root/{auth_file}") for auth_file in profile.auth_files]
+        # A provider that declares no auth files starts its container CLI
+        # logged out.
+        assert profile.auth_files
+        # Every declared auth file lies inside a declared state directory;
+        # agentshim's own `test_conventions.py` pins that per provider, so
+        # this only checks that VibeSys's read seam still sees it that way.
+        for auth_file in profile.auth_files:
+            assert any(
+                auth_file == state_dir or auth_file.startswith(f"{state_dir}/")
+                for state_dir in profile.state_dirs
+            ), auth_file
 
     @pytest.mark.parametrize("provider", _SHIPPED)
     def test_auth_env_vars_carry_credentials_and_no_model_selection(self, provider: str) -> None:

--- a/tests/vibesys/agents/test_host_resource_declarations.py
+++ b/tests/vibesys/agents/test_host_resource_declarations.py
@@ -27,6 +27,7 @@ _FAKE_PROFILES = {
             "Library/Application Support/claude",
             "Library/Caches/claude",
         ),
+        state_root_env="CLAUDE_CONFIG_DIR",
     ),
     "codex": fake_profiles.profile(
         "codex",
@@ -36,6 +37,7 @@ _FAKE_PROFILES = {
             "Library/Application Support/com.openai.codex",
             "Library/Caches/codex",
         ),
+        state_root_env="CODEX_HOME",
     ),
     "gemini": fake_profiles.profile("gemini", state_dirs=(".gemini", ".config/gemini")),
     "opencode": fake_profiles.profile(
@@ -251,6 +253,23 @@ def test_codex_home_relocates_the_state_leaves(tmp_path, _fake_profiles_installe
     assert ".codex/auth.json" not in writable
     # $CODEX_HOME does not move the XDG config directory.
     assert ".config/codex" in writable
+
+
+def test_claude_config_dir_relocates_the_state_root(tmp_path, _fake_profiles_installed):  # noqa: ANN001, ANN201, PT019
+    """A second provider with a state root variable gets the same generic rule.
+
+    Claude declares no narrowed leaves, so its whole relocated directory is
+    granted, unlike Codex's leaf-only grant.
+    """
+    relocated = tmp_path / "relocated-claude"
+
+    writable = _writable_state(tmp_path, "claude", {"CLAUDE_CONFIG_DIR": str(relocated)})
+
+    assert "relocated-claude" in writable
+    assert ".claude" not in writable
+    # $CLAUDE_CONFIG_DIR only relocates the first state directory.
+    assert ".claude.json" in writable
+    assert ".config/claude" in writable
 
 
 def test_a_provider_agentshim_does_not_register_is_rejected(tmp_path):  # noqa: ANN001, ANN201

--- a/tests/vibesys/sandbox/test_run_environment.py
+++ b/tests/vibesys/sandbox/test_run_environment.py
@@ -173,6 +173,7 @@ _CLI_PROFILES = {
     "claude": fake_profiles.profile(
         "claude",
         state_dirs=(".claude", ".claude.json", ".config/claude"),
+        auth_files=(".claude/.credentials.json", ".claude.json"),
         auth_env_vars=(
             "ANTHROPIC_AUTH_TOKEN",
             "ANTHROPIC_API_KEY",
@@ -184,6 +185,7 @@ _CLI_PROFILES = {
     "codex": fake_profiles.profile(
         "codex",
         state_dirs=(".codex", ".config/codex"),
+        auth_files=(".codex/auth.json",),
         auth_env_vars=("OPENAI_API_KEY", "OPENAI_BASE_URL"),
         container_install=("install-codex",),
     ),

--- a/uv.lock
+++ b/uv.lock
@@ -21,11 +21,11 @@ members = [
 
 [[package]]
 name = "agentshim"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/0a/50cda28318091c50b718f9e4a52aa76e26a4e5bc10ae7e7c68eacb3e8a1e/agentshim-0.6.0.tar.gz", hash = "sha256:d15b69eadc9c03db77635a8cc906f3a62642b9c79fc676ab47ea1bfdba0623c5", size = 71223, upload-time = "2026-09-10T09:05:38.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/06/5c16b00fc50f5dc82e172f0f1cb11dd2402214209c6bbc263dff5e67e889/agentshim-0.6.1.tar.gz", hash = "sha256:ffc82a169709ac838700bfec72d39ec49fa7ecb659f0dfbf9c9f785a4e12ff94", size = 78761, upload-time = "2026-09-10T21:26:06.348Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/6d/e48d7a8dc5e0f8ba45ce7a6bd30a93c03d8a3746c38bb1f5600b07691d1f/agentshim-0.6.0-py3-none-any.whl", hash = "sha256:721eb08c3fbdbc1d71284e95f794830a72d480dd90445cc7c68eec863c940787", size = 94746, upload-time = "2026-09-10T09:05:36.966Z" },
+    { url = "https://files.pythonhosted.org/packages/88/29/0980ec9fb52b89816ff4370e59fe156f8e985579fc2559c5fc8a30541367/agentshim-0.6.1-py3-none-any.whl", hash = "sha256:c15c428ac4b3fdba8b665bbb97ae70fb57c59f6fd38807827525377df80a4633", size = 101612, upload-time = "2026-09-10T21:26:04.965Z" },
 ]
 
 [[package]]
@@ -4552,7 +4552,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agentshim", specifier = ">=0.6.0,<0.7" },
+    { name = "agentshim", specifier = ">=0.6.1,<0.7" },
     { name = "cbor2", specifier = "<6" },
     { name = "cryptography", specifier = "<50" },
     { name = "deepagents" },


### PR DESCRIPTION
## Problem

Three pieces of provider knowledge were still hand-maintained in VibeSys because `ProviderProfile` had no field for them, each with a comment saying so: the credential leaf files per state directory (`_AUTH_LEAF_FILES` in `cli_docker.py`), Claude's `IS_SANDBOX=1` container requirement, and the Codex-only `CODEX_HOME` state-root branch in `host_resource_declarations.py`. The driver tests also hardcoded Codex's resume-failure stderr, Claude's `.mcp.json` file name, and Codex's `--config mcp_servers.*` argv syntax because `agentshim.testing` gave them no alternative. Fourth PR in the stack on #668, based on #671.

## Solution

agentshim 0.6.1 (released: https://github.com/vic-lsh/agentshim/releases/tag/v0.6.1, PRs vic-lsh/agentshim#14 and vic-lsh/agentshim#15) adds `auth_files`, `container_env`, `state_root_env`, and `mcp_config_file` to `ProviderProfile`, plus `scripted_resume_failure` and `installed_mcp_servers` in `agentshim.testing`. This PR pins `agentshim>=0.6.1,<0.7` and:

- `cli_docker.auth_paths` derives staged credential files from `profile.auth_files`; the leaf table is deleted.
- `provider_policy.DOCKER_PROVIDER_ENV` is the common `PYTHONPATH` merged with each shipped profile's `container_env`; the Claude constant is deleted.
- `host_resource_declarations._state_root` honours `profile.state_root_env` for the profile's first state directory on any provider; the Codex special case is deleted. `_NARROWED_STATE_DIRS` stays, since which Codex leaves the sandbox grants is VibeSys policy.
- Driver tests use `scripted_resume_failure` and `installed_mcp_servers`; the sandbox and driver fake profiles declare the new fields.

Values were asserted identical before and after for every shipped provider (auth paths, container env, state roots) during the change.

### Architecture

Ownership as documented in "Where agentshim lives": the library now declares every provider fact VibeSys had been carrying, and VibeSys reads them through `provider_profiles.py`.

## Verification

### Correctness properties

- `auth_paths(p)` for each shipped provider stages exactly the profile's `auth_files` at the same relative path under `/root`.
- `DOCKER_PROVIDER_ENV` is unchanged for all four shipped providers.
- With `CODEX_HOME` or `CLAUDE_CONFIG_DIR` set, the first state directory is granted at that path; otherwise under `HOME`.
- A resumed turn served the library's own resume failure restarts the session once and marks `RESET_REQUIRED`; MCP servers are installed for host and container turns with the interpreter substitution.

### Testing

```
uv run ruff check src tests            # All checks passed
uv run ruff format --check src tests   # 327 files already formatted
scripts/check_types.sh                 # All checks passed
uv run lint-imports                    # Contracts: 2 kept, 0 broken
uv run pytest tests -q -n auto         # 5102 passed, 15 skipped
```

Headless Docker round on the 0.6.1 pin: codex / gpt-5.6-sol on `queue-rs` task `spsc`, `--local --docker --max-rounds 1`: framework validation, accuracy, and benchmark PASS (total_ops_per_sec 23880111), 6 usage records, no tracebacks, workspace ownership repaired to the host uid, container removed, exit 0. The staged credentials and container env came from the new profile fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
