### PR TITLE
Publish agent images to GHCR by digest for Modal and SkyPilot runs

### DIFF
--- a/docs/contributing/agent-drivers.md
+++ b/docs/contributing/agent-drivers.md
@@ -185,6 +185,44 @@ base and task Dockerfile already is. Because setup happens once, at build
 time, an agent cannot `apt-get install` mid-round: a missing system package
 is a Dockerfile gap, not something a running turn can patch around.
 
+### Registry: GHCR by digest
+
+A local `--docker` run never contacts a registry: it runs the image
+`agent_image` just built straight from the local Docker image store. Modal
+and SkyPilot runs do, because neither backend's Docker daemon can be assumed
+to already have the image locally, so their local editor container is
+started from a pushed, pulled-back reference instead of the bare local image
+ID.
+
+`vibesys.sandbox.images` carries the push and verification side of this:
+
+- `push_agent_image(image_id)` tags the image as
+  `ghcr.io/uw-syfi/vibesys-agent:<short id>` (a name derived from the image's
+  own content address, not a moving tag), pushes it, and resolves the
+  `ghcr.io/uw-syfi/vibesys-agent@sha256:...` manifest digest Docker recorded
+  for that push. Remote backends reference this digest, never a tag.
+- `agent_image_is_pushed(reference)` asks the registry whether a digest is
+  live, via `docker manifest inspect`, without pulling any layers.
+- `ensure_pushed(image_id)` is what Modal and SkyPilot actually call: it
+  checks Docker's own record of where this exact image was already pushed
+  before pushing again, so a repeated launch against an unchanged agent
+  image after the first is a no-op past that first push. It raises
+  `ImagePushError`, naming the digest, when a push fails or the registry
+  does not confirm the result: the run refuses to start rather than pull an
+  unverified reference.
+
+GHCR because the repository is on GitHub and it is cloud-neutral for
+SkyPilot's arbitrary infra targets. Pushing requires the Docker daemon to
+already be logged in (`docker login ghcr.io` with a token carrying
+`write:packages`; CI supplies this as `GITHUB_TOKEN`); `vibesys.sandbox.images`
+performs no login of its own and never logs a credential value, only image
+references and exit codes.
+
+SkyPilot's own accelerator job is unrelated to this: the `image_id` it runs
+on comes from the operator's cluster profile
+(`SkyPilotProfile.remote_runtime_image`), chosen for the accuracy/benchmark
+command's own runtime needs, not for running agent CLIs.
+
 ## Container execution
 
 `--docker` runs the provider CLI inside the role's editor container. The

--- a/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import atexit
 import logging
 import os
+import shlex
 import shutil
 import signal
 import socket
@@ -199,6 +200,7 @@ class ModalSandbox(BaseSandbox):
         app_name: str = "vibesys",
         enable_fallback_restart: bool = True,  # noqa: FBT001, FBT002  # tracked: #288
         max_restart_attempts: int = 2,
+        auth_files: list[tuple[str, str]] | None = None,
     ) -> None:
         """Initialize the Modal sandbox configuration.
 
@@ -236,14 +238,33 @@ class ModalSandbox(BaseSandbox):
                 entries mounted read-write. Used for persistent CLI auth
                 state such as Codex ChatGPT login inside Modal.
             log_path: Optional file for Modal API call logging.
-            extra_init_commands: Additional bash one-liners run inside the
-                sandbox after the default ``pip install uv``.  Failures
-                raise ``RuntimeError``.
+            extra_init_commands: Unused. The sandbox now starts from a
+                prebuilt agent image (shipped CLIs, toolchains, and ``uv``
+                already installed; see :mod:`vibesys.sandbox.images`), so
+                nothing runs a per-launch install list at start, mirroring
+                :class:`~vs_sandbox.docker_sandbox.DockerSandbox`. Accepted
+                and ignored rather than removed: ``ComputeBackendImpl
+                .make_sandbox`` still offers this parameter to other sandbox
+                kinds, and this class's callers pass it through unconditionally.
             lifecycle_hooks: Trusted extensions invoked in order after
                 built-in initialization and before the sandbox becomes ready.
                 They run again after every container recreation.
             app_name: Modal App name to attach the sandbox to.  Created if
                 missing.
+            auth_files: ``(host_path, destination_path)`` pairs copied into
+                the sandbox's writable ``/home/agent`` at start, analogous to
+                ``DockerSandbox.auth_files``. Docker stages credentials
+                through a read-only bind mount and copies from that staged
+                *container* path; Modal has no equivalent arbitrary host
+                bind mount, so each pair's first element is instead a real
+                path on the host running VibeSys, and its bytes are uploaded
+                directly into the sandbox's writable filesystem through the
+                Sandbox filesystem API. The agent image's default user
+                already owns its own HOME, so, unlike Docker (which copies
+                as root and then chowns), no root elevation is needed or
+                attempted; Modal's ``Sandbox.exec`` has no way to run a
+                command as a different user than the image's default in the
+                first place.
         """
         self._host_workspace = Path(host_workspace)
         self._image_tag = image
@@ -264,6 +285,7 @@ class ModalSandbox(BaseSandbox):
         self._enable_fallback_restart = enable_fallback_restart
         self._max_restart_attempts = max_restart_attempts
         self._restart_attempts = 0
+        self._auth_files: list[tuple[str, str]] = list(auth_files or [])
 
         self._sandbox: modal.Sandbox | None = None
         self._sandbox_id: str | None = None
@@ -341,19 +363,22 @@ class ModalSandbox(BaseSandbox):
             self._delete_workspace_volume()
             raise
 
-    def _create_container(self) -> None:  # noqa: C901  # tracked: #288
-        """Create (or recreate) the Modal sandbox container on top of the
-        already-populated workspace volume. Shared by ``start`` and
-        ``_restart_sandbox``.
-        """  # noqa: D205  # tracked: #288
+    def _create_container(self) -> None:
+        """Create (or recreate) the Modal sandbox container.
+
+        Runs on top of the already-populated workspace volume; shared by
+        ``start`` and ``_restart_sandbox``.
+
+        The sandbox starts from a prebuilt agent image
+        (:mod:`vibesys.sandbox.images`) that already ships every CLI,
+        toolchain, and an empty, agent-owned ``/workspace``, unlike the
+        stock ``nvcr.io`` PyTorch base this class used to run directly, whose
+        prepopulated ``/workspace`` used to require clearing before the
+        volume could mount there. Nothing installs anything at start,
+        mirroring :class:`~vs_sandbox.docker_sandbox.DockerSandbox`.
+        """
         app = modal.App.lookup(self._app_name, create_if_missing=True)
-        # Clear the image's /workspace dir so our Volume can mount there —
-        # the nvcr.io pytorch image ships with a populated /workspace that
-        # triggers init_failure when a Volume is mounted on top.
-        image = modal.Image.from_registry(
-            self._image_tag,
-            add_python=None,
-        ).run_commands(f"rm -rf {self._CONTAINER_ROOT} && mkdir {self._CONTAINER_ROOT}")
+        image = modal.Image.from_registry(self._image_tag, add_python=None)
 
         # _workspace_volume is created by start() before _create_container().
         workspace_volume = self._workspace_volume
@@ -399,50 +424,53 @@ class ModalSandbox(BaseSandbox):
         _live_sandboxes[self._sandbox_id] = self
         self._log(f"sandbox created id={self._sandbox_id}")
 
-        # Install uv (non-fatal; mirrors DockerSandbox).
-        try:
-            proc = self._sandbox.exec(
-                "bash",
-                "-c",
-                "pip install uv",
-                workdir=self._CONTAINER_ROOT,
-                timeout=180,
-            )
-            proc.wait()
-        except Exception as exc:  # noqa: BLE001  # tracked: #288
-            self._log(f"pip install uv failed: {exc}")
-
-        # Run required init commands — fatal on failure.
-        for cmd in self._extra_init_commands:
-            self._log(f"init command: {cmd}")
-            proc = self._sandbox.exec(
-                "bash",
-                "-c",
-                cmd,
-                workdir=self._CONTAINER_ROOT,
-                timeout=600,
-            )
-            code = proc.wait()
-            if code != 0:
-                try:
-                    err = proc.stderr.read() if proc.stderr else ""
-                except Exception:  # noqa: BLE001  # tracked: #288
-                    err = ""
-                raise RuntimeError(  # noqa: TRY003  # tracked: #288
-                    f"Modal sandbox init command failed (exit {code}):\n"
-                    f"  command: {cmd}\n"
-                    f"  stderr: {err[:500]}"
-                )
-            if "codex login status" in cmd:
-                try:
-                    out = proc.stdout.read() if proc.stdout else ""
-                except Exception:  # noqa: BLE001  # tracked: #288
-                    out = ""
-                if out:
-                    self._log(f"init command stdout: {out.strip()[:500]}")
-            self._log(f"init command completed: {cmd}")
-
+        self._copy_auth_files()
         self._lifecycle.before_ready(self)
+
+    def _copy_auth_files(self) -> None:
+        """Upload staged host credentials into the sandbox's writable HOME.
+
+        Runs on every container creation, mirroring
+        ``DockerSandbox._copy_auth_files``: a restart gets a fresh container
+        with a clean ``/home/agent``, so credentials copied before the crash
+        do not survive it and must be restaged.
+        """
+        if not self._auth_files:
+            return
+        sandbox = self._require_sandbox()
+        for host_path, destination in self._auth_files:
+            source = Path(host_path)
+            if not source.exists():
+                continue
+            if source.is_dir():
+                self._upload_auth_directory(sandbox, source, destination)
+            else:
+                self._upload_auth_file(sandbox, source, destination)
+            self._log(f"copied auth file {host_path} -> {destination}")
+
+    def _mkdir(self, sandbox: modal.Sandbox, path: str) -> None:
+        sandbox.exec(
+            "bash",
+            "-c",
+            f"mkdir -p {shlex.quote(path)}",
+            workdir=self._CONTAINER_ROOT,
+        ).wait()
+
+    def _upload_auth_file(self, sandbox: modal.Sandbox, source: Path, destination: str) -> None:
+        self._mkdir(sandbox, str(PurePosixPath(destination).parent))
+        sandbox.filesystem.write_bytes(source.read_bytes(), destination)
+
+    def _upload_auth_directory(
+        self, sandbox: modal.Sandbox, source: Path, destination: str
+    ) -> None:
+        self._mkdir(sandbox, destination)
+        for path in source.rglob("*"):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(source)
+            remote = str(PurePosixPath(destination, *rel.parts))
+            self._mkdir(sandbox, str(PurePosixPath(remote).parent))
+            sandbox.filesystem.write_bytes(path.read_bytes(), remote)
 
     def _restart_sandbox(self) -> bool:
         """Terminate the (likely dead) sandbox container and recreate it.

--- a/libs/vs-sandbox/tests/test_modal_sandbox.py
+++ b/libs/vs-sandbox/tests/test_modal_sandbox.py
@@ -246,26 +246,17 @@ class TestStart:
         finally:
             sb.stop()
 
-    def test_init_failure_skips_hooks_and_cleans_up(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
-        from vs_sandbox.modal_sandbox import ModalSandbox, _live_sandboxes  # noqa: PLC0415
+    def test_extra_init_commands_are_accepted_but_never_run(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
+        """The sandbox now starts from a prebuilt agent image; nothing installs at start."""
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415
 
-        invocations: list[object] = []
-        mock_modal["proc"].wait.side_effect = [0, 17]
-        sb = ModalSandbox(
+        with ModalSandbox(
             host_workspace=str(tmp_path),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
             extra_init_commands=["install-required-tool"],
-            lifecycle_hooks=[_RecordingHooks(invocations)],
-        )
-
-        with pytest.raises(RuntimeError, match="Modal sandbox init command failed"):
-            sb.start()
-
-        assert invocations == []
-        assert sb._sandbox is None  # noqa: SLF001
-        assert not _live_sandboxes
-        mock_modal["sandbox"].terminate.assert_called_once()
-        mock_modal["objects"].delete.assert_called_once()
+        ):
+            commands = [call.args for call in mock_modal["sandbox"].exec.call_args_list]
+            assert not any("install-required-tool" in " ".join(args) for args in commands)
 
     def test_lifecycle_failure_cleans_up_sandbox_and_volume(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
         from vs_sandbox.modal_sandbox import ModalSandbox, _live_sandboxes  # noqa: PLC0415
@@ -362,6 +353,84 @@ class TestStart:
         assert (snapshot / "state_5.sqlite").exists()
         assert (snapshot / "state_5.sqlite-wal").exists()
         assert not (snapshot / "sessions").exists()
+
+
+class TestAuthFiles:
+    """``auth_files`` uploads staged host credentials into the sandbox's HOME."""
+
+    def test_uploads_single_file(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        token = tmp_path / "token.json"
+        token.write_text('{"key": "secret"}')
+
+        with ModalSandbox(
+            host_workspace=str(ws),
+            image="nvcr.io/nvidia/pytorch:25.04-py3",
+            auth_files=[(str(token), "/home/agent/token.json")],
+        ):
+            fs = mock_modal["sandbox"].filesystem
+            fs.write_bytes.assert_any_call(b'{"key": "secret"}', "/home/agent/token.json")
+
+    def test_uploads_directory_recursively(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        auth_dir = tmp_path / "codex"
+        auth_dir.mkdir()
+        (auth_dir / "auth.json").write_text("root-file")
+        (auth_dir / "nested").mkdir()
+        (auth_dir / "nested" / "config.toml").write_text("nested-file")
+
+        with ModalSandbox(
+            host_workspace=str(ws),
+            image="nvcr.io/nvidia/pytorch:25.04-py3",
+            auth_files=[(str(auth_dir), "/home/agent/.codex")],
+        ):
+            fs = mock_modal["sandbox"].filesystem
+            fs.write_bytes.assert_any_call(b"root-file", "/home/agent/.codex/auth.json")
+            fs.write_bytes.assert_any_call(b"nested-file", "/home/agent/.codex/nested/config.toml")
+
+    def test_missing_source_is_skipped(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        with ModalSandbox(
+            host_workspace=str(ws),
+            image="nvcr.io/nvidia/pytorch:25.04-py3",
+            auth_files=[(str(tmp_path / "does-not-exist"), "/home/agent/x")],
+        ):
+            mock_modal["sandbox"].filesystem.write_bytes.assert_not_called()
+
+    def test_no_auth_files_writes_nothing(self, sandbox, mock_modal):  # noqa: ANN001, ANN201
+        sandbox.start()
+        mock_modal["sandbox"].filesystem.write_bytes.assert_not_called()
+
+    def test_restart_restages_auth_files(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
+        """A restart gets a fresh container, so credentials must be restaged."""
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        token = tmp_path / "token.json"
+        token.write_text("secret")
+
+        with ModalSandbox(
+            host_workspace=str(ws),
+            image="nvcr.io/nvidia/pytorch:25.04-py3",
+            auth_files=[(str(token), "/home/agent/token.json")],
+        ) as sb:
+            assert sb._restart_sandbox()  # noqa: SLF001
+            fs = mock_modal["sandbox"].filesystem
+            assert (
+                fs.write_bytes.call_args_list.count(((b"secret", "/home/agent/token.json"), {}))
+                == 2
+            )
 
 
 class TestExecute:
@@ -558,7 +627,7 @@ class TestSandboxFallbackRestart:
         resp = sandbox.execute("echo hi")
         assert resp.exit_code == 0
         assert "after-restart-ok" in resp.output
-        # 1 failing call (sandbox-dead) + init commands on restart + 1 successful call
+        # 1 failing call (sandbox-dead) + 1 successful call after restart.
         assert call["n"] >= 2
 
     def test_restart_attempts_capped_by_max(self, sandbox, mock_modal, monkeypatch):  # noqa: ANN001, ANN201, ARG002  # tracked: #288

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -1,173 +1,38 @@
-"""Docker configuration for CLI agent providers.
+"""Docker auth staging for CLI agent providers.
 
 Provider facts come from ``agentshim``'s ``ProviderProfile`` at call time:
-state directories, auth environment variables, which files carry credentials,
-and the CLI's own container install recipe. What stays here is VibeSys policy
-that is not itself a provider *decision*: the toolchain a candidate
-repository needs, and the overrides VibeSys applies to a library recipe. The
-container environment table and the Codex CLI version pin are provider
-decisions and live in :mod:`vibesys.agents.provider_policy`; this module
-imports them.
+state directories, auth environment variables, and which files carry
+credentials. What stays here is VibeSys policy that is not itself a provider
+*decision*. The container environment table lives in
+:mod:`vibesys.agents.provider_policy`; this module imports it.
 
-The plain Docker path (``vibesys.sandbox.run_environment.DockerEnvironment``)
-now starts from a prebuilt agent image with every shipped CLI, toolchain, and
-the non-root ``agent`` user already installed, so it needs none of the
-shell-recipe machinery below: it copies auth files itself at container start
-(see :func:`auth_copy_paths`) instead of running :func:`auth_copy_commands`
-through ``extra_init_commands``. ``docker_init_commands`` and its supporting
-override tables stay here for Modal and SkyPilot, which still install
-per-run through ``extra_init_commands`` until their own image work
-(#676, #679) lands; delete them once those land.
+Every containerized CLI path (plain Docker, and Modal/SkyPilot's local editor
+container since #676) now starts from a prebuilt agent image with every
+shipped CLI, toolchain, and the non-root ``agent`` user already installed, so
+none of it needs a per-run shell-recipe install list any more: it copies auth
+files itself at container start (see :func:`auth_copy_paths`) instead of
+running shell commands through ``extra_init_commands``. The install-recipe
+machinery this module used to carry for Modal and SkyPilot
+(``docker_init_commands`` and its supporting override tables) is gone now
+that those two also consume the agent image; provider CLI version pins live
+in :mod:`vibesys.agents.provider_policy`, which owns provider decisions.
 """
 
 from __future__ import annotations
 
 import os
-import re
-import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
 from vibesys.agents import provider_profiles
-from vibesys.agents.provider_policy import (
-    CODEX_DOCKER_CLI_VERSION,
-    DOCKER_PROVIDER_ENV,
-)
+from vibesys.agents.provider_policy import DOCKER_PROVIDER_ENV
 from vs_sandbox import AGENT_HOME
 
 # Re-exported for existing importers (``vibesys.agents.factory``,
-# ``vibesys.sandbox.run_environment``, and this module's own tests reach them
-# as ``cli_docker.DOCKER_PROVIDER_ENV`` / ``cli_docker.CODEX_DOCKER_CLI_VERSION``);
-# the values themselves live in ``provider_policy`` now.
-__all__ = ["CODEX_DOCKER_CLI_VERSION", "DOCKER_PROVIDER_ENV"]
-
-# Native implementations are valid candidate designs across domains, so the
-# editor container must be able to build and test them before paid target work.
-# Pin the toolchain for reproducible local checks instead of letting each agent
-# independently bootstrap an arbitrary Rust release.
-RUST_DOCKER_TOOLCHAIN_VERSION = "1.92.0"
-
-
-# Bash one-liners run inside the container at start() time, per provider.
-# Each list runs sequentially; a non-zero exit at any step raises RuntimeError.
-#
-# Every provider gets the python3 + ``mcp`` install at the end so that the
-# in-container CLI can spawn ``python -m vs_issue_board.mcp``
-# as a stdio MCP child. agentshim installs the per-provider MCP config for the
-# turn (a config file for claude, gemini and opencode; ``--config`` flags for
-# codex) and removes it afterwards. The default base image
-# ``nvcr.io/nvidia/pytorch:25.04-py3`` already ships python3 + pip + a
-# compatible ``mcp`` install, so this is a defensive no-op for the default
-# image but keeps the install resilient on alternative images.
-# Retry apt-get up to 5x with backoff — Ubuntu archive mirrors regularly
-# return transient "connection timed out" / "mirror sync in progress"
-# errors that fail a single-shot `apt-get update`.
-def _apt_install(pkgs: str, check_bin: str | None = None) -> str:
-    bin_ = check_bin or pkgs.split(maxsplit=1)[0]
-    return (
-        f"command -v {bin_} >/dev/null || "
-        "{ for i in 1 2 3 4 5; do "
-        f"  apt-get update -qq && apt-get install -y -qq {pkgs} && break || "
-        '  (echo "apt retry $i..." >&2; sleep $((i*5))); '
-        "done; "
-        f"command -v {bin_} >/dev/null; }}"
-    )
-
-
-_RUST_TOOLCHAIN_INSTALL = (
-    "command -v cargo >/dev/null || { set -e; "
-    "curl -fsSL --retry 5 --retry-delay 5 -o /tmp/rustup-init.sh "
-    "https://sh.rustup.rs && "
-    "sh /tmp/rustup-init.sh -y --profile minimal "
-    f"--default-toolchain {RUST_DOCKER_TOOLCHAIN_VERSION} "
-    "--component rustfmt --component clippy && "
-    "ln -sf /root/.cargo/bin/* /usr/local/bin/ && "
-    "rm -f /tmp/rustup-init.sh; }"
-)
-
-
-_COMMON_DOCKER_TOOLING_INSTALL = [
-    _apt_install("curl ca-certificates", check_bin="curl"),
-    _RUST_TOOLCHAIN_INSTALL,
-    _apt_install("ripgrep", check_bin="rg"),
-    _apt_install("python3 python3-pip", check_bin="pip3"),
-    "PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --quiet 'mcp>=1.0,<2'",
-]
-
-
-# Steps a provider's own recipe may contain that VibeSys replaces before
-# running them in an editor container.
-#
-# ``apt-get update``: a library recipe bootstraps curl with a single-shot
-# ``apt-get``. Ubuntu archive mirrors reachable from our hosts return transient
-# fetch failures often enough that a single-shot update fails container start
-# outright, so the exact bootstrap step is swapped for the retrying, idempotent
-# VibeSys equivalent. An exact-string key on purpose: when the library changes
-# its recipe the override stops matching, and the test that pins this pairing
-# fails rather than silently hardening nothing.
-_PROFILE_STEP_OVERRIDES: dict[str, str] = {
-    "apt-get update && apt-get install -y --no-install-recommends curl ca-certificates": (
-        _apt_install("curl ca-certificates", check_bin="curl")
-    ),
-}
-
-# Node needs no entry. VibeSys used to install it from the nodejs.org tarball
-# because apt-get against archive.ubuntu.com is unreliable from several of our
-# hosts, and the codex and gemini profiles now fetch the same tarball behind
-# the same `command -v node` guard, so their recipes stand as written.
-#
-# One rough edge is left as the library ships it: the codex recipe fetches that
-# tarball with curl but, unlike gemini's, carries no curl bootstrap of its own,
-# so on an image without curl it would rely on the bootstrap in the common
-# tooling below, which runs after the recipe. The default editor image
-# (`nvcr.io/nvidia/pytorch:25.04-py3`) ships curl, and the pre-profile VibeSys
-# table had the same ordering, so this is a known hazard on an alternative
-# image rather than a regression.
-
-# ``npm install -g [--flags] @openai/codex`` with no ``@<version>`` suffix.
-_UNPINNED_CODEX_NPM_INSTALL = re.compile(r"(npm install -g\b[^&|;]*?)@openai/codex(?!@)(\s|$)")
-
-
-def _pin_codex_cli(step: str) -> str:
-    """Pin an unpinned ``@openai/codex`` install to the verified CLI version.
-
-    VibeSys pins because the container CLI must match the host feature set the
-    prompts were validated against; a floating ``@latest`` silently changes the
-    editor mid-campaign. A recipe that already names a version is left alone:
-    the library is then the one making the call, and disagreeing silently would
-    be worse than either choice.
-
-    ``--include=optional`` is added with the pin because newer codex packages
-    ship the Linux-x64 native binary as an optional dependency that
-    ``npm install -g`` skips on some npm configurations.
-    """
-
-    def pinned(match: re.Match[str]) -> str:
-        prefix = match.group(1)
-        flag = "" if "--include=optional" in prefix else "--include=optional "
-        return f"{prefix}{flag}@openai/codex@{CODEX_DOCKER_CLI_VERSION}{match.group(2)}"
-
-    return _UNPINNED_CODEX_NPM_INSTALL.sub(pinned, step, count=1)
-
-
-def docker_init_commands(provider: str) -> list[str]:
-    """Return the container init commands for *provider*.
-
-    The provider's own install recipe comes from its agentshim profile, with
-    the VibeSys overrides above applied, and is followed by the toolchain every
-    VibeSys editor container needs regardless of provider.
-
-    Raises:
-        ValueError: if agentshim does not register *provider*.
-    """
-    recipe = [
-        _pin_codex_cli(_PROFILE_STEP_OVERRIDES.get(step, step))
-        for step in provider_profiles.provider_profile(provider).container_install
-    ]
-    # A recipe whose bootstrap was replaced by a VibeSys step already contains
-    # that step; running it twice is harmless but hides what the recipe does.
-    tail = [step for step in _COMMON_DOCKER_TOOLING_INSTALL if step not in recipe]
-    return [*recipe, *tail]
+# ``vibesys.sandbox.run_environment``, and this module's own tests reach it as
+# ``cli_docker.DOCKER_PROVIDER_ENV``); the value itself lives in
+# ``provider_policy`` now.
+__all__ = ["DOCKER_PROVIDER_ENV"]
 
 
 @dataclass(frozen=True)
@@ -255,40 +120,13 @@ def auth_bind_mounts(provider: str) -> list[tuple[str, str, bool]]:
 def auth_copy_paths(provider: str) -> list[tuple[str, str]]:
     """Return ``(staged source, agent-home destination)`` pairs to copy at start.
 
-    Used by the plain Docker path, which hands these straight to
-    ``DockerSandbox(auth_files=...)`` to copy as a start-time step rather than
-    running shell commands through ``extra_init_commands`` (see
-    :func:`auth_copy_commands` for the Modal/SkyPilot form of the same list).
-    Indexing matches :func:`auth_bind_mounts`: entry *i*'s staging mount is
-    ``/opt/vibesys-auth/{i}``.
+    Handed straight to ``DockerSandbox(auth_files=...)``, which copies each
+    pair in as a start-time step rather than running shell commands through
+    ``extra_init_commands``. Indexing matches :func:`auth_bind_mounts`: entry
+    *i*'s staging mount is ``/opt/vibesys-auth/{i}``.
     """
     return [
         (f"/opt/vibesys-auth/{index}", spec.container_path)
         for index, spec in enumerate(auth_paths(provider))
         if spec.host_path.exists()
     ]
-
-
-def auth_copy_commands(provider: str) -> list[str]:
-    """Return commands that copy staged provider state into writable storage.
-
-    Directories contain runtime state such as sessions and history, so mounting
-    them read-only at their final locations can break otherwise valid CLI runs.
-    Copying from read-only staging keeps those writes inside the disposable
-    container layer.
-
-    Used by Modal and SkyPilot's ``extra_init_commands`` path; the plain
-    Docker path uses :func:`auth_copy_paths` instead (see module docstring).
-    """
-    commands: list[str] = []
-    for index, spec in enumerate(auth_paths(provider)):
-        if not spec.host_path.exists():
-            continue
-        source = shlex.quote(f"/opt/vibesys-auth/{index}")
-        destination = shlex.quote(spec.container_path)
-        parent = shlex.quote(str(Path(spec.container_path).parent))
-        if spec.host_path.is_dir():
-            commands.append(f"mkdir -p {destination} && cp -a {source}/. {destination}/")
-        else:
-            commands.append(f"mkdir -p {parent} && cp -a {source} {destination}")
-    return commands

--- a/src/vibesys/agents/provider_policy.py
+++ b/src/vibesys/agents/provider_policy.py
@@ -122,18 +122,17 @@ CLI_VERSIONS: dict[str, str] = {
 the time each was pinned, except Codex).
 
 Codex draws from :data:`CODEX_DOCKER_CLI_VERSION` instead of repeating its own
-literal, so the pin used by ``cli_docker`` (today's per-run container install)
-and the one used by ``agent_image`` (the prebuilt image) cannot disagree while
-both exist.
+literal: that constant is this module's own single source for the pin, used
+both here and (formerly) by ``cli_docker``'s now-removed per-run container
+install for Modal and SkyPilot.
 """
 
 RUST_TOOLCHAIN_VERSION = "1.92.0"
 """Rust toolchain pin for an agent image's optional ``rust`` toolchain layer.
 
-Mirrors ``cli_docker.RUST_DOCKER_TOOLCHAIN_VERSION``, the equivalent pin for
-today's per-run container install; the two are independent constants because
-that module's per-run install path and this image's build-time install path
-are deleted and added on different schedules.
+``cli_docker`` no longer has a per-run install path or its own Rust pin
+(#676): every containerized CLI environment builds from this prebuilt image
+now, so this is the only Rust toolchain version an editor container carries.
 """
 
 GO_TOOLCHAIN_VERSION = "1.23.12"

--- a/src/vibesys/sandbox/images.py
+++ b/src/vibesys/sandbox/images.py
@@ -164,15 +164,19 @@ def build_task_image(
     return _build_and_inspect(target, extra_build_args, runner=runner, timeout=timeout)
 
 
-def agent_image(
+def agent_image(  # noqa: PLR0913  # tracked: #288
     base_image: str,
     *,
     task_dockerfile: Path | None = None,
     toolchains: Collection[str] = (),
+    pip_extras: Collection[str] = (),
     command_runner: DockerBuildRunner | None = None,
     timeout: float = _DEFAULT_BUILD_TIMEOUT_SECONDS,
 ) -> str:
     """Build the agent layer on top of a task image, and return its image ID.
+
+    ``pip_extras`` are extra pip requirements an execution environment needs
+    inside the editor container (sorted and deduplicated like ``toolchains``).
 
     When ``task_dockerfile`` is given, the task image is built first (via
     :func:`build_task_image`, with ``base_image`` passed through so the task
@@ -210,6 +214,7 @@ def agent_image(
     build_args += ["--build-arg", f"TOOLCHAINS={' '.join(sorted(set(toolchains)))}"]
     build_args += ["--build-arg", f"RUST_VERSION={provider_policy.RUST_TOOLCHAIN_VERSION}"]
     build_args += ["--build-arg", f"GO_VERSION={provider_policy.GO_TOOLCHAIN_VERSION}"]
+    build_args += ["--build-arg", f"PIP_EXTRAS={' '.join(sorted(set(pip_extras)))}"]
 
     target = _BuildTarget(
         dockerfile=_AGENT_DOCKERFILE,

--- a/src/vibesys/sandbox/images.py
+++ b/src/vibesys/sandbox/images.py
@@ -15,6 +15,7 @@ metadata otherwise changes the manifest ID when all filesystem layers match.
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import uuid
@@ -28,10 +29,24 @@ if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
 
 _DEFAULT_BUILD_TIMEOUT_SECONDS = 1200.0
+_DEFAULT_PUSH_TIMEOUT_SECONDS = 1200.0
+_DEFAULT_VERIFY_TIMEOUT_SECONDS = 60.0
 _IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}")
 _DIAGNOSTIC_LIMIT = 1000
 _TASK_IMAGE_REPOSITORY = "vibesys-task-build"
 _AGENT_IMAGE_REPOSITORY = "vibesys-agent-build"
+
+#: Where a pushed agent image lives. GHCR because the repository is on GitHub
+#: and it is cloud-neutral for SkyPilot's arbitrary infra targets. Runs
+#: reference the resulting digest, never this repository's moving tags.
+DEFAULT_AGENT_IMAGE_REGISTRY = "ghcr.io/uw-syfi/vibesys-agent"
+
+#: Length of the content-derived tag `push_agent_image` pushes under. Not a
+#: security boundary, just short enough to read in logs while still keying
+#: the tag off the image content, so re-pushing the same image ID reuses the
+#: same tag and Docker's own layer-presence check makes the push itself a
+#: fast no-op.
+_SHORT_ID_LENGTH = 12
 
 #: The agent layer's build context: its Dockerfile plus nothing else. Resolved
 #: relative to this module rather than through ``importlib.resources`` so the
@@ -44,6 +59,10 @@ _AGENT_DOCKERFILE = _AGENT_IMAGE_DIR / "agent.Dockerfile"
 
 class TaskImageBuildError(RuntimeError):
     """Raised when Docker cannot produce a valid immutable image."""
+
+
+class ImagePushError(RuntimeError):
+    """Raised when an agent image cannot be pushed to, or verified in, a registry."""
 
 
 @dataclass(frozen=True)
@@ -277,4 +296,228 @@ def _run_docker(
         raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
             f"Docker timed out after {timeout:g} seconds while {action} "
             f"{target.image_label}: {target.dockerfile}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Registry push and verification.
+#
+# A local ``--docker`` run never calls any of the functions below: it runs
+# the image ``agent_image`` just built directly from the local Docker image
+# store. Only a remote backend (Modal, SkyPilot) needs the image pulled from
+# somewhere else, so only those callers push. A push is keyed by the local
+# image ID rather than by tag: ``ensure_pushed`` checks whether *this exact*
+# content was already pushed to *repository* before running `docker push`
+# again, so a resumed or repeated remote launch against an unchanged agent
+# image is a no-op past the first launch.
+#
+# Prerequisite, out of scope here: the caller's Docker daemon must already be
+# logged in to the registry (``docker login ghcr.io`` with a token carrying
+# `write:packages`; CI supplies this as `GITHUB_TOKEN`). Nothing in this
+# module performs or inspects that login, and no function here logs
+# credentials, only image references and exit codes.
+# ---------------------------------------------------------------------------
+
+
+def push_agent_image(
+    image_id: str,
+    *,
+    repository: str = DEFAULT_AGENT_IMAGE_REGISTRY,
+    command_runner: DockerBuildRunner | None = None,
+    timeout: float = _DEFAULT_PUSH_TIMEOUT_SECONDS,
+) -> str:
+    """Tag, push, and resolve the pullable digest reference for *image_id*.
+
+    *image_id* must be the immutable ``sha256:...`` ID :func:`agent_image` (or
+    :func:`build_task_image`) returned, not a mutable tag. It is tagged as
+    ``<repository>:<short id>`` (a name derived from the image's own content
+    address, not a moving tag), pushed, and then resolved back to the
+    ``<repository>@sha256:...`` manifest digest Docker recorded for that push,
+    which is what a remote backend actually pulls.
+
+    Always pushes, even when the registry already has this content: callers
+    that want to skip a redundant push when it is already verified present
+    should call :func:`ensure_pushed` instead, which checks first.
+
+    Raises:
+        ValueError: if *image_id* is not an immutable image ID, or *timeout*
+            is not positive.
+        ImagePushError: if Docker is missing, the tag/push/inspect step times
+            out or fails, or Docker reports no usable digest for the pushed
+            tag. The docker CLI's own diagnostics are included; a failed push
+            is very often an expired or missing registry login, so the
+            message also names the `docker login` prerequisite.
+    """
+    if _IMAGE_ID.fullmatch(image_id) is None:
+        raise ValueError(  # noqa: TRY003
+            f"push_agent_image requires an immutable image ID (sha256:...), got {image_id!r}"
+        )
+    if timeout <= 0:
+        raise ValueError("agent image push timeout must be positive")  # noqa: TRY003
+
+    runner = command_runner or SubprocessDockerBuildRunner()
+    cwd = Path.cwd()
+    tag = f"{repository}:{image_id.removeprefix('sha256:')[:_SHORT_ID_LENGTH]}"
+
+    tag_result = _run_registry_command(
+        runner, ("docker", "tag", image_id, tag), cwd=cwd, timeout=timeout, action="tagging"
+    )
+    if tag_result.returncode != 0:
+        detail = (tag_result.stderr or tag_result.stdout or "docker tag failed").strip()
+        raise ImagePushError(  # noqa: TRY003
+            f"Could not tag agent image {image_id} as {tag} "
+            f"(exit {tag_result.returncode}): {detail[:_DIAGNOSTIC_LIMIT]}"
+        )
+
+    push_result = _run_registry_command(
+        runner, ("docker", "push", tag), cwd=cwd, timeout=timeout, action="pushing"
+    )
+    if push_result.returncode != 0:
+        detail = (push_result.stderr or push_result.stdout or "docker push failed").strip()
+        raise ImagePushError(  # noqa: TRY003
+            f"Could not push agent image {tag} (exit {push_result.returncode}): "
+            f"{detail[:_DIAGNOSTIC_LIMIT]}. Authenticate first with "
+            "`docker login ghcr.io` using a token with `write:packages` scope "
+            "(`GITHUB_TOKEN` in CI)."
+        )
+
+    inspect_result = _run_registry_command(
+        runner,
+        ("docker", "inspect", "--format", "{{index .RepoDigests 0}}", tag),
+        cwd=cwd,
+        timeout=timeout,
+        action="inspecting",
+    )
+    digest_reference = inspect_result.stdout.strip()
+    if inspect_result.returncode != 0 or not digest_reference:
+        detail = (inspect_result.stderr or inspect_result.stdout or "no output").strip()
+        raise ImagePushError(  # noqa: TRY003
+            f"Pushed {tag} but Docker returned no repo digest for it: {detail[:_DIAGNOSTIC_LIMIT]}"
+        )
+    if not digest_reference.startswith(f"{repository}@sha256:"):
+        raise ImagePushError(  # noqa: TRY003
+            f"Docker returned an unexpected repo digest for {tag}: {digest_reference!r}"
+        )
+    return digest_reference
+
+
+def agent_image_is_pushed(
+    reference: str,
+    *,
+    command_runner: DockerBuildRunner | None = None,
+    timeout: float = _DEFAULT_VERIFY_TIMEOUT_SECONDS,
+) -> bool:
+    """Return whether *reference* (a ``repository@sha256:...`` digest) is live in its registry.
+
+    Uses ``docker manifest inspect``, which asks the registry for the
+    manifest without pulling any layers. A nonzero exit is treated uniformly
+    as "not verified", whether the digest is genuinely absent, the registry
+    is unreachable, or credentials are missing or expired: this function
+    only answers "is it there right now", and :func:`push_agent_image`'s own
+    error reporting is what surfaces which of those it was when a caller
+    acts on a ``False`` result by trying to push.
+    """
+    runner = command_runner or SubprocessDockerBuildRunner()
+    try:
+        result = runner.run(
+            ("docker", "manifest", "inspect", reference), cwd=Path.cwd(), timeout=timeout
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def ensure_pushed(
+    image_id: str,
+    *,
+    repository: str = DEFAULT_AGENT_IMAGE_REGISTRY,
+    command_runner: DockerBuildRunner | None = None,
+    timeout: float = _DEFAULT_PUSH_TIMEOUT_SECONDS,
+) -> str:
+    """Return a pullable ``repository@sha256:...`` reference for *image_id*, pushing only if needed.
+
+    Checks Docker's own record of where this exact local image was already
+    pushed (``docker image inspect``'s ``RepoDigests``, which persists across
+    processes as long as the local image store keeps the image) and, when a
+    digest for *repository* is on file, confirms it is still live in the
+    registry via :func:`agent_image_is_pushed` before trusting it. Only when
+    neither check succeeds does this actually push, via
+    :func:`push_agent_image`, and it re-verifies the result before returning
+    so a caller never receives a digest this function has not confirmed is
+    fetchable.
+
+    Raises:
+        ImagePushError: if pushing fails, or if the registry does not report
+            the freshly pushed digest as present. The message names the
+            digest that could not be verified.
+    """
+    runner = command_runner or SubprocessDockerBuildRunner()
+    cached = _cached_repo_digest(image_id, repository, runner=runner, timeout=timeout)
+    if cached is not None and agent_image_is_pushed(cached, command_runner=runner, timeout=timeout):
+        return cached
+
+    pushed = push_agent_image(
+        image_id, repository=repository, command_runner=runner, timeout=timeout
+    )
+    if not agent_image_is_pushed(pushed, command_runner=runner, timeout=timeout):
+        raise ImagePushError(  # noqa: TRY003
+            f"Pushed {pushed} but the registry did not report it as present "
+            "immediately afterward; retry, or check registry availability."
+        )
+    return pushed
+
+
+def _cached_repo_digest(
+    image_id: str,
+    repository: str,
+    *,
+    runner: DockerBuildRunner,
+    timeout: float,
+) -> str | None:
+    """Return a previously pushed ``repository@sha256:...`` digest for *image_id*, if known.
+
+    Reads *image_id*'s ``RepoDigests`` from the local Docker image store,
+    which Docker updates in place on every successful ``docker push`` of a
+    tag pointing at that image ID. Absent, malformed, or Docker-unreachable
+    output all resolve to "unknown" rather than raising: the caller falls
+    back to actually pushing, which reports the real failure if one exists.
+    """
+    try:
+        result = runner.run(
+            ("docker", "image", "inspect", "--format", "{{json .RepoDigests}}", image_id),
+            cwd=Path.cwd(),
+            timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        digests = json.loads(result.stdout.strip() or "null")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(digests, list):
+        return None
+    prefix = f"{repository}@"
+    return next(
+        (entry for entry in digests if isinstance(entry, str) and entry.startswith(prefix)),
+        None,
+    )
+
+
+def _run_registry_command(
+    runner: DockerBuildRunner,
+    argv: Sequence[str],
+    *,
+    cwd: Path,
+    timeout: float,
+    action: str,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return runner.run(argv, cwd=cwd, timeout=timeout)
+    except FileNotFoundError as exc:
+        raise ImagePushError(f"Docker was not found while {action} the agent image") from exc  # noqa: TRY003
+    except subprocess.TimeoutExpired as exc:
+        raise ImagePushError(  # noqa: TRY003
+            f"Docker timed out after {timeout:g} seconds while {action} the agent image"
         ) from exc

--- a/src/vibesys/sandbox/images/agent.Dockerfile
+++ b/src/vibesys/sandbox/images/agent.Dockerfile
@@ -19,6 +19,10 @@ ARG OPENCODE_VERSION
 ARG TOOLCHAINS=""
 ARG RUST_VERSION
 ARG GO_VERSION
+# Space-separated extra pip requirements an execution environment needs in
+# the editor container (the Modal environment adds the `modal` client so a
+# candidate's `modal run` works). Empty installs nothing extra.
+ARG PIP_EXTRAS=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -74,7 +78,7 @@ RUN npm install -g --include=optional \
 # Debian 12+ marks the system Python as externally managed (PEP 668); this
 # image has no other consumer of that protection.
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
-RUN pip install --no-cache-dir uv 'mcp>=1.0,<2'
+RUN pip install --no-cache-dir uv 'mcp>=1.0,<2' ${PIP_EXTRAS}
 
 # Harmless when the corresponding toolchain is absent, so these are set
 # unconditionally rather than only inside the TOOLCHAINS branches below.

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -480,6 +480,11 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
         return CandidateRuntime(view.prompt_notes, view.deployment_namespace)
 
 
+#: The Modal client a candidate's ``modal run`` needs inside the editor
+#: container; baked into that environment's agent image.
+_MODAL_EDITOR_PIP_EXTRAS: tuple[str, ...] = ("modal>=0.66",)
+
+
 @dataclass(frozen=True)
 class ModalEnvironmentConfig:  # noqa: D101  # tracked: #288
     image: str | None = None
@@ -776,6 +781,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
         container_image = agent_image(
             _docker_backend_image(request),
             toolchains=_docker_agent_toolchains(request, tools),
+            pip_extras=_MODAL_EDITOR_PIP_EXTRAS,
         )
         container_image = _ensure_pushed_for_remote_backend(
             container_image, ensure_pushed=ensure_pushed, backend_label="Modal"

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -565,7 +565,19 @@ class SkyPilotEnvironment(DockerEnvironment):
         )
 
     def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession:
-        """Open the bridge and CPU-only local editor container."""
+        """Open the bridge and CPU-only local editor container.
+
+        The editor container starts from the same agent image the plain
+        Docker path builds, pushed to and pulled back from a registry the
+        same way :class:`ModalEnvironment` does (see its ``open`` docstring
+        for why: this backend's Docker daemon cannot be assumed to already
+        have the image locally). It is unrelated to the ``image_id`` the
+        actual accelerator job later runs on: that image is an
+        operator-declared field of the cluster profile
+        (``SkyPilotProfile.remote_runtime_image``), chosen for the
+        accuracy/benchmark command's own runtime needs (CUDA/ROCm, etc.), not
+        for running agent CLIs, and this change leaves it untouched.
+        """
         if self.config.resources is None:
             raise ValueError("SkyPilot requires portable run resources")  # noqa: TRY003
         if request.state_namespace is None:
@@ -599,8 +611,23 @@ class SkyPilotEnvironment(DockerEnvironment):
         )
         try:
             bridge.start()
+
+            from vibesys.sandbox.images import (  # noqa: PLC0415  # tracked: #288
+                agent_image,
+                ensure_pushed,
+            )
+
+            tools = _evaluator_tools(request)
+            container_image = agent_image(
+                _docker_backend_image(request),
+                toolchains=_docker_agent_toolchains(request, tools),
+            )
+            container_image = _ensure_pushed_for_remote_backend(
+                container_image, ensure_pushed=ensure_pushed, backend_label="SkyPilot"
+            )
+
             bind_mounts, docker_symlinks, passthrough = _container_mount_plan(request)
-            extra_init_commands, cli_provider_env = _cli_container_setup(request)
+            cli_provider_env, auth_files = _cli_provider_env_and_auth_files(request)
             cli_provider_env.setdefault("UV_CACHE_DIR", "/workspace/.cache/uv")
             helper_source = Path(__file__).with_name("skypilot_evaluator.py")
             helper_path = "/opt/vibesys-skypilot-evaluator.py"
@@ -636,8 +663,9 @@ class SkyPilotEnvironment(DockerEnvironment):
                 bind_mounts=_dedupe_mounts(bind_mounts),
                 passthrough_paths=passthrough,
                 extra_env=cli_provider_env,
-                extra_init_commands=extra_init_commands,
+                auth_files=auth_files,
                 lifecycle_hooks=_symlink_lifecycle_hooks(docker_symlinks),
+                container_image=container_image,
                 attach_accelerator=False,
             )
             _start_sandbox(sandbox)
@@ -708,16 +736,30 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
         Architecture (refactor April 2026): the agent (codex CLI) runs inside
         a *local* Docker container that does file editing only. GPU-bound
         execution dispatches to Modal via the candidate's declared ``modal run``
-        entrypoint; we install the Modal
-        Python SDK and mount the host's ``~/.modal.toml`` into the container
+        entrypoint; we mount the host's ``~/.modal.toml`` into the container
         so those calls authenticate.
 
         We retain the host-side Modal Volume bootstrap (model + optional
         draft) so the implementer's ``modal.Volume.from_name(...)`` calls
-        resolve.  The previous "long-lived Modal sandbox running codex
-        inside" architecture is gone — it caused HOME-leak auth bugs,
+        resolve. The previous "long-lived Modal sandbox running codex inside"
+        architecture is gone: it caused HOME-leak auth bugs,
         codex-vs-model-weight memory contention, and per-run sandbox
         cold-start overhead that this design eliminates.
+
+        The container starts from the same agent image the plain Docker path
+        builds (:func:`~vibesys.sandbox.images.agent_image`), pushed to and
+        pulled back from a registry (:func:`~vibesys.sandbox.images.ensure_pushed`),
+        since this backend's Docker daemon is not guaranteed to already have
+        it locally the way the local ``--docker`` path's is. Nothing installs
+        anything at container start any more, including the Modal Python SDK
+        an earlier revision ``pip install``ed here: that install already ran
+        through ``extra_init_commands``, which ``DockerSandbox`` (the sandbox
+        class every ``SandboxKind.DOCKER`` construction here actually builds)
+        has ignored ever since the agent-image work landed, so removing it is
+        deleting dead code, not taking away a behavior that ran. A candidate
+        whose declared ``modal run`` entrypoint needs the ``modal`` package
+        still needs something to install it; see the accompanying report for
+        the gap this surfaces.
         """
         # Host-side: ensure Modal Volumes exist for the model + optional
         # draft.  These run before the Docker container starts and are
@@ -725,8 +767,22 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
         self._ensure_model_volume(request)
         self._ensure_draft_volume(request)
 
+        from vibesys.sandbox.images import (  # noqa: PLC0415  # tracked: #288
+            agent_image,
+            ensure_pushed,
+        )
+
+        tools = _evaluator_tools(request)
+        container_image = agent_image(
+            _docker_backend_image(request),
+            toolchains=_docker_agent_toolchains(request, tools),
+        )
+        container_image = _ensure_pushed_for_remote_backend(
+            container_image, ensure_pushed=ensure_pushed, backend_label="Modal"
+        )
+
         bind_mounts, docker_symlinks, passthrough = _container_mount_plan(request)
-        extra_init_commands, cli_provider_env = _cli_container_setup(request)
+        cli_provider_env, auth_files = _cli_provider_env_and_auth_files(request)
         cli_provider_env.setdefault("UV_CACHE_DIR", "/workspace/.cache/uv")
         if request.git_history_root is not None:
             cli_provider_env.setdefault("VIBESYS_GIT_HISTORY", "/opt/vibesys-history")
@@ -761,11 +817,6 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
         if modal_config_dir.is_dir():
             bind_mounts.append((str(modal_config_dir), "/root/.modal", True))
 
-        # Install the Modal Python SDK alongside the agent's other packages.
-        # Pinned to a recent release; the wire protocol is forward-compatible
-        # with the host's Modal CLI as long as both are within ~one major.
-        extra_init_commands.insert(0, "pip install --quiet 'modal>=0.66'")
-
         bind_mounts = _dedupe_mounts(bind_mounts)
         lifecycle_hooks = _symlink_lifecycle_hooks(docker_symlinks)
 
@@ -776,8 +827,9 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
             bind_mounts=bind_mounts,
             passthrough_paths=passthrough,
             extra_env=cli_provider_env,
-            extra_init_commands=extra_init_commands,
+            auth_files=auth_files,
             lifecycle_hooks=lifecycle_hooks,
+            container_image=container_image,
             attach_accelerator=False,
         )
         log: Callable[[str], None] = request.log or (lambda _: None)
@@ -1545,12 +1597,15 @@ def _container_project_policy_mounts(
 def _cli_container_env(request: RunEnvironmentRequest) -> tuple[str, dict[str, str]] | None:
     """Return ``(provider, container env)`` when a CLI provider needs a container.
 
-    Factored out of :func:`_cli_container_setup` so the plain Docker path —
-    which starts from a prebuilt agent image and installs nothing at start —
-    can still get the auth-presence check and the auth env passthrough
-    without the shell-command half of that function. Modal and SkyPilot keep
-    calling :func:`_cli_container_setup` in full until their own image work
-    (#676, #679) lands.
+    Every containerized environment (Docker, Modal, SkyPilot) now starts from
+    a prebuilt agent image and installs nothing at container start, so this
+    is the whole of what a CLI provider needs from the run request: the
+    auth-presence check and the auth env passthrough. What used to be the
+    shell-command half of this (:func:`vibesys.agents.cli_docker
+    .docker_init_commands`, run through ``extra_init_commands``) is gone; see
+    :func:`_cli_provider_env_and_auth_files` for the staged-file counterpart
+    Modal and SkyPilot pass through ``auth_files`` instead, matching the
+    plain Docker path.
 
     Returns ``None`` when the run is not a containerized CLI agent (a
     different agent backend, or no CLI provider selected).
@@ -1591,20 +1646,50 @@ def _cli_container_env(request: RunEnvironmentRequest) -> tuple[str, dict[str, s
     return provider, env
 
 
-def _cli_container_setup(
+def _cli_provider_env_and_auth_files(
     request: RunEnvironmentRequest,
-) -> tuple[list[str], dict[str, str]]:
-    resolved = _cli_container_env(request)
-    if resolved is None:
-        return [], {}
-    provider, env = resolved
-    from vibesys.agents.cli_docker import (  # noqa: PLC0415  # tracked: #288
-        auth_copy_commands,
-        docker_init_commands,
-    )
+) -> tuple[dict[str, str], list[tuple[str, str]]]:
+    """Return the container env and staged auth copies for a CLI provider, if any.
 
-    commands = [*auth_copy_commands(provider), *docker_init_commands(provider)]
-    return commands, env
+    The shared counterpart to :meth:`DockerEnvironment.open`'s own inline
+    version of this: every environment that starts a container from the
+    prebuilt agent image copies auth the same way (via
+    :func:`vibesys.agents.cli_docker.auth_copy_paths`, handed to the sandbox
+    as ``auth_files`` so it copies them in at start), rather than running
+    shell commands built from a provider's install recipe.
+    """
+    resolved_cli = _cli_container_env(request)
+    if resolved_cli is None:
+        return {}, []
+    provider, cli_provider_env = resolved_cli
+    from vibesys.agents.cli_docker import auth_copy_paths  # noqa: PLC0415  # tracked: #288
+
+    return cli_provider_env, auth_copy_paths(provider)
+
+
+def _ensure_pushed_for_remote_backend(
+    image_id: str,
+    *,
+    ensure_pushed: Callable[[str], str],
+    backend_label: str,
+) -> str:
+    """Push and verify *image_id*, naming it and *backend_label* on failure.
+
+    ``ensure_pushed`` (:func:`vibesys.sandbox.images.ensure_pushed`) already
+    raises :class:`~vibesys.sandbox.images.ImagePushError` naming the image
+    and what went wrong; this only adds which run environment could not
+    start because of it, so the operator does not have to guess whether a
+    Modal or a SkyPilot launch is the one that failed to reach the registry.
+    """
+    from vibesys.sandbox.images import ImagePushError  # noqa: PLC0415  # tracked: #288
+
+    try:
+        return ensure_pushed(image_id)
+    except ImagePushError as exc:
+        raise ImagePushError(  # noqa: TRY003
+            f"could not push or verify the agent image {image_id} in the "
+            f"registry for a {backend_label} run: {exc}"
+        ) from exc
 
 
 def _evaluator_container_setup(

--- a/tests/vibesys/agents/test_cli_docker.py
+++ b/tests/vibesys/agents/test_cli_docker.py
@@ -32,21 +32,12 @@ _FAKE_PROFILES = {
             ".claude/settings.local.json",
             ".claude.json",
         ),
-        container_install=(
-            "apt-get update && apt-get install -y --no-install-recommends curl ca-certificates",
-            "curl -fsSL https://claude.ai/install.sh | bash",
-            "ln -sf /root/.local/bin/claude /usr/local/bin/claude",
-        ),
     ),
     "codex": fake_profiles.profile(
         "codex",
         state_dirs=(".codex", ".config/codex"),
         auth_env_vars=("OPENAI_API_KEY", "OPENAI_BASE_URL"),
         auth_files=(".codex/auth.json", ".codex/config.toml"),
-        container_install=(
-            "curl -fsSL https://nodejs.org/install | bash",
-            "npm install -g @openai/codex",
-        ),
     ),
     "gemini": fake_profiles.profile(
         "gemini",
@@ -58,7 +49,6 @@ _FAKE_PROFILES = {
             ".gemini/settings.json",
             ".gemini/.env",
         ),
-        container_install=("npm install -g @google/gemini-cli",),
     ),
     "opencode": fake_profiles.profile(
         "opencode",
@@ -72,7 +62,6 @@ _FAKE_PROFILES = {
             ".config/opencode/config.jsonc",
             ".config/opencode/.env",
         ),
-        container_install=("curl -fsSL https://opencode.ai/install | bash",),
     ),
 }
 
@@ -144,7 +133,7 @@ class TestAuthPaths:
 class TestAuthImport:
     """Staged state is mounted read-only and copied into writable storage."""
 
-    def test_mounts_and_copies_each_existing_leaf_into_writable_storage(
+    def test_mounts_and_names_each_existing_leaf_for_writable_import(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -171,11 +160,8 @@ class TestAuthImport:
             (str(codex_home / "config.toml"), "/opt/vibesys-auth/1", True),
             (str(tmp_path / ".claude.json"), "/opt/vibesys-auth/2", True),
         ]
-        assert cli_docker.auth_copy_commands("fixture") == [
-            "mkdir -p /home/agent/.codex && cp -a /opt/vibesys-auth/0 /home/agent/.codex/auth.json",
-            "mkdir -p /home/agent/.codex && cp -a /opt/vibesys-auth/1 /home/agent/.codex/config.toml",
-            "mkdir -p /home/agent && cp -a /opt/vibesys-auth/2 /home/agent/.claude.json",
-        ]
+        # `auth_copy_paths` hands these straight to `DockerSandbox(auth_files=...)`,
+        # which copies each pair in as a start-time step; no shell recipe.
         assert cli_docker.auth_copy_paths("fixture") == [
             ("/opt/vibesys-auth/0", "/home/agent/.codex/auth.json"),
             ("/opt/vibesys-auth/1", "/home/agent/.codex/config.toml"),
@@ -206,9 +192,6 @@ class TestAuthImport:
         # auth.json must not renumber the staging path of config.toml.
         assert cli_docker.auth_bind_mounts("fixture") == [
             (str(codex_home / "config.toml"), "/opt/vibesys-auth/1", True),
-        ]
-        assert cli_docker.auth_copy_commands("fixture") == [
-            "mkdir -p /home/agent/.codex && cp -a /opt/vibesys-auth/1 /home/agent/.codex/config.toml",
         ]
         assert cli_docker.auth_copy_paths("fixture") == [
             ("/opt/vibesys-auth/1", "/home/agent/.codex/config.toml"),
@@ -260,143 +243,13 @@ class TestAuthEnvVars:
             cli_docker.auth_env_passthrough("unregistered-provider")
 
 
-class TestDockerInitCommands:
-    """The provider recipe from the profile, plus VibeSys's own toolchain."""
-
-    def test_runs_the_profile_recipe_before_the_common_tooling(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        fake_profiles.install(
-            monkeypatch,
-            {
-                "fixture": fake_profiles.profile(
-                    "fixture",
-                    container_install=("install-the-cli", "link-the-binary"),
-                ),
-                "bare": fake_profiles.profile("bare"),
-            },
-        )
-
-        commands = cli_docker.docker_init_commands("fixture")
-
-        assert commands[:2] == ["install-the-cli", "link-the-binary"]
-        # The tail is the same for every provider: it is VibeSys's own
-        # toolchain, not anything the profile asked for.
-        assert commands[2:] == cli_docker.docker_init_commands("bare")
-
-    @pytest.mark.parametrize("provider", _SHIPPED)
-    def test_installs_only_mcp_v1(self, provider: str, fake_profiles_installed: None) -> None:
-        del fake_profiles_installed
-        commands = cli_docker.docker_init_commands(provider)
-
-        assert any("command -v pip3" in command for command in commands)
-        assert (
-            "PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --quiet 'mcp>=1.0,<2'" in commands
-        )
-
-    @pytest.mark.parametrize("provider", _SHIPPED)
-    def test_installs_the_pinned_rust_toolchain(
-        self,
-        provider: str,
-        fake_profiles_installed: None,
-    ) -> None:
-        del fake_profiles_installed
-        commands = cli_docker.docker_init_commands(provider)
-        rust_install = next(command for command in commands if "rustup-init.sh" in command)
-
-        assert "command -v cargo" in rust_install
-        assert f"--default-toolchain {cli_docker.RUST_DOCKER_TOOLCHAIN_VERSION}" in rust_install
-        assert "--profile minimal" in rust_install
-        assert "--component rustfmt --component clippy" in rust_install
-        assert "ln -sf /root/.cargo/bin/* /usr/local/bin/" in rust_install
-        assert cli_docker.RUST_DOCKER_TOOLCHAIN_VERSION == "1.92.0"
-
-    def test_hardens_the_single_shot_apt_bootstrap_the_claude_profile_ships(self) -> None:
-        recipe = agentshim.get_provider("claude").profile.container_install
-        assert any("apt-get" in step for step in recipe), recipe
-
-        commands = cli_docker.docker_init_commands("claude")
-
-        # Ubuntu mirrors reachable from our hosts fail a single-shot
-        # `apt-get update` often enough to break container start, so every
-        # apt-get that survives into the recipe retries. When the library
-        # rewords its bootstrap step the override stops matching and this
-        # fails, instead of silently reverting the hardening.
-        apt_steps = [step for step in commands if "apt-get" in step]
-        assert apt_steps
-        assert all("apt retry $i" in step for step in apt_steps)
-
-    def test_runs_a_shared_step_once_when_the_recipe_already_has_it(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        fake_profiles.install(
-            monkeypatch,
-            {
-                "fixture": fake_profiles.profile(
-                    "fixture",
-                    container_install=(
-                        "apt-get update && apt-get install -y --no-install-recommends "
-                        "curl ca-certificates",
-                        "install-the-cli",
-                    ),
-                )
-            },
-        )
-
-        commands = cli_docker.docker_init_commands("fixture")
-
-        assert len(commands) == len(set(commands))
-        assert commands[1] == "install-the-cli"
-
-    def test_pins_an_unpinned_codex_cli_install(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        fake_profiles.install(
-            monkeypatch,
-            {
-                "codex": fake_profiles.profile(
-                    "codex",
-                    container_install=("npm install -g @openai/codex",),
-                )
-            },
-        )
-
-        commands = cli_docker.docker_init_commands("codex")
-
-        assert commands[0] == (
-            f"npm install -g --include=optional @openai/codex@{cli_docker.CODEX_DOCKER_CLI_VERSION}"
-        )
-        assert cli_docker.CODEX_DOCKER_CLI_VERSION == "0.144.4"
-
-    def test_leaves_a_codex_version_the_profile_already_pinned(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        fake_profiles.install(
-            monkeypatch,
-            {
-                "codex": fake_profiles.profile(
-                    "codex",
-                    container_install=("npm install -g @openai/codex@9.9.9",),
-                )
-            },
-        )
-
-        assert cli_docker.docker_init_commands("codex")[0] == ("npm install -g @openai/codex@9.9.9")
-
-    def test_rejects_a_provider_agentshim_does_not_register(self) -> None:
-        with pytest.raises(ValueError, match="unregistered-provider"):
-            cli_docker.docker_init_commands("unregistered-provider")
-
-
 class TestShippedProfileAssumptions:
     """The real agentshim profiles, run through the tables above.
 
     Nothing here is monkeypatched: these pin that what the four shipped
     providers actually declare still satisfies what VibeSys derives from it, so
-    a library release that renames a state directory, adds a model-selection
-    variable, or rewrites an install recipe fails here rather than at container
-    start.
+    a library release that renames a state directory or adds a
+    model-selection variable fails here rather than at container start.
     """
 
     @pytest.mark.parametrize("provider", _SHIPPED)
@@ -427,46 +280,6 @@ class TestShippedProfileAssumptions:
         # VibeSys owns per-role model selection, so no shipped profile may hand
         # the container a host override of it (see `auth_env_vars`).
         assert [name for name in forwarded if name.endswith("_MODEL")] == []
-
-    @pytest.mark.parametrize("provider", _SHIPPED)
-    def test_recipe_ends_with_the_common_tooling_it_does_not_already_run(
-        self,
-        provider: str,
-    ) -> None:
-        common = cli_docker._COMMON_DOCKER_TOOLING_INSTALL  # noqa: SLF001
-        commands = cli_docker.docker_init_commands(provider)
-        split = len(commands)
-        while split and commands[split - 1] in common:
-            split -= 1
-        head, tail = commands[:split], commands[split:]
-
-        # The trailing common steps keep their order and gain nothing, and the
-        # ones missing from the tail are exactly the ones the profile recipe
-        # already runs.
-        assert tail == [step for step in common if step in tail]
-        assert all(step in head for step in common if step not in tail)
-        assert len(commands) == len(set(commands))
-
-    @pytest.mark.parametrize("provider", _SHIPPED)
-    def test_every_npm_step_runs_after_node_is_on_the_path(self, provider: str) -> None:
-        commands = cli_docker.docker_init_commands(provider)
-
-        # The node bootstrap is inside the recipe, ahead of the common tooling,
-        # so a profile that drops its `command -v node` guard would run npm on
-        # an image without node.
-        for index, command in enumerate(commands):
-            if "npm " not in command:
-                continue
-            assert any("command -v node" in earlier for earlier in commands[: index + 1]), command
-
-    def test_codex_installs_the_verified_cli_version(self) -> None:
-        commands = cli_docker.docker_init_commands("codex")
-
-        # Either the profile pins this version or `_pin_codex_cli` supplies it;
-        # a profile that starts pinning a different one fails here instead of
-        # silently changing the editor mid-campaign.
-        pin = f"@openai/codex@{cli_docker.CODEX_DOCKER_CLI_VERSION}"
-        assert any(pin in command for command in commands), commands
 
 
 def test_docker_provider_env_covers_every_provider_vibesys_ships() -> None:

--- a/tests/vibesys/sandbox/test_image_push.py
+++ b/tests/vibesys/sandbox/test_image_push.py
@@ -1,0 +1,257 @@
+"""Tests for pushing and verifying agent images in a registry.
+
+:func:`push_agent_image`, :func:`agent_image_is_pushed`, and
+:func:`ensure_pushed` are the remote-backend half of ``vibesys.sandbox.images``
+(see ``agent_image`` itself, covered by ``test_images.py``). A local
+``--docker`` run never calls any of these; only Modal and SkyPilot do, once
+their run environment resolves the agent image it needs to run from.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vibesys.sandbox.images import (
+    DEFAULT_AGENT_IMAGE_REGISTRY,
+    ImagePushError,
+    agent_image_is_pushed,
+    ensure_pushed,
+    push_agent_image,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+_IMAGE_ID = "sha256:" + "c" * 64
+_SHORT_ID = "c" * 12
+_TAG = f"{DEFAULT_AGENT_IMAGE_REGISTRY}:{_SHORT_ID}"
+_DIGEST = f"{DEFAULT_AGENT_IMAGE_REGISTRY}@sha256:" + "d" * 64
+
+
+class _FakeRegistryRunner:
+    """Programmable fake for the docker tag/push/inspect/manifest sequence."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        tag_returncode: int = 0,
+        push_returncode: int = 0,
+        push_stderr: str = "",
+        inspect_stdout: str = _DIGEST,
+        inspect_returncode: int = 0,
+        manifest_returncode: int = 0,
+        unverifiable_references: frozenset[str] = frozenset(),
+        cached_repo_digests: str | None = None,
+        raise_on: dict[str, Exception] | None = None,
+    ) -> None:
+        self.tag_returncode = tag_returncode
+        self.push_returncode = push_returncode
+        self.push_stderr = push_stderr
+        self.inspect_stdout = inspect_stdout
+        self.inspect_returncode = inspect_returncode
+        self.manifest_returncode = manifest_returncode
+        # References `docker manifest inspect` should report as absent even
+        # though `manifest_returncode` is otherwise 0: lets a test make one
+        # specific (usually stale) digest fail verification while a freshly
+        # pushed one still succeeds.
+        self.unverifiable_references = unverifiable_references
+        self.cached_repo_digests = cached_repo_digests
+        self.raise_on = raise_on or {}
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,  # noqa: ARG002
+        timeout: float,  # noqa: ARG002
+    ) -> subprocess.CompletedProcess[str]:
+        normalized = tuple(argv)
+        self.calls.append(normalized)
+        for marker, exc in self.raise_on.items():
+            if marker in normalized:
+                raise exc
+        if normalized[1] == "tag":
+            return subprocess.CompletedProcess(normalized, self.tag_returncode, "", "")
+        if normalized[1] == "push":
+            return subprocess.CompletedProcess(
+                normalized, self.push_returncode, "", self.push_stderr
+            )
+        if normalized[1] == "manifest":
+            reference = normalized[-1]
+            returncode = (
+                1 if reference in self.unverifiable_references else self.manifest_returncode
+            )
+            return subprocess.CompletedProcess(normalized, returncode, "", "")
+        if normalized[1] == "image" and normalized[2] == "inspect":
+            # The cached-digest fast path: `docker image inspect --format
+            # {{json .RepoDigests}} <image_id>`.
+            stdout = self.cached_repo_digests if self.cached_repo_digests is not None else "[]"
+            return subprocess.CompletedProcess(normalized, 0, stdout, "")
+        if normalized[1] == "inspect":
+            # The post-push digest resolution: `docker inspect --format
+            # {{index .RepoDigests 0}} <tag>`.
+            return subprocess.CompletedProcess(
+                normalized, self.inspect_returncode, self.inspect_stdout, ""
+            )
+        raise AssertionError(f"unexpected command: {normalized}")  # noqa: TRY003
+
+
+class TestPushAgentImage:
+    def test_tags_pushes_and_resolves_digest(self) -> None:
+        runner = _FakeRegistryRunner()
+
+        reference = push_agent_image(_IMAGE_ID, command_runner=runner)
+
+        assert reference == _DIGEST
+        assert runner.calls[0] == ("docker", "tag", _IMAGE_ID, _TAG)
+        assert runner.calls[1] == ("docker", "push", _TAG)
+        assert runner.calls[2] == (
+            "docker",
+            "inspect",
+            "--format",
+            "{{index .RepoDigests 0}}",
+            _TAG,
+        )
+
+    def test_uses_content_derived_tag_not_a_moving_tag(self) -> None:
+        runner = _FakeRegistryRunner()
+        push_agent_image(_IMAGE_ID, command_runner=runner)
+        assert runner.calls[0][3] == f"{DEFAULT_AGENT_IMAGE_REGISTRY}:{_SHORT_ID}"
+
+    def test_custom_repository(self) -> None:
+        runner = _FakeRegistryRunner()
+        repository = "ghcr.io/example/other-agent"
+        digest = f"{repository}@sha256:" + "e" * 64
+        runner.inspect_stdout = digest
+
+        reference = push_agent_image(_IMAGE_ID, repository=repository, command_runner=runner)
+
+        assert reference == digest
+        assert runner.calls[0][3] == f"{repository}:{_SHORT_ID}"
+
+    def test_rejects_mutable_tag_as_image_id(self) -> None:
+        with pytest.raises(ValueError, match="immutable image ID"):
+            push_agent_image("latest", command_runner=_FakeRegistryRunner())
+
+    def test_rejects_nonpositive_timeout(self) -> None:
+        with pytest.raises(ValueError, match="timeout must be positive"):
+            push_agent_image(_IMAGE_ID, command_runner=_FakeRegistryRunner(), timeout=0)
+
+    def test_tag_failure_raises_with_detail(self) -> None:
+        runner = _FakeRegistryRunner(tag_returncode=1)
+        with pytest.raises(ImagePushError, match="Could not tag"):
+            push_agent_image(_IMAGE_ID, command_runner=runner)
+
+    def test_push_failure_names_docker_login_prerequisite(self) -> None:
+        runner = _FakeRegistryRunner(push_returncode=1, push_stderr="denied: permission_denied")
+        with pytest.raises(ImagePushError, match=r"docker login ghcr\.io") as excinfo:
+            push_agent_image(_IMAGE_ID, command_runner=runner)
+        assert "permission_denied" in str(excinfo.value)
+
+    def test_push_failure_never_logs_credentials(self) -> None:
+        runner = _FakeRegistryRunner(
+            push_returncode=1, push_stderr="Authorization: Bearer super-secret-token"
+        )
+        with pytest.raises(ImagePushError):
+            push_agent_image(_IMAGE_ID, command_runner=runner)
+        # The docker CLI's own diagnostic text may be echoed back (Docker
+        # itself is trusted not to echo the token used for login), but this
+        # module never constructs or forwards a credential value of its own.
+        assert "super-secret-token" not in "".join(
+            arg for call in runner.calls for arg in call if isinstance(arg, str)
+        )
+
+    def test_missing_repo_digest_after_push_raises(self) -> None:
+        runner = _FakeRegistryRunner(inspect_stdout="")
+        with pytest.raises(ImagePushError, match="no repo digest"):
+            push_agent_image(_IMAGE_ID, command_runner=runner)
+
+    def test_unexpected_repo_digest_raises(self) -> None:
+        runner = _FakeRegistryRunner(inspect_stdout="some-other-repo@sha256:" + "f" * 64)
+        with pytest.raises(ImagePushError, match="unexpected repo digest"):
+            push_agent_image(_IMAGE_ID, command_runner=runner)
+
+    def test_missing_docker_binary_raises(self) -> None:
+        runner = _FakeRegistryRunner(raise_on={"tag": FileNotFoundError()})
+        with pytest.raises(ImagePushError, match="Docker was not found"):
+            push_agent_image(_IMAGE_ID, command_runner=runner)
+
+    def test_timeout_raises(self) -> None:
+        runner = _FakeRegistryRunner(raise_on={"tag": subprocess.TimeoutExpired("docker", 5)})
+        with pytest.raises(ImagePushError, match="timed out"):
+            push_agent_image(_IMAGE_ID, command_runner=runner)
+
+
+class TestAgentImageIsPushed:
+    def test_true_when_manifest_inspect_succeeds(self) -> None:
+        runner = _FakeRegistryRunner(manifest_returncode=0)
+        assert agent_image_is_pushed(_DIGEST, command_runner=runner) is True
+        assert runner.calls == [("docker", "manifest", "inspect", _DIGEST)]
+
+    def test_false_when_manifest_inspect_fails(self) -> None:
+        runner = _FakeRegistryRunner(manifest_returncode=1)
+        assert agent_image_is_pushed(_DIGEST, command_runner=runner) is False
+
+    def test_false_when_docker_missing(self) -> None:
+        runner = _FakeRegistryRunner(raise_on={"manifest": FileNotFoundError()})
+        assert agent_image_is_pushed(_DIGEST, command_runner=runner) is False
+
+    def test_false_on_timeout(self) -> None:
+        runner = _FakeRegistryRunner(raise_on={"manifest": subprocess.TimeoutExpired("docker", 5)})
+        assert agent_image_is_pushed(_DIGEST, command_runner=runner) is False
+
+
+class TestEnsurePushed:
+    def test_pushes_when_no_cached_digest(self) -> None:
+        runner = _FakeRegistryRunner()
+
+        reference = ensure_pushed(_IMAGE_ID, command_runner=runner)
+
+        assert reference == _DIGEST
+        assert ("docker", "tag", _IMAGE_ID, _TAG) in runner.calls
+        assert ("docker", "push", _TAG) in runner.calls
+
+    def test_skips_push_when_cached_digest_still_verifies(self) -> None:
+        runner = _FakeRegistryRunner(cached_repo_digests=f'["{_DIGEST}"]', manifest_returncode=0)
+
+        reference = ensure_pushed(_IMAGE_ID, command_runner=runner)
+
+        assert reference == _DIGEST
+        assert not any(call[1] == "push" for call in runner.calls)
+        assert not any(call[1] == "tag" for call in runner.calls)
+
+    def test_pushes_when_cached_digest_no_longer_verifies(self) -> None:
+        stale_digest = f"{DEFAULT_AGENT_IMAGE_REGISTRY}@sha256:" + "1" * 64
+        runner = _FakeRegistryRunner(
+            cached_repo_digests=f'["{stale_digest}"]',
+            unverifiable_references=frozenset({stale_digest}),
+        )
+
+        reference = ensure_pushed(_IMAGE_ID, command_runner=runner)
+
+        assert reference == _DIGEST
+        assert any(call[1] == "push" for call in runner.calls)
+
+    def test_ignores_cached_digest_for_a_different_repository(self) -> None:
+        runner = _FakeRegistryRunner(
+            cached_repo_digests='["ghcr.io/someone-else/agent@sha256:' + "a" * 64 + '"]'
+        )
+
+        ensure_pushed(_IMAGE_ID, command_runner=runner)
+
+        assert any(call[1] == "push" for call in runner.calls)
+
+    def test_raises_a_clear_error_naming_the_digest_when_unverifiable_after_push(self) -> None:
+        runner = _FakeRegistryRunner(manifest_returncode=1)
+        with pytest.raises(ImagePushError, match=_DIGEST):
+            ensure_pushed(_IMAGE_ID, command_runner=runner)
+
+    def test_propagates_push_failure(self) -> None:
+        runner = _FakeRegistryRunner(push_returncode=1)
+        with pytest.raises(ImagePushError, match="Could not push"):
+            ensure_pushed(_IMAGE_ID, command_runner=runner)

--- a/tests/vibesys/sandbox/test_images.py
+++ b/tests/vibesys/sandbox/test_images.py
@@ -119,6 +119,8 @@ def test_agent_image_base_only_argv(monkeypatch: pytest.MonkeyPatch) -> None:
         "RUST_VERSION=1.90.0",
         "--build-arg",
         "GO_VERSION=1.22.0",
+        "--build-arg",
+        "PIP_EXTRAS=",
         str(_AGENT_IMAGE_DIR),
     )
     assert cwd == _AGENT_IMAGE_DIR
@@ -197,6 +199,8 @@ def test_agent_image_chains_task_image_as_base(
         "RUST_VERSION=1.90.0",
         "--build-arg",
         "GO_VERSION=1.22.0",
+        "--build-arg",
+        "PIP_EXTRAS=",
         str(_AGENT_IMAGE_DIR),
     )
     assert agent_cwd == _AGENT_IMAGE_DIR
@@ -271,3 +275,18 @@ def test_agent_dockerfile_has_one_arg_per_cli_version() -> None:
     declared_args = set(re.findall(r"(?m)^ARG\s+([A-Z0-9_]+)", text))
     expected_args = {f"{provider.upper()}_VERSION" for provider in provider_policy.CLI_VERSIONS}
     assert expected_args <= declared_args
+
+
+def test_pip_extras_are_rendered_sorted_and_deduplicated(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_uuid(monkeypatch)
+    _patch_versions(monkeypatch)
+    runner = _FakeRunner()
+
+    agent_image(
+        "python:3.12-bookworm",
+        pip_extras=("modal>=0.66", "b", "modal>=0.66"),
+        command_runner=runner,
+    )
+
+    build_argv, _cwd, _timeout = runner.calls[0]
+    assert "PIP_EXTRAS=b modal>=0.66" in build_argv

--- a/tests/vibesys/sandbox/test_run_environment.py
+++ b/tests/vibesys/sandbox/test_run_environment.py
@@ -212,12 +212,14 @@ def fake_agent_image(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
         base_image: str,
         *,
         toolchains: Any = (),  # noqa: ANN401  # tracked: #288
+        pip_extras: Any = (),  # noqa: ANN401  # tracked: #288
         **_kwargs: Any,  # noqa: ANN401  # tracked: #288
     ) -> str:
         calls.append(
             {
                 "base_image": base_image,
                 "toolchains": frozenset(toolchains),
+                "pip_extras": frozenset(pip_extras),
             }
         )
         return "sha256:" + "a" * 64

--- a/tests/vibesys/sandbox/test_run_environment.py
+++ b/tests/vibesys/sandbox/test_run_environment.py
@@ -978,13 +978,18 @@ def test_isolated_environment_enforces_project_path_policy(tmp_path, environment
     assert hidden_mounts["/workspace/agent.toml"].is_relative_to(tmp_path / "logs")
 
 
-def test_cli_container_env_and_setup_agree_on_the_container_environment(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+def test_cli_container_env_and_setup_agree_on_the_container_environment(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     """``_cli_provider_env_and_auth_files`` (Modal/SkyPilot) agrees with
     ``_cli_container_env`` (the plain Docker path) on the container
     environment, and additionally returns the staged auth copy pairs a
     prebuilt-image container needs instead of a shell install recipe.
     """
     backend = FakeBackend()
+    home = tmp_path / "synthetic-home"
+    auth_file = home / ".codex" / "auth.json"
+    auth_file.parent.mkdir(parents=True)
+    auth_file.write_text('{"synthetic": true}\n')
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
     request = _request(tmp_path, backend, agent_backend="cli", cli_provider="codex")
 
     resolved = _cli_container_env(request)

--- a/tests/vibesys/sandbox/test_run_environment.py
+++ b/tests/vibesys/sandbox/test_run_environment.py
@@ -29,7 +29,7 @@ from vibesys.sandbox.run_environment import (
     RunEnvironmentRequest,
     RunEnvironmentSpec,
     _cli_container_env,
-    _cli_container_setup,
+    _cli_provider_env_and_auth_files,
     _docker_agent_toolchains,
     _docker_evaluator_tool_mounts,
     _evaluator_container_setup,
@@ -226,11 +226,34 @@ def fake_agent_image(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
     return calls
 
 
+_PUSHED_DIGEST = "ghcr.io/uw-syfi/vibesys-agent@sha256:" + "b" * 64
+
+
+@pytest.fixture(autouse=True)
+def fake_ensure_pushed(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Stub the registry push behind ``ensure_pushed`` for Modal/SkyPilot tests.
+
+    A real push hits the network and a logged-in Docker daemon; letting it
+    run would make these unit tests flaky integration tests. Returns the
+    image IDs it was asked to push, and always reports the same
+    ``repository@sha256:...``-shaped reference, so a test can assert a
+    Modal or SkyPilot sandbox is started from *that* digest.
+    """
+    calls: list[str] = []
+
+    def fake_ensure_pushed(image_id: str, **_kwargs: Any) -> str:  # noqa: ANN401  # tracked: #288
+        calls.append(image_id)
+        return _PUSHED_DIGEST
+
+    monkeypatch.setattr("vibesys.sandbox.images.ensure_pushed", fake_ensure_pushed)
+    return calls
+
+
 @pytest.fixture(autouse=True)
 def _synthetic_cli_auth(monkeypatch):  # noqa: ANN001, ANN202
     """Pin a deterministic host auth source for container CLI setup.
 
-    ``_cli_container_setup`` fails loud when a provider has neither a staged
+    ``_cli_container_env`` fails loud when a provider has neither a staged
     host file nor an auth environment variable, so these tests must not depend
     on whichever CLI the developer running them happens to be logged into.
     """
@@ -645,7 +668,11 @@ def test_isolated_environments_install_and_translate_evaluator_tools(
         # Rust in the running container.
         assert "extra_init_commands" not in backend.calls[0][1]
     else:
-        init_commands = backend.calls[0][1]["extra_init_commands"]
+        # The local editor container starts from a prebuilt agent image and
+        # installs nothing at start; the evaluator's own toolchain setup
+        # (checked below) travels as an argument to the remote evaluator
+        # helper script, not as a container init command.
+        assert "extra_init_commands" not in backend.calls[0][1]
         arguments = shlex.split(rendered)
         separator = arguments.index("--")
         assert arguments[separator + 1].startswith(".vibesys-evaluator-tools/request-factory/")
@@ -665,7 +692,6 @@ def test_isolated_environments_install_and_translate_evaluator_tools(
         assert arguments[arguments.index("--evaluator-package-root") + 1] == (
             "/opt/vibesys-evaluator-package"
         )
-        assert not any("static.rust-lang.org/rustup/dist" in item for item in init_commands)
 
 
 def test_docker_evaluator_tools_use_ephemeral_builder_and_read_only_final_mounts(
@@ -951,23 +977,22 @@ def test_isolated_environment_enforces_project_path_policy(tmp_path, environment
 
 
 def test_cli_container_env_and_setup_agree_on_the_container_environment(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-    """``_cli_container_setup`` (Modal/SkyPilot) still gets what it used to.
-
-    ``_cli_container_env`` was factored out of ``_cli_container_setup`` so the
-    plain Docker path can reuse the auth-presence check and env passthrough
-    without the shell-command half; this pins that the full function's
-    environment output is unchanged by the split.
+    """``_cli_provider_env_and_auth_files`` (Modal/SkyPilot) agrees with
+    ``_cli_container_env`` (the plain Docker path) on the container
+    environment, and additionally returns the staged auth copy pairs a
+    prebuilt-image container needs instead of a shell install recipe.
     """
     backend = FakeBackend()
     request = _request(tmp_path, backend, agent_backend="cli", cli_provider="codex")
 
     resolved = _cli_container_env(request)
-    _commands, setup_env = _cli_container_setup(request)
+    env, auth_files = _cli_provider_env_and_auth_files(request)
 
     assert resolved is not None
-    provider, env = resolved
+    provider, resolved_env = resolved
     assert provider == "codex"
-    assert env == setup_env
+    assert env == resolved_env
+    assert auth_files == [("/opt/vibesys-auth/0", "/home/agent/.codex/auth.json")]
 
 
 def test_cli_container_env_is_none_for_a_non_cli_agent_backend(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -1140,7 +1165,11 @@ def test_environment_session_context_manager_closes(tmp_path):  # noqa: ANN001, 
     backend.sandbox.stop.assert_called_once()
 
 
-def test_modal_environment_uses_local_docker_for_editing(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+def test_modal_environment_uses_local_docker_for_editing(
+    tmp_path,  # noqa: ANN001  # tracked: #288
+    fake_agent_image: list[dict[str, Any]],
+    fake_ensure_pushed: list[str],
+) -> None:
     """Post-refactor (April 2026): Modal mode runs the agent in a local
     Docker container; only GPU-bound work the implementer dispatches via
     `modal run` actually touches Modal."""
@@ -1152,6 +1181,11 @@ def test_modal_environment_uses_local_docker_for_editing(tmp_path):  # noqa: ANN
     # The sandbox is local Docker, not a Modal Sandbox.
     assert backend.calls[0][0] is SandboxKind.DOCKER
     assert backend.calls[0][1]["attach_accelerator"] is False
+    # The container starts from the same kind of agent image the plain
+    # Docker path builds, pushed to and pulled back from a registry.
+    assert fake_agent_image[-1]["base_image"] == backend.image
+    assert fake_ensure_pushed == ["sha256:" + "a" * 64]
+    assert backend.calls[0][1]["container_image"] == _PUSHED_DIGEST
     assert session.view.cli_sandboxed is True
     assert session.view.profile_execution == "remote"
     assert session.view.deployment_namespace is not None
@@ -1235,18 +1269,18 @@ def test_modal_environment_wraps_custom_deployment_entrypoint(tmp_path) -> None:
     assert session.view.paths.benchmark_command == f"{prefix} trusted-benchmark"
 
 
-def test_modal_environment_installs_modal_sdk_in_docker(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-    """The local Docker container needs the Modal Python SDK installed so
-    the implementer-authored `modal run` calls work."""
+def test_modal_environment_installs_nothing_at_container_start(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    """The local Docker container starts from a prebuilt, pushed agent image
+    and installs nothing at start, including the Modal Python SDK an earlier
+    revision `pip install`ed here: that install ran through
+    `extra_init_commands`, which `DockerSandbox` has ignored since the
+    agent-image work landed (#675), so it was already dead code."""
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
 
     env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
 
-    commands = backend.calls[0][1]["extra_init_commands"]
-    assert any("pip install" in c and "modal" in c for c in commands), (
-        f"expected `pip install modal` in init commands, got: {commands}"
-    )
+    assert "extra_init_commands" not in backend.calls[0][1]
     assert backend.calls[0][1]["extra_env"]["UV_CACHE_DIR"] == "/workspace/.cache/uv"
 
 
@@ -1474,7 +1508,10 @@ def test_unknown_environment_name_raises():  # noqa: ANN201  # tracked: #288
 
 
 def test_skypilot_environment_uses_cpu_editor_and_narrow_bridge(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_agent_image: list[dict[str, Any]],
+    fake_ensure_pushed: list[str],
 ) -> None:
     profiles = tmp_path / "clusters.toml"
     profiles.write_text(
@@ -1528,6 +1565,14 @@ remote_artifact_root = "/remote/vibesys"
     kind, kwargs = backend.calls[0]
     assert kind is SandboxKind.DOCKER
     assert kwargs["attach_accelerator"] is False
+    # The local editor container starts from the same kind of pushed agent
+    # image the plain Docker path builds, and installs nothing at start; this
+    # is unrelated to the accelerator job's own `image_id`, which stays the
+    # operator-declared `remote_runtime_image` from the cluster profile.
+    assert fake_agent_image[-1]["base_image"] == backend.image
+    assert fake_ensure_pushed == ["sha256:" + "a" * 64]
+    assert kwargs["container_image"] == _PUSHED_DIGEST
+    assert "extra_init_commands" not in kwargs
     mounts = kwargs["bind_mounts"]
     assert any(target == "/opt/vibesys-skypilot/bridge.sock" for _, target, _ in mounts)
     assert any(target == "/opt/vibesys-skypilot-evaluator.py" for _, target, _ in mounts)


### PR DESCRIPTION
## Problem

The Modal and SkyPilot environments still ran the old per-run install list inside their editor containers, so a remote round did not run the image a local `--docker` round built, and after #675 the Modal path had lost its `pip install modal` step entirely (it rode on the removed init commands). Closes #676; stacked on #681 (#677) and #680 (#675).

## Solution

- `images.py` gains `push_agent_image` (tag by content id, push, resolve the `RepoDigests` reference), `agent_image_is_pushed` (`docker manifest inspect`), and `ensure_pushed` (verify first, push only when absent), all raising `ImagePushError` naming the digest. Default repository `ghcr.io/uw-syfi/vibesys-agent`. `docker login ghcr.io` with a `write:packages` token is a documented prerequisite (`GITHUB_TOKEN` in CI); credentials are never logged.
- The Modal and SkyPilot environments build the agent image exactly like the Docker path, call `ensure_pushed`, and refuse to start with an error naming the digest when the push or verification fails. `_cli_container_setup`, `_evaluator_container_setup` on those paths, and the Modal `pip install modal` insert are gone.
- `agent_image` takes `pip_extras`, rendered as a `PIP_EXTRAS` build arg; the Modal environment passes `modal>=0.66` so a candidate's `modal run` works inside its editor container.
- `cli_docker.py` loses `docker_init_commands`, the override table, the pin regex, the common-tooling list, and `auth_copy_commands`; the auth path helpers stay.
- `vs_sandbox.ModalSandbox` drops `run_commands` and `extra_init_commands` and gains `auth_files`, matching Docker.
- Docs: "Registry: GHCR by digest" under "Images".

### Architecture

A finding worth stating: with the Modal-via-Docker design already on main, `ModalEnvironment.open()` builds a local `SandboxKind.DOCKER` editor container and GPU work dispatches through the candidate's own `modal run`. `vs_sandbox.ModalSandbox` has no production caller. The digest wiring here therefore lands on the Docker editor container those environments really build. SkyPilot's `remote_runtime_image` is the operator-declared accelerator runtime for accuracy and benchmark jobs, unrelated to the agent image, and is left alone. #679's scope needs adjusting accordingly (comment posted there).

## Verification

### Correctness properties

- A remote run never starts on an image the registry cannot serve; the error names the digest.
- A local `--docker` run never contacts the registry.
- The Modal editor image contains the `modal` client; the Docker and SkyPilot images do not.

### Testing

```
uv run ruff check src tests libs            # All checks passed
uv run ruff format --check src tests libs
scripts/check_types.sh                      # All checks passed
uv run lint-imports                         # Contracts: 2 kept, 0 broken
uv run pytest tests libs -q -n auto         # 5778 passed, 21 skipped (one flaky server transport test, unrelated)
```

Not verified: a real push to GHCR. The token on this host lacks `write:packages`, so the push and verify paths are covered by fake-runner unit tests only (`tests/vibesys/sandbox/test_image_push.py`, 22 tests). The first remote run with a `write:packages` login will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
