### PR TITLE
Build a prebuilt agent image per task and run containers as a non-root agent user

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       tui: ${{ steps.filter.outputs.tui }}
       examples: ${{ steps.filter.outputs.examples }}
+      agent_image: ${{ steps.filter.outputs.agent_image }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -89,6 +90,13 @@ jobs:
               - 'scripts/example_repositories.py'
               - 'tests/vibesys/test_microservice_inputs.py'
               - 'tests/vibesys/test_input_sources.py'
+              - '.github/workflows/test.yml'
+            # The agent image build: its Dockerfile, the module that builds
+            # it, and the version pins it takes as build args.
+            agent_image:
+              - 'src/vibesys/sandbox/images/**'
+              - 'src/vibesys/sandbox/images.py'
+              - 'src/vibesys/agents/provider_policy.py'
               - '.github/workflows/test.yml'
 
   # One environment setup for every cheap Python check. Issue #89 split these
@@ -432,6 +440,35 @@ jobs:
           go run ./cmd/servicebench --workload "$GITHUB_WORKSPACE/examples/microservices/repositories/deathstarbench/.vibesys/tasks/hotel-reservation/benchmark/workload.toml" --telemetry-command-json '["go","run","./cmd/otelcapture","--input-json","/tmp/vibesys-hotel-traces.otlp.ndjson","--settle-seconds","5"]' --telemetry-output /tmp/vibesys-hotel-telemetry.json --telemetry-timeout 60 --validate-only
           go run ./cmd/servicebench --mode accuracy --workload "$GITHUB_WORKSPACE/examples/microservices/repositories/deathstarbench/.vibesys/tasks/hotel-reservation/benchmark/workload.toml" --validate-only
 
+  # Builds the CPU agent image for real and runs every shipped CLI inside it
+  # as the non-root `agent` user (issue #675). ubuntu-latest ships Docker, so
+  # no separate engine setup is needed. Filtered narrowly: only a change that
+  # can actually change the image's contents pays for this job's build time.
+  agent-image:
+    needs: changes
+    if: needs.changes.outputs.agent_image == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Build the CPU agent image and run every shipped CLI in it
+        env:
+          VIBESYS_E2E_DOCKER: "1"
+        run: uv run pytest tests/e2e/test_agent_image_e2e.py -v -s --no-cov
+
   # Deliberately unfiltered: several tests read clients/ directly (packaging,
   # theme, and distribution tests), so a TypeScript-only change still needs
   # this job.
@@ -582,6 +619,7 @@ jobs:
       - tui
       - queue-native
       - validate-examples
+      - agent-image
       - test
       - sandbox-linux
       - sandbox-macos

--- a/docs/contributing/agent-drivers.md
+++ b/docs/contributing/agent-drivers.md
@@ -143,6 +143,48 @@ caller that shortened its prompt has to ask again in full. The
 experiment chat is the caller that does this today
 (`src/server/chat/session.py`).
 
+## Images
+
+A `--docker` run starts from two images, built by `vibesys.sandbox.images`:
+
+- The **task image**, built from the task's own `Dockerfile` when it has one
+  (`build_task_image`), or the backend's base image otherwise. It installs
+  only what the task needs to build and test candidate code, and serves the
+  evaluator as well as the agent.
+- The **agent image**, built on top of the task image from
+  `src/vibesys/sandbox/images/agent.Dockerfile` (`agent_image`). It installs
+  Node, all four shipped CLIs (`claude`, `codex`, `gemini`, `opencode`),
+  ripgrep, `uv`, and Python's `mcp` package, then creates a non-root `agent`
+  user and ends with `USER agent`. The provider a session runs is a run-time
+  choice, so every shipped CLI lands in this one layer rather than one image
+  per provider.
+
+The agent layer sits on top so that a CLI version bump rebuilds only that top
+layer, and a task image stays pure enough to serve the evaluator on its own.
+Docker's layer cache is what makes a repeat build of either image cheap;
+`vibesys.sandbox.images` builds an image once per launch and resolves its
+immutable manifest ID rather than keeping a manifest of its own.
+
+CLI and toolchain versions are not in the Dockerfile: they are build args
+supplied from `vibesys.agents.provider_policy` (`NODE_VERSION`,
+`CLI_VERSIONS`, `RUST_TOOLCHAIN_VERSION`, `GO_TOOLCHAIN_VERSION`), so a
+version bump is a one-line change in one module instead of an edit to the
+Dockerfile itself.
+
+A task Dockerfile that needs the backend's base image declares `ARG
+BASE_IMAGE` and `FROM ${BASE_IMAGE}`; `agent_image` always passes
+`--build-arg BASE_IMAGE=<resolved base>` when building a task image, so this
+is opt-in from the task Dockerfile's side. A task Dockerfile with its own
+`FROM` line (the Verus task under
+`examples/data-structures/repositories/queue-rs/.vibesys/tasks/verus-mpmc-open/`
+is one) ignores the unused build arg and keeps its own base.
+
+The agent layer installs with `apt-get`, so every task Dockerfile and every
+backend base image must be Debian- or Ubuntu-derived; every current backend
+base and task Dockerfile already is. Because setup happens once, at build
+time, an agent cannot `apt-get install` mid-round: a missing system package
+is a Dockerfile gap, not something a running turn can patch around.
+
 ## Container execution
 
 `--docker` runs the provider CLI inside the role's editor container. The
@@ -161,9 +203,10 @@ still builds argv, parses the stream, and owns the session.
   the host. Forwarding by inspection would point the container CLI at host
   paths and could carry a host `ANTHROPIC_MODEL` past the container's own
   configuration.
-- After every container turn the driver repairs workspace ownership. CLI
-  agents run as root in the editor container, and an atomic file replacement
-  leaves the replacement owned by root on a bind-mounted workspace.
+- The CLI runs as the image's `agent` user, remapped at container start to
+  the host user's uid and gid, so files it writes to the bind-mounted
+  workspace are owned by the host user. Nothing repairs ownership afterwards,
+  and git needs no `safe.directory` entry inside the container.
 - The binary health check (`<binary> --help`) runs inside the container, once
   per session, before the first turn. See the section below for what a failure
   costs.

--- a/libs/vs-sandbox/src/vs_sandbox/__init__.py
+++ b/libs/vs-sandbox/src/vs_sandbox/__init__.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from vs_sandbox.project_paths import ProjectPathPolicy, ProjectPathPolicyError
 
 if TYPE_CHECKING:
-    from vs_sandbox.docker_sandbox import DockerSandbox
+    from vs_sandbox.docker_sandbox import AGENT_HOME, DockerSandbox
     from vs_sandbox.host_resources import (
         HostResource,
         HostResourceAccess,
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from vs_sandbox.modal_sandbox import ModalSandbox
 
 __all__ = [
+    "AGENT_HOME",
     "BeforeReadyContext",
     "DockerSandbox",
     "HostResource",
@@ -66,10 +67,10 @@ __all__ = [
 
 
 def __getattr__(name: str) -> Any:  # noqa: ANN401, PLR0911  # tracked: #288
-    if name == "DockerSandbox":
-        from vs_sandbox.docker_sandbox import DockerSandbox  # noqa: PLC0415  # tracked: #288
+    if name in {"AGENT_HOME", "DockerSandbox"}:
+        from vs_sandbox import docker_sandbox  # noqa: PLC0415  # tracked: #288
 
-        return DockerSandbox
+        return getattr(docker_sandbox, name)
     if name in {
         "HostResource",
         "HostResourceAccess",

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import signal
 import subprocess
 import tempfile
@@ -43,6 +44,13 @@ _SECRET_ENV_NAME_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _REDACTED_VALUE = "<redacted>"
+
+#: HOME of the non-root ``agent`` user baked into the agent image. The image
+#: creates this user with a real HOME; nothing here creates it.
+AGENT_HOME = "/home/agent"
+
+_AGENT_USER = "agent"
+_ROOT_SETUP_TIMEOUT_S = 60
 
 
 def _is_secret_env_name(name: str) -> bool:
@@ -133,6 +141,14 @@ class DockerSandbox(BaseSandbox):
     the workspace root — matching ``LocalShellBackend(virtual_mode=True)``
     behaviour.  All filesystem methods translate these to container paths
     (``/workspace/foo``) before delegating to ``BaseSandbox``.
+
+    The container starts from a prebuilt agent image (shipped CLIs, toolchains,
+    and a non-root ``agent`` user with a real HOME already baked in), so no
+    install runs at start. Only two things still happen at start, both as
+    root: the image's ``agent`` user is remapped to the host uid/gid so
+    bind-mounted workspace writes come back owned by the host user, and any
+    staged provider credentials are copied into the agent's HOME. Every other
+    command, including the agent's own, runs as the image's default user.
     """
 
     _CONTAINER_ROOT = "/workspace"
@@ -154,7 +170,9 @@ class DockerSandbox(BaseSandbox):
         bind_mounts: list[tuple[str, str, bool]] | None = None,
         passthrough_paths: list[str] | None = None,
         log_path: str | Path | None = None,
-        extra_init_commands: list[str] | None = None,
+        agent_uid: int | None = None,
+        agent_gid: int | None = None,
+        auth_files: list[tuple[str, str]] | None = None,
         lifecycle_hooks: list[SandboxLifecycleHooks] | None = None,
     ) -> None:
         """Initialize Docker sandbox configuration.
@@ -194,11 +212,19 @@ class DockerSandbox(BaseSandbox):
             passthrough_paths: Container paths outside /workspace that should
                 not be rewritten by virtual-path translation (e.g. ``["/model"]``).
             log_path: File path to log docker commands to. If None, no logging.
-            extra_init_commands: Additional bash commands to run inside the
-                container after the default ``pip install uv`` step.  Unlike
-                ``uv``, failures here **raise RuntimeError** — use this for
-                commands that must succeed (e.g. installing a CLI binary the
-                loop depends on).
+            agent_uid: Host uid the image's ``agent`` user is remapped to at
+                start, so files the agent writes to the bind-mounted
+                workspace are owned by the host user. Defaults to this
+                process's uid. The remap is skipped when the image's
+                ``agent`` user already has this uid.
+            agent_gid: Host gid the image's ``agent`` group is remapped to,
+                analogous to *agent_uid*. Defaults to this process's gid.
+            auth_files: ``(staged_path, destination_path)`` pairs copied into
+                the container as root at start, then chowned to ``agent``.
+                *staged_path* is a read-only staging location already reached
+                through *bind_mounts* (conventionally under
+                ``/opt/vibesys-auth``); *destination_path* is where the CLI
+                expects to find it, conventionally under :data:`AGENT_HOME`.
             lifecycle_hooks: Trusted extensions invoked in order after
                 built-in initialization and before the sandbox becomes ready.
                 They run again after every container recreation.
@@ -218,7 +244,9 @@ class DockerSandbox(BaseSandbox):
         self._bind_mounts = bind_mounts or []
         self._container_id: str | None = None
         self._logger = self._setup_logger(log_path)
-        self._extra_init_commands: list[str] = list(extra_init_commands or [])
+        self._agent_uid = agent_uid if agent_uid is not None else os.getuid()
+        self._agent_gid = agent_gid if agent_gid is not None else os.getgid()
+        self._auth_files: list[tuple[str, str]] = list(auth_files or [])
         self._lifecycle = SandboxLifecycle(lifecycle_hooks)
 
         # Container paths outside /workspace that _vpath must not rewrite.
@@ -479,56 +507,99 @@ class DockerSandbox(BaseSandbox):
         }
         self._save_metadata()
 
-        # Install uv (with timeout to avoid hanging on network issues)
-        uv_cmd = ["docker", "exec", container_id, "bash", "-c", "pip install uv"]
+        self._remap_agent_user(container_id)
+        self._copy_auth_files(container_id)
+
+        self._lifecycle.before_ready(self)
+
+    def _run_as_root(self, container_id: str, script: str, *, what: str) -> None:
+        """Run *script* as root inside the container; raise on failure or timeout.
+
+        These steps (the uid/gid remap, the auth-file copy) are required: the
+        agent image ships no root fallback, so a failure here would otherwise
+        surface much later as a confusing permission error deep in a turn.
+        """
+        cmd = ["docker", "exec", "-u", "root", container_id, "bash", "-c", script]
+        self._log_cmd(cmd)
         try:
-            uv_result = subprocess.run(  # noqa: S603  # tracked: #288
-                uv_cmd,
+            result = subprocess.run(  # noqa: S603  # tracked: #288
+                cmd,
                 capture_output=True,
                 text=True,
                 check=False,
-                timeout=120,
+                timeout=_ROOT_SETUP_TIMEOUT_S,
             )
-            self._log_cmd(uv_cmd, uv_result)
-        except subprocess.TimeoutExpired:
-            self._log_cmd(uv_cmd, error="pip install uv timed out after 120s")
-            # Non-fatal: uv is optional, the agent can still use pip directly
+        except subprocess.TimeoutExpired as exc:
+            self._log_cmd(cmd, error=f"{what} timed out after {_ROOT_SETUP_TIMEOUT_S}s")
+            raise RuntimeError(  # noqa: TRY003  # tracked: #288
+                f"{what} timed out after {_ROOT_SETUP_TIMEOUT_S}s"
+            ) from exc
+        self._log_cmd(cmd, result)
+        if result.returncode != 0:
+            raise RuntimeError(  # noqa: TRY003  # tracked: #288
+                f"{what} failed (exit {result.returncode}):\n"
+                f"  stdout: {result.stdout.strip()[:500]}\n"
+                f"  stderr: {result.stderr.strip()[:500]}"
+            )
 
-        # Run any additional init commands (e.g. installing a CLI binary).
-        # Unlike uv, these are required — a failure raises RuntimeError.
-        for init_cmd_str in self._extra_init_commands:
-            init_cmd = [
+    def _current_agent_ids(self, container_id: str) -> tuple[int, int] | None:
+        """Return the image's ``agent`` user's current (uid, gid), if resolvable."""
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            [  # noqa: S607  # tracked: #288
                 "docker",
                 "exec",
                 container_id,
-                "bash",
+                "sh",
                 "-c",
-                init_cmd_str,
-            ]
-            self._log_cmd(init_cmd)
-            try:
-                init_result = subprocess.run(  # noqa: S603  # tracked: #288
-                    init_cmd,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                    timeout=600,
-                )
-                self._log_cmd(init_cmd, init_result)
-                if init_result.returncode != 0:
-                    raise RuntimeError(  # noqa: TRY003  # tracked: #288
-                        f"Container init command failed (exit {init_result.returncode}):\n"
-                        f"  command: {init_cmd_str}\n"
-                        f"  stdout: {init_result.stdout.strip()[:500]}\n"
-                        f"  stderr: {init_result.stderr.strip()[:500]}"
-                    )
-            except subprocess.TimeoutExpired as exc:
-                self._log_cmd(init_cmd, error=f"init command timed out after 600s: {init_cmd_str}")
-                raise RuntimeError(  # noqa: TRY003  # tracked: #288
-                    f"Container init command timed out after 600s: {init_cmd_str}"
-                ) from exc
+                f"id -u {_AGENT_USER} && id -g {_AGENT_USER}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_ROOT_SETUP_TIMEOUT_S,
+        )
+        if result.returncode != 0:
+            return None
+        lines = result.stdout.split()
+        if len(lines) != 2:  # noqa: PLR2004  # tracked: #288
+            return None
+        try:
+            return int(lines[0]), int(lines[1])
+        except ValueError:
+            return None
 
-        self._lifecycle.before_ready(self)
+    def _remap_agent_user(self, container_id: str) -> None:
+        """Remap the image's ``agent`` user to the configured host uid/gid.
+
+        Skipped when the image's ``agent`` user already carries these ids, so
+        a host user that happens to already be uid/gid 1000 (the image's
+        baked-in default) pays no extra ``docker exec``.
+        """
+        current = self._current_agent_ids(container_id)
+        if current == (self._agent_uid, self._agent_gid):
+            return
+        script = (
+            f"usermod -o -u {self._agent_uid} {_AGENT_USER} && "
+            f"groupmod -o -g {self._agent_gid} {_AGENT_USER} && "
+            f"chown -R {_AGENT_USER}:{_AGENT_USER} {AGENT_HOME}"
+        )
+        self._run_as_root(container_id, script, what="agent user id remap")
+
+    def _copy_auth_files(self, container_id: str) -> None:
+        """Copy staged provider credentials into the agent's writable HOME.
+
+        Copying from the read-only staging mount into the agent's own
+        writable layer, rather than mounting the destination itself, keeps
+        session/history writes inside the disposable container.
+        """
+        for source, destination in self._auth_files:
+            parent = str(Path(destination).parent)
+            script = (
+                f"mkdir -p {shlex.quote(parent)} && "
+                f"cp -a {shlex.quote(source)} {shlex.quote(destination)} && "
+                f"chown -R {_AGENT_USER}:{_AGENT_USER} {shlex.quote(destination)}"
+            )
+            self._run_as_root(container_id, script, what=f"auth file copy to {destination}")
 
     def _discard_started_container(self) -> None:
         """Best-effort rollback for a container whose startup did not finish."""

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -131,6 +131,16 @@ def _sigint_handler(signum: int, frame: FrameType | None) -> None:
 signal.signal(signal.SIGINT, _sigint_handler)
 
 
+def _first_component_below(home: str, destination: str) -> str:
+    """Return the first path component of *destination* under *home*.
+
+    ``/home/agent/.codex/auth.json`` gives ``/home/agent/.codex``; a file
+    directly under HOME gives itself.
+    """
+    relative = Path(destination).relative_to(home)
+    return str(Path(home) / relative.parts[0])
+
+
 class DockerSandbox(BaseSandbox):
     """Sandbox that runs all agent operations inside a Docker container.
 
@@ -592,12 +602,16 @@ class DockerSandbox(BaseSandbox):
         writable layer, rather than mounting the destination itself, keeps
         session/history writes inside the disposable container.
         """
+        # Every directory created on the way to the destination must belong to
+        # the agent too: a CLI writes sessions and caches next to its auth
+        # file, and a root-owned ``~/.codex`` would refuse them. The trailing
+        # chown covers the whole path below HOME, not just the copied file.
         for source, destination in self._auth_files:
-            parent = str(Path(destination).parent)
+            top = _first_component_below(AGENT_HOME, destination)
             script = (
-                f"mkdir -p {shlex.quote(parent)} && "
+                f"mkdir -p {shlex.quote(str(Path(destination).parent))} && "
                 f"cp -a {shlex.quote(source)} {shlex.quote(destination)} && "
-                f"chown -R {_AGENT_USER}:{_AGENT_USER} {shlex.quote(destination)}"
+                f"chown -R {_AGENT_USER}:{_AGENT_USER} {shlex.quote(top)}"
             )
             self._run_as_root(container_id, script, what=f"auth file copy to {destination}")
 

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -188,21 +188,17 @@ class TestStart:
         assert "/workspace/accuracy_checker:ro" in cmd_str
 
     @patch("subprocess.run")
-    def test_start_installs_uv(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+    def test_no_install_step_runs_at_start(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        """The agent image ships every tool baked in; start() installs nothing."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
 
         sandbox.start()
 
-        # Second call should install uv
-        assert len(mock_run.call_args_list) == 2
-        uv_call = mock_run.call_args_list[1]
-        cmd = uv_call[0][0]
-        assert "docker" in cmd[0]
-        assert "exec" in cmd
-        cmd_str = " ".join(cmd)
-        assert "pip install uv" in cmd_str
+        cmd_strs = [" ".join(c[0][0]) for c in mock_run.call_args_list]
+        assert not any("pip install" in cmd for cmd in cmd_strs)
+        assert not any("apt-get" in cmd for cmd in cmd_strs)
 
     @patch("subprocess.run")
     def test_init_failure_stops_and_removes_created_container(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -212,21 +208,23 @@ class TestStart:
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="test-image",
-            extra_init_commands=["install-required-tool"],
+            agent_uid=1234,
+            agent_gid=5678,
             lifecycle_hooks=[_RecordingHooks(invocations)],
         )
         mock_run.side_effect = [
             subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
-            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            # Current agent user ids, mismatched, so a remap is attempted.
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="1000\n1000\n", stderr=""),
             subprocess.CompletedProcess(
-                args=[], returncode=17, stdout="partial output", stderr="install failed"
+                args=[], returncode=17, stdout="partial output", stderr="usermod failed"
             ),
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
         ]
 
         try:
-            with pytest.raises(RuntimeError, match="Container init command failed"):
+            with pytest.raises(RuntimeError, match="agent user id remap failed"):
                 sandbox.start()
 
             assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
@@ -236,6 +234,113 @@ class TestStart:
             assert mock_run.call_args_list[-1][0][0] == ["docker", "rm", "-f", "abc123"]
         finally:
             _live_containers.pop("abc123", None)
+
+
+class TestAgentUserRemap:
+    @patch("subprocess.run")
+    def test_remaps_agent_user_when_ids_differ(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="test-image",
+            agent_uid=4242,
+            agent_gid=4343,
+        )
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
+            # Image default agent user is 1000:1000.
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="1000\n1000\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+
+        sandbox.start()
+
+        remap_call = mock_run.call_args_list[2]
+        cmd = remap_call[0][0]
+        assert cmd[:4] == ["docker", "exec", "-u", "root"]
+        cmd_str = " ".join(cmd)
+        assert "usermod -o -u 4242 agent" in cmd_str
+        assert "groupmod -o -g 4343 agent" in cmd_str
+        assert "chown -R agent:agent /home/agent" in cmd_str
+
+    @patch("subprocess.run")
+    def test_skips_remap_when_ids_already_match(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="test-image",
+            agent_uid=1000,
+            agent_gid=1000,
+        )
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="1000\n1000\n", stderr=""),
+        ]
+
+        sandbox.start()
+
+        # Only the id query follows `docker run`; no usermod/groupmod exec.
+        assert mock_run.call_count == 2
+        assert not any("usermod" in " ".join(c[0][0]) for c in mock_run.call_args_list)
+
+    @patch("subprocess.run")
+    def test_remap_runs_as_root_but_agent_commands_do_not(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="test-image",
+            agent_uid=4242,
+            agent_gid=4343,
+        )
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="1000\n1000\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+        sandbox.start()
+        mock_run.reset_mock()
+        mock_run.side_effect = None
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="hi\n", stderr=""
+        )
+
+        sandbox.execute("echo hi")
+
+        exec_cmd = mock_run.call_args[0][0]
+        assert "-u" not in exec_cmd
+
+
+class TestAuthFileCopy:
+    @patch("subprocess.run")
+    def test_copies_staged_files_into_agent_home_and_chowns_them(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="test-image",
+            agent_uid=1000,
+            agent_gid=1000,
+            auth_files=[("/opt/vibesys-auth/0", "/home/agent/.claude.json")],
+        )
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="1000\n1000\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+
+        sandbox.start()
+
+        copy_call = mock_run.call_args_list[2]
+        cmd = copy_call[0][0]
+        assert cmd[:4] == ["docker", "exec", "-u", "root"]
+        cmd_str = " ".join(cmd)
+        assert "cp -a /opt/vibesys-auth/0 /home/agent/.claude.json" in cmd_str
+        assert "chown -R agent:agent /home/agent/.claude.json" in cmd_str
+
+    @patch("subprocess.run")
+    def test_no_auth_files_by_default(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+
+        sandbox.start()
+
+        assert not any("cp -a" in " ".join(c[0][0]) for c in mock_run.call_args_list)
 
 
 class TestExecute:

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from vs_sandbox import BeforeReadyContext, SandboxLifecycleError, SandboxLifecycleHooks
-from vs_sandbox.docker_sandbox import DockerSandbox
+from vs_sandbox.docker_sandbox import DockerSandbox, _first_component_below
 
 
 class _RecordingHooks(SandboxLifecycleHooks):
@@ -1285,3 +1285,17 @@ class TestAutoRemove:
         )
         sandbox.start()
         assert "--rm" not in mock_run.call_args_list[0][0][0]
+
+
+class TestAuthCopyOwnership:
+    def test_a_nested_auth_file_chowns_its_top_directory(self) -> None:
+        assert _first_component_below("/home/agent", "/home/agent/.codex/auth.json") == (
+            "/home/agent/.codex"
+        )
+        assert _first_component_below("/home/agent", "/home/agent/.claude.json") == (
+            "/home/agent/.claude.json"
+        )
+        assert (
+            _first_component_below("/home/agent", "/home/agent/.config/opencode/opencode.json")
+            == "/home/agent/.config"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ vibesys = "entrypoints.launcher:main"
 [tool.setuptools.package-data]
 # ``entrypoints/_tui`` is produced at build time by setup.py's build_py step;
 # the glob keeps it as package data when present.
-vibesys = ["prompts/*.j2", "prompts/**/*.j2", "prompts/**/*.md", "domains/README.md", "_resources/**/*", "_sdk/**/*"]
+vibesys = ["prompts/*.j2", "prompts/**/*.j2", "prompts/**/*.md", "domains/README.md", "_resources/**/*", "_sdk/**/*", "sandbox/images/**"]
 entrypoints = ["py.typed", "_tui/**/*"]
 server = ["py.typed"]
 vs_evaluator_protocol = ["py.typed"]

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -8,6 +8,16 @@ repository needs, and the overrides VibeSys applies to a library recipe. The
 container environment table and the Codex CLI version pin are provider
 decisions and live in :mod:`vibesys.agents.provider_policy`; this module
 imports them.
+
+The plain Docker path (``vibesys.sandbox.run_environment.DockerEnvironment``)
+now starts from a prebuilt agent image with every shipped CLI, toolchain, and
+the non-root ``agent`` user already installed, so it needs none of the
+shell-recipe machinery below: it copies auth files itself at container start
+(see :func:`auth_copy_paths`) instead of running :func:`auth_copy_commands`
+through ``extra_init_commands``. ``docker_init_commands`` and its supporting
+override tables stay here for Modal and SkyPilot, which still install
+per-run through ``extra_init_commands`` until their own image work
+(#676, #679) lands; delete them once those land.
 """
 
 from __future__ import annotations
@@ -23,6 +33,7 @@ from vibesys.agents.provider_policy import (
     CODEX_DOCKER_CLI_VERSION,
     DOCKER_PROVIDER_ENV,
 )
+from vs_sandbox import AGENT_HOME
 
 # Re-exported for existing importers (``vibesys.agents.factory``,
 # ``vibesys.sandbox.run_environment``, and this module's own tests reach them
@@ -176,15 +187,15 @@ def auth_paths(provider: str) -> list[DockerAuthPath]:
     straight from ``ProviderProfile.auth_files`` (agentshim 0.6.1+): each
     entry is either a state directory's leaf file or a state entry that is
     itself a single file, and is staged at the same relative path under
-    ``/root``. A state directory the profile does not list a leaf for
-    contributes nothing.
+    the agent image's HOME. A state directory the profile does not list a
+    leaf for contributes nothing.
 
     Raises:
         ValueError: if agentshim does not register *provider*.
     """
     home = Path.home()
     return [
-        DockerAuthPath(home / auth_file, f"/root/{auth_file}")
+        DockerAuthPath(home / auth_file, f"{AGENT_HOME}/{auth_file}")
         for auth_file in provider_profiles.provider_profile(provider).auth_files
     ]
 
@@ -241,6 +252,23 @@ def auth_bind_mounts(provider: str) -> list[tuple[str, str, bool]]:
     return out
 
 
+def auth_copy_paths(provider: str) -> list[tuple[str, str]]:
+    """Return ``(staged source, agent-home destination)`` pairs to copy at start.
+
+    Used by the plain Docker path, which hands these straight to
+    ``DockerSandbox(auth_files=...)`` to copy as a start-time step rather than
+    running shell commands through ``extra_init_commands`` (see
+    :func:`auth_copy_commands` for the Modal/SkyPilot form of the same list).
+    Indexing matches :func:`auth_bind_mounts`: entry *i*'s staging mount is
+    ``/opt/vibesys-auth/{i}``.
+    """
+    return [
+        (f"/opt/vibesys-auth/{index}", spec.container_path)
+        for index, spec in enumerate(auth_paths(provider))
+        if spec.host_path.exists()
+    ]
+
+
 def auth_copy_commands(provider: str) -> list[str]:
     """Return commands that copy staged provider state into writable storage.
 
@@ -248,6 +276,9 @@ def auth_copy_commands(provider: str) -> list[str]:
     them read-only at their final locations can break otherwise valid CLI runs.
     Copying from read-only staging keeps those writes inside the disposable
     container layer.
+
+    Used by Modal and SkyPilot's ``extra_init_commands`` path; the plain
+    Docker path uses :func:`auth_copy_paths` instead (see module docstring).
     """
     commands: list[str] = []
     for index, spec in enumerate(auth_paths(provider)):

--- a/src/vibesys/agents/docker_executor.py
+++ b/src/vibesys/agents/docker_executor.py
@@ -1,13 +1,11 @@
 """Run agentshim CLI commands inside an already-running VibeSys Docker sandbox.
 
-Three pieces live here:
+Two pieces live here:
 
 * :class:`DockerCommandExecutor` -- a ``docker exec`` transport built on the
   library's ``TransformingExecutor``. It carries no provider knowledge: it
   rewrites argv, forwards the environment entries its caller nominated, and
   lets agentshim own everything else.
-* :func:`repair_workspace_ownership` -- returns bind-mounted workspace files to
-  the host user after a container turn.
 * :class:`CodexRolloutWatchdogExecutor` -- provider-behaviour compensation, not
   transport. A resumed ``codex exec ... --json`` run inside a container
   regularly finishes its work and writes the terminal events to its rollout
@@ -37,6 +35,8 @@ from agentshim import (
     TransformingExecutor,
 )
 
+from vs_sandbox import AGENT_HOME
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
 
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
 #: Where a container turn runs when the request does not name a directory.
 DEFAULT_CONTAINER_WORKDIR = "/workspace"
 
-_OWNERSHIP_REPAIR_TIMEOUT_S = 120
 _DOCKER_QUERY_TIMEOUT_S = 5
 
 
@@ -123,47 +122,6 @@ class DockerCommandExecutor(TransformingExecutor):
             # to reach the daemon at all.
             env=os.environ,
             timeout=request.timeout,
-        )
-
-
-def repair_workspace_ownership(container_id: str, *, uid: int, gid: int) -> None:
-    """Return bind-mounted workspace files to the host user.
-
-    CLI agents run as root in the editor container. Some editors replace files
-    atomically, which leaves the replacement owned by root and can make the
-    host-side checkpoint code unable to read it. Repair ownership before
-    control returns to the framework rather than waiting until a later resume.
-
-    Raises:
-        RuntimeError: if the in-container ``chown`` sweep failed.
-    """
-    result = subprocess.run(  # noqa: S603  # tracked: #288
-        [  # noqa: S607  # tracked: #288
-            "docker",
-            "exec",
-            container_id,
-            "find",
-            "/workspace",
-            "-xdev",
-            "-user",
-            "0",
-            "-writable",
-            "-exec",
-            "chown",
-            f"{uid}:{gid}",
-            "{}",
-            "+",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=_OWNERSHIP_REPAIR_TIMEOUT_S,
-        check=False,
-    )
-    if result.returncode != 0:
-        detail = result.stderr.strip() or result.stdout.strip()
-        raise RuntimeError(
-            "failed to restore writable Docker workspace ownership"
-            + (f": {detail}" if detail else "")
         )
 
 
@@ -546,7 +504,7 @@ class CodexRolloutWatchdogExecutor:
                 "exec",
                 container_id,
                 "find",
-                "/root/.codex/sessions",
+                f"{AGENT_HOME}/.codex/sessions",
                 "-type",
                 "f",
                 "-name",

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -10,7 +10,6 @@ translation between library events and :mod:`vibesys.agents.contracts`.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 from dataclasses import replace
@@ -271,19 +270,6 @@ class _AgentShimEventHandler:
             observer.on_event(translated)
 
 
-class _ContainerCleanup(Protocol):
-    """The container-side cleanup a container session owns.
-
-    The driver binds this to
-    :func:`vibesys.agents.docker_executor.repair_workspace_ownership` for the
-    session's container; the session only knows there is one to run.
-    """
-
-    def __call__(self) -> None:
-        """Return bind-mounted workspace files to the host user."""
-        ...
-
-
 class AgentShimSession:
     """One configured AgentShim conversation."""
 
@@ -296,7 +282,7 @@ class AgentShimSession:
         timeout: int | None,
         event_handler: _AgentShimEventHandler,
         turn_env: Mapping[str, str] | None,
-        container_cleanup: _ContainerCleanup | None,
+        in_container: bool,
         log: Callable[[str], None],
     ) -> None:
         """Bind one library session to the VibeSys policy that drives it."""
@@ -306,7 +292,7 @@ class AgentShimSession:
         self._timeout = timeout
         self._event_handler = event_handler
         self._turn_env = dict(turn_env) if turn_env else None
-        self._container_cleanup = container_cleanup
+        self._in_container = in_container
         self._log = log
         self._mcp_servers = tuple(
             _as_mcp_server(server, in_container=self._in_container) for server in spec.mcp_servers
@@ -316,15 +302,6 @@ class AgentShimSession:
         # serving the current turn, so the turn's result can report it.
         self._restarted = False
         self._closed = False
-
-    @property
-    def _in_container(self) -> bool:
-        """Whether this session's CLI runs inside a container.
-
-        The container-side cleanup hook is the one thing only a container
-        session owns, so its presence is what the mode is read from.
-        """
-        return self._container_cleanup is not None
 
     def run_turn(
         self,
@@ -338,28 +315,12 @@ class AgentShimSession:
         self._event_handler.observer = observer
         self._event_handler.structured = request.output_schema is not None
         self._restarted = False
-        turn_error: BaseException | None = None
         try:
             result = self._turn_with_restart(self._build_request(request))
             self._turn_count += 1
-        except BaseException as exc:
-            turn_error = exc
-            raise
         finally:
-            cleanup_error: Exception | None = None
-            try:
-                self._repair_workspace_ownership()
-            except Exception as exc:  # noqa: BLE001  # tracked: #288
-                cleanup_error = exc
-                if turn_error is not None:
-                    self._log(
-                        "workspace ownership repair failed while preserving the original "
-                        f"agent error: {exc}"
-                    )
             self._event_handler.observer = None
             self._event_handler.structured = False
-            if turn_error is None and cleanup_error is not None:
-                raise cleanup_error
 
         # Read the conversation ID before the thread-budget check, which may
         # drop it: the caller still deserves to know which conversation ran.
@@ -567,25 +528,6 @@ class AgentShimSession:
         self._turn_count = 0
         return True
 
-    def _repair_workspace_ownership(self) -> None:
-        """Return the container's writes to the host user, on every exit path.
-
-        Raises:
-            RuntimeError: if the repair failed, including when it timed out.
-                The repair runs from the turn's ``finally``, and it shells out
-                with its own budget, so a ``subprocess.TimeoutExpired`` from it
-                would reach the loop as the agent having timed out. That is a
-                different failure with a different response, so the timeout is
-                re-raised under a type the loop reads as a plain error.
-        """
-        if self._container_cleanup is None:
-            return
-        try:
-            self._container_cleanup()
-        except subprocess.TimeoutExpired as exc:
-            message = str(exc)
-            raise RuntimeError(message) from exc
-
 
 def _result_text(result: agentshim.TurnResult) -> str:
     """Return the turn's answer, preferring the schema-conformant payload.
@@ -691,12 +633,10 @@ class AgentShimDriver:
         provider = agentshim.get_provider(spec.provider)
         event_handler = _AgentShimEventHandler()
         overlay = dict(spec.environment)
-        container_cleanup: _ContainerCleanup | None = None
         turn_env: Mapping[str, str] | None = None
         executor: agentshim.CommandExecutor
         if in_container:
             executor = self._container_executor(spec, forward_env=tuple(overlay))
-            container_cleanup = self._container_cleanup(spec)
             # The container's own environment is built by the image and the
             # exec invocation; the session overlay is forwarded per turn so it
             # reaches the CLI inside the container instead of the docker client.
@@ -727,7 +667,7 @@ class AgentShimDriver:
             timeout=self._timeout,
             event_handler=event_handler,
             turn_env=turn_env,
-            container_cleanup=container_cleanup,
+            in_container=in_container,
             log=self._log,
         )
         self._sessions.add(session)
@@ -799,16 +739,6 @@ class AgentShimDriver:
             # compensation, so it wraps the transport rather than replacing it.
             executor = CodexRolloutWatchdogExecutor(executor, resolve, log=self._log)
         return executor
-
-    def _container_cleanup(self, spec: AgentSessionSpec) -> _ContainerCleanup:
-        """Bind the module-level ownership repair to this session's container."""
-        resolve = self._container_id_resolver(spec)
-        from vibesys.agents.docker_executor import repair_workspace_ownership  # noqa: PLC0415
-
-        def repair() -> None:
-            repair_workspace_ownership(resolve(), uid=os.getuid(), gid=os.getgid())
-
-        return repair
 
     def close(self) -> None:
         """Close every session created by this driver, idempotently."""

--- a/src/vibesys/agents/provider_policy.py
+++ b/src/vibesys/agents/provider_policy.py
@@ -52,19 +52,14 @@ _COMMON_DOCKER_ENV: dict[str, str] = {"PYTHONPATH": "/opt/vibesys"}
 in ``DockerSandbox.start`` for all four CLI providers). Without it the MCP
 server module would not be importable inside the container."""
 
-# Claude Code refuses ``--dangerously-skip-permissions`` when running as root
-# unless ``IS_SANDBOX=1`` is set, and VibeSys runs every container provider as
-# root (the default) to avoid uv/pip permission errors when the agent installs
-# packages. agentshim 0.6.1 declares this on ``ProviderProfile.container_env``
-# for every provider that needs container-only environment beyond auth
-# (Claude Code today), so VibeSys folds each shipped profile's answer into the
-# common table rather than pinning Claude's requirement by hand.
+# Claude Code used to refuse ``--dangerously-skip-permissions`` when running
+# as root unless ``IS_SANDBOX=1`` was set, back when VibeSys ran every
+# container provider as root. The agent image now runs the CLI as the non-root
+# ``agent`` user, so that requirement no longer applies and
+# ``ProviderProfile.container_env`` (agentshim 0.6.1's home for exactly this
+# kind of root-only escape hatch) is deliberately not merged in here.
 DOCKER_PROVIDER_ENV: dict[str, dict[str, str]] = {
-    provider: {
-        **_COMMON_DOCKER_ENV,
-        **provider_profiles.provider_profile(provider).container_env,
-    }
-    for provider in SHIPPED_PROVIDERS
+    provider: dict(_COMMON_DOCKER_ENV) for provider in SHIPPED_PROVIDERS
 }
 """Per-provider environment variables to set inside the container.
 
@@ -103,3 +98,47 @@ def cli_skill_dirs() -> tuple[str, ...]:
             seen.setdefault(skill_dir, None)
     seen.setdefault(_CURSOR_SKILL_DIR, None)
     return tuple(seen)
+
+
+# --- Agent image ------------------------------------------------------------
+#
+# Versions baked into ``vibesys/sandbox/images/agent.Dockerfile`` as build
+# args (see ``vibesys.sandbox.images.agent_image``). Pinned rather than left
+# to float so the container CLI matches the feature set VibeSys prompts were
+# validated against, and so a rebuild with unchanged pins resolves to the same
+# image from Docker's layer cache.
+
+NODE_VERSION = "24.21.0"
+"""Current Node.js LTS ("Krypton"), matching what the shipped CLIs are
+verified against upstream."""
+
+CLI_VERSIONS: dict[str, str] = {
+    "claude": "2.1.268",
+    "codex": CODEX_DOCKER_CLI_VERSION,
+    "gemini": "0.59.0",
+    "opencode": "1.18.30",
+}
+"""Container CLI version per shipped provider (``npm view <pkg> version`` at
+the time each was pinned, except Codex).
+
+Codex draws from :data:`CODEX_DOCKER_CLI_VERSION` instead of repeating its own
+literal, so the pin used by ``cli_docker`` (today's per-run container install)
+and the one used by ``agent_image`` (the prebuilt image) cannot disagree while
+both exist.
+"""
+
+RUST_TOOLCHAIN_VERSION = "1.92.0"
+"""Rust toolchain pin for an agent image's optional ``rust`` toolchain layer.
+
+Mirrors ``cli_docker.RUST_DOCKER_TOOLCHAIN_VERSION``, the equivalent pin for
+today's per-run container install; the two are independent constants because
+that module's per-run install path and this image's build-time install path
+are deleted and added on different schedules.
+"""
+
+GO_TOOLCHAIN_VERSION = "1.23.12"
+"""Go toolchain pin for an agent image's optional ``go`` toolchain layer.
+
+Mirrors the Go pin ``run_environment``'s evaluator setup already downloads at
+run time.
+"""

--- a/src/vibesys/backends/base.py
+++ b/src/vibesys/backends/base.py
@@ -68,14 +68,19 @@ class ComputeBackendImpl(Protocol):
         bind_mounts: list[tuple[str, str, bool]],
         passthrough_paths: list[str],
         extra_env: dict[str, str],
-        extra_init_commands: list[str],
+        extra_init_commands: list[str] | None = None,
         lifecycle_hooks: list[SandboxLifecycleHooks] | None = None,
         modal_options: ModalOptions | None = None,
         attach_accelerator: bool = True,
         ephemeral: bool = False,
         container_image: str | None = None,
+        auth_files: list[tuple[str, str]] | None = None,
     ) -> SandboxBackendProtocol:
         """Construct (do not start) a sandbox configured for this backend.
+
+        ``extra_init_commands`` is ignored by a Docker sandbox, which starts
+        from a prebuilt agent image and installs nothing at start; Modal
+        still runs these per-launch until its own image work lands.
 
         ``lifecycle_hooks`` are invoked before the sandbox becomes ready,
         during both initial creation and replacement.
@@ -89,6 +94,10 @@ class ComputeBackendImpl(Protocol):
 
         ``container_image`` pins a Docker sandbox to a resolved image ID. It is
         ignored by non-Docker sandboxes.
+
+        ``auth_files`` names ``(staged source, agent-home destination)`` pairs
+        a Docker sandbox copies in as root at start, then chowns to the agent
+        user. Ignored by non-Docker sandboxes.
         """
         ...
 

--- a/src/vibesys/backends/cuda/__init__.py
+++ b/src/vibesys/backends/cuda/__init__.py
@@ -82,6 +82,7 @@ class CudaBackend:
         attach_accelerator: bool = True,
         ephemeral: bool = False,
         container_image: str | None = None,
+        auth_files: list[tuple[str, str]] | None = None,
     ) -> SandboxBackendProtocol:
         """Construct a sandbox configured for CUDA execution."""
         # Deferred: the sandbox classes subclass deepagents' BaseSandbox, which
@@ -119,7 +120,7 @@ class CudaBackend:
                 passthrough_paths=passthrough_paths,
                 env=env,
                 log_path=log_path,
-                extra_init_commands=extra_init_commands,
+                auth_files=auth_files,
                 lifecycle_hooks=lifecycle_hooks,
             )
         elif kind is SandboxKind.MODAL:

--- a/src/vibesys/backends/local.py
+++ b/src/vibesys/backends/local.py
@@ -79,16 +79,20 @@ class LocalBackend:
         attach_accelerator: bool = True,
         ephemeral: bool = False,
         container_image: str | None = None,
+        auth_files: list[tuple[str, str]] | None = None,
     ) -> SandboxBackendProtocol:
         # Deferred: the sandbox classes subclass deepagents' BaseSandbox, which
         # pulls langchain + anthropic. Registration must stay import-cheap.
         from vs_sandbox import DockerSandbox  # noqa: PLC0415  # tracked: #288
 
-        del attach_accelerator, ephemeral
+        # extra_init_commands is accepted for ComputeBackendImpl protocol
+        # parity (LocalEnvironment.open() passes it unconditionally) but never
+        # used: neither the LOCAL sandbox nor the agent-image-based DOCKER
+        # sandbox runs per-launch install commands.
+        del attach_accelerator, ephemeral, extra_init_commands
         bind_mounts = list(bind_mounts or [])
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})
-        extra_init_commands = list(extra_init_commands or [])
         lifecycle_hooks = lifecycle_hooks or []
 
         if kind is SandboxKind.LOCAL:
@@ -102,13 +106,20 @@ class LocalBackend:
                 raise ValueError(f"{self.name.value} backend requires a Docker image")  # noqa: TRY003  # tracked: #288
             return DockerSandbox(
                 host_workspace=host_workspace,
+                # ``DockerEnvironment.open()`` (the plain --docker path)
+                # always resolves and passes an agent image, so this only
+                # falls back to the backend's own base image for a caller
+                # that builds its own Docker sandbox without one — Modal and
+                # SkyPilot's CPU-only local editor container, which still
+                # installs everything per-run until their own image work
+                # (#676, #679) lands.
                 image=container_image or self.image,
                 gpus=None,
                 bind_mounts=bind_mounts,
                 passthrough_paths=passthrough_paths,
                 env=extra_env,
                 log_path=log_path,
-                extra_init_commands=extra_init_commands,
+                auth_files=auth_files,
                 lifecycle_hooks=lifecycle_hooks,
             )
         if kind in (SandboxKind.DOCKER, SandboxKind.MODAL):

--- a/src/vibesys/backends/rocm/__init__.py
+++ b/src/vibesys/backends/rocm/__init__.py
@@ -163,6 +163,7 @@ class RocmBackend:
         attach_accelerator: bool = True,
         ephemeral: bool = False,
         container_image: str | None = None,
+        auth_files: list[tuple[str, str]] | None = None,
     ) -> SandboxBackendProtocol:
         # Deferred: the sandbox classes subclass deepagents' BaseSandbox, which
         # pulls langchain + anthropic. Registration must stay import-cheap.
@@ -171,9 +172,11 @@ class RocmBackend:
         bind_mounts = list(bind_mounts or [])
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})
-        extra_init_commands = list(extra_init_commands or [])
         lifecycle_hooks = lifecycle_hooks or []
-        del ephemeral
+        # Accepted for ComputeBackendImpl protocol parity but unused: ROCm
+        # rejects Modal outright, and the agent-image-based DOCKER sandbox
+        # runs no per-launch install commands.
+        del ephemeral, extra_init_commands
 
         if kind is SandboxKind.MODAL:
             raise ValueError(  # noqa: TRY003  # tracked: #288
@@ -203,7 +206,7 @@ class RocmBackend:
                 passthrough_paths=passthrough_paths,
                 env=env,
                 log_path=log_path,
-                extra_init_commands=extra_init_commands,
+                auth_files=auth_files,
                 lifecycle_hooks=lifecycle_hooks,
             )
 

--- a/src/vibesys/backends/trainium/__init__.py
+++ b/src/vibesys/backends/trainium/__init__.py
@@ -123,6 +123,7 @@ class TrainiumBackend:
         attach_accelerator: bool = True,
         ephemeral: bool = False,
         container_image: str | None = None,
+        auth_files: list[tuple[str, str]] | None = None,
     ) -> SandboxBackendProtocol:
         # Deferred: the sandbox classes subclass deepagents' BaseSandbox, which
         # pulls langchain + anthropic. Registration must stay import-cheap.
@@ -131,9 +132,11 @@ class TrainiumBackend:
         bind_mounts = list(bind_mounts or [])
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})
-        extra_init_commands = list(extra_init_commands or [])
         lifecycle_hooks = lifecycle_hooks or []
-        del ephemeral
+        # Accepted for ComputeBackendImpl protocol parity but unused: Trainium
+        # rejects Modal outright, and the agent-image-based DOCKER sandbox
+        # runs no per-launch install commands.
+        del ephemeral, extra_init_commands
 
         if kind is SandboxKind.MODAL:
             raise ValueError(  # noqa: TRY003  # tracked: #288
@@ -202,7 +205,7 @@ class TrainiumBackend:
                 passthrough_paths=passthrough_paths,
                 env=env,
                 log_path=log_path,
-                extra_init_commands=extra_init_commands,
+                auth_files=auth_files,
                 lifecycle_hooks=lifecycle_hooks,
             )
 

--- a/src/vibesys/sandbox/images.py
+++ b/src/vibesys/sandbox/images.py
@@ -1,0 +1,280 @@
+"""Build the two Docker images a task runs from.
+
+A task runs from an *agent image*: the shipped CLIs, helper tools, and a
+non-root ``agent`` user layered on top of a *task image* (built from the
+task's own Dockerfile, when it has one) or directly on a backend base image.
+Task images stay pure and serve the evaluator; the agent layer is what a CLI
+provider actually runs in, so a CLI version bump rebuilds only that top
+layer.
+
+Docker owns layer caching for both images; VibeSys invokes each build once
+per launch and consumes the runnable manifest ID resolved from a unique local
+tag. Default provenance attestations are disabled because their generated
+metadata otherwise changes the manifest ID when all filesystem layers match.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+from vibesys.agents import provider_policy
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Sequence
+
+_DEFAULT_BUILD_TIMEOUT_SECONDS = 1200.0
+_IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}")
+_DIAGNOSTIC_LIMIT = 1000
+_TASK_IMAGE_REPOSITORY = "vibesys-task-build"
+_AGENT_IMAGE_REPOSITORY = "vibesys-agent-build"
+
+#: The agent layer's build context: its Dockerfile plus nothing else. Resolved
+#: relative to this module rather than through ``importlib.resources`` so the
+#: path is always a real filesystem path Docker can build from, whether this
+#: package runs from a source checkout or an installed wheel (package data is
+#: unpacked to disk, never zipped, for this project).
+_AGENT_IMAGE_DIR = Path(__file__).resolve().parent / "images"
+_AGENT_DOCKERFILE = _AGENT_IMAGE_DIR / "agent.Dockerfile"
+
+
+class TaskImageBuildError(RuntimeError):
+    """Raised when Docker cannot produce a valid immutable image."""
+
+
+@dataclass(frozen=True)
+class _BuildTarget:
+    """Where a Dockerfile and its build context are, and how to tag and name it.
+
+    Bundled so the build/inspect/error-reporting helpers below stay under the
+    project's argument-count limit now that this module builds two images.
+    """
+
+    dockerfile: Path
+    context: Path
+    image_repository: str
+    image_label: str
+
+
+class DockerBuildRunner(Protocol):
+    """Injectable process boundary for a Docker image build."""
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run one Docker command without a shell."""
+        ...
+
+
+class SubprocessDockerBuildRunner:
+    """Run Docker directly and capture its diagnostics."""
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run one Docker command without invoking a shell."""
+        return subprocess.run(  # noqa: S603
+            tuple(argv),
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+
+
+def build_task_image(
+    dockerfile_path: Path,
+    *,
+    base_image: str | None = None,
+    command_runner: DockerBuildRunner | None = None,
+    timeout: float = _DEFAULT_BUILD_TIMEOUT_SECONDS,
+) -> str:
+    """Build a task Dockerfile and return its immutable Docker image ID.
+
+    The task directory is the complete Docker build context. Candidate source,
+    Git metadata, and other project inputs therefore cannot be copied into the
+    image. Docker owns layer caching; VibeSys invokes the build once per launch
+    and consumes the runnable manifest ID resolved from a unique local tag.
+    Default provenance attestations are disabled because their generated
+    metadata otherwise changes the manifest ID when all filesystem layers
+    match. The unique tag remains as a local reachability anchor: containerd's
+    image store cannot run the stable config digest emitted by ``--iidfile``
+    when an otherwise untagged image has no retained manifest reference.
+
+    ``base_image``, when given, is passed as ``--build-arg BASE_IMAGE=...``,
+    so a task Dockerfile may declare ``ARG BASE_IMAGE`` and
+    ``FROM ${BASE_IMAGE}`` to build on top of the backend's base image instead
+    of naming its own. A task Dockerfile with its own ``FROM`` line ignores an
+    unused build arg, so this is safe to pass unconditionally from a caller
+    that does not know whether the task Dockerfile uses it.
+    """
+    # Keep the lexical parent as the build context. Resolving the Dockerfile
+    # itself could silently widen the context to a symlink target elsewhere.
+    dockerfile = dockerfile_path.expanduser().absolute()
+    root = dockerfile.parent
+    if not dockerfile.is_file() or dockerfile.is_symlink():
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Task Dockerfile must be a regular file: {dockerfile}"
+        )
+    if timeout <= 0:
+        raise ValueError("task image build timeout must be positive")  # noqa: TRY003
+
+    runner = command_runner or SubprocessDockerBuildRunner()
+    extra_build_args = ("--build-arg", f"BASE_IMAGE={base_image}") if base_image is not None else ()
+    target = _BuildTarget(
+        dockerfile=dockerfile,
+        context=root,
+        image_repository=_TASK_IMAGE_REPOSITORY,
+        image_label="task image",
+    )
+    return _build_and_inspect(target, extra_build_args, runner=runner, timeout=timeout)
+
+
+def agent_image(
+    base_image: str,
+    *,
+    task_dockerfile: Path | None = None,
+    toolchains: Collection[str] = (),
+    command_runner: DockerBuildRunner | None = None,
+    timeout: float = _DEFAULT_BUILD_TIMEOUT_SECONDS,
+) -> str:
+    """Build the agent layer on top of a task image, and return its image ID.
+
+    When ``task_dockerfile`` is given, the task image is built first (via
+    :func:`build_task_image`, with ``base_image`` passed through so the task
+    Dockerfile may ``FROM ${BASE_IMAGE}``) and the agent layer is built on top
+    of the resulting image ID. Otherwise the agent layer is built directly on
+    ``base_image``.
+
+    CLI and toolchain versions come from :mod:`vibesys.agents.provider_policy`
+    and are passed as build args, so a version bump changes this module's
+    caller nowhere: rebuilding with an unchanged Dockerfile and unchanged
+    build args resolves to the same image from Docker's layer cache.
+    ``toolchains`` is sorted and deduplicated before being rendered, so the
+    build args (and therefore the cache key) do not depend on collection
+    order.
+    """
+    if timeout <= 0:
+        raise ValueError("agent image build timeout must be positive")  # noqa: TRY003
+
+    runner = command_runner or SubprocessDockerBuildRunner()
+    base = (
+        build_task_image(
+            task_dockerfile,
+            base_image=base_image,
+            command_runner=runner,
+            timeout=timeout,
+        )
+        if task_dockerfile is not None
+        else base_image
+    )
+
+    build_args: list[str] = ["--build-arg", f"BASE_IMAGE={base}"]
+    build_args += ["--build-arg", f"NODE_VERSION={provider_policy.NODE_VERSION}"]
+    for provider, version in provider_policy.CLI_VERSIONS.items():
+        build_args += ["--build-arg", f"{provider.upper()}_VERSION={version}"]
+    build_args += ["--build-arg", f"TOOLCHAINS={' '.join(sorted(set(toolchains)))}"]
+    build_args += ["--build-arg", f"RUST_VERSION={provider_policy.RUST_TOOLCHAIN_VERSION}"]
+    build_args += ["--build-arg", f"GO_VERSION={provider_policy.GO_TOOLCHAIN_VERSION}"]
+
+    target = _BuildTarget(
+        dockerfile=_AGENT_DOCKERFILE,
+        context=_AGENT_IMAGE_DIR,
+        image_repository=_AGENT_IMAGE_REPOSITORY,
+        image_label="agent image",
+    )
+    return _build_and_inspect(target, tuple(build_args), runner=runner, timeout=timeout)
+
+
+def _build_and_inspect(
+    target: _BuildTarget,
+    extra_build_args: Sequence[str],
+    *,
+    runner: DockerBuildRunner,
+    timeout: float,
+) -> str:
+    """Build one Dockerfile to a unique tag and resolve its immutable ID."""
+    image_tag = f"{target.image_repository}:{uuid.uuid4().hex}"
+    build_argv = (
+        "docker",
+        "build",
+        "--provenance=false",
+        "--tag",
+        image_tag,
+        "--file",
+        str(target.dockerfile),
+        *extra_build_args,
+        str(target.context),
+    )
+    build_result = _run_docker(
+        runner, build_argv, timeout=timeout, action="building", target=target
+    )
+    if build_result.returncode != 0:
+        detail = (build_result.stderr or build_result.stdout or "docker build failed").strip()
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Could not build {target.image_label} from {target.dockerfile} "
+            f"(exit {build_result.returncode}): {detail[:_DIAGNOSTIC_LIMIT]}"
+        )
+
+    inspect_argv = (
+        "docker",
+        "image",
+        "inspect",
+        "--format",
+        "{{.Id}}",
+        image_tag,
+    )
+    inspect_result = _run_docker(
+        runner, inspect_argv, timeout=timeout, action="inspecting", target=target
+    )
+    if inspect_result.returncode != 0:
+        detail = (inspect_result.stderr or inspect_result.stdout or "docker inspect failed").strip()
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Could not resolve runnable {target.image_label} {image_tag} built from "
+            f"{target.dockerfile} (exit {inspect_result.returncode}): "
+            f"{detail[:_DIAGNOSTIC_LIMIT]}"
+        )
+    image_id = inspect_result.stdout.strip()
+    if _IMAGE_ID.fullmatch(image_id) is None:
+        displayed = image_id[:_DIAGNOSTIC_LIMIT] or "<empty>"
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Docker returned an invalid runnable {target.image_label} ID for "
+            f"{target.dockerfile}: {displayed!r}"
+        )
+    return image_id
+
+
+def _run_docker(
+    runner: DockerBuildRunner,
+    argv: Sequence[str],
+    *,
+    timeout: float,
+    action: str,
+    target: _BuildTarget,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return runner.run(argv, cwd=target.dockerfile.parent, timeout=timeout)
+    except FileNotFoundError as exc:
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Docker was not found while {action} {target.image_label}: {target.dockerfile}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Docker timed out after {timeout:g} seconds while {action} "
+            f"{target.image_label}: {target.dockerfile}"
+        ) from exc

--- a/src/vibesys/sandbox/images/agent.Dockerfile
+++ b/src/vibesys/sandbox/images/agent.Dockerfile
@@ -1,0 +1,145 @@
+# Agent layer, built on top of a task image (or a backend base image when the
+# task has no Dockerfile of its own). Installs the shipped CLIs, helper
+# tools, and a non-root `agent` user; ends with `USER agent` so a container
+# never runs a provider CLI as root. Built by `vibesys.sandbox.images.agent_image`,
+# which supplies every ARG below from `vibesys.agents.provider_policy`.
+#
+# Debian/Ubuntu only: the apt step below requires it. All current backend
+# bases and task Dockerfiles are.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG NODE_VERSION
+ARG CLAUDE_VERSION
+ARG CODEX_VERSION
+ARG GEMINI_VERSION
+ARG OPENCODE_VERSION
+# Space-separated subset of "rust go". Empty skips both toolchains.
+ARG TOOLCHAINS=""
+ARG RUST_VERSION
+ARG GO_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Retrying because archive mirrors reachable from our hosts return transient
+# fetch failures often enough to abort a single-shot `apt-get update`.
+# Idempotent: re-running against packages already installed is a no-op, and
+# Docker's own layer cache means this step only actually runs once per
+# unchanged base image.
+RUN set -eux; \
+    installed=""; \
+    for attempt in 1 2 3 4 5; do \
+        if apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+            curl ca-certificates git ripgrep python3 python3-pip python3-venv \
+            tar unzip build-essential; then \
+            installed=1; \
+            break; \
+        fi; \
+        echo "apt retry ${attempt}..." >&2; \
+        sleep $((attempt * 5)); \
+    done; \
+    [ -n "${installed}" ]; \
+    rm -rf /var/lib/apt/lists/*
+
+# Node from the nodejs.org tarball, pinned, extracted straight into
+# /usr/local (its bin/lib/share/include layout merges with what's already
+# there). apt-get install nodejs is not used: the version in Debian/Ubuntu
+# archives lags far behind the CLIs below and archive mirrors are the least
+# reliable network path from our hosts.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "${arch}" in \
+        amd64) node_arch=x64 ;; \
+        arm64) node_arch=arm64 ;; \
+        *) echo "unsupported architecture for Node: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL --retry 5 --retry-delay 5 -o /tmp/node.tar.gz \
+        "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${node_arch}.tar.gz"; \
+    tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1; \
+    rm -f /tmp/node.tar.gz; \
+    node --version; \
+    npm --version
+
+# All four shipped CLIs in one layer: the provider a session runs is a
+# run-time choice, not something baked into the image.
+# --include=optional: codex ships its Linux-x64 native binary as an optional
+# dependency that `npm install -g` skips under some npm configurations.
+RUN npm install -g --include=optional \
+        @anthropic-ai/claude-code@${CLAUDE_VERSION} \
+        @openai/codex@${CODEX_VERSION} \
+        @google/gemini-cli@${GEMINI_VERSION} \
+        opencode-ai@${OPENCODE_VERSION}
+
+# Debian 12+ marks the system Python as externally managed (PEP 668); this
+# image has no other consumer of that protection.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN pip install --no-cache-dir uv 'mcp>=1.0,<2'
+
+# Harmless when the corresponding toolchain is absent, so these are set
+# unconditionally rather than only inside the TOOLCHAINS branches below.
+ENV RUSTUP_HOME=/opt/rustup \
+    CARGO_HOME=/opt/cargo
+ENV PATH="/opt/cargo/bin:/usr/local/go/bin:${PATH}"
+
+# `ENV PATH` only reaches a process that inherits the image's environment.
+# Debian's /etc/profile resets PATH from scratch for a *login* shell (`bash
+# -l`, or `bash -lc "..."`) before sourcing /etc/profile.d/*.sh, which would
+# otherwise silently drop the toolchain directories above for exactly that
+# invocation style. Re-adding them here keeps a login shell and a plain
+# `docker exec` agreeing on PATH.
+RUN echo 'export PATH="/opt/cargo/bin:/usr/local/go/bin:${PATH}"' \
+        > /etc/profile.d/vibesys-agent-toolchains.sh
+
+# Toolchains are opt-in per task and installed at build time so agents never
+# need to bootstrap one mid-round. Mirrors the rustup invocation task
+# Dockerfiles already use (see
+# examples/data-structures/repositories/queue-rs/.vibesys/tasks/verus-mpmc-open/Dockerfile).
+RUN set -eux; \
+    case " ${TOOLCHAINS} " in \
+        *" rust "*) \
+            curl -fsSL --retry 5 --retry-delay 5 -o /tmp/rustup-init.sh https://sh.rustup.rs; \
+            sh /tmp/rustup-init.sh -y --profile minimal --default-toolchain "${RUST_VERSION}"; \
+            rm -f /tmp/rustup-init.sh; \
+            chmod -R a+rX /opt/rustup /opt/cargo; \
+            ;; \
+        *) ;; \
+    esac
+
+RUN set -eux; \
+    case " ${TOOLCHAINS} " in \
+        *" go "*) \
+            arch="$(dpkg --print-architecture)"; \
+            case "${arch}" in \
+                amd64) go_arch=amd64 ;; \
+                arm64) go_arch=arm64 ;; \
+                *) echo "unsupported architecture for Go: ${arch}" >&2; exit 1 ;; \
+            esac; \
+            curl -fsSL --retry 5 --retry-delay 5 -o /tmp/go.tar.gz \
+                "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz"; \
+            rm -rf /usr/local/go; \
+            tar -xzf /tmp/go.tar.gz -C /usr/local; \
+            rm -f /tmp/go.tar.gz; \
+            chmod -R a+rX /usr/local/go; \
+            ;; \
+        *) ;; \
+    esac
+
+# The sandbox remaps this uid to the host uid at container start, so what
+# matters here is the fixed uid (1000), not the name. Reuse a base image's
+# existing uid-1000 account by renaming it instead of failing on a collision.
+RUN set -eux; \
+    if id -u agent >/dev/null 2>&1; then \
+        : ; \
+    elif getent passwd 1000 >/dev/null 2>&1; then \
+        existing="$(getent passwd 1000 | cut -d: -f1)"; \
+        usermod --login agent --home /home/agent --move-home --shell /bin/bash "${existing}"; \
+    else \
+        useradd --create-home --uid 1000 --shell /bin/bash agent; \
+    fi
+
+RUN mkdir -p /workspace && chown agent /workspace
+
+WORKDIR /workspace
+USER agent
+ENV HOME=/home/agent

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -365,18 +365,28 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
         return cls(DockerEnvironmentConfig(image=str(image) if image else None))
 
     def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession:  # noqa: D102  # tracked: #288
+        from vibesys.sandbox.images import agent_image  # noqa: PLC0415  # tracked: #288
+
         tools = _evaluator_tools(request)
-        container_image = (
-            _resolve_docker_image_id(_docker_backend_image(request)) if tools else None
+        # The task image, when a task has a Dockerfile, is built by the
+        # headless entrypoint and arrives here as the backend image; only the
+        # agent layer is applied on top of it.
+        container_image = agent_image(
+            _docker_backend_image(request),
+            toolchains=_docker_agent_toolchains(request, tools),
         )
         bind_mounts, docker_symlinks, passthrough = _container_mount_plan(request)
         bind_mounts.extend(
             _docker_evaluator_tool_mounts(request, tools, container_image=container_image)
         )
-        extra_init_commands, cli_provider_env = _cli_container_setup(request)
-        extra_init_commands.extend(
-            _evaluator_container_setup(request, include_declared_tools=False)
-        )
+        resolved_cli = _cli_container_env(request)
+        cli_provider_env: dict[str, str] = {}
+        auth_files: list[tuple[str, str]] = []
+        if resolved_cli is not None:
+            provider, cli_provider_env = resolved_cli
+            from vibesys.agents.cli_docker import auth_copy_paths  # noqa: PLC0415  # tracked: #288
+
+            auth_files = auth_copy_paths(provider)
         cli_provider_env.setdefault("UV_CACHE_DIR", "/workspace/.cache/uv")
         if request.git_history_root is not None:
             cli_provider_env.setdefault("VIBESYS_GIT_HISTORY", "/opt/vibesys-history")
@@ -390,13 +400,12 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
             bind_mounts=bind_mounts,
             passthrough_paths=passthrough,
             extra_env=cli_provider_env,
-            extra_init_commands=extra_init_commands,
+            auth_files=auth_files,
             lifecycle_hooks=lifecycle_hooks,
             container_image=container_image,
         )
         log: Callable[[str], None] = request.log or (lambda _: None)
-        label = getattr(request.backend, "image", self.config.image or "<backend-default>")
-        log(f"[docker] starting container with image {label}")
+        log(f"[docker] starting container with image {container_image}")
         # DOCKER-kind sandboxes always manage a container lifetime.
         _start_sandbox(sandbox)
 
@@ -1533,25 +1542,37 @@ def _container_project_policy_mounts(
     return mounts
 
 
-def _cli_container_setup(
-    request: RunEnvironmentRequest,
-) -> tuple[list[str], dict[str, str]]:
+def _cli_container_env(request: RunEnvironmentRequest) -> tuple[str, dict[str, str]] | None:
+    """Return ``(provider, container env)`` when a CLI provider needs a container.
+
+    Factored out of :func:`_cli_container_setup` so the plain Docker path —
+    which starts from a prebuilt agent image and installs nothing at start —
+    can still get the auth-presence check and the auth env passthrough
+    without the shell-command half of that function. Modal and SkyPilot keep
+    calling :func:`_cli_container_setup` in full until their own image work
+    (#676, #679) lands.
+
+    Returns ``None`` when the run is not a containerized CLI agent (a
+    different agent backend, or no CLI provider selected).
+
+    Raises:
+        ValueError: if *request.cli_provider* has neither a staged auth file
+            nor a usable auth environment variable on this host.
+    """
     effective_agent = request.agent_backend or DEFAULT_AGENT_BACKEND
     if effective_agent != "cli" or not request.cli_provider:
-        return [], {}
+        return None
     from vibesys.agents.cli_docker import (  # noqa: PLC0415  # tracked: #288
         DOCKER_PROVIDER_ENV,
-        auth_copy_commands,
         auth_env_passthrough,
         auth_env_vars,
         auth_paths,
-        docker_init_commands,
     )
 
     provider = request.cli_provider
-    auth_commands = auth_copy_commands(provider)
     auth_env = auth_env_passthrough(provider)
-    if not auth_commands and not auth_env:
+    staged_auth = [spec for spec in auth_paths(provider) if spec.host_path.exists()]
+    if not staged_auth and not auth_env:
         checked_files = (
             ", ".join(str(spec.host_path) for spec in auth_paths(provider)) or "<none registered>"
         )
@@ -1567,7 +1588,22 @@ def _cli_container_setup(
     # Container processes inherit only what ``docker run -e`` sets; the editor
     # container has no other view of the host environment.
     env.update(auth_env)
-    commands = [*auth_commands, *docker_init_commands(provider)]
+    return provider, env
+
+
+def _cli_container_setup(
+    request: RunEnvironmentRequest,
+) -> tuple[list[str], dict[str, str]]:
+    resolved = _cli_container_env(request)
+    if resolved is None:
+        return [], {}
+    provider, env = resolved
+    from vibesys.agents.cli_docker import (  # noqa: PLC0415  # tracked: #288
+        auth_copy_commands,
+        docker_init_commands,
+    )
+
+    commands = [*auth_copy_commands(provider), *docker_init_commands(provider)]
     return commands, env
 
 
@@ -1790,9 +1826,15 @@ def _docker_evaluator_tools_root(
 
 
 def _docker_backend_image(request: RunEnvironmentRequest) -> str:
+    """Return the compute backend's base image, the ``agent_image`` build input.
+
+    Used both to build the agent image every Docker run starts from and, when
+    the run also needs cargo-git evaluator tools, to key their host-side
+    build cache.
+    """
     image = getattr(request.backend, "image", None)
     if not isinstance(image, str) or not image:
-        raise EvaluatorToolError("Docker evaluator tools require a configured backend image")  # noqa: TRY003
+        raise EvaluatorToolError("Docker execution requires a configured backend image")  # noqa: TRY003
     return image
 
 
@@ -1871,6 +1913,27 @@ def _evaluator_tools(request: RunEnvironmentRequest) -> dict[str, CargoGitToolSp
     if request.evaluator_package_root is None:
         return {}
     return load_evaluator_package(request.evaluator_package_root).metadata.tools
+
+
+def _docker_agent_toolchains(
+    request: RunEnvironmentRequest,
+    tools: Mapping[str, CargoGitToolSpec],
+) -> frozenset[str]:
+    """Return the toolchains the agent image should bake in for this run.
+
+    Mirrors what :func:`_evaluator_container_setup` installs per-run today:
+    the evaluator package's declared toolchains, plus ``"rust"`` when the run
+    also needs cargo-git evaluator tools. *tools* is the caller's own
+    :func:`_evaluator_tools` result, passed in rather than recomputed.
+    """
+    toolchains: set[str] = set()
+    if request.evaluator_package_root is not None:
+        toolchains |= set(
+            load_evaluator_package(request.evaluator_package_root).metadata.toolchains
+        )
+    if tools:
+        toolchains.add("rust")
+    return frozenset(toolchains)
 
 
 def _required_evaluator_tools_root(request: RunEnvironmentRequest) -> Path:

--- a/src/vibesys/sandbox/task_image.py
+++ b/src/vibesys/sandbox/task_image.py
@@ -1,163 +1,17 @@
-"""Build the conventional Docker image owned by a repository-native task."""
+"""Compatibility re-export. The implementation moved to :mod:`vibesys.sandbox.images`."""
 
 from __future__ import annotations
 
-import re
-import subprocess
-import uuid
-from typing import TYPE_CHECKING, Protocol
+from vibesys.sandbox.images import (
+    DockerBuildRunner,
+    SubprocessDockerBuildRunner,
+    TaskImageBuildError,
+    build_task_image,
+)
 
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from pathlib import Path
-
-_DEFAULT_BUILD_TIMEOUT_SECONDS = 1200.0
-_IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}")
-_DIAGNOSTIC_LIMIT = 1000
-_TASK_IMAGE_REPOSITORY = "vibesys-task-build"
-
-
-class TaskImageBuildError(RuntimeError):
-    """Raised when Docker cannot produce a valid immutable task image."""
-
-
-class DockerBuildRunner(Protocol):
-    """Injectable process boundary for a Docker image build."""
-
-    def run(
-        self,
-        argv: Sequence[str],
-        *,
-        cwd: Path,
-        timeout: float,
-    ) -> subprocess.CompletedProcess[str]:
-        """Run one Docker command without a shell."""
-        ...
-
-
-class SubprocessDockerBuildRunner:
-    """Run Docker directly and capture its diagnostics."""
-
-    def run(
-        self,
-        argv: Sequence[str],
-        *,
-        cwd: Path,
-        timeout: float,
-    ) -> subprocess.CompletedProcess[str]:
-        """Run one Docker command without invoking a shell."""
-        return subprocess.run(  # noqa: S603
-            tuple(argv),
-            cwd=cwd,
-            capture_output=True,
-            check=False,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=timeout,
-        )
-
-
-def build_task_image(
-    dockerfile_path: Path,
-    *,
-    command_runner: DockerBuildRunner | None = None,
-    timeout: float = _DEFAULT_BUILD_TIMEOUT_SECONDS,
-) -> str:
-    """Build a task Dockerfile and return its immutable Docker image ID.
-
-    The task directory is the complete Docker build context. Candidate source,
-    Git metadata, and other project inputs therefore cannot be copied into the
-    image. Docker owns layer caching; VibeSys invokes the build once per launch
-    and consumes the runnable manifest ID resolved from a unique local tag.
-    Default provenance attestations are disabled because their generated
-    metadata otherwise changes the manifest ID when all filesystem layers
-    match. The unique tag remains as a local reachability anchor: containerd's
-    image store cannot run the stable config digest emitted by ``--iidfile``
-    when an otherwise untagged image has no retained manifest reference.
-    """
-    # Keep the lexical parent as the build context. Resolving the Dockerfile
-    # itself could silently widen the context to a symlink target elsewhere.
-    dockerfile = dockerfile_path.expanduser().absolute()
-    root = dockerfile.parent
-    if not dockerfile.is_file() or dockerfile.is_symlink():
-        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-            f"Task Dockerfile must be a regular file: {dockerfile}"
-        )
-    if timeout <= 0:
-        raise ValueError("task image build timeout must be positive")  # noqa: TRY003
-
-    runner = command_runner or SubprocessDockerBuildRunner()
-    image_tag = f"{_TASK_IMAGE_REPOSITORY}:{uuid.uuid4().hex}"
-    build_argv = (
-        "docker",
-        "build",
-        "--provenance=false",
-        "--tag",
-        image_tag,
-        "--file",
-        str(dockerfile),
-        str(root),
-    )
-    build_result = _run_docker(
-        runner,
-        build_argv,
-        timeout=timeout,
-        action="building",
-        dockerfile=dockerfile,
-    )
-    if build_result.returncode != 0:
-        detail = (build_result.stderr or build_result.stdout or "docker build failed").strip()
-        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-            f"Could not build task image from {dockerfile} "
-            f"(exit {build_result.returncode}): {detail[:_DIAGNOSTIC_LIMIT]}"
-        )
-
-    inspect_argv = (
-        "docker",
-        "image",
-        "inspect",
-        "--format",
-        "{{.Id}}",
-        image_tag,
-    )
-    inspect_result = _run_docker(
-        runner,
-        inspect_argv,
-        timeout=timeout,
-        action="inspecting",
-        dockerfile=dockerfile,
-    )
-    if inspect_result.returncode != 0:
-        detail = (inspect_result.stderr or inspect_result.stdout or "docker inspect failed").strip()
-        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-            f"Could not resolve runnable task image {image_tag} built from {dockerfile} "
-            f"(exit {inspect_result.returncode}): {detail[:_DIAGNOSTIC_LIMIT]}"
-        )
-    image_id = inspect_result.stdout.strip()
-    if _IMAGE_ID.fullmatch(image_id) is None:
-        displayed = image_id[:_DIAGNOSTIC_LIMIT] or "<empty>"
-        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-            f"Docker returned an invalid runnable task image ID for {dockerfile}: {displayed!r}"
-        )
-    return image_id
-
-
-def _run_docker(
-    runner: DockerBuildRunner,
-    argv: Sequence[str],
-    *,
-    timeout: float,
-    action: str,
-    dockerfile: Path,
-) -> subprocess.CompletedProcess[str]:
-    try:
-        return runner.run(argv, cwd=dockerfile.parent, timeout=timeout)
-    except FileNotFoundError as exc:
-        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-            f"Docker was not found while {action} task image: {dockerfile}"
-        ) from exc
-    except subprocess.TimeoutExpired as exc:
-        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-            f"Docker timed out after {timeout:g} seconds while {action} task image: {dockerfile}"
-        ) from exc
+__all__ = [
+    "DockerBuildRunner",
+    "SubprocessDockerBuildRunner",
+    "TaskImageBuildError",
+    "build_task_image",
+]

--- a/tests/e2e/test_agent_image_e2e.py
+++ b/tests/e2e/test_agent_image_e2e.py
@@ -1,0 +1,81 @@
+"""Builds a real agent image and runs every shipped CLI inside it.
+
+Skipped unless ``VIBESYS_E2E_DOCKER=1`` and ``docker`` is on PATH, so an
+ordinary ``pytest`` run needs neither Docker nor network access:
+
+```bash
+VIBESYS_E2E_DOCKER=1 uv run pytest tests/e2e/test_agent_image_e2e.py -q -s
+```
+
+Building the CPU variant (``python:3.12-bookworm`` base, both optional
+toolchains) needs network access to fetch Node, the four CLI packages,
+rustup, and the Go toolchain, and can take several minutes even on a fast
+connection. A rebuild with nothing changed is fast: Docker's layer cache
+answers it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from vibesys.sandbox.images import agent_image
+
+ENABLE_ENV = "VIBESYS_E2E_DOCKER"
+
+pytestmark = pytest.mark.e2e
+
+#: Generous: fetching Node, four npm-installed CLIs, rustup, and the Go
+#: toolchain over a real network, from a cold Docker layer cache.
+_BUILD_TIMEOUT_S = 900.0
+_RUN_TIMEOUT_S = 120.0
+
+#: Proves the image runs as the non-root ``agent`` user with the fixed uid
+#: the sandbox remaps to the host uid at container start (see
+#: ``agent.Dockerfile``), then that every shipped CLI, both optional
+#: toolchains, ripgrep, and the ``mcp`` package are all reachable.
+_CHECK_SCRIPT = (
+    "set -e; "
+    "id -u; "
+    "claude --version; "
+    "codex --version; "
+    "gemini --version; "
+    "opencode --version; "
+    "cargo --version; "
+    "go version; "
+    "rg --version; "
+    'python3 -c "import mcp"'
+)
+
+
+def _enabled() -> bool:
+    return os.environ.get(ENABLE_ENV) == "1"
+
+
+@pytest.mark.skipif(
+    not _enabled() or shutil.which("docker") is None,
+    reason=f"set {ENABLE_ENV}=1 with docker on PATH to build and run the agent image",
+)
+def test_cpu_agent_image_runs_every_shipped_cli_as_the_agent_user() -> None:
+    image_id = agent_image(
+        "python:3.12-bookworm",
+        toolchains=("rust", "go"),
+        timeout=_BUILD_TIMEOUT_S,
+    )
+
+    result = subprocess.run(  # noqa: S603
+        ("docker", "run", "--rm", image_id, "bash", "-lc", _CHECK_SCRIPT),  # noqa: S607
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=_RUN_TIMEOUT_S,
+    )
+
+    print(result.stdout)  # noqa: T201  # -s surfaces this for a human reading the e2e run
+    print(result.stderr)  # noqa: T201
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    output_lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert output_lines[0] == "1000", output_lines

--- a/tests/vibesys/agents/drivers/test_agentshim_driver.py
+++ b/tests/vibesys/agents/drivers/test_agentshim_driver.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import concurrent.futures
 import json
-import os
 import subprocess
 import threading
 import time
@@ -538,7 +537,7 @@ def _container_driver(
     provider: str,
     runs: FakeRun | Sequence[FakeRun] | Callable[[agentshim.CommandRequest], FakeRun],
     **options: Any,  # noqa: ANN401
-) -> tuple[subject.AgentShimDriver, FakeExecutor, list[tuple[str, int, int]]]:
+) -> tuple[subject.AgentShimDriver, FakeExecutor]:
     """Build a container-mode driver whose ``docker`` client is the fake.
 
     The Docker executor rewrites each request into a ``docker exec`` command
@@ -546,20 +545,14 @@ def _container_driver(
     lets the argv the container would have received be asserted directly.
     """
     fake = FakeExecutor(runs)
-    repairs: list[tuple[str, int, int]] = []
 
     monkeypatch.setattr(docker_executor, "HostCommandExecutor", lambda: fake)
-    monkeypatch.setattr(
-        docker_executor,
-        "repair_workspace_ownership",
-        lambda container_id, *, uid, gid: repairs.append((container_id, uid, gid)),
-    )
     driver = subject.AgentShimDriver(
         provider=provider,
         docker_sandboxes={"implementer": SimpleNamespace(container_id="container-1")},
         **options,
     )
-    return driver, fake, repairs
+    return driver, fake
 
 
 def _container_spec(tmp_path: Path, provider: str, **changes: Any) -> AgentSessionSpec:  # noqa: ANN401
@@ -583,9 +576,7 @@ def test_a_container_turn_carries_the_session_environment_and_workdir(
     to be handed to ``docker exec`` as ``-e`` flags; and the container turn
     names no ``cwd`` of its own, so the executor supplies ``-w``.
     """
-    driver, fake, _repairs = _container_driver(
-        monkeypatch, provider, scripted_turn(provider, text="ok")
-    )
+    driver, fake = _container_driver(monkeypatch, provider, scripted_turn(provider, text="ok"))
     session = driver.create_session(_container_spec(tmp_path, provider))
 
     session.run_turn(AgentTurnRequest(message="Do it"))
@@ -622,9 +613,7 @@ def test_a_container_turn_carries_no_host_device_pin(
     variable off the host environment.
     """
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
-    driver, fake, _repairs = _container_driver(
-        monkeypatch, provider, scripted_turn(provider, text="ok")
-    )
+    driver, fake = _container_driver(monkeypatch, provider, scripted_turn(provider, text="ok"))
     session = driver.create_session(_container_spec(tmp_path, provider, environment=()))
 
     session.run_turn(AgentTurnRequest(message="Do it"))
@@ -646,9 +635,7 @@ def test_a_container_binary_check_gets_the_container_budget(
     A failed health check ends the run before the first turn, so the budget
     has to survive a daemon that is busy rather than dead.
     """
-    driver, fake, _repairs = _container_driver(
-        monkeypatch, provider, scripted_turn(provider, text="ok")
-    )
+    driver, fake = _container_driver(monkeypatch, provider, scripted_turn(provider, text="ok"))
 
     driver.create_session(_container_spec(tmp_path, provider))
 
@@ -663,30 +650,13 @@ def test_the_binary_check_budget_is_a_driver_option(
     tmp_path: Path,
     provider: str,
 ) -> None:
-    driver, fake, _repairs = _container_driver(
+    driver, fake = _container_driver(
         monkeypatch, provider, scripted_turn(provider, text="ok"), check_timeout=5
     )
 
     driver.create_session(_container_spec(tmp_path, provider))
 
     assert fake.requests[0].timeout == 5
-
-
-@pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
-def test_a_container_turn_repairs_workspace_ownership_afterwards(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    provider: str,
-) -> None:
-    """CLI agents run as root in the container; the host user gets its files back."""
-    driver, _fake, repairs = _container_driver(
-        monkeypatch, provider, scripted_turn(provider, text="ok")
-    )
-    session = driver.create_session(_container_spec(tmp_path, provider))
-
-    session.run_turn(AgentTurnRequest(message="Do it"))
-
-    assert repairs == [("container-1", os.getuid(), os.getgid())]
 
 
 def _watchdog_spy(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, ...]]:
@@ -712,36 +682,6 @@ def _watchdog_spy(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, ...]]:
     return watched
 
 
-@pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
-def test_a_stuck_ownership_repair_is_not_reported_as_an_agent_timeout(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    provider: str,
-) -> None:
-    """The repair shells out with its own budget, from the turn's ``finally``.
-
-    Loops fail closed on ``subprocess.TimeoutExpired`` and read it as the agent
-    having run out of time, which is a different failure with a different
-    response, so the repair's own timeout must not wear that type.
-    """
-    driver, _fake, _repairs = _container_driver(
-        monkeypatch, provider, scripted_turn(provider, text="ok")
-    )
-
-    def stuck(container_id: str, *, uid: int, gid: int) -> None:
-        del container_id, uid, gid
-        raise subprocess.TimeoutExpired(cmd=["docker", "exec", "c", "find"], timeout=120)
-
-    monkeypatch.setattr(docker_executor, "repair_workspace_ownership", stuck)
-    session = driver.create_session(_container_spec(tmp_path, provider))
-
-    with pytest.raises(RuntimeError) as raised:
-        session.run_turn(AgentTurnRequest(message="Do it"))
-
-    assert not isinstance(raised.value, subprocess.TimeoutExpired)
-    assert "120 seconds" in str(raised.value)
-
-
 def test_a_container_codex_session_runs_its_turns_through_the_watchdog(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -752,9 +692,7 @@ def test_a_container_codex_session_runs_its_turns_through_the_watchdog(
     merely constructible from the driver.
     """
     watched = _watchdog_spy(monkeypatch)
-    driver, _fake, _repairs = _container_driver(
-        monkeypatch, "codex", scripted_turn("codex", text="ok")
-    )
+    driver, _fake = _container_driver(monkeypatch, "codex", scripted_turn("codex", text="ok"))
     session = driver.create_session(_container_spec(tmp_path, "codex"))
 
     session.run_turn(AgentTurnRequest(message="Do it"))
@@ -771,9 +709,7 @@ def test_a_container_session_for_another_provider_gets_no_watchdog(
 ) -> None:
     """The watchdog compensates for one provider's behaviour, not for containers."""
     watched = _watchdog_spy(monkeypatch)
-    driver, fake, _repairs = _container_driver(
-        monkeypatch, provider, scripted_turn(provider, text="ok")
-    )
+    driver, fake = _container_driver(monkeypatch, provider, scripted_turn(provider, text="ok"))
     session = driver.create_session(_container_spec(tmp_path, provider))
 
     session.run_turn(AgentTurnRequest(message="Do it"))
@@ -809,7 +745,7 @@ def test_container_session_mcp_servers_are_installed_on_the_host_workspace(
         installed.append(installed_mcp_servers(provider, request, tmp_path))
         return scripted_turn(provider, text="ok")
 
-    driver, _fake, _repairs = _container_driver(monkeypatch, provider, run)
+    driver, _fake = _container_driver(monkeypatch, provider, run)
     session = driver.create_session(_container_spec(tmp_path, provider, mcp_servers=(server,)))
 
     session.run_turn(AgentTurnRequest(message="review"))
@@ -1228,7 +1164,7 @@ def test_a_container_timeout_reports_no_forwarded_environment_value(
         # included; only the turn itself is the one that hangs.
         return FakeRun() if "--help" in request.argv else FakeRun(timeout=True)
 
-    driver, _fake, _repairs = _container_driver(monkeypatch, provider, run)
+    driver, _fake = _container_driver(monkeypatch, provider, run)
     session = driver.create_session(
         _container_spec(
             tmp_path,
@@ -1472,9 +1408,7 @@ def test_a_container_turn_does_not_forward_the_inherited_pwd(
     tmp_path: Path,
     provider: str,
 ) -> None:
-    driver, fake, _repairs = _container_driver(
-        monkeypatch, provider, scripted_turn(provider, text="ok")
-    )
+    driver, fake = _container_driver(monkeypatch, provider, scripted_turn(provider, text="ok"))
     session = driver.create_session(
         _container_spec(tmp_path, provider, environment=(("PWD", "/somewhere/stale"), ("GPU", "1")))
     )

--- a/tests/vibesys/agents/test_cli_docker.py
+++ b/tests/vibesys/agents/test_cli_docker.py
@@ -100,7 +100,7 @@ class TestAuthPaths:
 
         for provider in _SHIPPED:
             expected = [
-                (auth_file, f"/root/{auth_file}")
+                (auth_file, f"/home/agent/{auth_file}")
                 for auth_file in _FAKE_PROFILES[provider].auth_files
             ]
             staged = [
@@ -172,9 +172,14 @@ class TestAuthImport:
             (str(tmp_path / ".claude.json"), "/opt/vibesys-auth/2", True),
         ]
         assert cli_docker.auth_copy_commands("fixture") == [
-            "mkdir -p /root/.codex && cp -a /opt/vibesys-auth/0 /root/.codex/auth.json",
-            "mkdir -p /root/.codex && cp -a /opt/vibesys-auth/1 /root/.codex/config.toml",
-            "mkdir -p /root && cp -a /opt/vibesys-auth/2 /root/.claude.json",
+            "mkdir -p /home/agent/.codex && cp -a /opt/vibesys-auth/0 /home/agent/.codex/auth.json",
+            "mkdir -p /home/agent/.codex && cp -a /opt/vibesys-auth/1 /home/agent/.codex/config.toml",
+            "mkdir -p /home/agent && cp -a /opt/vibesys-auth/2 /home/agent/.claude.json",
+        ]
+        assert cli_docker.auth_copy_paths("fixture") == [
+            ("/opt/vibesys-auth/0", "/home/agent/.codex/auth.json"),
+            ("/opt/vibesys-auth/1", "/home/agent/.codex/config.toml"),
+            ("/opt/vibesys-auth/2", "/home/agent/.claude.json"),
         ]
 
     def test_keeps_staging_indexes_stable_when_a_host_file_is_absent(
@@ -203,7 +208,10 @@ class TestAuthImport:
             (str(codex_home / "config.toml"), "/opt/vibesys-auth/1", True),
         ]
         assert cli_docker.auth_copy_commands("fixture") == [
-            "mkdir -p /root/.codex && cp -a /opt/vibesys-auth/1 /root/.codex/config.toml",
+            "mkdir -p /home/agent/.codex && cp -a /opt/vibesys-auth/1 /home/agent/.codex/config.toml",
+        ]
+        assert cli_docker.auth_copy_paths("fixture") == [
+            ("/opt/vibesys-auth/1", "/home/agent/.codex/config.toml"),
         ]
 
 
@@ -398,7 +406,7 @@ class TestShippedProfileAssumptions:
 
         assert [
             (spec.host_path, spec.container_path) for spec in cli_docker.auth_paths(provider)
-        ] == [(home / auth_file, f"/root/{auth_file}") for auth_file in profile.auth_files]
+        ] == [(home / auth_file, f"/home/agent/{auth_file}") for auth_file in profile.auth_files]
         # A provider that declares no auth files starts its container CLI
         # logged out.
         assert profile.auth_files
@@ -463,7 +471,10 @@ class TestShippedProfileAssumptions:
 
 def test_docker_provider_env_covers_every_provider_vibesys_ships() -> None:
     assert set(cli_docker.DOCKER_PROVIDER_ENV) == set(_SHIPPED)
-    assert cli_docker.DOCKER_PROVIDER_ENV["claude"]["IS_SANDBOX"] == "1"
+    # The agent image runs the CLI as the non-root ``agent`` user, so Claude's
+    # root-only IS_SANDBOX=1 escape hatch (a profile.container_env entry) is no
+    # longer folded in.
+    assert "IS_SANDBOX" not in cli_docker.DOCKER_PROVIDER_ENV["claude"]
     assert all(
         env["PYTHONPATH"] == "/opt/vibesys" for env in cli_docker.DOCKER_PROVIDER_ENV.values()
     )

--- a/tests/vibesys/agents/test_docker_executor.py
+++ b/tests/vibesys/agents/test_docker_executor.py
@@ -6,7 +6,6 @@ import threading
 import time
 from typing import TYPE_CHECKING, cast
 
-import pytest
 from agentshim import (
     CallbackCommandStreamSink,
     CliAgent,
@@ -26,12 +25,12 @@ from vibesys.agents.docker_executor import (
     _CodexRolloutCompletion,
     _discard,
     _scan_codex_rollout_completion,
-    repair_workspace_ownership,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
+    import pytest
     from agentshim import CommandExecutor, CommandStreamSink
 
 THREAD_ID = "019fc654-87f2-7702-8bf2-05b6f4f006dc"
@@ -193,67 +192,6 @@ class TestDockerCommandExecutor:
             "claude",
             "--help",
         ]
-
-
-class TestRepairWorkspaceOwnership:
-    """Root-owned replacements in the bind mount must go back to the host user."""
-
-    def test_runs_the_chown_sweep_inside_the_container(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        calls: list[tuple[list[str], dict[str, object]]] = []
-
-        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-            calls.append((cmd, kwargs))
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-
-        monkeypatch.setattr("vibesys.agents.docker_executor.subprocess.run", fake_run)
-
-        repair_workspace_ownership("container-123", uid=123, gid=456)
-
-        assert calls == [
-            (
-                [
-                    "docker",
-                    "exec",
-                    "container-123",
-                    "find",
-                    "/workspace",
-                    "-xdev",
-                    "-user",
-                    "0",
-                    "-writable",
-                    "-exec",
-                    "chown",
-                    "123:456",
-                    "{}",
-                    "+",
-                ],
-                {
-                    "capture_output": True,
-                    "text": True,
-                    "timeout": 120,
-                    "check": False,
-                },
-            )
-        ]
-
-    def test_reports_the_command_diagnostic_when_the_sweep_fails(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setattr(
-            "vibesys.agents.docker_executor.subprocess.run",
-            lambda cmd, **_kwargs: subprocess.CompletedProcess(cmd, 1, "", "chown: no such user"),
-        )
-
-        with pytest.raises(RuntimeError) as excinfo:
-            repair_workspace_ownership("container-123", uid=1, gid=2)
-
-        assert str(excinfo.value) == (
-            "failed to restore writable Docker workspace ownership: chown: no such user"
-        )
 
 
 class _BlockingHandle:
@@ -554,7 +492,7 @@ class _FakeDockerQueries:
         self,
         *,
         rollout: list[str] | None,
-        path: str = "/root/.codex/sessions/r.jsonl",
+        path: str = "/home/agent/.codex/sessions/r.jsonl",
     ) -> None:
         """Serve *rollout* as the file at *path*, or no file at all when None."""
         self.rollout = rollout
@@ -589,6 +527,18 @@ class TestCodexRolloutReading:
 
         assert self._read(monkeypatch, queries) is None
         assert not any("tail" in cmd for cmd in queries.commands)
+
+    def test_locates_the_rollout_under_the_agent_home(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex runs as the non-root ``agent`` user, so ``CODEX_HOME`` is its own."""
+        queries = _FakeDockerQueries(rollout=None)
+
+        self._read(monkeypatch, queries)
+
+        find_command = next(cmd for cmd in queries.commands if "find" in cmd)
+        assert "/home/agent/.codex/sessions" in find_command
+        assert "/root/.codex/sessions" not in find_command
 
     def test_a_rollout_still_working_is_no_evidence(
         self,

--- a/tests/vibesys/backends/test_cpu_backend.py
+++ b/tests/vibesys/backends/test_cpu_backend.py
@@ -73,11 +73,33 @@ class TestCpuSandbox:
             host_workspace=str(tmp_path),
             log_path=None,
             extra_env={"FOO": "bar"},
+            container_image="sha256:" + "a" * 64,
         )
         assert isinstance(sb, DockerSandbox)
         assert sb._gpus is None  # noqa: SLF001  # tracked: #288
-        assert sb._image == impl.image  # noqa: SLF001  # tracked: #288
+        assert sb._image == "sha256:" + "a" * 64  # noqa: SLF001  # tracked: #288
         assert sb._env["FOO"] == "bar"  # noqa: SLF001  # tracked: #288
+
+    def test_docker_falls_back_to_the_backend_image_without_a_resolved_container_image(  # noqa: ANN201  # tracked: #288
+        self,
+        tmp_path,  # noqa: ANN001  # tracked: #288
+    ):
+        """A caller that builds its own Docker sandbox without one still works.
+
+        ``DockerEnvironment.open()`` (the plain ``--docker`` path) always
+        resolves an agent image and passes it as ``container_image``, so in
+        practice this fallback is dead there; it still matters for Modal and
+        SkyPilot's CPU-only local editor container, which builds no agent
+        image and never passes ``container_image``.
+        """
+        impl = _make_backend(tmp_path)
+        sb = impl.make_sandbox(
+            SandboxKind.DOCKER,
+            host_workspace=str(tmp_path),
+            log_path=None,
+        )
+        assert isinstance(sb, DockerSandbox)
+        assert sb._image == impl.image  # noqa: SLF001  # tracked: #288
 
     def test_modal_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)

--- a/tests/vibesys/sandbox/test_images.py
+++ b/tests/vibesys/sandbox/test_images.py
@@ -1,0 +1,273 @@
+"""Tests for the agent image build (:func:`vibesys.sandbox.images.agent_image`).
+
+``build_task_image`` itself is covered by ``test_task_image.py`` (the module
+it now lives in moved to :mod:`vibesys.sandbox.images`, but its behavior and
+tests did not change). This file covers the agent layer: its build args, how
+it chains onto a task image, and that the Dockerfile it builds ships with the
+package.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import re
+import subprocess
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from vibesys.agents import provider_policy
+from vibesys.sandbox.images import _AGENT_DOCKERFILE, _AGENT_IMAGE_DIR, agent_image
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Sequence
+    from pathlib import Path
+
+_TASK_IMAGE_ID = "sha256:" + "a" * 64
+_AGENT_IMAGE_ID = "sha256:" + "b" * 64
+
+
+class _FakeRunner:
+    """Distinguishes a task-image build/inspect pair from an agent-image one
+    by the repository prefix of the tag being built or inspected, so a test
+    can chain the two builds the way ``agent_image`` really does."""
+
+    def __init__(
+        self,
+        *,
+        task_image_id: str = _TASK_IMAGE_ID,
+        agent_image_id: str = _AGENT_IMAGE_ID,
+    ) -> None:
+        self.task_image_id = task_image_id
+        self.agent_image_id = agent_image_id
+        self.calls: list[tuple[tuple[str, ...], Path, float]] = []
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        normalized = tuple(argv)
+        self.calls.append((normalized, cwd, timeout))
+        if normalized[1] == "build":
+            return subprocess.CompletedProcess(("docker",), 0, "", "")
+        tag = normalized[-1]
+        image_id = (
+            self.task_image_id if tag.startswith("vibesys-task-build:") else self.agent_image_id
+        )
+        return subprocess.CompletedProcess(("docker",), 0, image_id, "")
+
+
+def _patch_uuid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("vibesys.sandbox.images.uuid.uuid4", lambda: MagicMock(hex="build-id"))
+
+
+def _patch_versions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(provider_policy, "NODE_VERSION", "24.21.0")
+    monkeypatch.setattr(
+        provider_policy,
+        "CLI_VERSIONS",
+        {"claude": "2.0.0", "codex": "0.1.0", "gemini": "0.2.0", "opencode": "0.3.0"},
+    )
+    monkeypatch.setattr(provider_policy, "RUST_TOOLCHAIN_VERSION", "1.90.0")
+    monkeypatch.setattr(provider_policy, "GO_TOOLCHAIN_VERSION", "1.22.0")
+
+
+def _expected_version_args() -> tuple[str, ...]:
+    return (
+        "--build-arg",
+        "NODE_VERSION=24.21.0",
+        "--build-arg",
+        "CLAUDE_VERSION=2.0.0",
+        "--build-arg",
+        "CODEX_VERSION=0.1.0",
+        "--build-arg",
+        "GEMINI_VERSION=0.2.0",
+        "--build-arg",
+        "OPENCODE_VERSION=0.3.0",
+    )
+
+
+def test_agent_image_base_only_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No task Dockerfile: one build, directly on the base image."""
+    _patch_uuid(monkeypatch)
+    _patch_versions(monkeypatch)
+    runner = _FakeRunner()
+
+    image_id = agent_image("python:3.12-bookworm", command_runner=runner, timeout=42)
+
+    assert image_id == _AGENT_IMAGE_ID
+    assert len(runner.calls) == 2
+    build_argv, cwd, timeout = runner.calls[0]
+    assert build_argv == (
+        "docker",
+        "build",
+        "--provenance=false",
+        "--tag",
+        "vibesys-agent-build:build-id",
+        "--file",
+        str(_AGENT_DOCKERFILE),
+        "--build-arg",
+        "BASE_IMAGE=python:3.12-bookworm",
+        *_expected_version_args(),
+        "--build-arg",
+        "TOOLCHAINS=",
+        "--build-arg",
+        "RUST_VERSION=1.90.0",
+        "--build-arg",
+        "GO_VERSION=1.22.0",
+        str(_AGENT_IMAGE_DIR),
+    )
+    assert cwd == _AGENT_IMAGE_DIR
+    assert timeout == 42
+    assert runner.calls[1] == (
+        ("docker", "image", "inspect", "--format", "{{.Id}}", "vibesys-agent-build:build-id"),
+        _AGENT_IMAGE_DIR,
+        42,
+    )
+
+
+def test_agent_image_chains_task_image_as_base(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A task Dockerfile is built first; its image ID becomes BASE_IMAGE for
+    the agent layer, and BASE_IMAGE is also forwarded into the task build so
+    a task Dockerfile may declare ``ARG BASE_IMAGE`` / ``FROM ${BASE_IMAGE}``.
+    """
+    _patch_uuid(monkeypatch)
+    _patch_versions(monkeypatch)
+    task_root = tmp_path / "task"
+    task_root.mkdir()
+    task_dockerfile = task_root / "Dockerfile"
+    task_dockerfile.write_text("ARG BASE_IMAGE\nFROM ${BASE_IMAGE}\n", encoding="utf-8")
+    runner = _FakeRunner()
+
+    image_id = agent_image(
+        "python:3.12-bookworm",
+        task_dockerfile=task_dockerfile,
+        command_runner=runner,
+    )
+
+    assert image_id == _AGENT_IMAGE_ID
+    assert len(runner.calls) == 4
+
+    task_build_argv, task_cwd, _ = runner.calls[0]
+    assert task_build_argv == (
+        "docker",
+        "build",
+        "--provenance=false",
+        "--tag",
+        "vibesys-task-build:build-id",
+        "--file",
+        str(task_dockerfile),
+        "--build-arg",
+        "BASE_IMAGE=python:3.12-bookworm",
+        str(task_root),
+    )
+    assert task_cwd == task_root
+
+    task_inspect_argv, _, _ = runner.calls[1]
+    assert task_inspect_argv == (
+        "docker",
+        "image",
+        "inspect",
+        "--format",
+        "{{.Id}}",
+        "vibesys-task-build:build-id",
+    )
+
+    agent_build_argv, agent_cwd, _ = runner.calls[2]
+    assert agent_build_argv == (
+        "docker",
+        "build",
+        "--provenance=false",
+        "--tag",
+        "vibesys-agent-build:build-id",
+        "--file",
+        str(_AGENT_DOCKERFILE),
+        "--build-arg",
+        f"BASE_IMAGE={_TASK_IMAGE_ID}",
+        *_expected_version_args(),
+        "--build-arg",
+        "TOOLCHAINS=",
+        "--build-arg",
+        "RUST_VERSION=1.90.0",
+        "--build-arg",
+        "GO_VERSION=1.22.0",
+        str(_AGENT_IMAGE_DIR),
+    )
+    assert agent_cwd == _AGENT_IMAGE_DIR
+
+
+@pytest.mark.parametrize(
+    ("toolchains", "expected"),
+    [
+        (("go", "rust"), "go rust"),
+        (("rust", "go"), "go rust"),
+        (["rust", "rust", "go"], "go rust"),
+        ({"go"}, "go"),
+        ((), ""),
+    ],
+)
+def test_agent_image_sorts_and_dedupes_toolchains(
+    monkeypatch: pytest.MonkeyPatch,
+    toolchains: Collection[str],
+    expected: str,
+) -> None:
+    _patch_uuid(monkeypatch)
+    _patch_versions(monkeypatch)
+    runner = _FakeRunner()
+
+    agent_image("python:3.12-bookworm", toolchains=toolchains, command_runner=runner)
+
+    build_argv, _, _ = runner.calls[0]
+    toolchains_arg = next(arg for arg in build_argv if arg.startswith("TOOLCHAINS="))
+    assert toolchains_arg == f"TOOLCHAINS={expected}"
+
+
+def test_agent_image_versions_come_from_provider_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_uuid(monkeypatch)
+    monkeypatch.setattr(provider_policy, "NODE_VERSION", "1.2.3")
+    monkeypatch.setattr(provider_policy, "CLI_VERSIONS", {"claude": "9.9.9", "codex": "8.8.8"})
+    monkeypatch.setattr(provider_policy, "RUST_TOOLCHAIN_VERSION", "1.0.0")
+    monkeypatch.setattr(provider_policy, "GO_TOOLCHAIN_VERSION", "1.0.1")
+    runner = _FakeRunner()
+
+    agent_image("python:3.12-bookworm", command_runner=runner)
+
+    build_argv, _, _ = runner.calls[0]
+    assert "--build-arg" in build_argv
+    assert "NODE_VERSION=1.2.3" in build_argv
+    assert "CLAUDE_VERSION=9.9.9" in build_argv
+    assert "CODEX_VERSION=8.8.8" in build_argv
+    assert "RUST_VERSION=1.0.0" in build_argv
+    assert "GO_VERSION=1.0.1" in build_argv
+    # Only the providers CLI_VERSIONS names should appear; no leftover
+    # GEMINI/OPENCODE args from a stale patch in another test.
+    assert not any(arg.startswith("GEMINI_VERSION=") for arg in build_argv)
+
+
+def test_agent_image_rejects_nonpositive_timeout() -> None:
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        agent_image("python:3.12-bookworm", command_runner=_FakeRunner(), timeout=0)
+
+
+def test_agent_dockerfile_ships_as_package_data() -> None:
+    """The build context directory (and Dockerfile) resolve through
+    ``importlib.resources`` against the installed package, not just as a
+    source-tree-relative path, so this catches a wheel that forgot to declare
+    the data in ``[tool.setuptools.package-data]``.
+    """
+    dockerfile = importlib.resources.files("vibesys.sandbox").joinpath("images", "agent.Dockerfile")
+    assert dockerfile.is_file()
+    assert "USER agent" in dockerfile.read_text(encoding="utf-8")
+
+
+def test_agent_dockerfile_has_one_arg_per_cli_version() -> None:
+    text = _AGENT_DOCKERFILE.read_text(encoding="utf-8")
+    declared_args = set(re.findall(r"(?m)^ARG\s+([A-Z0-9_]+)", text))
+    expected_args = {f"{provider.upper()}_VERSION" for provider in provider_policy.CLI_VERSIONS}
+    assert expected_args <= declared_args

--- a/tests/vibesys/sandbox/test_run_environment.py
+++ b/tests/vibesys/sandbox/test_run_environment.py
@@ -28,8 +28,12 @@ from vibesys.profilers import ProfilerKind
 from vibesys.sandbox.run_environment import (
     RunEnvironmentRequest,
     RunEnvironmentSpec,
+    _cli_container_env,
+    _cli_container_setup,
+    _docker_agent_toolchains,
     _docker_evaluator_tool_mounts,
     _evaluator_container_setup,
+    _evaluator_tools,
     _EvaluatorToolBuildRequiredError,
     _resolve_docker_image_id,
     _SkyPilotRunEnvironmentSession,
@@ -193,6 +197,36 @@ _CLI_PROFILES = {
 
 
 @pytest.fixture(autouse=True)
+def fake_agent_image(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Stub the real Docker build behind ``agent_image`` for every Docker-path test.
+
+    ``DockerEnvironment.open()`` always resolves an agent image before
+    starting the container now; letting it shell out to a real ``docker
+    build`` would make these unit tests into (slow, Docker-dependent)
+    integration tests. Returns the recorded calls so a test can assert on the
+    base image and toolchains it was asked to build.
+    """
+    calls: list[dict[str, Any]] = []
+
+    def fake_agent_image(
+        base_image: str,
+        *,
+        toolchains: Any = (),  # noqa: ANN401  # tracked: #288
+        **_kwargs: Any,  # noqa: ANN401  # tracked: #288
+    ) -> str:
+        calls.append(
+            {
+                "base_image": base_image,
+                "toolchains": frozenset(toolchains),
+            }
+        )
+        return "sha256:" + "a" * 64
+
+    monkeypatch.setattr("vibesys.sandbox.images.agent_image", fake_agent_image)
+    return calls
+
+
+@pytest.fixture(autouse=True)
 def _synthetic_cli_auth(monkeypatch):  # noqa: ANN001, ANN202
     """Pin a deterministic host auth source for container CLI setup.
 
@@ -338,7 +372,10 @@ def test_local_environment_materializes_effective_objective_outside_workspace(tm
     assert not objective_path.is_relative_to(tmp_path / "workspace")
 
 
-def test_docker_environment_opens_one_started_sandbox_with_agent_paths(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+def test_docker_environment_opens_one_started_sandbox_with_agent_paths(
+    tmp_path: Path,
+    fake_agent_image: list[dict[str, Any]],
+) -> None:
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
 
@@ -359,6 +396,11 @@ def test_docker_environment_opens_one_started_sandbox_with_agent_paths(tmp_path)
     assert session.view.paths.benchmark_command == "uv run python benchmark/benchmark.py"
     assert backend.calls[0][1]["extra_env"]["UV_CACHE_DIR"] == "/workspace/.cache/uv"
     assert backend.calls[0][1]["lifecycle_hooks"] == []
+    # The container always starts from a resolved agent image, built from the
+    # backend's own base image, even when the run needs no evaluator tools.
+    assert backend.calls[0][1]["container_image"] == "sha256:" + "a" * 64
+    assert fake_agent_image[-1]["base_image"] == backend.image
+    assert fake_agent_image[-1]["toolchains"] == frozenset()
     backend.sandbox.start.assert_called_once()
 
     session.close()
@@ -388,7 +430,10 @@ def test_symlink_lifecycle_hooks_reject_failed_setup() -> None:
     sandbox.save_symlink_commands.assert_not_called()
 
 
-def test_isolated_environment_mounts_and_translates_evaluator_package(tmp_path: Path) -> None:
+def test_isolated_environment_mounts_and_translates_evaluator_package(
+    tmp_path: Path,
+    fake_agent_image: list[dict[str, Any]],
+) -> None:
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
     package = resolve_evaluator_package(
@@ -426,11 +471,10 @@ def test_isolated_environment_mounts_and_translates_evaluator_package(tmp_path: 
         "/opt/vibesys-evaluator-package",
         True,
     ) in backend.calls[0][1]["bind_mounts"]
-    init_commands = backend.calls[0][1]["extra_init_commands"]
-    assert any("go1.23.12" in item for item in init_commands)
-    assert any("static.rust-lang.org/rustup/dist" in item for item in init_commands)
-    assert any("--no-modify-path" in item for item in init_commands)
-    assert any("cargo --version" in item for item in init_commands)
+    # The evaluator package's declared toolchains (go, rust) are baked into
+    # the agent image at build time now, not installed per-run.
+    assert "extra_init_commands" not in backend.calls[0][1]
+    assert fake_agent_image[-1]["toolchains"] == frozenset({"go", "rust"})
 
 
 def test_rootless_rust_setup_replaces_broken_rustup_cargo_shim(tmp_path: Path) -> None:
@@ -572,8 +616,8 @@ def test_isolated_environments_install_and_translate_evaluator_tools(
             lambda _request, _tools, **_kwargs: [(str(built_root), str(container_root), True)],
         )
         monkeypatch.setattr(
-            "vibesys.sandbox.run_environment._resolve_docker_image_id",
-            lambda _image: "sha256:pinned",
+            "vibesys.sandbox.images.agent_image",
+            lambda *_args, **_kwargs: "sha256:pinned",
         )
 
     session = env.open(
@@ -589,7 +633,6 @@ def test_isolated_environments_install_and_translate_evaluator_tools(
     rendered = session.view.paths.benchmark_command or ""
     assert "${TOOL:" not in rendered
     assert "evaluator-tools" in rendered
-    init_commands = backend.calls[0][1]["extra_init_commands"]
     if environment_name == "docker":
         assert "/opt/vibesys-evaluator-tools" in rendered
         assert backend.calls[0][1]["container_image"] == "sha256:pinned"
@@ -598,8 +641,11 @@ def test_isolated_environments_install_and_translate_evaluator_tools(
             for hook in backend.calls[0][1]["lifecycle_hooks"]
         )
         assert (str(built_root), str(container_root), True) in backend.calls[0][1]["bind_mounts"]
-        assert not any("static.rust-lang.org/rustup/dist" in item for item in init_commands)
+        # Cargo-git tools are prebuilt and mounted read-only; nothing installs
+        # Rust in the running container.
+        assert "extra_init_commands" not in backend.calls[0][1]
     else:
+        init_commands = backend.calls[0][1]["extra_init_commands"]
         arguments = shlex.split(rendered)
         separator = arguments.index("--")
         assert arguments[separator + 1].startswith(".vibesys-evaluator-tools/request-factory/")
@@ -816,7 +862,10 @@ def test_environment_rejects_semantic_tokens_in_top_level_executable_source(
         )
 
 
-def test_microservice_package_does_not_install_rust(tmp_path: Path) -> None:
+def test_microservice_package_does_not_install_rust(
+    tmp_path: Path,
+    fake_agent_image: list[dict[str, Any]],
+) -> None:
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
     package = resolve_evaluator_package(
@@ -836,9 +885,7 @@ def test_microservice_package_does_not_install_rust(tmp_path: Path) -> None:
         )
     )
 
-    init_commands = backend.calls[0][1]["extra_init_commands"]
-    assert any("go1.23.12" in item for item in init_commands)
-    assert not any("static.rust-lang.org/rustup/dist" in item for item in init_commands)
+    assert fake_agent_image[-1]["toolchains"] == frozenset({"go"})
 
 
 def test_docker_environment_mounts_effective_objective_read_only(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -903,6 +950,47 @@ def test_isolated_environment_enforces_project_path_policy(tmp_path, environment
     assert hidden_mounts["/workspace/agent.toml"].is_relative_to(tmp_path / "logs")
 
 
+def test_cli_container_env_and_setup_agree_on_the_container_environment(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    """``_cli_container_setup`` (Modal/SkyPilot) still gets what it used to.
+
+    ``_cli_container_env`` was factored out of ``_cli_container_setup`` so the
+    plain Docker path can reuse the auth-presence check and env passthrough
+    without the shell-command half; this pins that the full function's
+    environment output is unchanged by the split.
+    """
+    backend = FakeBackend()
+    request = _request(tmp_path, backend, agent_backend="cli", cli_provider="codex")
+
+    resolved = _cli_container_env(request)
+    _commands, setup_env = _cli_container_setup(request)
+
+    assert resolved is not None
+    provider, env = resolved
+    assert provider == "codex"
+    assert env == setup_env
+
+
+def test_cli_container_env_is_none_for_a_non_cli_agent_backend(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    backend = FakeBackend()
+    request = _request(tmp_path, backend, agent_backend="deepagents", cli_provider="codex")
+
+    assert _cli_container_env(request) is None
+
+
+def test_docker_agent_toolchains_adds_rust_only_when_tools_are_needed(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    backend = FakeBackend()
+    package = resolve_evaluator_package(
+        EvaluatorPackageRequirement(
+            name="vibesys-evaluator-request-factory",
+            version="0.1.0",
+        )
+    )
+    request = _request(tmp_path, backend, evaluator_package_root=package.root)
+
+    assert "rust" in _docker_agent_toolchains(request, _evaluator_tools(request))
+    assert _docker_agent_toolchains(_request(tmp_path, backend), {}) == frozenset()
+
+
 def test_docker_environment_copies_cli_auth_from_readonly_staging(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
@@ -916,9 +1004,10 @@ def test_docker_environment_copies_cli_auth_from_readonly_staging(tmp_path, monk
 
     kwargs = backend.calls[0][1]
     assert (str(auth_file), "/opt/vibesys-auth/0", True) in kwargs["bind_mounts"]
-    assert kwargs["extra_init_commands"][0] == (
-        "mkdir -p /root/.codex && cp -a /opt/vibesys-auth/0 /root/.codex/auth.json"
-    )
+    # The plain Docker path copies staged auth files into the agent HOME as a
+    # start-time DockerSandbox step, not via extra_init_commands.
+    assert "extra_init_commands" not in kwargs
+    assert kwargs["auth_files"] == [("/opt/vibesys-auth/0", "/home/agent/.codex/auth.json")]
 
 
 def test_docker_environment_forwards_host_cli_auth_environment(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
@@ -936,7 +1025,9 @@ def test_docker_environment_forwards_host_cli_auth_environment(tmp_path, monkeyp
     # VibeSys owns per-role model selection, so a host export must not reach
     # the container and override it.
     assert "ANTHROPIC_MODEL" not in container_env
-    assert container_env["IS_SANDBOX"] == "1"
+    # The agent image runs the CLI as the non-root "agent" user, so Claude's
+    # root-only IS_SANDBOX=1 escape hatch is no longer needed or forwarded.
+    assert "IS_SANDBOX" not in container_env
     assert container_env["PYTHONPATH"] == "/opt/vibesys"
 
 

--- a/tests/vibesys/sandbox/test_task_image.py
+++ b/tests/vibesys/sandbox/test_task_image.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from vibesys.sandbox.task_image import (
+from vibesys.sandbox.images import (
     SubprocessDockerBuildRunner,
     TaskImageBuildError,
     build_task_image,
@@ -60,7 +60,7 @@ def test_build_uses_task_context_and_returns_runnable_image_id(
 ) -> None:
     task_root = _task(tmp_path)
     runner = FakeDockerBuildRunner()
-    monkeypatch.setattr("vibesys.sandbox.task_image.uuid.uuid4", lambda: MagicMock(hex="build-id"))
+    monkeypatch.setattr("vibesys.sandbox.images.uuid.uuid4", lambda: MagicMock(hex="build-id"))
 
     assert (
         build_task_image(task_root / "Dockerfile", command_runner=runner, timeout=42) == _IMAGE_ID
@@ -93,9 +93,35 @@ def test_build_uses_task_context_and_returns_runnable_image_id(
     )
 
 
+def test_build_passes_base_image_as_build_arg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task_root = _task(tmp_path)
+    runner = FakeDockerBuildRunner()
+    monkeypatch.setattr("vibesys.sandbox.images.uuid.uuid4", lambda: MagicMock(hex="build-id"))
+
+    build_task_image(
+        task_root / "Dockerfile", base_image="python:3.12-bookworm", command_runner=runner
+    )
+
+    build_argv, _cwd, _timeout = runner.calls[0]
+    assert build_argv == (
+        "docker",
+        "build",
+        "--provenance=false",
+        "--tag",
+        "vibesys-task-build:build-id",
+        "--file",
+        str(task_root / "Dockerfile"),
+        "--build-arg",
+        "BASE_IMAGE=python:3.12-bookworm",
+        str(task_root),
+    )
+
+
 def test_subprocess_runner_uses_no_shell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     run = MagicMock(return_value=subprocess.CompletedProcess(("docker",), 0, "", ""))
-    monkeypatch.setattr("vibesys.sandbox.task_image.subprocess.run", run)
+    monkeypatch.setattr("vibesys.sandbox.images.subprocess.run", run)
 
     SubprocessDockerBuildRunner().run(("docker", "build", "."), cwd=tmp_path, timeout=5)
 


### PR DESCRIPTION
## Problem

Every `--docker` run started a stock image and installed node, the CLI, Rust, ripgrep, `mcp`, and uv through a per-run list of shell commands, as root, after the container started. The list was assembled from the library's install strings with an exact-match override table and a version-pin regex, plus auth copies and evaluator toolchains from `run_environment.py`. Nothing was cached, so a round spent about a minute installing and the apt-retry override existed because that step failed often enough to abort runs. Because setup and execution shared one phase, the agent stayed root: the driver repaired workspace ownership after every turn, git refused the mounted workspace until the agent found `safe.directory`, and Claude needed `IS_SANDBOX=1`. Closes #675; first sub-issue of #674.

## Solution

- `src/vibesys/sandbox/images/agent.Dockerfile` (shipped as package data) is the recipe: one layer on top of the task image or the backend base, with node, all four shipped CLIs at the versions in `provider_policy.CLI_VERSIONS`, ripgrep, python, uv, `mcp`, optional pinned Rust and Go toolchains selected by build arg, and a non-root `agent` user with `USER agent`.
- `src/vibesys/sandbox/images.py` (grown from `task_image.py`) adds `agent_image(base_image, *, task_dockerfile=None, toolchains=())`, building through Docker's own layer cache and returning the manifest id. The headless entrypoint remains the one place a task Dockerfile is built; the run environment applies only the agent layer on top of the backend image.
- `DockerSandbox` starts from that image, remaps `agent` to the host uid and gid at start (as root, skipped when they already match), copies the profile's `auth_files` into the agent HOME and chowns each top-level directory below HOME, and runs everything else as the image's default user. `extra_init_commands` and the `pip install uv` step are gone.
- Deleted on the Docker path: the per-run install commands, the override table, the pin regex, the common-tooling list, `repair_workspace_ownership` and its calls, `_ContainerCleanup`, and the `IS_SANDBOX` merge. `docker_init_commands` and `auth_copy_commands` stay only for Modal and SkyPilot until #676 and #679.
- Codex rollout watchdog reads rollouts under the agent HOME instead of `/root`.
- CI job `agent-image` builds the CPU image and runs each CLI's `--version` as the agent user when the Dockerfile or versions change. Docs: "Images" section in `docs/contributing/agent-drivers.md`; "Container execution" no longer describes ownership repair.

### Architecture

Two images per task on a backend: the task image (task Dockerfile, or the backend base) and the agent layer on top. Setup happens at build time as root; execution starts from the image as the agent user with only credentials injected. Agents cannot install system packages mid-round; the recipe is the Dockerfile.

## Verification

### Correctness properties

- A container's first process, and every `docker exec` for the agent, runs as `agent` with the host uid and gid; files written to the bind-mounted workspace are owned by the host user without any repair step.
- The agent image is content-addressed: an unchanged Dockerfile and versions rebuild from cache; a version change in `provider_policy` changes the image.
- Auth files land at the same relative path under `/home/agent` as under the host HOME, owned by the agent, with their parent directories owned by the agent.
- `DOCKER_PROVIDER_ENV` no longer sets `IS_SANDBOX`.

### Testing

```
uv run ruff check src tests libs            # All checks passed
uv run ruff format --check src tests libs   # already formatted
scripts/check_types.sh                      # All checks passed
uv run lint-imports                         # Contracts: 2 kept, 0 broken
uv run python scripts/check_doc_links.py    # no broken links
uv run pytest tests libs -q -n auto         # 5738 passed, 20 skipped (one flaky server transport test passed 3/3 in isolation, untouched here)
```

Real Docker:
- `VIBESYS_E2E_DOCKER=1` agent image e2e: built `python:3.12-bookworm` + rust + go; inside the container as uid 1000: claude 2.1.268, codex 0.144.4, gemini 0.59.0, opencode 1.18.30, cargo 1.92.0, go 1.23.12, `import mcp` ok.
- Headless round, codex / gpt-5.6-sol on `queue-rs` task `spsc`, `--local --docker --max-rounds 1`: container started from the agent image digest, framework validation, accuracy, and benchmark PASS (total_ops_per_sec 20147767), 6 usage records, no tracebacks, no git ownership error, zero workspace files owned by anyone but the host user, container removed, exit 0. The first attempt failed on a root-owned `~/.codex`; the fix is the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
