### PR TITLE
Make DockerSandbox a WorkspaceSandbox that enforces the host resource list

### DIFF
--- a/libs/vs-sandbox/README.md
+++ b/libs/vs-sandbox/README.md
@@ -15,10 +15,19 @@ Applications wire these into their own run-environment policy.
 - `DockerSandbox` runs agent operations in a local Docker container with
   host bind mounts, and cleans up tracked containers on exit or SIGINT.
 - `HostResource` and related declaration types form a backend-neutral SDK for
-  describing which host paths an application needs to import.
-- `HostSandbox` and `SeatbeltSandbox` consume those declarations to confine a
-  local process with bubblewrap on Linux or Seatbelt on macOS. Applications own
-  their resource lists; this package owns validation and import mechanics.
+  describing which host paths an application needs to import. `agent_path`
+  names the path the confined process should see when it differs from the
+  host path; leave it unset unless a resource is presented at a fixed
+  container path. Host backends cannot remap, so `build_host_sandbox` rejects
+  a resource whose `agent_path` disagrees with its host path.
+- `HostSandbox`, `LandlockSandbox`, and `SeatbeltSandbox` consume those
+  declarations to confine a local process with bubblewrap, Landlock, or
+  Seatbelt. Applications own their resource lists; this package owns
+  validation and import mechanics. Every `WorkspaceSandbox` exposes
+  `agent_path(host_path)` (identity on host backends) and an `env` property
+  (the environment the confined process runs with, guaranteed to carry HOME
+  and PATH) so callers do not need backend-specific branches to answer either
+  question.
 - `ProjectPathPolicy` protects workspace-relative files and directories inside
   an otherwise writable project. It supports read-only paths and hidden paths,
   validates containment and overlap, and can require the host backend to fail

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -24,10 +24,15 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.sandbox import BaseSandbox
 
+from vs_sandbox.host_resources import HostResourceAccess
+from vs_sandbox.host_sandbox import WorkspaceSandbox
 from vs_sandbox.lifecycle import SandboxLifecycle, SandboxLifecycleHooks
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
     from types import FrameType
+
+    from vs_sandbox.host_resources import HostResource
 
 # Global registry of live containers for cleanup on exit / SIGINT.
 _live_containers: dict[str, str] = {}  # container_id -> container_name
@@ -141,7 +146,52 @@ def _first_component_below(home: str, destination: str) -> str:
     return str(Path(home) / relative.parts[0])
 
 
-class DockerSandbox(BaseSandbox):
+def _bind_mounts_for_resources(
+    resources: Sequence[HostResource],
+) -> list[tuple[str, str, bool]]:
+    """Lower a host resource list to the ``(host, container, readonly)`` mounts.
+
+    A resource's ``agent_path`` becomes the container-side mount destination;
+    an unset ``agent_path`` mounts at the same path the host uses, mirroring
+    what the host confinement backends do for a resource they cannot remap.
+    An unlisted path is simply never in this list, so it is never mounted.
+    """
+    return [
+        (
+            str(resource.path),
+            resource.agent_path if resource.agent_path is not None else str(resource.path),
+            resource.access is HostResourceAccess.READ_ONLY,
+        )
+        for resource in resources
+    ]
+
+
+def _agent_path_map(
+    host_workspace: str,
+    container_root: str,
+    resources: Sequence[HostResource],
+) -> tuple[tuple[str, str], ...]:
+    """Build the ``(host prefix, container prefix)`` table :meth:`DockerSandbox.agent_path` uses.
+
+    Includes the workspace's fixed mapping to *container_root* plus one entry
+    per resource (its own host path unless ``agent_path`` overrides it).
+    Sorted by host-prefix length, longest first, so a resource nested inside
+    another mapped path — or inside the workspace — wins over its ancestor.
+    """
+    entries = [
+        (str(Path(host_workspace)), container_root),
+        *(
+            (
+                str(resource.path),
+                resource.agent_path if resource.agent_path is not None else str(resource.path),
+            )
+            for resource in resources
+        ),
+    ]
+    return tuple(sorted(entries, key=lambda pair: len(pair[0]), reverse=True))
+
+
+class DockerSandbox(BaseSandbox, WorkspaceSandbox):
     """Sandbox that runs all agent operations inside a Docker container.
 
     Model weights and other host directories are bind-mounted, eliminating
@@ -159,9 +209,40 @@ class DockerSandbox(BaseSandbox):
     bind-mounted workspace writes come back owned by the host user, and any
     staged provider credentials are copied into the agent's HOME. Every other
     command, including the agent's own, runs as the image's default user.
+
+    Also a :class:`~vs_sandbox.host_sandbox.WorkspaceSandbox`: the container
+    is Docker's own confinement boundary, enforcing the same
+    :class:`~vs_sandbox.host_resources.HostResource` list the host backends
+    consume, lowered to bind mounts instead of a mount namespace. ``resources``
+    is the resource-list construction path; ``bind_mounts`` keeps working
+    unchanged for callers that build their own mount tuples directly, and the
+    two combine when both are given. :meth:`agent_path` and :attr:`env`
+    override the host-only defaults :class:`WorkspaceSandbox` provides, and
+    :meth:`wrap` yields a ``docker exec`` prefix rather than a namespace tool.
+
+    ``WorkspaceSandbox`` is a frozen dataclass; this class predates it and
+    owns a great deal of mutable state (``self._container_id`` and friends)
+    through its own conventional ``__init__``, never calling the generated
+    dataclass ``__init__``. A frozen dataclass's generated ``__setattr__``
+    only rejects assignment to its own field names (or to any name at all on
+    an instance of the dataclass's exact type); an ordinary attribute name
+    assigned on a *subclass* instance still goes through unimpeded. None of
+    ``WorkspaceSandbox``'s dataclass field names (``workspace``,
+    ``read_paths``, ``write_paths``, ``project_path_policy``, ``build_env``)
+    are used as attribute names here, so this class's own mutable state never
+    collides with that restriction. It does opt out of the generated
+    ``__eq__``/``__hash__`` (both would otherwise read those same unset
+    fields off ``self`` and raise), reverting to identity comparison.
     """
 
     _CONTAINER_ROOT = "/workspace"
+
+    __eq__ = object.__eq__
+    __hash__ = object.__hash__
+
+    def __repr__(self) -> str:
+        """Return a debug repr that never touches the unset dataclass fields."""
+        return f"DockerSandbox(image={self._image!r}, container_id={self._container_id!r})"
 
     def __init__(  # noqa: D417, PLR0913  # tracked: #288
         self,
@@ -178,6 +259,7 @@ class DockerSandbox(BaseSandbox):
         max_output_bytes: int = 100_000,
         env: dict[str, str] | None = None,
         bind_mounts: list[tuple[str, str, bool]] | None = None,
+        resources: Sequence[HostResource] = (),
         passthrough_paths: list[str] | None = None,
         log_path: str | Path | None = None,
         agent_uid: int | None = None,
@@ -219,6 +301,14 @@ class DockerSandbox(BaseSandbox):
             max_output_bytes: Maximum output bytes before truncation.
             env: Environment variables to set in the container.
             bind_mounts: List of (host_path, container_path, readonly) tuples.
+            resources: Host resources to enforce, lowered to bind mounts:
+                read-only resources mount ``:ro``, read-write ones mount
+                writable, and a path with no resource is never mounted. A
+                resource's ``agent_path`` becomes the container-side mount
+                destination; unset, it mounts at its own host path. Combines
+                with *bind_mounts* rather than replacing it, so existing
+                callers that build mount tuples directly keep working
+                unchanged. Also the source :meth:`agent_path` consults.
             passthrough_paths: Container paths outside /workspace that should
                 not be rewritten by virtual-path translation (e.g. ``["/model"]``).
             log_path: File path to log docker commands to. If None, no logging.
@@ -251,7 +341,14 @@ class DockerSandbox(BaseSandbox):
         self._start_timeout = start_timeout
         self._max_output_bytes = max_output_bytes
         self._env = env or {}
-        self._bind_mounts = bind_mounts or []
+        self._resources: tuple[HostResource, ...] = tuple(resources)
+        self._bind_mounts = list(bind_mounts or []) + _bind_mounts_for_resources(self._resources)
+        self._agent_path_map: tuple[tuple[str, str], ...] = _agent_path_map(
+            host_workspace, self._CONTAINER_ROOT, self._resources
+        )
+        #: The container's own PATH, read once via :attr:`env` and cached for
+        #: the sandbox's lifetime; ``None`` until first read.
+        self._cached_container_path: str | None = None
         self._container_id: str | None = None
         self._logger = self._setup_logger(log_path)
         self._agent_uid = agent_uid if agent_uid is not None else os.getuid()
@@ -712,6 +809,87 @@ class DockerSandbox(BaseSandbox):
         if self._container_id:
             return self._container_name
         return "vibesys-not-started"
+
+    def agent_path(self, host_path: Path | str) -> str:
+        """Return the container path the agent sees for *host_path*.
+
+        Consults the resource list this sandbox was built from — each
+        resource's ``agent_path``, or its own host path when unset — plus the
+        workspace's fixed mapping to ``/workspace``, matched by longest
+        host-path prefix so a path nested inside a mapped resource maps too.
+        Falls back to identity, normalised the same way the host backends'
+        default implementation does, when nothing matches: a container-only
+        path (already under ``/workspace`` or another mount) passed back in
+        is unaffected.
+        """
+        normalized = str(Path(host_path))
+        for host_prefix, container_prefix in self._agent_path_map:
+            if normalized == host_prefix:
+                return container_prefix
+            if normalized.startswith(host_prefix + "/"):
+                return container_prefix + normalized[len(host_prefix) :]
+        return normalized
+
+    @property
+    def env(self) -> Mapping[str, str]:
+        """Return the environment the container's agent user runs with.
+
+        ``HOME`` is the image's fixed agent home. ``PATH`` is read once from
+        the running container and cached for this sandbox's lifetime: the
+        agent layer prepends toolchain directories onto whatever PATH the
+        base image already set, so no constant is portable across the base
+        images different backends choose. ``extra_env`` (the *env* this
+        sandbox was constructed with) is applied last, so a caller's override
+        wins over either.
+        """
+        if self._container_id is None:
+            raise RuntimeError("Container not started — call start() first")  # noqa: TRY003  # tracked: #288
+        if self._cached_container_path is None:
+            self._cached_container_path = self._read_container_path(self._container_id)
+        return {"HOME": AGENT_HOME, "PATH": self._cached_container_path, **self._env}
+
+    def _read_container_path(self, container_id: str) -> str:
+        """Read the running container's PATH via a one-shot ``docker exec``."""
+        cmd = ["docker", "exec", container_id, "sh", "-c", "echo $PATH"]
+        self._log_cmd(cmd)
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_ROOT_SETUP_TIMEOUT_S,
+        )
+        self._log_cmd(cmd, result)
+        path = result.stdout.strip()
+        if result.returncode != 0 or not path:
+            raise RuntimeError(  # noqa: TRY003  # tracked: #288
+                f"could not read PATH from container {container_id} "
+                f"(exit {result.returncode}): {result.stderr.strip()}"
+            )
+        return path
+
+    def wrap(self, argv: list[str], cwd: Path | str | None = None) -> list[str]:
+        """Return *argv* wrapped as a ``docker exec`` call into this container.
+
+        ``-w`` is the agent path of *cwd*: unlike a host backend, whose
+        ``wrap`` fixes the working directory to its own workspace internally,
+        one Docker container serves every turn regardless of working
+        directory, so the caller supplies *cwd* per call. Omitting *cwd*
+        (matching the base ``WorkspaceSandbox.wrap(argv)`` signature) defaults
+        to the workspace root, the same directory every other backend's
+        ``wrap`` fixes unconditionally. Extra environment entries this sandbox
+        was constructed with are forwarded as ``-e`` flags. The container
+        already runs as the image's non-root default user (remapped to the
+        host uid/gid at :meth:`start`), so no ``-u`` is emitted; this differs
+        from :meth:`execute`, which always runs bash in ``/workspace`` for the
+        framework's own filesystem operations rather than an agent turn's
+        working directory.
+        """
+        if self._container_id is None:
+            raise RuntimeError("Container not started — call start() first")  # noqa: TRY003  # tracked: #288
+        workdir = self.agent_path(cwd) if cwd is not None else self._CONTAINER_ROOT
+        env_flags = [flag for key, value in self._env.items() for flag in ("-e", f"{key}={value}")]
+        return ["docker", "exec", "-i", "-w", workdir, *env_flags, self._container_id, *argv]
 
     def execute(
         self,

--- a/libs/vs-sandbox/src/vs_sandbox/host_resources.py
+++ b/libs/vs-sandbox/src/vs_sandbox/host_resources.py
@@ -23,11 +23,22 @@ class HostResourceAccess(StrEnum):
 
 @dataclass(frozen=True)
 class HostResource:
-    """A host path an agent needs, independent of import implementation."""
+    """A host path an agent needs, independent of import implementation.
+
+    ``agent_path`` is the path the confined process sees for this resource,
+    when it differs from ``path`` on the host. Leave it ``None`` for anything
+    imported at its own host path; only a resource a framework presents at a
+    fixed container path (for example a container's ``/workspace`` or an
+    ``/opt/vibesys-*`` toolchain mount) should set it. Host confinement
+    backends run the agent directly against the host filesystem and cannot
+    remap a resource: a mismatched ``agent_path`` on a host backend is a
+    caller error, rejected where the resource list is applied.
+    """
 
     path: Path
     access: HostResourceAccess = HostResourceAccess.READ_ONLY
     purpose: str = "caller-provided resource"
+    agent_path: str | None = None
 
 
 @dataclass(frozen=True)

--- a/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
@@ -599,6 +599,7 @@ def build(  # noqa: PLR0913
     log: Callable[[str], None] | None = None,
     project_path_policy: ProjectPathPolicy | None = None,
     require_enforcement: bool = False,
+    docker: WorkspaceSandbox | None = None,
 ) -> WorkspaceSandbox | None:
     """Build a host confinement policy for *workspace*, or ``None`` if not enforced.
 
@@ -610,7 +611,18 @@ def build(  # noqa: PLR0913
     *break* a run that used to work, it only ever adds a boundary. Set
     ``require_enforcement`` to fail closed with :class:`SandboxUnavailableError`
     instead. Omitting both new policy arguments preserves the legacy behavior.
+
+    Pass *docker* — an already constructed
+    :class:`~vs_sandbox.docker_sandbox.DockerSandbox` — to select container
+    confinement outright instead of a host backend. Every other argument is
+    then ignored and the host dispatch below never runs. This module never
+    imports :mod:`vs_sandbox.docker_sandbox` itself, at module load or here,
+    so a host-only caller never pays for Docker's heavier dependencies: the
+    caller builds the Docker sandbox and hands it in like any other
+    :class:`WorkspaceSandbox`.
     """
+    if docker is not None:
+        return docker
 
     def _log(msg: str) -> None:
         if log is not None:

--- a/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
@@ -56,11 +56,12 @@ validates them and implements their requested access.
 from __future__ import annotations
 
 import enum
+import os
 import shutil
 import subprocess
 import sys
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable  # noqa: TC003  # tracked: #288
+from collections.abc import Callable, Iterable, Mapping  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -100,7 +101,7 @@ class _BuildOptions:
     """Validated shared inputs passed to an OS-specific sandbox builder."""
 
     env: dict[str, str]
-    resources: Iterable[HostResource]
+    resources: tuple[HostResource, ...]
     log: Callable[[str], None]
     project_path_policy: ProjectPathPolicy
     require_enforcement: bool
@@ -186,10 +187,43 @@ class WorkspaceSandbox(ABC):
     read_paths: tuple[Path, ...] = ()
     write_paths: tuple[Path, ...] = ()
     project_path_policy: ProjectPathPolicy = field(default_factory=ProjectPathPolicy)
+    #: The environment :func:`build` was called with, or ``None`` when the
+    #: sandbox was constructed directly. Named apart from the public ``env``
+    #: property below so the two do not collide on a frozen dataclass.
+    build_env: Mapping[str, str] | None = None
 
     @abstractmethod
     def wrap(self, argv: list[str]) -> list[str]:
         """Return *argv* rewritten to run confined to :attr:`workspace`."""
+
+    def agent_path(self, host_path: Path | str) -> str:
+        """Return the path the confined process sees for *host_path*.
+
+        Host backends run the agent directly against the host filesystem, so
+        the confined process sees exactly the path the host does; there is no
+        remapping table to consult. Only a container backend (Docker) presents
+        a resource at a different path than its host location, and overrides
+        this method to look it up. The result is a normalised string: distinct
+        separators collapse and redundant ``.`` segments drop, but the path is
+        not resolved or made absolute.
+        """
+        return str(Path(host_path))
+
+    @property
+    def env(self) -> Mapping[str, str]:
+        """Return the environment variables the confined process runs with.
+
+        This is :attr:`build_env`, the environment :func:`build` was given,
+        falling back to the current process's own environment when the
+        sandbox was constructed directly. Either way, HOME and PATH are
+        guaranteed to be present: whichever of the two is missing from the
+        chosen source is filled in from ``os.environ``, so a launched agent
+        CLI can always resolve its own binaries and home-relative config.
+        """
+        base = self.build_env if self.build_env is not None else os.environ
+        if "HOME" in base and "PATH" in base:
+            return base
+        return {**os.environ, **base}
 
 
 @dataclass(frozen=True)
@@ -534,6 +568,29 @@ def _resource_paths(
     return list(imports.read_paths), list(imports.write_paths)
 
 
+def _reject_agent_path_remap(resources: Iterable[HostResource]) -> None:
+    """Fail fast when a declaration asks for a remap no host backend can do.
+
+    Bubblewrap could remap a bind mount to a different destination inside the
+    namespace, but Landlock and Seatbelt confine the process's own view of the
+    filesystem and cannot remap anything at all, so the three host backends
+    must agree: none of them honor :attr:`HostResource.agent_path`. Only a
+    container backend (Docker) may present a resource at a path other than its
+    host path.
+    """
+    for resource in resources:
+        if resource.agent_path is None:
+            continue
+        host_path = str(resource.path)
+        if resource.agent_path != host_path:
+            raise ValueError(  # noqa: TRY003  # tracked: #288
+                f"resource {resource.purpose!r} at {host_path} declares "
+                f"agent_path={resource.agent_path!r}, but host backends "
+                "(bubblewrap, Landlock, Seatbelt) cannot remap paths; set "
+                "agent_path to the host path or leave it unset."
+            )
+
+
 def build(  # noqa: PLR0913
     workspace: Path | str,
     *,
@@ -560,6 +617,10 @@ def build(  # noqa: PLR0913
             log(msg)
 
     workspace = Path(workspace).resolve()
+    # Materialize before validating: a generator would otherwise be consumed
+    # here and again by ``_resource_paths`` below, silently dropping it there.
+    resources = tuple(resources)
+    _reject_agent_path_remap(resources)
     policy = project_path_policy or ProjectPathPolicy()
     policy.validate(workspace)
     options = _BuildOptions(
@@ -657,6 +718,7 @@ def _build_linux(
                 write_paths=tuple(write_paths),
                 project_path_policy=options.project_path_policy,
                 gpu_device_nodes=tuple(_gpu_device_nodes()),
+                build_env=options.env,
             )
         reason = (
             f"'bwrap' at {bwrap} cannot create a user namespace"
@@ -692,6 +754,7 @@ def _build_linux(
         write_paths=tuple(write_paths),
         project_path_policy=options.project_path_policy,
         scratch_write_roots=_LINUX_SCRATCH_WRITE_ROOTS,
+        build_env=options.env,
     )
     # Compile eagerly so an unconfinable project layout is one clear error at
     # startup rather than a surprise on the first agent turn.
@@ -730,4 +793,5 @@ def _build_macos(
         read_paths=tuple(read_paths),
         write_paths=tuple(write_paths),
         project_path_policy=options.project_path_policy,
+        build_env=options.env,
     )

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -8,7 +8,8 @@ from unittest.mock import patch
 import pytest
 
 from vs_sandbox import BeforeReadyContext, SandboxLifecycleError, SandboxLifecycleHooks
-from vs_sandbox.docker_sandbox import DockerSandbox, _first_component_below
+from vs_sandbox.docker_sandbox import AGENT_HOME, DockerSandbox, _first_component_below
+from vs_sandbox.host_resources import HostResource, HostResourceAccess
 
 
 class _RecordingHooks(SandboxLifecycleHooks):
@@ -1299,3 +1300,347 @@ class TestAuthCopyOwnership:
             _first_component_below("/home/agent", "/home/agent/.config/opencode/opencode.json")
             == "/home/agent/.config"
         )
+
+
+class TestResources:
+    """Constructing from a ``HostResource`` list, as ``WorkspaceSandbox`` does."""
+
+    @patch("subprocess.run")
+    def test_read_only_resource_mounts_ro(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="img",
+            resources=(
+                HostResource(tmp_path / "toolchain", HostResourceAccess.READ_ONLY, "toolchain"),
+            ),
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc\n", stderr=""
+        )
+        sandbox.start()
+        cmd_str = " ".join(mock_run.call_args_list[0][0][0])
+        assert f"{tmp_path / 'toolchain'}:{tmp_path / 'toolchain'}:ro" in cmd_str
+
+    @patch("subprocess.run")
+    def test_read_write_resource_mounts_without_ro_suffix(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="img",
+            resources=(HostResource(tmp_path / "state", HostResourceAccess.READ_WRITE, "state"),),
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc\n", stderr=""
+        )
+        sandbox.start()
+        cmd = mock_run.call_args_list[0][0][0]
+        cmd_str = " ".join(cmd)
+        mount = f"{tmp_path / 'state'}:{tmp_path / 'state'}"
+        assert mount in cmd_str
+        assert f"{mount}:ro" not in cmd_str
+
+    @patch("subprocess.run")
+    def test_agent_path_becomes_the_mount_destination(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        resource_path = tmp_path / "toolchain"
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="img",
+            resources=(
+                HostResource(
+                    resource_path,
+                    HostResourceAccess.READ_ONLY,
+                    "toolchain",
+                    agent_path="/opt/vibesys-toolchain",
+                ),
+            ),
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc\n", stderr=""
+        )
+        sandbox.start()
+        cmd_str = " ".join(mock_run.call_args_list[0][0][0])
+        assert f"{resource_path}:/opt/vibesys-toolchain:ro" in cmd_str
+
+    @patch("subprocess.run")
+    def test_unlisted_path_is_never_mounted(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="img",
+            resources=(HostResource(tmp_path / "listed", HostResourceAccess.READ_ONLY, "listed"),),
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc\n", stderr=""
+        )
+        sandbox.start()
+        cmd_str = " ".join(mock_run.call_args_list[0][0][0])
+        assert str(tmp_path / "unlisted") not in cmd_str
+
+    @patch("subprocess.run")
+    def test_resources_combine_with_explicit_bind_mounts(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """Existing callers that pass bind_mounts directly keep working unchanged."""
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="img",
+            bind_mounts=[(str(tmp_path / "explicit"), "/explicit", True)],
+            resources=(
+                HostResource(tmp_path / "declared", HostResourceAccess.READ_ONLY, "declared"),
+            ),
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc\n", stderr=""
+        )
+        sandbox.start()
+        cmd_str = " ".join(mock_run.call_args_list[0][0][0])
+        assert f"{tmp_path / 'explicit'}:/explicit:ro" in cmd_str
+        assert f"{tmp_path / 'declared'}:{tmp_path / 'declared'}:ro" in cmd_str
+
+    def test_no_resources_by_default(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(host_workspace=str(tmp_path / "workspace"), image="img")
+        assert sandbox._bind_mounts == []  # noqa: SLF001  # tracked: #288
+
+
+class TestAgentPath:
+    """``agent_path`` maps a host path to what the agent sees inside the container."""
+
+    def test_workspace_path_maps_under_the_container_root(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        workspace = tmp_path / "workspace"
+        sandbox = DockerSandbox(host_workspace=str(workspace), image="img")
+
+        assert sandbox.agent_path(workspace) == "/workspace"
+        assert sandbox.agent_path(workspace / "sub" / "file.py") == "/workspace/sub/file.py"
+
+    def test_unset_agent_path_resource_maps_to_its_own_host_path(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        resource_path = tmp_path / "toolchain"
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="img",
+            resources=(HostResource(resource_path, HostResourceAccess.READ_ONLY, "toolchain"),),
+        )
+
+        assert sandbox.agent_path(resource_path / "bin" / "rustc") == str(
+            resource_path / "bin" / "rustc"
+        )
+
+    def test_declared_agent_path_remaps_a_nested_path(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        resource_path = tmp_path / "toolchain"
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="img",
+            resources=(
+                HostResource(
+                    resource_path,
+                    HostResourceAccess.READ_ONLY,
+                    "toolchain",
+                    agent_path="/opt/vibesys-toolchain",
+                ),
+            ),
+        )
+
+        assert (
+            sandbox.agent_path(resource_path / "bin" / "rustc")
+            == "/opt/vibesys-toolchain/bin/rustc"
+        )
+
+    def test_longest_prefix_wins_for_a_resource_nested_in_the_workspace(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        workspace = tmp_path / "workspace"
+        nested_resource = workspace / "vendor"
+        sandbox = DockerSandbox(
+            host_workspace=str(workspace),
+            image="img",
+            resources=(
+                HostResource(
+                    nested_resource,
+                    HostResourceAccess.READ_ONLY,
+                    "vendor",
+                    agent_path="/opt/vibesys-vendor",
+                ),
+            ),
+        )
+
+        assert sandbox.agent_path(nested_resource / "lib.so") == "/opt/vibesys-vendor/lib.so"
+        assert sandbox.agent_path(workspace / "src" / "main.py") == "/workspace/src/main.py"
+
+    def test_unrelated_path_is_identity(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(host_workspace=str(tmp_path / "workspace"), image="img")
+
+        assert sandbox.agent_path("/etc/passwd") == "/etc/passwd"
+
+    def test_normalizes_like_the_host_default(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(host_workspace=str(tmp_path / "workspace"), image="img")
+
+        assert sandbox.agent_path("/foo//bar/") == "/foo/bar"
+        assert sandbox.agent_path(Path("/foo/./bar")) == "/foo/bar"
+
+
+class TestWrap:
+    """``wrap`` builds the ``docker exec`` prefix a driver's command executor needs."""
+
+    @patch("subprocess.run")
+    def test_wrap_before_start_raises(self, mock_run, tmp_path):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
+        sandbox = DockerSandbox(host_workspace=str(tmp_path / "workspace"), image="img")
+        with pytest.raises(RuntimeError, match="not started"):
+            sandbox.wrap(["echo", "hi"], str(tmp_path / "workspace"))
+
+    @patch("subprocess.run")
+    def test_wrap_shape(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        workspace = tmp_path / "workspace"
+        sandbox = DockerSandbox(host_workspace=str(workspace), image="img")
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+        sandbox.start()
+
+        argv = sandbox.wrap(["echo", "hi"], workspace)
+
+        assert argv == ["docker", "exec", "-i", "-w", "/workspace", "abc123", "echo", "hi"]
+
+    @patch("subprocess.run")
+    def test_wrap_defaults_cwd_to_the_workspace_root(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """Omitting cwd matches the base ``WorkspaceSandbox.wrap(argv)`` shape."""
+        workspace = tmp_path / "workspace"
+        sandbox = DockerSandbox(host_workspace=str(workspace), image="img")
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+        sandbox.start()
+
+        argv = sandbox.wrap(["echo", "hi"])
+
+        assert argv == ["docker", "exec", "-i", "-w", "/workspace", "abc123", "echo", "hi"]
+
+    @patch("subprocess.run")
+    def test_wrap_uses_agent_path_of_cwd(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        workspace = tmp_path / "workspace"
+        sandbox = DockerSandbox(host_workspace=str(workspace), image="img")
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+        sandbox.start()
+
+        argv = sandbox.wrap(["ls"], workspace / "sub")
+
+        assert argv[4] == "/workspace/sub"
+
+    @patch("subprocess.run")
+    def test_wrap_forwards_extra_env_as_dash_e_flags(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        workspace = tmp_path / "workspace"
+        sandbox = DockerSandbox(
+            host_workspace=str(workspace),
+            image="img",
+            env={"FOO": "bar"},
+        )
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+        sandbox.start()
+
+        argv = sandbox.wrap(["echo", "hi"], workspace)
+
+        assert "-e" in argv
+        assert "FOO=bar" in argv
+        assert argv.index("-e") + 1 == argv.index("FOO=bar")
+
+    @patch("subprocess.run")
+    def test_wrap_runs_as_the_image_default_user(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """No ``-u`` flag: the container already runs as the remapped agent user."""
+        workspace = tmp_path / "workspace"
+        sandbox = DockerSandbox(host_workspace=str(workspace), image="img")
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+        sandbox.start()
+
+        argv = sandbox.wrap(["echo", "hi"], workspace)
+
+        assert "-u" not in argv
+
+
+class TestEnv:
+    """``env`` reports HOME, the image's own PATH, and any extra env."""
+
+    @patch("subprocess.run")
+    def test_env_before_start_raises(self, mock_run, tmp_path):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
+        sandbox = DockerSandbox(host_workspace=str(tmp_path / "workspace"), image="img")
+        with pytest.raises(RuntimeError, match="not started"):
+            _ = sandbox.env
+
+    @patch("subprocess.run")
+    def test_env_reads_path_from_the_running_container(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"), image="img", agent_uid=1000, agent_gid=1000
+        )
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
+            # Id query: already matches (agent_uid, agent_gid), so the remap
+            # step is skipped and the very next call is the PATH read below.
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="1000\n1000\n", stderr=""),
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="/usr/local/bin:/usr/bin:/bin\n", stderr=""
+            ),
+        ]
+        sandbox.start()
+
+        env = sandbox.env
+
+        assert env["HOME"] == AGENT_HOME
+        assert env["PATH"] == "/usr/local/bin:/usr/bin:/bin"
+        exec_cmd = mock_run.call_args_list[2][0][0]
+        assert exec_cmd == ["docker", "exec", "abc123", "sh", "-c", "echo $PATH"]
+
+    @patch("subprocess.run")
+    def test_env_caches_path_across_calls(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"), image="img", agent_uid=1000, agent_gid=1000
+        )
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="1000\n1000\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="/usr/bin:/bin\n", stderr=""),
+        ]
+        sandbox.start()
+
+        first = sandbox.env
+        second = sandbox.env
+
+        assert first["PATH"] == second["PATH"] == "/usr/bin:/bin"
+        # Only one PATH-reading exec call across both reads.
+        path_reads = [c for c in mock_run.call_args_list if "echo $PATH" in " ".join(c[0][0])]
+        assert len(path_reads) == 1
+
+    @patch("subprocess.run")
+    def test_extra_env_overrides_home_and_path(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="img",
+            env={"HOME": "/custom/home", "EXTRA": "1"},
+            agent_uid=1000,
+            agent_gid=1000,
+        )
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="1000\n1000\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="/usr/bin\n", stderr=""),
+        ]
+        sandbox.start()
+
+        env = sandbox.env
+
+        assert env["HOME"] == "/custom/home"
+        assert env["EXTRA"] == "1"
+        assert env["PATH"] == "/usr/bin"
+
+    @patch("subprocess.run")
+    def test_env_raises_when_path_cannot_be_read(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"), image="img", agent_uid=1000, agent_gid=1000
+        )
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="1000\n1000\n", stderr=""),
+            subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="no such container"
+            ),
+        ]
+        sandbox.start()
+
+        with pytest.raises(RuntimeError, match="could not read PATH"):
+            _ = sandbox.env

--- a/libs/vs-sandbox/tests/test_landlock_sandbox.py
+++ b/libs/vs-sandbox/tests/test_landlock_sandbox.py
@@ -123,56 +123,6 @@ class TestLandlockPolicyCompilation:
         assert sandbox.unenforced_policy() == ()
 
 
-@requires_landlock
-class TestLandlockEnforcesTheProjectBoundary:
-    """The guarantee this backend does make, and the escape from issue #149."""
-
-    def test_project_is_writable(self, tmp_path: Path) -> None:
-        workspace = _workspace(tmp_path)
-        sandbox = _confined(workspace)
-
-        result = _run(sandbox, "printf edited > source.txt && printf new > created.txt")
-
-        assert result.returncode == 0, result.stderr
-        assert (workspace / "source.txt").read_text() == "edited"
-        assert (workspace / "created.txt").read_text() == "new"
-
-    def test_paths_outside_the_project_are_denied(self, tmp_path: Path) -> None:
-        workspace = _workspace(tmp_path)
-        sibling = tmp_path / "sibling"
-        sibling.mkdir()
-        (sibling / "secret.txt").write_text("sibling secret\n")
-        sandbox = _confined(workspace)
-
-        result = _run(
-            sandbox,
-            f"cat {sibling / 'secret.txt'} 2>/dev/null; echo read=$?;"
-            f" (printf x > {sibling / 'escape.txt'}) 2>/dev/null; echo write=$?",
-        )
-
-        assert "read=1" in result.stdout
-        assert "write=" in result.stdout
-        assert "write=0" not in result.stdout
-        assert not (sibling / "escape.txt").exists()
-
-    def test_declared_read_resources_stay_readable_but_not_writable(self, tmp_path: Path) -> None:
-        workspace = _workspace(tmp_path)
-        resource = tmp_path / "toolchain"
-        resource.mkdir()
-        (resource / "config.json").write_text("{}\n")
-        sandbox = _confined(workspace, read_paths=(resource,))
-
-        result = _run(
-            sandbox,
-            f"cat {resource / 'config.json'} >/dev/null 2>&1; echo read=$?;"
-            f" (printf x > {resource / 'config.json'}) 2>/dev/null; echo write=$?",
-        )
-
-        assert "read=0" in result.stdout
-        assert "write=0" not in result.stdout
-        assert (resource / "config.json").read_text() == "{}\n"
-
-
 @pytest.mark.skipif(
     not landlock.supports_scoping(),
     reason="requires Landlock ABI 6 for scoping",

--- a/libs/vs-sandbox/tests/test_project_path_policy.py
+++ b/libs/vs-sandbox/tests/test_project_path_policy.py
@@ -6,12 +6,14 @@ import os
 import shutil
 import subprocess
 import sys
+from collections.abc import Iterable  # noqa: TC003  # tracked: #288
 from pathlib import Path
 
 import pytest
 
 import vs_sandbox
 from vs_sandbox import host_sandbox
+from vs_sandbox.host_resources import HostResource
 from vs_sandbox.project_paths import ProjectPathPolicy, ProjectPathPolicyError
 
 
@@ -331,3 +333,145 @@ class TestRequiredEnforcement:
 
         assert result is None
         assert any("bwrap" in message for message in logs)
+
+
+class TestHostResourceAgentPathRejection:
+    """Host backends run on the host filesystem, so none of them can remap.
+
+    Only a container backend may present a resource at a different path than
+    its host location; ``build()`` fails fast for the three host backends
+    rather than silently ignoring an ``agent_path`` it cannot honor.
+    """
+
+    def test_matching_agent_path_is_accepted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        workspace = _workspace(tmp_path)
+        resource_path = tmp_path / "toolchain"
+        resource_path.mkdir()
+        resource = HostResource(resource_path, agent_path=str(resource_path))
+        monkeypatch.setattr(host_sandbox.sys, "platform", "linux")
+        monkeypatch.setattr(
+            host_sandbox.shutil, "which", lambda *_args, **_kwargs: "/usr/bin/bwrap"
+        )
+        monkeypatch.setattr(host_sandbox, "_bwrap_confines", lambda _path: True)
+
+        sandbox = host_sandbox.build(
+            workspace,
+            env={},
+            resources=(resource,),
+            require_enforcement=True,
+        )
+
+        assert isinstance(sandbox, host_sandbox.HostSandbox)
+
+    def test_unset_agent_path_is_accepted(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        resource = HostResource(tmp_path / "toolchain")
+
+        # No backend needs to be available: rejection happens before dispatch.
+        host_sandbox.build(workspace, env={}, resources=(resource,))
+
+    def test_mismatched_agent_path_names_the_resource_and_the_backends(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace = _workspace(tmp_path)
+        resource_path = tmp_path / "toolchain"
+        resource = HostResource(
+            resource_path,
+            purpose="test toolchain",
+            agent_path="/opt/vibesys-toolchain",
+        )
+
+        with pytest.raises(ValueError, match="test toolchain") as excinfo:
+            host_sandbox.build(workspace, env={}, resources=(resource,))
+
+        message = str(excinfo.value)
+        assert str(resource_path) in message
+        assert "/opt/vibesys-toolchain" in message
+        assert "bubblewrap" in message
+        assert "Landlock" in message
+        assert "Seatbelt" in message
+
+    def test_rejection_survives_a_one_shot_resource_iterable(self, tmp_path: Path) -> None:
+        """A generator of resources must not be silently exhausted before validation."""
+        workspace = _workspace(tmp_path)
+        resource = HostResource(
+            tmp_path / "toolchain",
+            purpose="generator resource",
+            agent_path="/opt/vibesys-toolchain",
+        )
+
+        def resources() -> Iterable[HostResource]:
+            yield resource
+
+        with pytest.raises(ValueError, match="generator resource"):
+            host_sandbox.build(workspace, env={}, resources=resources())
+
+
+class TestWorkspaceSandboxAgentPath:
+    def test_host_backends_return_the_host_path_normalised(self, tmp_path: Path) -> None:
+        sandbox = host_sandbox.HostSandbox(
+            workspace=_workspace(tmp_path),
+            bwrap_path="/usr/bin/bwrap",
+        )
+
+        assert sandbox.agent_path("/foo//bar/") == "/foo/bar"
+        assert sandbox.agent_path(Path("/foo/./bar")) == "/foo/bar"
+
+
+class TestWorkspaceSandboxEnv:
+    def test_falls_back_to_os_environ_without_a_build_env(self, tmp_path: Path) -> None:
+        sandbox = host_sandbox.HostSandbox(
+            workspace=_workspace(tmp_path),
+            bwrap_path="/usr/bin/bwrap",
+        )
+
+        assert sandbox.env is os.environ
+
+    def test_returns_the_build_env_unmodified_when_it_has_home_and_path(
+        self, tmp_path: Path
+    ) -> None:
+        build_env = {"HOME": "/home/agent", "PATH": "/usr/bin", "EXTRA": "1"}
+        sandbox = host_sandbox.HostSandbox(
+            workspace=_workspace(tmp_path),
+            bwrap_path="/usr/bin/bwrap",
+            build_env=build_env,
+        )
+
+        assert sandbox.env == build_env
+        assert sandbox.env is build_env
+
+    def test_fills_in_a_missing_home_or_path_from_os_environ(self, tmp_path: Path) -> None:
+        build_env = {"PATH": "/usr/bin"}
+        sandbox = host_sandbox.HostSandbox(
+            workspace=_workspace(tmp_path),
+            bwrap_path="/usr/bin/bwrap",
+            build_env=build_env,
+        )
+
+        env = sandbox.env
+
+        assert env["PATH"] == "/usr/bin"
+        assert env["HOME"] == os.environ["HOME"]
+
+    def test_build_passes_the_caller_env_through_to_the_sandbox(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        workspace = _workspace(tmp_path)
+        monkeypatch.setattr(host_sandbox.sys, "platform", "linux")
+        monkeypatch.setattr(
+            host_sandbox.shutil, "which", lambda *_args, **_kwargs: "/usr/bin/bwrap"
+        )
+        monkeypatch.setattr(host_sandbox, "_bwrap_confines", lambda _path: True)
+        env = {"HOME": "/home/agent", "PATH": "/usr/bin"}
+
+        sandbox = host_sandbox.build(workspace, env=env, require_enforcement=True)
+
+        assert isinstance(sandbox, host_sandbox.HostSandbox)
+        assert sandbox.env == env

--- a/libs/vs-sandbox/tests/test_project_path_policy.py
+++ b/libs/vs-sandbox/tests/test_project_path_policy.py
@@ -475,3 +475,52 @@ class TestWorkspaceSandboxEnv:
 
         assert isinstance(sandbox, host_sandbox.HostSandbox)
         assert sandbox.env == env
+
+
+class TestBuildSelectsDocker:
+    """``docker=`` short-circuits ``build()`` past every host backend."""
+
+    def test_docker_sandbox_is_returned_unchanged(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        # Any WorkspaceSandbox stands in for a real DockerSandbox here: the
+        # point under test is that build() returns it untouched, not that it
+        # is specifically a Docker one.
+        docker_sandbox = host_sandbox.HostSandbox(workspace=workspace, bwrap_path="/usr/bin/bwrap")
+
+        result = host_sandbox.build(workspace, env={}, docker=docker_sandbox)
+
+        assert result is docker_sandbox
+
+    def test_docker_short_circuits_before_resource_validation(self, tmp_path: Path) -> None:
+        """A mismatched ``agent_path`` would normally raise before dispatch;
+        selecting Docker skips that host-only check entirely."""
+        workspace = _workspace(tmp_path)
+        resource = HostResource(
+            tmp_path / "toolchain",
+            purpose="test toolchain",
+            agent_path="/opt/vibesys-toolchain",
+        )
+        # Any WorkspaceSandbox stands in for a real DockerSandbox here: the
+        # point under test is that build() returns it untouched, not that it
+        # is specifically a Docker one.
+        docker_sandbox = host_sandbox.HostSandbox(workspace=workspace, bwrap_path="/usr/bin/bwrap")
+
+        result = host_sandbox.build(workspace, env={}, resources=(resource,), docker=docker_sandbox)
+
+        assert result is docker_sandbox
+
+    def test_host_dispatch_runs_unchanged_when_docker_is_not_given(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        workspace = _workspace(tmp_path)
+        monkeypatch.setattr(host_sandbox.sys, "platform", "linux")
+        monkeypatch.setattr(
+            host_sandbox.shutil, "which", lambda *_args, **_kwargs: "/usr/bin/bwrap"
+        )
+        monkeypatch.setattr(host_sandbox, "_bwrap_confines", lambda _path: True)
+
+        sandbox = host_sandbox.build(workspace, env={}, require_enforcement=True)
+
+        assert isinstance(sandbox, host_sandbox.HostSandbox)

--- a/libs/vs-sandbox/tests/test_sandbox_conformance.py
+++ b/libs/vs-sandbox/tests/test_sandbox_conformance.py
@@ -1,0 +1,188 @@
+"""Conformance suite proving every host confinement backend enforces the same
+resource-list contract.
+
+Each backend is built from an identical, tiny resource list (a writable
+workspace, one declared read-only file, one path nothing declares) and probed
+through :meth:`~vs_sandbox.host_sandbox.WorkspaceSandbox.wrap` with a real
+subprocess. bubblewrap and Landlock run for real on Linux hosts with the
+respective tooling; Seatbelt only runs on macOS. A backend absent from the
+current host skips with a reason rather than failing.
+
+This folds in what ``TestLandlockEnforcesTheProjectBoundary`` in
+``test_landlock_sandbox.py`` used to check on its own (project writable,
+siblings denied, a declared read-only resource stays read-only): that
+coverage now lives here, parametrized across every backend instead of pinned
+to one.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vs_sandbox import host_sandbox, landlock
+from vs_sandbox.host_resources import HostResource, HostResourceAccess
+from vs_sandbox.host_sandbox import HostSandbox, LandlockSandbox, LinuxBackend, SeatbeltSandbox
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from vs_sandbox.host_sandbox import WorkspaceSandbox
+
+# Deliberately distinct from the test process's own HOME/PATH, so a probe
+# that echoes the wrong value (falling back to os.environ instead of
+# build_env, say) is caught rather than accidentally matching by coincidence.
+_PROBE_ENV = {"HOME": "/home/conformance-probe", "PATH": "/usr/bin:/bin"}
+
+
+def _bwrap_path() -> str | None:
+    """Return a working bubblewrap binary, or ``None`` if none is usable."""
+    bwrap = shutil.which("bwrap")
+    if bwrap is None or not host_sandbox._bwrap_confines(bwrap):  # noqa: SLF001
+        return None
+    return bwrap
+
+
+def _build_bubblewrap(
+    workspace: Path,
+    resources: tuple[HostResource, ...],
+    _monkeypatch: pytest.MonkeyPatch,
+) -> WorkspaceSandbox:
+    if _bwrap_path() is None:
+        pytest.skip("requires a working bubblewrap")
+    sandbox = host_sandbox.build(
+        workspace,
+        env=dict(_PROBE_ENV),
+        resources=resources,
+        require_enforcement=True,
+    )
+    assert isinstance(sandbox, HostSandbox)
+    return sandbox
+
+
+def _build_landlock(
+    workspace: Path,
+    resources: tuple[HostResource, ...],
+    monkeypatch: pytest.MonkeyPatch,
+) -> WorkspaceSandbox:
+    if landlock.abi_version() is None:
+        pytest.skip("requires a kernel with Landlock support")
+    # The fixture workspace lives under /tmp, which the production scratch
+    # roots grant write access to, and a granted ancestor cannot be narrowed
+    # back down (Landlock rules only add rights). Drop /tmp and /var/tmp here
+    # so the boundary under test is the project's own, exactly as
+    # test_opt_in_selects_landlock_without_bwrap does.
+    monkeypatch.setattr(host_sandbox, "_LINUX_SCRATCH_WRITE_ROOTS", ("/dev", "/proc"))
+    sandbox = host_sandbox.build(
+        workspace,
+        env={**_PROBE_ENV, host_sandbox.DISABLE_ENV: LinuxBackend.LANDLOCK.value},
+        resources=resources,
+        require_enforcement=True,
+    )
+    assert isinstance(sandbox, LandlockSandbox)
+    return sandbox
+
+
+def _build_seatbelt(
+    workspace: Path,
+    resources: tuple[HostResource, ...],
+    _monkeypatch: pytest.MonkeyPatch,
+) -> WorkspaceSandbox:
+    if sys.platform != "darwin" or shutil.which("sandbox-exec") is None:
+        pytest.skip("requires macOS with sandbox-exec")
+    sandbox = host_sandbox.build(
+        workspace,
+        env=dict(_PROBE_ENV),
+        resources=resources,
+        require_enforcement=True,
+    )
+    assert isinstance(sandbox, SeatbeltSandbox)
+    return sandbox
+
+
+_BACKEND_BUILDERS = {
+    "bubblewrap": _build_bubblewrap,
+    "landlock": _build_landlock,
+    "seatbelt": _build_seatbelt,
+}
+
+
+def _probe_script(workspace: Path, readonly_path: Path, unlisted_path: Path) -> str:
+    """Shell script exercising every conformance check in one subprocess."""
+    written = workspace / "written-by-probe.txt"
+    return (
+        f"printf ok > {written}; printf 'write_ws=%s\\n' $?; "
+        f"(printf x > {readonly_path}) 2>/dev/null; printf 'write_ro=%s\\n' $?; "
+        f"cat {unlisted_path} >/dev/null 2>&1; printf 'read_unlisted=%s\\n' $?; "
+        "printf 'uid=%s\\n' \"$(id -u)\"; "
+        "printf 'HOME=%s\\n' \"$HOME\"; "
+        "printf 'PATH=%s\\n' \"$PATH\""
+    )
+
+
+def _run_probe(sandbox: WorkspaceSandbox, script: str, *, cwd: Path) -> dict[str, str]:
+    result = subprocess.run(  # noqa: S603
+        sandbox.wrap(["/bin/sh", "-c", script]),
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=cwd,
+        env=dict(sandbox.env),
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    fields: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        name, separator, value = line.partition("=")
+        if separator:
+            fields[name] = value
+    return fields
+
+
+@pytest.mark.parametrize("backend_name", sorted(_BACKEND_BUILDERS))
+class TestSandboxConformance:
+    """Every backend, probed through the same resource list and assertions."""
+
+    def test_probe_enforces_the_shared_resource_contract(
+        self,
+        backend_name: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        readonly_path = tmp_path / "readonly" / "config.json"
+        readonly_path.parent.mkdir()
+        readonly_path.write_text('{"k": "v"}\n')
+        unlisted_path = tmp_path / "unlisted" / "secret.txt"
+        unlisted_path.parent.mkdir()
+        unlisted_path.write_text("do not read\n")
+        resources = (
+            HostResource(readonly_path, HostResourceAccess.READ_ONLY, "conformance fixture"),
+        )
+
+        sandbox = _BACKEND_BUILDERS[backend_name](workspace, resources, monkeypatch)
+        fields = _run_probe(
+            sandbox,
+            _probe_script(workspace, readonly_path, unlisted_path),
+            cwd=workspace,
+        )
+
+        # Write inside the workspace succeeds.
+        assert fields["write_ws"] == "0"
+        assert (workspace / "written-by-probe.txt").read_text() == "ok"
+        # Write to the declared read-only resource fails, and nothing changed.
+        assert fields["write_ro"] != "0"
+        assert readonly_path.read_text() == '{"k": "v"}\n'
+        # The unlisted path is unreadable (or, on bubblewrap, simply absent).
+        assert fields["read_unlisted"] != "0"
+        # The confined process keeps the caller's uid: no privilege change.
+        assert fields["uid"] == str(os.getuid())
+        # HOME and PATH inside match what the sandbox promises through env.
+        assert fields["HOME"] == sandbox.env["HOME"]
+        assert fields["PATH"] == sandbox.env["PATH"]

--- a/libs/vs-sandbox/tests/test_sandbox_conformance.py
+++ b/libs/vs-sandbox/tests/test_sandbox_conformance.py
@@ -21,6 +21,7 @@ import os
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -30,8 +31,6 @@ from vs_sandbox.host_resources import HostResource, HostResourceAccess
 from vs_sandbox.host_sandbox import HostSandbox, LandlockSandbox, LinuxBackend, SeatbeltSandbox
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from vs_sandbox.host_sandbox import WorkspaceSandbox
 
 # Deliberately distinct from the test process's own HOME/PATH, so a probe
@@ -125,6 +124,16 @@ def _probe_script(workspace: Path, readonly_path: Path, unlisted_path: Path) -> 
     )
 
 
+def _parse_probe_output(stdout: str) -> dict[str, str]:
+    """Parse the ``name=value`` lines :func:`_probe_script` prints, one per check."""
+    fields: dict[str, str] = {}
+    for line in stdout.splitlines():
+        name, separator, value = line.partition("=")
+        if separator:
+            fields[name] = value
+    return fields
+
+
 def _run_probe(sandbox: WorkspaceSandbox, script: str, *, cwd: Path) -> dict[str, str]:
     result = subprocess.run(  # noqa: S603
         sandbox.wrap(["/bin/sh", "-c", script]),
@@ -136,12 +145,7 @@ def _run_probe(sandbox: WorkspaceSandbox, script: str, *, cwd: Path) -> dict[str
         timeout=30,
     )
     assert result.returncode == 0, result.stderr
-    fields: dict[str, str] = {}
-    for line in result.stdout.splitlines():
-        name, separator, value = line.partition("=")
-        if separator:
-            fields[name] = value
-    return fields
+    return _parse_probe_output(result.stdout)
 
 
 @pytest.mark.parametrize("backend_name", sorted(_BACKEND_BUILDERS))
@@ -186,3 +190,76 @@ class TestSandboxConformance:
         # HOME and PATH inside match what the sandbox promises through env.
         assert fields["HOME"] == sandbox.env["HOME"]
         assert fields["PATH"] == sandbox.env["PATH"]
+
+
+#: Base image for the Docker case: small, Debian-derived (the agent layer's
+#: apt step requires it), and already used by ``tests/e2e/test_agent_image_e2e.py``
+#: and the CPU backend, so it and its early layers are typically cached.
+_DOCKER_BASE_IMAGE = "python:3.12-bookworm"
+_DOCKER_BUILD_TIMEOUT_S = 600.0
+
+
+@pytest.mark.skipif(shutil.which("docker") is None, reason="requires docker on PATH")
+def test_docker_probe_enforces_the_shared_resource_contract(tmp_path: Path) -> None:
+    """Docker's own case: the container is the confinement, not a namespace tool.
+
+    Builds the real CPU agent image (cached by Docker's layer cache after the
+    first run), starts a real container from a resource list, and drives the
+    same checks as :class:`TestSandboxConformance` through
+    :meth:`~vs_sandbox.docker_sandbox.DockerSandbox.wrap` — but manages its
+    own container lifecycle explicitly, since that shared harness has no
+    per-backend teardown and a container must be stopped and removed however
+    the test ends.
+    """
+    from vibesys.sandbox.images import agent_image  # noqa: PLC0415  # tracked: #288
+    from vs_sandbox.docker_sandbox import DockerSandbox  # noqa: PLC0415  # tracked: #288
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    readonly_path = tmp_path / "readonly" / "config.json"
+    readonly_path.parent.mkdir()
+    readonly_path.write_text('{"k": "v"}\n')
+    unlisted_path = tmp_path / "unlisted" / "secret.txt"
+    unlisted_path.parent.mkdir()
+    unlisted_path.write_text("do not read\n")
+    resources = (HostResource(readonly_path, HostResourceAccess.READ_ONLY, "conformance fixture"),)
+
+    image = agent_image(_DOCKER_BASE_IMAGE, timeout=_DOCKER_BUILD_TIMEOUT_S)
+    sandbox = DockerSandbox(
+        host_workspace=str(workspace),
+        image=image,
+        resources=resources,
+    )
+    sandbox.start()
+    try:
+        script = _probe_script(
+            Path(sandbox.agent_path(workspace)),
+            Path(sandbox.agent_path(readonly_path)),
+            unlisted_path,
+        )
+        result = subprocess.run(  # noqa: S603
+            sandbox.wrap(["/bin/sh", "-c", script], workspace),
+            capture_output=True,
+            text=True,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        fields = _parse_probe_output(result.stdout)
+
+        # Write inside the workspace succeeds.
+        assert fields["write_ws"] == "0"
+        assert (workspace / "written-by-probe.txt").read_text() == "ok"
+        # Write to the declared read-only resource fails, and nothing changed.
+        assert fields["write_ro"] != "0"
+        assert readonly_path.read_text() == '{"k": "v"}\n'
+        # The unlisted path was never mounted, so it is simply absent.
+        assert fields["read_unlisted"] != "0"
+        # The agent user is remapped to the host uid at start(): no privilege change.
+        assert fields["uid"] == str(os.getuid())
+        # HOME and PATH inside match what the sandbox promises through env.
+        assert fields["HOME"] == sandbox.env["HOME"]
+        assert fields["PATH"] == sandbox.env["PATH"]
+    finally:
+        sandbox.stop()


### PR DESCRIPTION
## Problem

On the host, `vs_sandbox.build()` lowers the `HostResource` list to bubblewrap, Landlock, or Seatbelt, so the agent sees only what VibeSys declared. `DockerSandbox` sat outside this: it took raw bind mounts, mounted everything writable, and the driver kept a separate `docker exec` executor because Docker was not a `WorkspaceSandbox`. Closes #677; stacked on #680 (#675).

## Solution

- `HostResource.agent_path`: the path the confined process sees, set only on the framework resources presented at fixed container paths. Host backends reject a remap at build time with a clear error.
- `WorkspaceSandbox.agent_path(host_path)` and `WorkspaceSandbox.env`: identity and the build environment for host backends.
- `DockerSandbox` is now a `WorkspaceSandbox`. It accepts `resources` and lowers them to `-v :ro` / `-v :rw` mounts, keeps `bind_mounts` for current callers, maps paths by longest prefix over the resources' `agent_path` plus the workspace at `/workspace`, exposes `env` (HOME, the image PATH read once, extra env), and `wrap(argv, cwd)` yields the `docker exec` prefix as the image's default user. `build(docker=...)` hands a prepared Docker sandbox through without importing Docker on host-only paths.
- One conformance suite over bubblewrap, Landlock, Seatbelt, and Docker: workspace write succeeds, read-only write fails, unlisted path absent, uid matches the host user, HOME and PATH match `sandbox.env`. The Landlock duplicate tests are folded in.

Callers in `run_environment.py` and the backends still pass `bind_mounts`; #678 migrates them.

### Architecture

The resource list is the policy; each `WorkspaceSandbox` subclass is one lowering. Docker joins the three host backends behind the same `wrap`, `agent_path`, and `env`.

## Verification

### Correctness properties

- An unlisted host path is not reachable under any backend.
- A read-only resource cannot be written under any backend.
- The confined process runs as the host uid under every backend, including Docker.
- `agent_path` is identity on host backends and prefix-mapped on Docker.

### Testing

```
uv run ruff check libs/vs-sandbox         # All checks passed
uv run ruff format --check libs/vs-sandbox
scripts/check_types.sh                    # All checks passed
uv run lint-imports                       # Contracts: 2 kept, 0 broken
uv run pytest -q libs/vs-sandbox/tests -n auto   # 225 passed, 5 skipped
```

The bubblewrap, Landlock, and Docker conformance cases ran for real on this host (the Docker case builds the CPU agent image and starts a container); Seatbelt skips off macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
