### PR TITLE
Collapse the AgentShim driver to one host/container path

### DIFF
--- a/docs/contributing/agent-drivers.md
+++ b/docs/contributing/agent-drivers.md
@@ -225,35 +225,56 @@ command's own runtime needs, not for running agent CLIs.
 
 ## Container execution
 
-`--docker` runs the provider CLI inside the role's editor container. The
-driver keeps a `DockerCommandExecutor` that rewrites every agentshim command
-into `docker exec -i -w <workdir> [-e ...] <container> <argv>`, so the library
-still builds argv, parses the stream, and owns the session.
+`--docker` runs the provider CLI inside the role's editor container, through
+the same path a host session runs. `create_session` looks up or builds a
+`vs_sandbox.WorkspaceSandbox`, wraps a plain `agentshim.HostCommandExecutor()`
+through `confine_to_sandbox`, and hands `CliAgent` the sandbox's own
+environment; nothing in it branches on which backend it has. A container
+session's sandbox is not built by the driver: it is the run environment's
+already-started `vs_sandbox.DockerSandbox`, looked up by role from the
+`docker_sandboxes` dict the driver was configured with. `sandbox.wrap` and
+`sandbox.agent_path` are the only two operations the driver calls to adapt
+everything else to a container.
 
+- `confine_to_sandbox` calls `sandbox.wrap(argv, cwd)` when the sandbox's
+  `wrap` accepts a `cwd` argument (only `DockerSandbox` does, because one
+  container serves every turn regardless of working directory, so the caller
+  supplies it per call; a host sandbox's `wrap(argv)` fixes its own workspace
+  and ignores the argument). The session's own `cwd`, passed to
+  `agent.start_session`, is always the real host workspace path, for a host
+  and a container session alike. `DockerSandbox.wrap` maps that host path to
+  the container's bind mount and emits `docker exec -i -w <container path>
+  ... <argv>`.
+- A container session's binary lookup is overridden to trust the bare
+  provider binary name to `docker exec`'s own PATH: a host-side lookup
+  against the container's PATH string would search host directories the CLI
+  does not live in.
 - The container ID is read from the sandbox on every command, so a GPU
   reselect that replaces the container needs no new executor.
-- A container turn names no working directory of its own. `-w` carries it, and
-  the executor's default is `/workspace`.
-- `AgentSessionSpec.environment` reaches the CLI through `TurnRequest.env`,
-  which the executor turns into `-e` flags. Which variables cross is declared
-  by the driver, not inferred: a container starts from its image's
-  environment, and the environment agentshim assembles for a turn describes
-  the host. Forwarding by inspection would point the container CLI at host
-  paths and could carry a host `ANTHROPIC_MODEL` past the container's own
-  configuration.
 - The CLI runs as the image's `agent` user, remapped at container start to
   the host user's uid and gid, so files it writes to the bind-mounted
   workspace are owned by the host user. Nothing repairs ownership afterwards,
   and git needs no `safe.directory` entry inside the container.
-- The binary health check (`<binary> --help`) runs inside the container, once
-  per session, before the first turn. See the section below for what a failure
-  costs.
-- Codex gets a `CodexRolloutWatchdogExecutor` in front of the transport. A
-  resumed `codex exec --json` inside a container regularly finishes its work,
-  writes the terminal events to its rollout file, and never exits; the
-  watchdog reads the rollout, replays the completion into the stream, and
-  stops the process. It is provider-behaviour compensation and stays in
-  VibeSys until the behaviour is verified fixed upstream.
+- The binary health check (`<binary> --help`) runs through the same
+  `confine_to_sandbox` wrapping, inside the container, once per session,
+  before the first turn. See the section below for what a failure costs.
+- `AgentSessionSpec.environment` is a real per-session overlay on a host
+  session, folded into the environment the host sandbox is built from. It
+  reaches nothing on a container session today: a container session's
+  environment is `sandbox.env`, and no current caller populates `environment`
+  for a containerized session (the run context's `gpu_env()`, the only source
+  `AgentClient.invoke` draws it from, returns an empty mapping whenever
+  `capabilities.container_execution` is true).
+- Every container session runs through a `CodexRolloutWatchdogExecutor`,
+  regardless of provider; it no-ops for any command that is not a resumed
+  `codex exec --json` run. A resumed one inside a container regularly
+  finishes its work, writes the terminal events to its rollout file, and
+  never exits; the watchdog reads the rollout, replays the completion into
+  the stream, and stops the process. It derives the rollout-sessions
+  directory it polls from the sandbox's own `env["HOME"]` and the Codex
+  provider profile's state directory, instead of a hardcoded `/home/agent` or
+  `/root`. It is provider-behaviour compensation and stays in VibeSys until
+  the behaviour is verified fixed upstream.
 
 ### A failed health check ends the run
 
@@ -275,19 +296,26 @@ agent timeout) rather than letting it escape as an unclassified error. That
 would give the operator a diagnostic naming the container and the provider
 instead of a bare `CliCheckError`.
 
-### Session MCP servers in a container
+### Session MCP servers and paths
 
 A provider that discovers MCP servers from a config file (`claude`, `gemini`,
 `opencode`) needs a directory to write it into, and agentshim derives that
-directory from the turn's working directory. A container turn has none, so it
-names the host workspace in `TurnRequest.mcp_workspace` instead: the library
-writes the config there for the turn and removes it afterwards, and the CLI
-reads it through the bind mount at `/workspace`. Codex passes its servers as
-`--config` flags and touches no workspace file either way.
+directory from the session's `cwd`. That `cwd` is always the host workspace
+path now, in both modes, so the config lands on the host without the driver
+naming a separate location, and a container CLI reads it back through the
+bind mount at `/workspace`. Codex passes its servers as `--config` flags and
+touches no workspace file either way.
 
-The MCP command is left as the caller wrote it in container mode. Only a host
-turn rewrites a bare `python` to the interpreter running VibeSys, because the
-container image resolves its own.
+Every absolute path in an MCP server's command or args, and the
+response-schema directory `OutputSchema.cli_dir`, is mapped through
+`sandbox.agent_path`: identity on the host, the container mount path under
+Docker. A host session additionally substitutes the interpreter running
+VibeSys for a bare `python` or `python3` command, because a host agent
+inherits a login shell's PATH, where that name may resolve to an interpreter
+without the MCP dependencies. A container session leaves the command as
+written, because the image resolves its own. That distinction is one keyword
+argument (`pin_interpreter`) on `_as_mcp_server`, not a container/host branch
+elsewhere in the driver.
 
 ## Usage records
 
@@ -355,11 +383,10 @@ stays an implementation detail.
 
 ## Sandboxing
 
-The agentshim driver applies its `vs_sandbox` host sandbox as an executor
-transform: `confine_to_sandbox` wraps every command that names a working
-directory, which is the single chokepoint through which the provider CLI is
-launched. A command without a working directory (the binary health check, and
-a container-executed turn) is left alone. The
+The agentshim driver applies its `vs_sandbox` sandbox as an executor
+transform: `confine_to_sandbox` rewrites every command's argv through
+`sandbox.wrap`, unconditionally, the single chokepoint through which the
+provider CLI is launched on the host or in a container alike. The
 Omnigent driver builds an `OSEnvSpec` that grants workspace write access and
 narrow read access to the active Rust toolchain. It selects bubblewrap on Linux
 or Seatbelt on macOS and never permits an unconfined fallback.

--- a/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
@@ -193,8 +193,14 @@ class WorkspaceSandbox(ABC):
     build_env: Mapping[str, str] | None = None
 
     @abstractmethod
-    def wrap(self, argv: list[str]) -> list[str]:
-        """Return *argv* rewritten to run confined to :attr:`workspace`."""
+    def wrap(self, argv: list[str], cwd: Path | str | None = None) -> list[str]:
+        """Return *argv* rewritten to run confined to :attr:`workspace`.
+
+        *cwd* is accepted for parity with a container sandbox, whose single
+        instance serves every workspace's turns and so needs telling which
+        one a given command belongs to. A host sandbox confines to exactly
+        one workspace already (:attr:`workspace`) and ignores the argument.
+        """
 
     def agent_path(self, host_path: Path | str) -> str:
         """Return the path the confined process sees for *host_path*.
@@ -234,8 +240,13 @@ class HostSandbox(WorkspaceSandbox):
     system_read_roots: tuple[str, ...] = _SYSTEM_READ_ROOTS
     gpu_device_nodes: tuple[Path, ...] = field(default_factory=tuple)
 
-    def wrap(self, argv: list[str]) -> list[str]:
-        """Return *argv* wrapped so it runs inside the confinement namespace."""
+    def wrap(self, argv: list[str], cwd: Path | str | None = None) -> list[str]:
+        """Return *argv* wrapped so it runs inside the confinement namespace.
+
+        *cwd* is part of the shared ``wrap`` signature but unused: this
+        backend always confines to :attr:`workspace`.
+        """
+        del cwd
         ws = str(self.workspace.resolve())
         project_paths = self.project_path_policy.resolve(self.workspace)
         cmd: list[str] = [
@@ -411,8 +422,13 @@ class LandlockSandbox(WorkspaceSandbox):
             chdir=workspace,
         )
 
-    def wrap(self, argv: list[str]) -> list[str]:
-        """Return *argv* wrapped so it runs under this Landlock ruleset."""
+    def wrap(self, argv: list[str], cwd: Path | str | None = None) -> list[str]:
+        """Return *argv* wrapped so it runs under this Landlock ruleset.
+
+        *cwd* is part of the shared ``wrap`` signature but unused: this
+        backend always confines to :attr:`workspace`.
+        """
+        del cwd
         return [
             sys.executable,
             "-m",
@@ -538,8 +554,13 @@ class SeatbeltSandbox(WorkspaceSandbox):
 
         return "\n".join(lines) + "\n"
 
-    def wrap(self, argv: list[str]) -> list[str]:
-        """Return *argv* wrapped so it runs inside the Seatbelt profile."""
+    def wrap(self, argv: list[str], cwd: Path | str | None = None) -> list[str]:
+        """Return *argv* wrapped so it runs inside the Seatbelt profile.
+
+        *cwd* is part of the shared ``wrap`` signature but unused: this
+        backend always confines to :attr:`workspace`.
+        """
+        del cwd
         # ``-p`` takes the profile inline, keeping ``wrap`` pure (no temp files).
         # ``sandbox-exec`` runs the command from the caller's cwd, which the CLI
         # runner already sets to the workspace.

--- a/src/vibesys/agents/docker_executor.py
+++ b/src/vibesys/agents/docker_executor.py
@@ -1,19 +1,16 @@
-"""Run agentshim CLI commands inside an already-running VibeSys Docker sandbox.
+"""Compensate for one Codex container behavior that agentshim does not model.
 
-Two pieces live here:
+A resumed ``codex exec ... --json`` run inside a container regularly finishes
+its work and writes the terminal events to its rollout file, then never
+exits, so the ``docker exec`` in front of it blocks until the turn budget
+expires. :class:`CodexRolloutWatchdogExecutor` reads the rollout, replays the
+completion into the stream, and stops the process. This stays in VibeSys
+until Codex resume inside containers is verified fixed upstream; it does not
+belong in agentshim, which models what a provider is documented to do.
 
-* :class:`DockerCommandExecutor` -- a ``docker exec`` transport built on the
-  library's ``TransformingExecutor``. It carries no provider knowledge: it
-  rewrites argv, forwards the environment entries its caller nominated, and
-  lets agentshim own everything else.
-* :class:`CodexRolloutWatchdogExecutor` -- provider-behaviour compensation, not
-  transport. A resumed ``codex exec ... --json`` run inside a container
-  regularly finishes its work and writes the terminal events to its rollout
-  file, then never exits, so the ``docker exec`` in front of it blocks until
-  the turn budget expires. The watchdog reads the rollout, replays the
-  completion into the stream, and stops the process. This stays in VibeSys
-  until Codex resume inside containers is verified fixed upstream; it does not
-  belong in agentshim, which models what a provider is documented to do.
+The transport itself -- rewriting a command into ``docker exec`` -- is not
+here: :func:`vibesys.agents.drivers.agentshim.confine_to_sandbox` wraps every
+executor, host or container, through the sandbox's own ``wrap``.
 """
 
 from __future__ import annotations
@@ -28,101 +25,14 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
-from agentshim import (
-    CommandRequest,
-    CommandResult,
-    HostCommandExecutor,
-    TransformingExecutor,
-)
-
-from vs_sandbox import AGENT_HOME
+from agentshim import CommandResult
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
 
-    from agentshim import CommandExecutor, CommandHandle, CommandStreamSink
-
-#: Where a container turn runs when the request does not name a directory.
-DEFAULT_CONTAINER_WORKDIR = "/workspace"
+    from agentshim import CommandExecutor, CommandHandle, CommandRequest, CommandStreamSink
 
 _DOCKER_QUERY_TIMEOUT_S = 5
-
-
-def _binary_in_container(name: str, env: Mapping[str, str]) -> str:
-    """Resolve the provider binary inside the container, not on the host.
-
-    The host running VibeSys usually has no copy of the CLI, so the bare name
-    is the right ``argv[0]``: the container's ``PATH`` resolves it.
-    """
-    del env
-    return name
-
-
-class DockerCommandExecutor(TransformingExecutor):
-    """Prefix every agentshim command with ``docker exec`` into one container.
-
-    ``container_id_resolver`` is read once per request rather than captured at
-    construction, so a sandbox that replaces its container (a GPU reselect, for
-    instance) needs no new executor.
-
-    The health check goes through the same transform, so ``<binary> --help`` is
-    checked inside the container where the binary actually exists.
-    """
-
-    def __init__(
-        self,
-        container_id_resolver: Callable[[], str],
-        *,
-        workdir: str = DEFAULT_CONTAINER_WORKDIR,
-        forward_env: Sequence[str] = (),
-        inner: CommandExecutor | None = None,
-    ) -> None:
-        """Wrap *inner* (the local host by default) in ``docker exec``.
-
-        *forward_env* names the environment variables that cross into the
-        container; their values are read from each request, so a per-turn
-        override still takes effect. Everything else stays outside.
-        """
-        self._container_id_resolver = container_id_resolver
-        self._workdir = workdir
-        self._forward_env = tuple(forward_env)
-        super().__init__(
-            inner if inner is not None else HostCommandExecutor(),
-            self._to_docker_exec,
-            find_binary=_binary_in_container,
-        )
-
-    def _forwarded_env(self, env: Mapping[str, str]) -> dict[str, str]:
-        """Return the request environment entries that belong in the container.
-
-        A container starts from its image's environment, not the host's. The
-        environment agentshim assembles for a turn describes the *host*
-        (``PATH``, ``HOME``, interpreter and toolchain locations, whatever a
-        login shell exports), so forwarding entries by inspection would point
-        the container CLI at directories that do not exist inside it and could
-        smuggle host settings such as a model override past the container's own
-        configuration. The caller that knows which variables are meant for the
-        container names them instead.
-        """
-        return {key: env[key] for key in self._forward_env if key in env}
-
-    def _to_docker_exec(self, request: CommandRequest) -> CommandRequest:
-        """Rewrite one request into the equivalent ``docker exec`` invocation."""
-        argv: list[str] = ["docker", "exec", "-i", "-w", request.cwd or self._workdir]
-        for key, value in self._forwarded_env(request.env).items():
-            argv += ["-e", f"{key}={value}"]
-        argv.append(self._container_id_resolver())
-        argv.extend(request.argv)
-        return CommandRequest(
-            argv=argv,
-            stdin=request.stdin,
-            cwd=None,
-            # The transformed command is `docker` itself, running on the host:
-            # it needs the host environment (PATH, DOCKER_HOST, certificates)
-            # to reach the daemon at all.
-            env=os.environ,
-            timeout=request.timeout,
-        )
 
 
 @dataclass(frozen=True)
@@ -133,9 +43,9 @@ class _CodexRolloutCompletion:
     message: str
 
 
-# The container-side process argv is exactly the request.argv the host built
-# (``DockerCommandExecutor`` only prepends ``docker exec ... <container>``), so
-# this script's match criteria are written to agree with the host-side
+# The container-side process argv is exactly the request.argv the sandbox's
+# own ``wrap`` prepended ``docker exec ... <container>`` to, so this script's
+# match criteria are written to agree with the host-side
 # ``_is_codex_json_command``/``_codex_resume_thread_id`` predicate: the binary
 # basename is ``codex``, ``exec`` and ``--json`` are both present, and the
 # thread ID sits immediately after ``resume``. That precision is required here
@@ -294,6 +204,7 @@ class CodexRolloutWatchdogExecutor:
         inner: CommandExecutor,
         container_id_resolver: Callable[[], str],
         *,
+        rollout_sessions_root: str,
         log: Callable[[str], None] = _discard,
         tick_seconds: float = 5.0,
         rollout_poll_seconds: float = 15.0,
@@ -306,6 +217,11 @@ class CodexRolloutWatchdogExecutor:
             inner: The transport a Codex JSON command ultimately runs through.
             container_id_resolver: Names the container to poll, read each time
                 a Codex run needs it.
+            rollout_sessions_root: Where a resumed thread's rollout file lives
+                inside the container. The caller derives this from the
+                sandbox's own ``HOME`` and the Codex provider's state
+                directory, so nothing here hardcodes a home directory that a
+                different base image could relocate.
             log: Sink for the watchdog's own progress lines; dropped by
                 default.
             tick_seconds: Seconds between liveness checks while a Codex JSON
@@ -318,6 +234,7 @@ class CodexRolloutWatchdogExecutor:
         """
         self._inner = inner
         self._container_id_resolver = container_id_resolver
+        self._rollout_sessions_root = rollout_sessions_root
         self._log = log
         self._codex_rollout_paths: dict[str, str] = {}
         self.tick_seconds = tick_seconds
@@ -504,7 +421,7 @@ class CodexRolloutWatchdogExecutor:
                 "exec",
                 container_id,
                 "find",
-                f"{AGENT_HOME}/.codex/sessions",
+                self._rollout_sessions_root,
                 "-type",
                 "f",
                 "-name",

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -2,9 +2,16 @@
 
 VibeSys consumes the ``agentshim`` library only through its public API. The
 library owns provider knowledge (argv, stream parsing, MCP config files,
-schema dialects, resume flags); this module owns VibeSys policy: host
+schema dialects, resume flags); this module owns VibeSys policy: sandbox
 confinement, structured-output fallback, conversation budgets, and the
 translation between library events and :mod:`vibesys.agents.contracts`.
+
+One path runs every session, host or container: build (or look up) a
+:class:`~vs_sandbox.WorkspaceSandbox`, wrap a plain ``HostCommandExecutor`` to
+confine it, and hand the library the sandbox's own environment. Every path the
+agent is told about -- the schema directory, an MCP server's command -- goes
+through :meth:`~vs_sandbox.WorkspaceSandbox.agent_path`, so nothing here names
+a backend.
 """
 
 from __future__ import annotations
@@ -34,7 +41,7 @@ from vibesys.agents.contracts import (
     SessionDisposition,
 )
 from vibesys.agents.host_resource_declarations import declare_agent_host_resources
-from vibesys.agents.provider_policy import SHIPPED_PROVIDERS, is_codex
+from vibesys.agents.provider_policy import CODEX_PROVIDER, SHIPPED_PROVIDERS, is_codex
 from vibesys.run.events import CommandResultPayload
 from vs_sandbox import build_host_sandbox
 
@@ -91,35 +98,72 @@ def _ignore_log(_message: str) -> None:
 
 
 class ExecutorFactory(Protocol):
-    """Builds the command executor a host session runs its CLI through."""
+    """Builds the unconfined command executor :func:`confine_to_sandbox` wraps."""
 
-    def __call__(self, sandbox: WorkspaceSandbox | None, /) -> agentshim.CommandExecutor:
-        """Return an executor confined by *sandbox*, or unconfined when it is ``None``."""
+    def __call__(self) -> agentshim.CommandExecutor:
+        """Return a fresh, unconfined executor for one session."""
+        ...
+
+
+class _ConfinableSandbox(Protocol):
+    """The shape :func:`confine_to_sandbox` needs, real or a test double alike.
+
+    Both ``vs_sandbox.WorkspaceSandbox`` (a host confinement policy) and
+    ``vs_sandbox.DockerSandbox`` satisfy this structurally, and so does any
+    lightweight double a test builds for either: nothing here requires the
+    concrete class.
+    """
+
+    def wrap(self, argv: list[str], cwd: Path | str | None = None, /) -> list[str]:
+        """Return *argv* rewritten to run confined to one workspace."""
+        ...
+
+    def agent_path(self, path: Path | str, /) -> str:
+        """Return the path the confined process sees for *path*."""
+        ...
+
+    @property
+    def env(self) -> Mapping[str, str]:
+        """Return the environment variables the confined process runs with."""
         ...
 
 
 def confine_to_sandbox(
     executor: agentshim.CommandExecutor,
-    sandbox: WorkspaceSandbox,
+    sandbox: _ConfinableSandbox,
+    *,
+    find_binary: Callable[[str, Mapping[str, str]], str] | None = None,
 ) -> agentshim.CommandExecutor:
-    """Return *executor* with every workspace command wrapped by *sandbox*.
+    """Return *executor* with every command rewritten through *sandbox*.
 
-    A command without a working directory is left alone: that is the binary
-    health check and, in container mode, the agent itself, both of which run
-    outside the confined workspace (bwrap re-establishes the working directory
-    inside the namespace via ``--chdir``, so a wrapped command needs one).
+    This is the one chokepoint through which the provider CLI launches, for a
+    host confinement policy and an already-running Docker sandbox alike:
+    *sandbox* supplies the ``wrap`` call, so the caller never branches on which
+    kind of sandbox it was given. Every ``wrap`` implementation accepts the
+    request's ``cwd``; a host sandbox confines to exactly one workspace
+    already and ignores it, while a Docker sandbox serves every turn from one
+    container regardless of working directory and maps the argument to ``-w``.
+
+    *find_binary*, when given, replaces the default host-side lookup
+    (``shutil.which`` against the request's own environment). A Docker
+    sandbox's ``env`` carries the *container's* ``PATH``, which resolves to
+    nothing on this host, so its caller passes an override that trusts the
+    bare name to the far side of ``docker exec`` instead.
     """
 
     def transform(request: agentshim.CommandRequest) -> agentshim.CommandRequest:
-        if request.cwd is None:
-            return request
-        return replace(request, argv=sandbox.wrap(list(request.argv)))
+        return replace(request, argv=sandbox.wrap(list(request.argv), request.cwd))
 
-    return agentshim.TransformingExecutor(executor, transform)
+    return agentshim.TransformingExecutor(executor, transform, find_binary=find_binary)
 
 
 def build_host_executor(sandbox: WorkspaceSandbox | None) -> agentshim.CommandExecutor:
-    """Default :class:`ExecutorFactory`: run on this host, confined when possible."""
+    """Run on this host, confined to *sandbox* when one is given.
+
+    A thin convenience over :func:`confine_to_sandbox` for callers (notably
+    the host-confinement test suite) that want the driver's own default
+    executor policy without going through :class:`AgentShimDriver` itself.
+    """
     host = agentshim.HostCommandExecutor()
     return host if sandbox is None else confine_to_sandbox(host, sandbox)
 
@@ -138,22 +182,53 @@ def _resolve_binary_path(binary: str, env: Mapping[str, str]) -> str | None:
         return None
 
 
-def _as_mcp_server(spec: MCPServerSpec, *, in_container: bool) -> agentshim.StdioMcpServer:
+def _bare_binary_name(name: str, env: Mapping[str, str]) -> str:
+    """Trust *name* to resolve on the far side of ``docker exec``.
+
+    A host-side lookup against a container's own ``PATH`` would search
+    directories that only exist inside the image; the container's shell
+    resolves its own binaries once the wrapped command actually runs there.
+    """
+    del env
+    return name
+
+
+def _agent_path(sandbox: _ConfinableSandbox | None, path: Path | str) -> str:
+    """Map *path* through *sandbox*, or return it unchanged with no sandbox."""
+    return sandbox.agent_path(path) if sandbox is not None else str(Path(path))
+
+
+def _as_mcp_server(
+    spec: MCPServerSpec,
+    sandbox: _ConfinableSandbox | None,
+    *,
+    pin_interpreter: bool,
+) -> agentshim.StdioMcpServer:
     """Translate one VibeSys MCP spec into the library's stdio spec.
 
     A host agent inherits a login shell's PATH, where a bare ``python`` may be
-    an interpreter without the MCP dependencies, so host runs are pinned to
-    the interpreter running VibeSys. A container image resolves its own.
+    an interpreter without the MCP dependencies, so *pin_interpreter* (true
+    only on the host) substitutes the interpreter running VibeSys itself. A
+    container image resolves its own, so nothing is substituted there. Every
+    absolute path in the command or args -- including that pinned interpreter
+    -- is then mapped through ``sandbox.agent_path`` so a file the sandbox
+    presents at a different location (a bind-mounted workspace, say) still
+    resolves; a relative argument such as a flag or a workspace-relative path
+    is left untouched.
     """
-    command = spec.command
-    if not in_container and command in _PYTHON_MCP_COMMANDS:
-        command = sys.executable
+    command = (
+        sys.executable if pin_interpreter and spec.command in _PYTHON_MCP_COMMANDS else spec.command
+    )
     return agentshim.StdioMcpServer(
         name=spec.name,
-        command=command,
-        args=tuple(spec.args),
+        command=_agent_path_if_absolute(command, sandbox),
+        args=tuple(_agent_path_if_absolute(arg, sandbox) for arg in spec.args),
         env=dict(spec.env),
     )
+
+
+def _agent_path_if_absolute(value: str, sandbox: _ConfinableSandbox | None) -> str:
+    return _agent_path(sandbox, value) if value.startswith("/") else value
 
 
 def _usage_from(
@@ -281,8 +356,7 @@ class AgentShimSession:
         profile: agentshim.ProviderProfile,
         timeout: int | None,
         event_handler: _AgentShimEventHandler,
-        turn_env: Mapping[str, str] | None,
-        in_container: bool,
+        sandbox: _ConfinableSandbox | None,
         log: Callable[[str], None],
     ) -> None:
         """Bind one library session to the VibeSys policy that drives it."""
@@ -291,11 +365,11 @@ class AgentShimSession:
         self._profile = profile
         self._timeout = timeout
         self._event_handler = event_handler
-        self._turn_env = dict(turn_env) if turn_env else None
-        self._in_container = in_container
+        self._sandbox = sandbox
         self._log = log
         self._mcp_servers = tuple(
-            _as_mcp_server(server, in_container=self._in_container) for server in spec.mcp_servers
+            _as_mcp_server(server, sandbox, pin_interpreter=not spec.policy.containerized)
+            for server in spec.mcp_servers
         )
         self._turn_count = 0
         # Set when the provider conversation was dropped and restarted while
@@ -363,15 +437,7 @@ class AgentShimSession:
         return self._session.adopt(session_id)
 
     def _build_request(self, request: AgentTurnRequest) -> agentshim.TurnRequest:
-        """Translate one VibeSys turn into the library's request.
-
-        A config-file provider writes its MCP config into the workspace, and
-        agentshim derives that directory from the turn's ``cwd``. A container
-        turn names none, so it points ``mcp_workspace`` at the host workspace
-        that is bind-mounted into the container: the file the library writes on
-        the host is the one the CLI reads at ``/workspace``. A host turn already
-        runs in the workspace, so it leaves the field unset.
-        """
+        """Translate one VibeSys turn into the library's request."""
         schema, schema_hint = self._output_schema(request.output_schema)
         timeout = self._timeout
         if request.timeout is not None:
@@ -383,9 +449,7 @@ class AgentShimSession:
             reasoning_effort=(
                 self._spec.reasoning_effort if self._profile.supports_reasoning_effort else None
             ),
-            env=self._turn_env,
             mcp_servers=self._mcp_servers,
-            mcp_workspace=self._spec.workspace if self._in_container else None,
         )
 
     def _output_schema(
@@ -428,9 +492,7 @@ class AgentShimSession:
             agentshim.OutputSchema(
                 schema=agentshim.normalize(schema, dialect),
                 host_dir=host_dir,
-                # The container resolves the schema path against its own
-                # workspace mount, which is not the host path it was written to.
-                cli_dir=_SCHEMA_DIR.as_posix() if self._in_container else str(host_dir),
+                cli_dir=_agent_path(self._sandbox, host_dir),
             ),
             "",
         )
@@ -498,9 +560,9 @@ class AgentShimSession:
             #
             # Only the provider name goes in ``cmd``. ``str(TimeoutExpired)``
             # renders the whole command, and the argv the library timed out on
-            # is the transformed one: in container mode that is a
-            # ``docker exec -e KEY=VALUE ...`` line carrying every forwarded
-            # environment value, which callers log verbatim.
+            # is the transformed one: a containerized turn's is a
+            # ``docker exec -e KEY=VALUE ...`` line carrying every environment
+            # value the sandbox was built with, which callers log verbatim.
             raise subprocess.TimeoutExpired(
                 cmd=[self._profile.binary], timeout=exc.timeout
             ) from exc
@@ -555,9 +617,7 @@ def _without_stale_pwd(env: Mapping[str, str]) -> dict[str, str]:
 
     A subprocess cwd does not rewrite ``$PWD``, and bun-based CLIs (opencode)
     trust ``$PWD`` over the real cwd for workspace config discovery, so a
-    stale value makes them miss ``<workspace>/opencode.json``. Applied to the
-    session environment on the host and to the overlay forwarded into a
-    container, so the cwd wins in both.
+    stale value makes them miss ``<workspace>/opencode.json``.
     """
     return {key: value for key, value in env.items() if key != "PWD"}
 
@@ -575,7 +635,13 @@ class AgentShimDriver:
         executor_factory: ExecutorFactory | None = None,
         check_timeout: float | None = None,
     ) -> None:
-        """Configure one provider; ``executor_factory`` replaces host execution.
+        """Configure one provider; ``executor_factory`` replaces the base executor.
+
+        ``docker_sandboxes`` maps a session's role to an already-started
+        :class:`~vs_sandbox.DockerSandbox` (built and started by the run
+        environment, not by this driver). Its presence is what selects
+        container execution: every session this driver creates then looks up
+        its sandbox there instead of building a host one.
 
         ``check_timeout`` bounds the one-off ``<binary> --help`` health check
         each session runs before its first turn. It defaults to the execution
@@ -590,7 +656,7 @@ class AgentShimDriver:
         self._timeout = timeout
         self._docker_sandboxes = docker_sandboxes
         self._log = log or _ignore_log
-        self._executor_factory: ExecutorFactory = executor_factory or build_host_executor
+        self._executor_factory: ExecutorFactory = executor_factory or agentshim.HostCommandExecutor
         self._check_timeout = (
             check_timeout
             if check_timeout is not None
@@ -616,7 +682,14 @@ class AgentShimDriver:
         )
 
     def create_session(self, spec: AgentSessionSpec) -> AgentSession:
-        """Create one configured AgentShim conversation."""
+        """Create one configured AgentShim conversation.
+
+        Every session takes the same route: look up or build the sandbox for
+        this role, confine a fresh executor to it, and hand the library the
+        sandbox's own environment. A container session additionally runs
+        through the Codex rollout watchdog, which no-ops for every other
+        provider and every non-``exec --json`` command.
+        """
         if self._closed:
             raise RuntimeError("agent driver is closed")  # noqa: TRY003  # tracked: #288
         if spec.provider != self._provider:
@@ -632,20 +705,22 @@ class AgentShimDriver:
 
         provider = agentshim.get_provider(spec.provider)
         event_handler = _AgentShimEventHandler()
-        overlay = dict(spec.environment)
-        turn_env: Mapping[str, str] | None = None
-        executor: agentshim.CommandExecutor
-        if in_container:
-            executor = self._container_executor(spec, forward_env=tuple(overlay))
-            # The container's own environment is built by the image and the
-            # exec invocation; the session overlay is forwarded per turn so it
-            # reaches the CLI inside the container instead of the docker client.
-            env = _without_stale_pwd(agentshim.interactive_env())
-            turn_env = _without_stale_pwd(overlay)
-        else:
-            env = _without_stale_pwd({**agentshim.interactive_env(), **overlay})
-            executor = self._executor_factory(self._host_sandbox(spec, env))
+        sandbox, find_binary = self._sandbox_for(spec)
 
+        executor: agentshim.CommandExecutor = self._executor_factory()
+        if sandbox is not None:
+            executor = confine_to_sandbox(executor, sandbox, find_binary=find_binary)
+        if in_container:
+            from vibesys.agents.docker_executor import CodexRolloutWatchdogExecutor  # noqa: PLC0415
+
+            executor = CodexRolloutWatchdogExecutor(
+                executor,
+                self._container_id_resolver(spec),
+                rollout_sessions_root=_codex_rollout_sessions_root(sandbox),
+                log=self._log,
+            )
+
+        env = sandbox.env if sandbox is not None else self._unconfined_host_env(spec)
         agent = agentshim.CliAgent(
             provider,
             model=spec.model,
@@ -656,22 +731,43 @@ class AgentShimDriver:
             log=self._log,
         )
         session = AgentShimSession(
-            # A container command names its own working directory, so the
-            # session leaves cwd unset there and the executor supplies it.
-            session=agent.start_session(
-                cwd=None if in_container else str(spec.workspace),
-                timeout=self._timeout,
-            ),
+            session=agent.start_session(cwd=str(spec.workspace), timeout=self._timeout),
             spec=spec,
             profile=agent.profile,
             timeout=self._timeout,
             event_handler=event_handler,
-            turn_env=turn_env,
-            in_container=in_container,
+            sandbox=sandbox,
             log=self._log,
         )
         self._sessions.add(session)
         return session
+
+    def _sandbox_for(
+        self,
+        spec: AgentSessionSpec,
+    ) -> tuple[Any, Callable[[str, Mapping[str, str]], str] | None]:
+        """Return the sandbox this session confines to, and its binary lookup.
+
+        A container session's sandbox already exists, started by the run
+        environment; a host session's is built fresh from the declared
+        resources (and may come back ``None`` where confinement is
+        unavailable or disabled). A container's binary lookup trusts the bare
+        name to ``docker exec``'s own ``PATH`` instead of searching this host,
+        which the container's environment does not describe.
+        """
+        if self._docker_sandboxes is not None:
+            return self._docker_sandbox_for(spec), _bare_binary_name
+        env = self._unconfined_host_env(spec)
+        return self._host_sandbox(spec, env), None
+
+    def _unconfined_host_env(self, spec: AgentSessionSpec) -> dict[str, str]:
+        """Return the host session environment before any sandbox is applied.
+
+        Used both to build the host sandbox (whose own ``env`` then reflects
+        it) and as the session environment when confinement came back
+        unavailable.
+        """
+        return _without_stale_pwd({**agentshim.interactive_env(), **dict(spec.environment)})
 
     def _host_sandbox(
         self,
@@ -694,6 +790,15 @@ class AgentShimDriver:
             require_enforcement=spec.policy.require_enforcement,
         )
 
+    def _docker_sandbox_for(self, spec: AgentSessionSpec) -> Any:  # noqa: ANN401  # tracked: #288
+        assert self._docker_sandboxes is not None  # noqa: S101  # tracked: #288
+        sandbox = self._docker_sandboxes.get(spec.role)
+        if sandbox is None:
+            raise ValueError(  # noqa: TRY003  # tracked: #288
+                f"no AgentShim Docker sandbox configured for role {spec.role!r}"
+            )
+        return sandbox
+
     def _container_id_resolver(self, spec: AgentSessionSpec) -> Callable[[], str]:
         """Return the sandbox's current container ID, read at every call.
 
@@ -701,44 +806,11 @@ class AgentShimDriver:
         replaces the container and nothing should then have to rebuild the
         executor or the cleanup hook.
         """
-        assert self._docker_sandboxes is not None  # noqa: S101  # tracked: #288
-        sandbox = self._docker_sandboxes.get(spec.role)
-        if sandbox is None:
-            raise ValueError(  # noqa: TRY003  # tracked: #288
-                f"no AgentShim Docker sandbox configured for role {spec.role!r}"
-            )
-        return lambda: str(sandbox.container_id)
 
-    def _container_executor(
-        self,
-        spec: AgentSessionSpec,
-        *,
-        forward_env: tuple[str, ...] = (),
-    ) -> agentshim.CommandExecutor:
-        """Build the ``docker exec`` transport this session's turns run through.
+        def resolve() -> str:
+            return str(self._docker_sandbox_for(spec).container_id)
 
-        *forward_env* names the session-overlay variables that cross into the
-        container. Their values arrive per turn through ``TurnRequest.env``,
-        which is why the transport is told the names rather than the values.
-        """
-        resolve = self._container_id_resolver(spec)
-        # Imported here because the Docker executor is only reachable in
-        # container mode and pulls in the docker command plumbing with it.
-        from vibesys.agents.docker_executor import (  # noqa: PLC0415
-            CodexRolloutWatchdogExecutor,
-            DockerCommandExecutor,
-        )
-
-        executor: agentshim.CommandExecutor = DockerCommandExecutor(
-            resolve, forward_env=forward_env
-        )
-        if is_codex(self._provider):
-            # A resumed containerized `codex exec --json` regularly finishes
-            # its work and then never exits; the watchdog recovers the answer
-            # from the rollout file and stops the process. Provider-behaviour
-            # compensation, so it wraps the transport rather than replacing it.
-            executor = CodexRolloutWatchdogExecutor(executor, resolve, log=self._log)
-        return executor
+        return resolve
 
     def close(self) -> None:
         """Close every session created by this driver, idempotently."""
@@ -748,3 +820,16 @@ class AgentShimDriver:
         for session in self._sessions:
             session.close()
         self._sessions.clear()
+
+
+def _codex_rollout_sessions_root(sandbox: _ConfinableSandbox | None) -> str:
+    """Return the sessions directory a resumed Codex thread writes its rollout to.
+
+    Derived from the sandbox's own ``HOME`` and the Codex provider's state
+    directory convention, never a hardcoded ``/root`` or ``/home/agent``: the
+    watchdog only ever polls a container sandbox, but the value is computed
+    generically so nothing here has to know that in advance.
+    """
+    home = "" if sandbox is None else sandbox.env.get("HOME", "")
+    state_dir = agentshim.get_provider(CODEX_PROVIDER).profile.state_dirs[0]
+    return f"{home}/{state_dir}/sessions"

--- a/src/vibesys/agents/provider_policy.py
+++ b/src/vibesys/agents/provider_policy.py
@@ -29,6 +29,11 @@ declarations nor a container install recipe for, so it is not offered here.
 DEFAULT_CLI_PROVIDER = "codex"
 """The CLI provider selected when neither a flag nor config names one."""
 
+CODEX_PROVIDER = "codex"
+"""The provider name naming Codex itself, for call sites that need the name
+(to look up its ``agentshim`` profile, say) rather than a yes/no answer to
+:func:`is_codex`."""
+
 
 def is_codex(provider: str | None) -> bool:
     """Whether *provider* is Codex (``None``, an unset provider, is not).
@@ -41,7 +46,7 @@ def is_codex(provider: str | None) -> bool:
     driver branches on a documented VibeSys decision instead of repeating the
     provider's literal name at each call site.
     """
-    return provider == "codex"
+    return provider == CODEX_PROVIDER
 
 
 # --- Docker container environment -------------------------------------------
@@ -50,7 +55,13 @@ _COMMON_DOCKER_ENV: dict[str, str] = {"PYTHONPATH": "/opt/vibesys"}
 """Every shipped provider's container CLI needs this so it can spawn
 ``python -m vs_issue_board.mcp`` against the bind-mounted project root (added
 in ``DockerSandbox.start`` for all four CLI providers). Without it the MCP
-server module would not be importable inside the container."""
+server module would not be importable inside the container.
+
+This is the whole of ``DOCKER_PROVIDER_ENV``'s per-provider contribution: the
+rest of a containerized run's extra environment (``UV_CACHE_DIR``, and
+``VIBESYS_GIT_HISTORY`` when the run carries git history) is set once, for
+every provider alike, by ``run_environment`` rather than duplicated per
+provider here."""
 
 # Claude Code used to refuse ``--dangerously-skip-permissions`` when running
 # as root unless ``IS_SANDBOX=1`` was set, back when VibeSys ran every

--- a/src/vibesys/backends/base.py
+++ b/src/vibesys/backends/base.py
@@ -24,9 +24,12 @@ from vibesys.profilers import ProfilerKind  # noqa: TC001  # tracked: #288
 from vs_sandbox.lifecycle import SandboxLifecycle
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence  # tracked: #288
+
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
 
+    from vs_sandbox.host_resources import HostResource
     from vs_sandbox.lifecycle import SandboxLifecycleHooks
 
 
@@ -75,6 +78,7 @@ class ComputeBackendImpl(Protocol):
         ephemeral: bool = False,
         container_image: str | None = None,
         auth_files: list[tuple[str, str]] | None = None,
+        resources: Sequence[HostResource] = (),
     ) -> SandboxBackendProtocol:
         """Construct (do not start) a sandbox configured for this backend.
 
@@ -98,6 +102,14 @@ class ComputeBackendImpl(Protocol):
         ``auth_files`` names ``(staged source, agent-home destination)`` pairs
         a Docker sandbox copies in as root at start, then chowns to the agent
         user. Ignored by non-Docker sandboxes.
+
+        ``resources`` is the caller's :class:`~vs_sandbox.host_resources.HostResource`
+        list for this sandbox, forwarded to ``DockerSandbox(resources=...)``
+        unchanged: a Docker sandbox lowers it to bind mounts and consults it
+        for :meth:`agent_path`. ``bind_mounts`` keeps working for a caller that
+        still builds its own mount tuples directly; the two combine rather
+        than one replacing the other. Ignored by non-Docker sandboxes, whose
+        accelerator device and model-volume mounts stay backend-specific.
         """
         ...
 

--- a/src/vibesys/backends/cuda/__init__.py
+++ b/src/vibesys/backends/cuda/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from collections.abc import Callable, Sequence  # noqa: TC003  # tracked: #288
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
 
+    from vs_sandbox.host_resources import HostResource
     from vs_sandbox.lifecycle import SandboxLifecycleHooks
 
 # Default container image for the cuda backend.  Carries CUDA toolkit + PyTorch.
@@ -83,6 +84,7 @@ class CudaBackend:
         ephemeral: bool = False,
         container_image: str | None = None,
         auth_files: list[tuple[str, str]] | None = None,
+        resources: Sequence[HostResource] = (),
     ) -> SandboxBackendProtocol:
         """Construct a sandbox configured for CUDA execution."""
         # Deferred: the sandbox classes subclass deepagents' BaseSandbox, which
@@ -117,6 +119,7 @@ class CudaBackend:
                 image=container_image or self.image,
                 gpus=self._docker_gpu_spec() if attach_accelerator else None,
                 bind_mounts=bind_mounts,
+                resources=resources,
                 passthrough_paths=passthrough_paths,
                 env=env,
                 log_path=log_path,

--- a/src/vibesys/backends/local.py
+++ b/src/vibesys/backends/local.py
@@ -15,7 +15,7 @@ run inside Docker because it needs no accelerator passthrough. Per-platform
 
 from __future__ import annotations
 
-from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from collections.abc import Callable, Sequence  # noqa: TC003  # tracked: #288
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
 
+    from vs_sandbox.host_resources import HostResource
     from vs_sandbox.lifecycle import SandboxLifecycleHooks
 
 _DEFAULT_CPU_IMAGE = "python:3.12-bookworm"
@@ -80,6 +81,7 @@ class LocalBackend:
         ephemeral: bool = False,
         container_image: str | None = None,
         auth_files: list[tuple[str, str]] | None = None,
+        resources: Sequence[HostResource] = (),
     ) -> SandboxBackendProtocol:
         # Deferred: the sandbox classes subclass deepagents' BaseSandbox, which
         # pulls langchain + anthropic. Registration must stay import-cheap.
@@ -116,6 +118,7 @@ class LocalBackend:
                 image=container_image or self.image,
                 gpus=None,
                 bind_mounts=bind_mounts,
+                resources=resources,
                 passthrough_paths=passthrough_paths,
                 env=extra_env,
                 log_path=log_path,

--- a/src/vibesys/backends/rocm/__init__.py
+++ b/src/vibesys/backends/rocm/__init__.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import glob
 import os
 import subprocess
-from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from collections.abc import Callable, Sequence  # noqa: TC003  # tracked: #288
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
 
+    from vs_sandbox.host_resources import HostResource
     from vs_sandbox.lifecycle import SandboxLifecycleHooks
 
 # ROCm PyTorch image. Carries the ROCm runtime + a matching torch build.
@@ -164,6 +165,7 @@ class RocmBackend:
         ephemeral: bool = False,
         container_image: str | None = None,
         auth_files: list[tuple[str, str]] | None = None,
+        resources: Sequence[HostResource] = (),
     ) -> SandboxBackendProtocol:
         # Deferred: the sandbox classes subclass deepagents' BaseSandbox, which
         # pulls langchain + anthropic. Registration must stay import-cheap.
@@ -203,6 +205,7 @@ class RocmBackend:
                 group_add=list(_DEVICE_GROUPS),
                 shm_size=_DEFAULT_SHM_SIZE,
                 bind_mounts=bind_mounts,
+                resources=resources,
                 passthrough_paths=passthrough_paths,
                 env=env,
                 log_path=log_path,

--- a/src/vibesys/backends/trainium/__init__.py
+++ b/src/vibesys/backends/trainium/__init__.py
@@ -23,7 +23,7 @@ is a no-op (parity with :class:`LocalBackend`).
 from __future__ import annotations
 
 import glob
-from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from collections.abc import Callable, Sequence  # noqa: TC003  # tracked: #288
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
 
+    from vs_sandbox.host_resources import HostResource
     from vs_sandbox.lifecycle import SandboxLifecycleHooks
 
 # AWS Neuron DLC.  Tag chosen to match the host's Neuron tools (2.30):
@@ -124,6 +125,7 @@ class TrainiumBackend:
         ephemeral: bool = False,
         container_image: str | None = None,
         auth_files: list[tuple[str, str]] | None = None,
+        resources: Sequence[HostResource] = (),
     ) -> SandboxBackendProtocol:
         # Deferred: the sandbox classes subclass deepagents' BaseSandbox, which
         # pulls langchain + anthropic. Registration must stay import-cheap.
@@ -202,6 +204,7 @@ class TrainiumBackend:
                 # automatically when it goes away, even on a hard kill.
                 auto_remove=True,
                 bind_mounts=bind_mounts,
+                resources=resources,
                 passthrough_paths=passthrough_paths,
                 env=env,
                 log_path=log_path,

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -35,7 +35,7 @@ import tempfile
 from collections.abc import Callable, Mapping, Sequence  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol, cast
 
 from vibesys.backends import SandboxKind
 from vibesys.backends.base import ComputeBackendImpl  # noqa: TC001  # tracked: #288
@@ -60,7 +60,13 @@ from vibesys.skypilot.bridge import SkyPilotBridge
 from vibesys.skypilot.config import load_cluster_profiles, resolve_profile
 from vibesys.skypilot.runner import SkyPilotJobRunner, stable_cluster_name
 from vs_project import RunEnvironmentRecord, RunResourceRequest
-from vs_sandbox import BeforeReadyContext, ProjectPathPolicy, SandboxLifecycleHooks
+from vs_sandbox import (
+    BeforeReadyContext,
+    HostResource,
+    HostResourceAccess,
+    ProjectPathPolicy,
+    SandboxLifecycleHooks,
+)
 
 _SHELL_COMMAND_ARG_COUNT = 3
 _RunEnvironmentName = Literal["local", "docker", "modal", "skypilot"]
@@ -72,12 +78,14 @@ _RECORDED_ENVIRONMENT_NAMES: tuple[_RunEnvironmentName, ...] = (
 )
 _ENVIRONMENTS_TEMPLATE_DIR = PROMPTS_DIR / "environments"
 _RUNTIME_OBJECTIVE_CONTAINER_PATH = "/opt/vibesys-runtime/objective.md"
-"""Where the effective objective is bind-mounted in every isolated environment.
+"""The runtime resource declaration's ``agent_path`` for the effective objective.
 
-Named once so the mount (:func:`_container_mount_plan`) and every
-environment's :class:`AgentPaths` agree on the same string instead of
-repeating the literal at each of Docker's, Modal's, and SkyPilot's own
-``AgentPaths`` construction."""
+Used in exactly one place: the ``HostResource`` :func:`_container_mount_plan`
+declares for the materialized objective document. Every environment's
+:class:`AgentPaths` instead asks the started sandbox's own
+:meth:`~vs_sandbox.docker_sandbox.DockerSandbox.agent_path` for that document's
+container path, so this constant and the resource declaration are the single
+source of truth an environment consults."""
 _SANDBOX_EVALUATOR_TOOLS_ROOT = Path("/opt/vibesys-evaluator-tools")
 _REMOTE_EVALUATOR_TOOLS_ROOT = Path(".vibesys-evaluator-tools")
 _REMOTE_EVALUATOR_TOOLCHAINS_ROOT = Path(".vibesys-evaluator-toolchains")
@@ -191,6 +199,18 @@ class RunEnvironmentRequest:  # noqa: D101  # tracked: #288
     framework_root: Path = PROJECT_ROOT
     project_path_policy: ProjectPathPolicy = field(default_factory=ProjectPathPolicy)
     state_namespace: StateNamespace | None = None
+
+
+class _AgentPathSandbox(Protocol):
+    """The one lookup ``AgentPaths`` construction needs from a started sandbox.
+
+    Narrower than ``SandboxBackendProtocol``: a host-only sandbox never
+    reaches this contract (``LocalEnvironment`` builds host paths directly),
+    while every ``SandboxKind.DOCKER`` build
+    (:class:`~vs_sandbox.docker_sandbox.DockerSandbox`) satisfies it.
+    """
+
+    def agent_path(self, host_path: Path | str) -> str: ...  # tracked: #288
 
 
 class RunEnvironmentSession(Protocol):  # noqa: D101  # tracked: #288
@@ -382,9 +402,10 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
             _docker_backend_image(request),
             toolchains=_docker_agent_toolchains(request, tools),
         )
-        bind_mounts, docker_symlinks, passthrough = _container_mount_plan(request)
-        bind_mounts.extend(
-            _docker_evaluator_tool_mounts(request, tools, container_image=container_image)
+        resources, docker_symlinks, passthrough = _container_mount_plan(request)
+        resources = resources + _resources_for_mounts(
+            _docker_evaluator_tool_mounts(request, tools, container_image=container_image),
+            purpose="evaluator tool",
         )
         resolved_cli = _cli_container_env(request)
         cli_provider_env: dict[str, str] = {}
@@ -406,14 +427,15 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
         cli_provider_env.setdefault("CARGO_HOME", "/workspace/.cache/cargo")
         if request.git_history_root is not None:
             cli_provider_env.setdefault("VIBESYS_GIT_HISTORY", "/opt/vibesys-history")
-        bind_mounts = _dedupe_mounts(bind_mounts)
+        resources = _dedupe_resources(resources)
         lifecycle_hooks = _symlink_lifecycle_hooks(docker_symlinks)
 
         sandbox = request.backend.make_sandbox(
             SandboxKind.DOCKER,
             host_workspace=str(request.workspace),
             log_path=request.log_dir / "docker.log",
-            bind_mounts=bind_mounts,
+            bind_mounts=[],
+            resources=resources,
             passthrough_paths=passthrough,
             extra_env=cli_provider_env,
             auth_files=auth_files,
@@ -430,6 +452,7 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
             view=RunEnvironmentView(
                 paths=_isolated_paths(
                     request,
+                    cast("_AgentPathSandbox", sandbox),
                     evaluator_tools_root=_SANDBOX_EVALUATOR_TOOLS_ROOT,
                 ),
                 prompt_notes=render_template(
@@ -604,8 +627,8 @@ class SkyPilotEnvironment(DockerEnvironment):
         if request.state_namespace is None:
             raise ValueError("SkyPilot requires a machine-local state namespace")  # noqa: TRY003
         profiles = load_cluster_profiles(self.config.profiles_file)
-        resources = resolve_profile(profiles, self.config.profile, self.config.resources)
-        cluster_name = stable_cluster_name(request.run_id, resources)
+        cluster_resources = resolve_profile(profiles, self.config.profile, self.config.resources)
+        cluster_name = stable_cluster_name(request.run_id, cluster_resources)
         commands: dict[str, tuple[str, ...]] = {}
         for kind, raw_command in (
             ("accuracy", request.accuracy_command),
@@ -619,7 +642,7 @@ class SkyPilotEnvironment(DockerEnvironment):
         bridge = SkyPilotBridge(
             runner=SkyPilotJobRunner(executable=self.config.executable),
             cluster_name=cluster_name,
-            resources=resources,
+            resources=cluster_resources,
             workspace=request.workspace,
             evaluator_package_root=request.evaluator_package_root,
             hidden_paths=request.project_path_policy.hidden_paths,
@@ -647,7 +670,7 @@ class SkyPilotEnvironment(DockerEnvironment):
                 container_image, ensure_pushed=ensure_pushed, backend_label="SkyPilot"
             )
 
-            bind_mounts, docker_symlinks, passthrough = _container_mount_plan(request)
+            resources, docker_symlinks, passthrough = _container_mount_plan(request)
             cli_provider_env, auth_files = _cli_provider_env_and_auth_files(request)
             cli_provider_env.setdefault("UV_CACHE_DIR", "/workspace/.cache/uv")
             helper_source = Path(__file__).with_name("skypilot_evaluator.py")
@@ -656,7 +679,7 @@ class SkyPilotEnvironment(DockerEnvironment):
             caller_state_path = "/opt/vibesys-skypilot/caller-state"
             caller_state = request.state_namespace.external_directory("caller")
             cli_provider_env["VIBESYS_SKYPILOT_CALLER_STATE"] = caller_state_path
-            bind_mounts.extend(
+            resources = resources + _resources_for_mounts(
                 [
                     (str(helper_source), helper_path, True),
                     (str(bridge.socket_path), socket_path, False),
@@ -668,20 +691,23 @@ class SkyPilotEnvironment(DockerEnvironment):
                 render_template(
                     "skypilot/runtime_notes.j2",
                     template_dir=_ENVIRONMENTS_TEMPLATE_DIR,
-                    nodes=resources.nodes,
-                    accelerators_per_node=resources.accelerators_per_node,
-                    accelerator_type=resources.accelerator_type,
-                    profile_name=resources.profile_name,
+                    nodes=cluster_resources.nodes,
+                    accelerators_per_node=cluster_resources.accelerators_per_node,
+                    accelerator_type=cluster_resources.accelerator_type,
+                    profile_name=cluster_resources.profile_name,
                 )
             )
             runtime_path = "/opt/vibesys-runtime/environment.md"
-            bind_mounts.append((str(runtime_document), runtime_path, True))
+            resources.append(
+                _resource_for_mount(str(runtime_document), runtime_path, read_only=True)
+            )
             passthrough.extend(["/opt/vibesys-runtime", "/opt/vibesys-skypilot"])
             sandbox = request.backend.make_sandbox(
                 SandboxKind.DOCKER,
                 host_workspace=str(request.workspace),
                 log_path=request.log_dir / "docker.log",
-                bind_mounts=_dedupe_mounts(bind_mounts),
+                bind_mounts=[],
+                resources=_dedupe_resources(resources),
                 passthrough_paths=passthrough,
                 extra_env=cli_provider_env,
                 auth_files=auth_files,
@@ -694,6 +720,8 @@ class SkyPilotEnvironment(DockerEnvironment):
             bridge.close()
             raise
 
+        agent_path_sandbox = cast("_AgentPathSandbox", sandbox)
+        objective_document = _materialize_effective_objective(request)
         prefix = f"python {helper_path} --socket {socket_path}"
         return _SkyPilotRunEnvironmentSession(
             sandbox=sandbox,
@@ -701,8 +729,8 @@ class SkyPilotEnvironment(DockerEnvironment):
             view=RunEnvironmentView(
                 paths=AgentPaths(
                     objective=(
-                        _RUNTIME_OBJECTIVE_CONTAINER_PATH
-                        if request.objective is not None
+                        agent_path_sandbox.agent_path(objective_document)
+                        if objective_document is not None
                         else "OBJECTIVE.md"
                     ),
                     accuracy_command=(f"{prefix} accuracy" if "accuracy" in commands else None),
@@ -712,7 +740,7 @@ class SkyPilotEnvironment(DockerEnvironment):
                 prompt_notes=render_template(
                     "skypilot/prompt_notes.j2",
                     template_dir=_ENVIRONMENTS_TEMPLATE_DIR,
-                    runtime_container_path=runtime_path,
+                    runtime_container_path=agent_path_sandbox.agent_path(runtime_document),
                 ),
                 isolated=True,
                 cli_sandboxed=True,
@@ -803,7 +831,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
             container_image, ensure_pushed=ensure_pushed, backend_label="Modal"
         )
 
-        bind_mounts, docker_symlinks, passthrough = _container_mount_plan(request)
+        resources, docker_symlinks, passthrough = _container_mount_plan(request)
         cli_provider_env, auth_files = _cli_provider_env_and_auth_files(request)
         cli_provider_env.setdefault("UV_CACHE_DIR", "/workspace/.cache/uv")
         if request.git_history_root is not None:
@@ -824,29 +852,38 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
             )
         )
         runtime_container_path = "/opt/vibesys-runtime/environment.md"
-        bind_mounts.append((str(runtime_document), runtime_container_path, True))
+        resources.append(
+            _resource_for_mount(str(runtime_document), runtime_container_path, read_only=True)
+        )
         passthrough.append("/opt/vibesys-runtime")
         evaluator_helper = request.framework_root / "src/vibesys/sandbox/modal_evaluator.py"
         evaluator_container_path = "/opt/vibesys-modal-evaluator.py"
-        bind_mounts.append((str(evaluator_helper), evaluator_container_path, True))
+        resources.append(
+            _resource_for_mount(str(evaluator_helper), evaluator_container_path, read_only=True)
+        )
 
         # Mount host Modal auth so `modal run` inside the container
         # authenticates as the host user.
         modal_auth = Path.home() / ".modal.toml"
         if modal_auth.exists():
-            bind_mounts.append((str(modal_auth), "/root/.modal.toml", True))
+            resources.append(
+                _resource_for_mount(str(modal_auth), "/root/.modal.toml", read_only=True)
+            )
         modal_config_dir = Path.home() / ".modal"
         if modal_config_dir.is_dir():
-            bind_mounts.append((str(modal_config_dir), "/root/.modal", True))
+            resources.append(
+                _resource_for_mount(str(modal_config_dir), "/root/.modal", read_only=True)
+            )
 
-        bind_mounts = _dedupe_mounts(bind_mounts)
+        resources = _dedupe_resources(resources)
         lifecycle_hooks = _symlink_lifecycle_hooks(docker_symlinks)
 
         sandbox = request.backend.make_sandbox(
             SandboxKind.DOCKER,
             host_workspace=str(request.workspace),
             log_path=request.log_dir / "docker.log",
-            bind_mounts=bind_mounts,
+            bind_mounts=[],
+            resources=resources,
             passthrough_paths=passthrough,
             extra_env=cli_provider_env,
             auth_files=auth_files,
@@ -877,13 +914,15 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
                 ("--evaluator-package-root", "/opt/vibesys-evaluator-package")
             )
         evaluator_prefix = f"{shlex.join(evaluator_arguments)} --"
+        agent_path_sandbox = cast("_AgentPathSandbox", sandbox)
+        objective_document = _materialize_effective_objective(request)
         return _DefaultRunEnvironmentSession(
             sandbox=sandbox,
             view=RunEnvironmentView(
                 paths=AgentPaths(
                     objective=(
-                        _RUNTIME_OBJECTIVE_CONTAINER_PATH
-                        if request.objective is not None
+                        agent_path_sandbox.agent_path(objective_document)
+                        if objective_document is not None
                         else "OBJECTIVE.md"
                     ),
                     accuracy_command=_prefix_command(
@@ -913,7 +952,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
                 prompt_notes=render_template(
                     "modal/prompt_notes.j2",
                     template_dir=_ENVIRONMENTS_TEMPLATE_DIR,
-                    runtime_container_path=runtime_container_path,
+                    runtime_container_path=agent_path_sandbox.agent_path(runtime_document),
                 ),
                 isolated=True,
                 cli_sandboxed=True,
@@ -1208,24 +1247,37 @@ def _materialize_effective_objective(request: RunEnvironmentRequest) -> Path | N
 
 def _isolated_paths(
     request: RunEnvironmentRequest,
+    sandbox: _AgentPathSandbox,
     *,
     evaluator_tools_root: Path | None = None,
 ) -> AgentPaths:
+    """Build agent-facing paths for an already-started container sandbox.
+
+    Every path the agent is told about is asked of *sandbox* rather than
+    hardcoded: :meth:`~vs_sandbox.docker_sandbox.DockerSandbox.agent_path`
+    is the one table mapping a host path to where the container sees it,
+    built from the same resource list :func:`_container_mount_plan` declared.
+    """
+    objective_document = _materialize_effective_objective(request)
     return AgentPaths(
         objective=(
-            _RUNTIME_OBJECTIVE_CONTAINER_PATH if request.objective is not None else "OBJECTIVE.md"
+            sandbox.agent_path(objective_document)
+            if objective_document is not None
+            else "OBJECTIVE.md"
         ),
         accuracy_command=_environment_command(
             request,
             request.accuracy_command,
             isolated=True,
             evaluator_tools_root=evaluator_tools_root,
+            agent_path=sandbox.agent_path,
         ),
         benchmark_command=_environment_command(
             request,
             request.benchmark_command,
             isolated=True,
             evaluator_tools_root=evaluator_tools_root,
+            agent_path=sandbox.agent_path,
         ),
         profiler_support=(request.profiler_support_name if request.profiler_support_path else None),
     )
@@ -1241,15 +1293,25 @@ def _noop_log(message: str) -> None:
     del message
 
 
-def _environment_command(
+def _environment_command(  # noqa: PLR0913  # tracked: #288
     request: RunEnvironmentRequest,
     command: str | None,
     *,
     isolated: bool = False,
     evaluator_package_root: str | None = None,
     evaluator_tools_root: Path | None = None,
+    agent_path: Callable[[Path | str], str] | None = None,
 ) -> str | None:
-    """Translate semantic paths in argv, then quote the translated command."""
+    """Translate semantic paths in argv, then quote the translated command.
+
+    ``agent_path`` is the started sandbox's own lookup
+    (:meth:`~vs_sandbox.docker_sandbox.DockerSandbox.agent_path`), consulted
+    for the evaluator package root when the caller has one and does not pass
+    an explicit ``evaluator_package_root`` override. A caller with no sandbox
+    yet (or one whose evaluator package lives at a remote-synced path outside
+    the container's own resource list, such as Modal's and SkyPilot's
+    dispatch wrappers) keeps passing an explicit override instead.
+    """
     if command is None:
         return None
     try:
@@ -1259,19 +1321,15 @@ def _environment_command(
     project_root = "/workspace" if isolated else str(request.workspace)
     replacements = [(PROJECT_ROOT_TOKEN, project_root)]
     if request.evaluator_package_root is not None:
-        replacements.append(
-            (
-                str(request.evaluator_package_root),
-                (
-                    evaluator_package_root
-                    or (
-                        "/opt/vibesys-evaluator-package"
-                        if isolated
-                        else str(request.evaluator_package_root)
-                    )
-                ),
-            )
-        )
+        if evaluator_package_root is not None:
+            translated_root = evaluator_package_root
+        elif agent_path is not None:
+            translated_root = agent_path(request.evaluator_package_root)
+        elif isolated:
+            translated_root = "/opt/vibesys-evaluator-package"
+        else:
+            translated_root = str(request.evaluator_package_root)
+        replacements.append((str(request.evaluator_package_root), translated_root))
     tools = _evaluator_tools(request)
     if tools:
         tools_root = evaluator_tools_root or _required_evaluator_tools_root(request)
@@ -1478,12 +1536,64 @@ def _docker_workspace_run(
     )
 
 
+def _resource_for_mount(
+    host_path: str,
+    container_path: str,
+    *,
+    read_only: bool,
+    purpose: str = "container mount",
+) -> HostResource:
+    """Lower one ``(host, container, readonly)`` mount tuple to a ``HostResource``.
+
+    ``agent_path`` is left unset (identity) only when the container path
+    matches the host path verbatim; every mount built here presents at a
+    dedicated container location, so this is effectively always set.
+    """
+    access = HostResourceAccess.READ_ONLY if read_only else HostResourceAccess.READ_WRITE
+    normalized_host = str(Path(host_path))
+    agent_path = container_path if container_path != normalized_host else None
+    return HostResource(Path(host_path), access, purpose, agent_path)
+
+
+def _resources_for_mounts(
+    mounts: Sequence[tuple[str, str, bool]],
+    *,
+    purpose: str = "container mount",
+) -> list[HostResource]:
+    """Lower a batch of ``(host, container, readonly)`` mounts to resources."""
+    return [
+        _resource_for_mount(host, container, read_only=read_only, purpose=purpose)
+        for host, container, read_only in mounts
+    ]
+
+
+def _dedupe_resources(resources: Sequence[HostResource]) -> list[HostResource]:
+    """Keep one resource per container-visible path, preferring the last declared.
+
+    Mirrors the historical ``bind_mounts`` dedup: a path re-declared later
+    (for example an evaluator-tool mount landing on a path an earlier, coarser
+    grant already covered) wins, while the position of the first declaration
+    is preserved.
+    """
+    seen: dict[str, HostResource] = {}
+    for resource in resources:
+        key = resource.agent_path if resource.agent_path is not None else str(resource.path)
+        seen[key] = resource
+    return list(seen.values())
+
+
 def _container_mount_plan(  # noqa: C901  # tracked: #288
     request: RunEnvironmentRequest,
     *,
     include_cli_provider_mounts: bool = True,
-) -> tuple[list[tuple[str, str, bool]], list[tuple[str, str]], list[str]]:
-    """Build the bind mounts + setup symlinks for a sandbox.
+) -> tuple[list[HostResource], list[tuple[str, str]], list[str]]:
+    """Build the host resources + setup symlinks for a sandbox.
+
+    Returns the resource list the sandbox enforces and exposes through
+    :meth:`~vs_sandbox.docker_sandbox.DockerSandbox.agent_path` (workspace
+    read-write mapping aside, which the sandbox itself always provides),
+    the setup symlinks a lifecycle hook must create once the container is
+    up, and the container paths virtual-path translation must leave alone.
 
     ``include_cli_provider_mounts`` controls whether CLI auth state and the
     full project tree are added under ``/opt/vibesys-auth`` and
@@ -1569,7 +1679,7 @@ def _container_mount_plan(  # noqa: C901  # tracked: #288
         bind_mounts.extend(auth_bind_mounts(request.cli_provider))
         bind_mounts.append((str(request.framework_root), "/opt/vibesys", True))
 
-    return bind_mounts, symlinks, passthrough_paths
+    return _resources_for_mounts(bind_mounts), symlinks, passthrough_paths
 
 
 def _reference_container_path(request: RunEnvironmentRequest) -> str:
@@ -2052,15 +2162,6 @@ def _required_evaluator_tools_root(request: RunEnvironmentRequest) -> Path:
     except ValueError:
         return root
     raise ValueError("evaluator tools root must be outside the candidate workspace")  # noqa: TRY003
-
-
-def _dedupe_mounts(
-    mounts: list[tuple[str, str, bool]],
-) -> list[tuple[str, str, bool]]:
-    seen: dict[str, tuple[str, str, bool]] = {}
-    for host_path, container_path, readonly in mounts:
-        seen[container_path] = (host_path, container_path, readonly)
-    return list(seen.values())
 
 
 @dataclass(frozen=True)

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -71,6 +71,13 @@ _RECORDED_ENVIRONMENT_NAMES: tuple[_RunEnvironmentName, ...] = (
     "skypilot",
 )
 _ENVIRONMENTS_TEMPLATE_DIR = PROMPTS_DIR / "environments"
+_RUNTIME_OBJECTIVE_CONTAINER_PATH = "/opt/vibesys-runtime/objective.md"
+"""Where the effective objective is bind-mounted in every isolated environment.
+
+Named once so the mount (:func:`_container_mount_plan`) and every
+environment's :class:`AgentPaths` agree on the same string instead of
+repeating the literal at each of Docker's, Modal's, and SkyPilot's own
+``AgentPaths`` construction."""
 _SANDBOX_EVALUATOR_TOOLS_ROOT = Path("/opt/vibesys-evaluator-tools")
 _REMOTE_EVALUATOR_TOOLS_ROOT = Path(".vibesys-evaluator-tools")
 _REMOTE_EVALUATOR_TOOLCHAINS_ROOT = Path(".vibesys-evaluator-toolchains")
@@ -388,6 +395,15 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
 
             auth_files = auth_copy_paths(provider)
         cli_provider_env.setdefault("UV_CACHE_DIR", "/workspace/.cache/uv")
+        # The agent image's baked toolchain root is read-only (agent.Dockerfile
+        # chmods /opt/cargo a+rX, deliberately: an agent cannot apt/cargo
+        # install mid-round). A Cargo invocation that needs a crate the image
+        # did not prebuild -- an evaluator's own trusted-runner build, most
+        # commonly -- still has to create its registry cache somewhere, so
+        # CARGO_HOME is redirected onto the writable, bind-mounted workspace.
+        # This is unrelated to which crates a candidate build needs: one with
+        # no external dependencies never touches the registry at all.
+        cli_provider_env.setdefault("CARGO_HOME", "/workspace/.cache/cargo")
         if request.git_history_root is not None:
             cli_provider_env.setdefault("VIBESYS_GIT_HISTORY", "/opt/vibesys-history")
         bind_mounts = _dedupe_mounts(bind_mounts)
@@ -685,7 +701,7 @@ class SkyPilotEnvironment(DockerEnvironment):
             view=RunEnvironmentView(
                 paths=AgentPaths(
                     objective=(
-                        "/opt/vibesys-runtime/objective.md"
+                        _RUNTIME_OBJECTIVE_CONTAINER_PATH
                         if request.objective is not None
                         else "OBJECTIVE.md"
                     ),
@@ -866,7 +882,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
             view=RunEnvironmentView(
                 paths=AgentPaths(
                     objective=(
-                        "/opt/vibesys-runtime/objective.md"
+                        _RUNTIME_OBJECTIVE_CONTAINER_PATH
                         if request.objective is not None
                         else "OBJECTIVE.md"
                     ),
@@ -1197,7 +1213,7 @@ def _isolated_paths(
 ) -> AgentPaths:
     return AgentPaths(
         objective=(
-            "/opt/vibesys-runtime/objective.md" if request.objective is not None else "OBJECTIVE.md"
+            _RUNTIME_OBJECTIVE_CONTAINER_PATH if request.objective is not None else "OBJECTIVE.md"
         ),
         accuracy_command=_environment_command(
             request,
@@ -1504,7 +1520,7 @@ def _container_mount_plan(  # noqa: C901  # tracked: #288
     passthrough_paths: list[str] = []
     objective_document = _materialize_effective_objective(request)
     if objective_document is not None:
-        bind_mounts.append((str(objective_document), "/opt/vibesys-runtime/objective.md", True))
+        bind_mounts.append((str(objective_document), _RUNTIME_OBJECTIVE_CONTAINER_PATH, True))
         passthrough_paths.append("/opt/vibesys-runtime")
     if request.git_history_root is not None:
         bind_mounts.append((str(request.git_history_root), "/opt/vibesys-history", True))

--- a/tests/e2e/test_agentshim_driver_e2e.py
+++ b/tests/e2e/test_agentshim_driver_e2e.py
@@ -19,6 +19,7 @@ import os
 import shutil
 import subprocess
 from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -35,7 +36,6 @@ from vibesys.agents.contracts import (
     MCPServerSpec,
     SessionDisposition,
 )
-from vibesys.agents.docker_executor import DockerCommandExecutor
 from vibesys.agents.drivers import agentshim as agentshim_driver
 from vibesys.agents.drivers.agentshim import AgentShimDriver
 from vs_sandbox import HostResource, HostResourceAccess
@@ -355,7 +355,7 @@ def test_upstream_codex_resume_exit_bug_probe_on_the_host(workspace: Path) -> No
     exists because a resumed ``codex exec resume <id> --json`` finishes its
     turn but never exits *inside a container*. This drives the identical
     resumed-turn shape through plain ``agentshim.CliAgent`` on the host --
-    no container, no ``DockerCommandExecutor``, no watchdog -- to check
+    no container, no ``docker exec`` transform, no watchdog -- to check
     whether the same failure to exit also shows up there.
 
     A PASS here is expected: the bug as documented is container-specific, so
@@ -397,8 +397,8 @@ def test_watchdog_retire_signal_resumed_codex_turn_exits_on_its_own_in_a_contain
     ``codex exec --json`` run inside a container finishes its turn but never
     exits, so the ``docker exec`` fronting it blocks until the turn budget is
     spent. This drives that exact shape -- a resumed turn inside a real
-    container, through the plain ``DockerCommandExecutor`` transport, with no
-    watchdog in front of it.
+    container, through a plain ``docker exec`` transform, with no watchdog in
+    front of it.
 
     A PASS means the upstream bug is fixed and the watchdog can be deleted.
     It is expected to FAIL (the second turn hangs until ``timeout`` kills it)
@@ -406,7 +406,19 @@ def test_watchdog_retire_signal_resumed_codex_turn_exits_on_its_own_in_a_contain
     """
     container_id = _codex_container_id()
     assert container_id
-    executor = DockerCommandExecutor(lambda: container_id)
+
+    def _docker_exec(request: agentshim.CommandRequest) -> agentshim.CommandRequest:
+        return replace(
+            request,
+            argv=["docker", "exec", "-i", "-w", "/workspace", container_id, *request.argv],
+            cwd=None,
+        )
+
+    executor = agentshim.TransformingExecutor(
+        agentshim.HostCommandExecutor(),
+        _docker_exec,
+        find_binary=lambda name, env: name,  # noqa: ARG005
+    )
     agent = agentshim.CliAgent("codex", executor=executor)
     first = agent.start_session().turn(
         agentshim.TurnRequest(

--- a/tests/server/test_chat_session.py
+++ b/tests/server/test_chat_session.py
@@ -173,7 +173,7 @@ def _chat_driver(
     fake = FakeExecutor(runs)
     driver = agentshim_driver.AgentShimDriver(
         provider=provider,
-        executor_factory=lambda _sandbox: fake,
+        executor_factory=lambda: fake,
     )
     return AgentClient(driver, provider=provider), fake
 

--- a/tests/vibesys/agents/drivers/test_agentshim_driver.py
+++ b/tests/vibesys/agents/drivers/test_agentshim_driver.py
@@ -6,6 +6,12 @@ JSON or reaches into ``agentshim.core``/``agentshim.providers``. The assertions
 are about VibeSys policy: what argv the provider was launched with, which
 events the observer saw, how usage maps onto the neutral contract, and when a
 conversation is retired.
+
+Sandbox-facing scenarios run against two ``WorkspaceSandbox`` doubles,
+``_FakeHostSandbox`` and ``_FakeDockerSandbox``: the driver has one code path
+for both (:func:`vibesys.agents.drivers.agentshim.confine_to_sandbox`), so a
+test that is really about that path is parametrized over both rather than
+duplicated per mode.
 """
 
 from __future__ import annotations
@@ -17,7 +23,6 @@ import threading
 import time
 from dataclasses import dataclass, field
 from datetime import timedelta
-from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import agentshim
@@ -85,11 +90,67 @@ class _Observer:
         return [event for event in self.events if event.kind is kind]
 
 
-class _StubSandbox:
-    """A confinement policy that only records that it was applied."""
+@dataclass
+class _FakeHostSandbox:
+    """A ``WorkspaceSandbox`` double shaped like the real host backends.
 
-    def wrap(self, argv: list[str]) -> list[str]:
+    ``agent_path`` is identity, matching every host backend: there is no
+    remapping table, the confined process sees exactly the host path.
+    """
+
+    home: str = "/home/user"
+    path: str = "/usr/bin"
+    calls: list[list[str]] = field(default_factory=list)
+
+    def wrap(self, argv: list[str], cwd: Path | str | None = None) -> list[str]:
+        del cwd
+        self.calls.append(list(argv))
         return ["/usr/bin/stub-sandbox", "--", *argv]
+
+    def agent_path(self, path: Path | str) -> str:
+        return str(path)
+
+    @property
+    def env(self) -> dict[str, str]:
+        return {"HOME": self.home, "PATH": self.path}
+
+
+@dataclass
+class _FakeDockerSandbox:
+    """A ``WorkspaceSandbox`` double shaped like ``vs_sandbox.DockerSandbox``.
+
+    ``wrap`` accepts the optional ``cwd`` the real sandbox does (the
+    capability :func:`confine_to_sandbox` probes for), maps it through the
+    same workspace-prefix rule ``agent_path`` uses, and renders its own extra
+    environment as ``-e`` flags exactly the way the real sandbox's ``wrap``
+    does.
+    """
+
+    workspace: Path
+    container_id: str = "container-1"
+    extra_env: dict[str, str] = field(default_factory=dict)
+    home: str = "/home/agent"
+    container_path: str = "/usr/local/bin:/usr/bin"
+
+    def agent_path(self, path: Path | str) -> str:
+        normalized = str(path)
+        workspace = str(self.workspace)
+        if normalized == workspace:
+            return "/workspace"
+        if normalized.startswith(workspace + "/"):
+            return "/workspace" + normalized[len(workspace) :]
+        return normalized
+
+    def wrap(self, argv: list[str], cwd: Path | str | None = None) -> list[str]:
+        workdir = self.agent_path(cwd) if cwd is not None else "/workspace"
+        env_flags = [
+            flag for key, value in self.extra_env.items() for flag in ("-e", f"{key}={value}")
+        ]
+        return ["docker", "exec", "-i", "-w", workdir, *env_flags, self.container_id, *argv]
+
+    @property
+    def env(self) -> dict[str, str]:
+        return {"HOME": self.home, "PATH": self.container_path, **self.extra_env}
 
 
 @pytest.fixture
@@ -118,27 +179,31 @@ def _spec(tmp_path: Path, **changes: Any) -> AgentSessionSpec:  # noqa: ANN401
     return AgentSessionSpec(**values)
 
 
-def _driver(
+def _driver(  # noqa: PLR0913
     provider: str,
     runs: FakeRun | Sequence[FakeRun] | Callable[[agentshim.CommandRequest], FakeRun],
     *,
     timeout: int | None = None,
     log: Callable[[str], None] | None = None,
-    confined: bool = False,
+    docker_sandboxes: dict[str, Any] | None = None,
+    check_timeout: float | None = None,
 ) -> tuple[subject.AgentShimDriver, FakeExecutor]:
-    """Build a driver whose provider process is the scripted fake executor."""
+    """Build a driver whose provider process is the scripted fake executor.
+
+    The same factory backs every mode: the driver applies
+    ``confine_to_sandbox`` itself whenever it has a sandbox, so a test
+    controls confinement through what ``build_host_sandbox`` returns (the
+    ``sandbox_builds`` fixture below) or through ``docker_sandboxes``, never
+    through the executor factory.
+    """
     fake = FakeExecutor(runs)
-
-    def factory(sandbox: Any) -> agentshim.CommandExecutor:  # noqa: ANN401
-        if confined and sandbox is not None:
-            return subject.confine_to_sandbox(fake, sandbox)
-        return fake
-
     driver = subject.AgentShimDriver(
         provider=provider,
         timeout=timeout,
         log=log,
-        executor_factory=factory,
+        docker_sandboxes=docker_sandboxes,
+        check_timeout=check_timeout,
+        executor_factory=lambda: fake,
     )
     return driver, fake
 
@@ -387,7 +452,7 @@ def test_provider_plumbing_is_marked_for_the_diagnostic_channel(
 
 
 # ---------------------------------------------------------------------------
-# Confinement and host resources
+# Confinement: one wrapping path for every sandbox
 # ---------------------------------------------------------------------------
 
 
@@ -397,8 +462,8 @@ def test_the_host_sandbox_wraps_the_provider_launch(
     tmp_path: Path,
     provider: str,
 ) -> None:
-    monkeypatch.setattr(subject, "build_host_sandbox", lambda *_a, **_k: _StubSandbox())
-    driver, fake = _driver(provider, scripted_turn(provider, text="ok"), confined=True)
+    monkeypatch.setattr(subject, "build_host_sandbox", lambda *_a, **_k: _FakeHostSandbox())
+    driver, fake = _driver(provider, scripted_turn(provider, text="ok"))
     session = driver.create_session(_spec(tmp_path, provider=provider))
 
     session.run_turn(AgentTurnRequest(message="Do it"))
@@ -416,7 +481,7 @@ def test_an_unconfined_host_runs_the_provider_binary_directly(
 ) -> None:
     """``build_host_sandbox`` returns ``None`` where confinement is unavailable."""
     del sandbox_builds
-    session, fake = _session(tmp_path, provider, scripted_turn(provider, text="ok"), confined=True)
+    session, fake = _session(tmp_path, provider, scripted_turn(provider, text="ok"))
 
     session.run_turn(AgentTurnRequest(message="Do it"))
 
@@ -455,6 +520,33 @@ def test_declared_host_resources_reach_the_sandbox(
     assert build["env"]["GPU"] == "0"
 
 
+@pytest.mark.parametrize("sandbox_kind", ["host", "docker"])
+def test_confine_to_sandbox_rewrites_argv_through_any_workspace_sandbox(
+    tmp_path: Path,
+    sandbox_kind: str,
+) -> None:
+    """One transform serves a host confinement policy and a Docker sandbox alike."""
+    sandbox = (
+        _FakeHostSandbox() if sandbox_kind == "host" else _FakeDockerSandbox(workspace=tmp_path)
+    )
+    fake = FakeExecutor(scripted_turn("claude", text="ok"))
+
+    executor = subject.confine_to_sandbox(fake, sandbox)
+    executor.run(
+        agentshim.CommandRequest(
+            argv=["claude", "-p"], stdin=None, cwd=str(tmp_path), env={}, timeout=None
+        ),
+        agentshim.NullSink(),
+    )
+
+    argv = list(fake.requests[-1].argv)
+    if isinstance(sandbox, _FakeDockerSandbox):
+        assert argv[:3] == ["docker", "exec", "-i"]
+        assert argv[argv.index("-w") + 1] == "/workspace"
+    else:
+        assert argv[0] == "/usr/bin/stub-sandbox"
+
+
 # ---------------------------------------------------------------------------
 # MCP servers
 # ---------------------------------------------------------------------------
@@ -485,8 +577,9 @@ def test_mcp_servers_are_installed_for_the_turn_and_removed_after(tmp_path: Path
     session.run_turn(AgentTurnRequest(message="review"))
 
     entry = installed[0]["issues"]
-    # A host run pins the interpreter that VibeSys itself is running under: a
-    # login shell's bare ``python`` may not have the MCP dependencies.
+    # A host session pins the interpreter that VibeSys itself is running
+    # under: a login shell's bare ``python`` may not have the MCP
+    # dependencies.
     assert entry["command"] == subject.sys.executable
     assert entry["args"] == ["-m", "issues"]
     assert _workspace_files(tmp_path) == {}
@@ -513,6 +606,35 @@ def test_a_non_python_mcp_command_is_left_alone(tmp_path: Path) -> None:
     assert installed[0]["other"]["command"] == "node"
 
 
+def test_a_container_mcp_command_is_left_for_the_image_to_resolve(tmp_path: Path) -> None:
+    """The container image resolves its own interpreter, so nothing is pinned."""
+    server = MCPServerSpec(name="issues", command="python", args=("-m", "issues"))
+    installed: list[dict[str, dict[str, Any]]] = []
+
+    def run(request: agentshim.CommandRequest) -> FakeRun:
+        installed.append(installed_mcp_servers("claude", request, tmp_path))
+        return scripted_turn("claude", text="ok")
+
+    sandbox = _FakeDockerSandbox(workspace=tmp_path)
+    driver, _fake = _driver("claude", run, docker_sandboxes={"implementer": sandbox})
+    session = driver.create_session(
+        _spec(
+            tmp_path,
+            provider="claude",
+            policy=AgentExecutionPolicy(containerized=True),
+            mcp_servers=(server,),
+        )
+    )
+
+    session.run_turn(AgentTurnRequest(message="review"))
+
+    # installed[0] is the binary health check's own scripted run (it runs
+    # through the same confined executor); the turn is the last snapshot.
+    entry = installed[-1]["issues"]
+    assert entry["command"] == "python"
+    assert entry["args"] == ["-m", "issues"]
+
+
 # ---------------------------------------------------------------------------
 # Container execution
 # ---------------------------------------------------------------------------
@@ -532,29 +654,6 @@ def _workspace_files(root: Path) -> dict[str, str]:
     }
 
 
-def _container_driver(
-    monkeypatch: pytest.MonkeyPatch,
-    provider: str,
-    runs: FakeRun | Sequence[FakeRun] | Callable[[agentshim.CommandRequest], FakeRun],
-    **options: Any,  # noqa: ANN401
-) -> tuple[subject.AgentShimDriver, FakeExecutor]:
-    """Build a container-mode driver whose ``docker`` client is the fake.
-
-    The Docker executor rewrites each request into a ``docker exec`` command
-    and hands it to a host executor; substituting that inner executor is what
-    lets the argv the container would have received be asserted directly.
-    """
-    fake = FakeExecutor(runs)
-
-    monkeypatch.setattr(docker_executor, "HostCommandExecutor", lambda: fake)
-    driver = subject.AgentShimDriver(
-        provider=provider,
-        docker_sandboxes={"implementer": SimpleNamespace(container_id="container-1")},
-        **options,
-    )
-    return driver, fake
-
-
 def _container_spec(tmp_path: Path, provider: str, **changes: Any) -> AgentSessionSpec:  # noqa: ANN401
     return _spec(
         tmp_path,
@@ -565,68 +664,38 @@ def _container_spec(tmp_path: Path, provider: str, **changes: Any) -> AgentSessi
 
 
 @pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
-def test_a_container_turn_carries_the_session_environment_and_workdir(
-    monkeypatch: pytest.MonkeyPatch,
+def test_a_container_turn_carries_the_sandbox_environment_and_workdir(
     tmp_path: Path,
     provider: str,
 ) -> None:
-    """The overlay reaches the CLI inside the container, not the docker client.
+    """The sandbox's own environment reaches the CLI, and ``-w`` carries the workdir.
 
-    A container starts from its image's environment, so the session overlay has
-    to be handed to ``docker exec`` as ``-e`` flags; and the container turn
-    names no ``cwd`` of its own, so the executor supplies ``-w``.
+    A container starts from its image's environment; there is no separate
+    per-turn environment-forwarding path any more, so the session hands the
+    library exactly ``sandbox.env``.
     """
-    driver, fake = _container_driver(monkeypatch, provider, scripted_turn(provider, text="ok"))
+    sandbox = _FakeDockerSandbox(workspace=tmp_path, extra_env={"VIBESYS_ROUND": "3"})
+    driver, fake = _driver(
+        provider, scripted_turn(provider, text="ok"), docker_sandboxes={"implementer": sandbox}
+    )
     session = driver.create_session(_container_spec(tmp_path, provider))
 
     session.run_turn(AgentTurnRequest(message="Do it"))
 
     argv = list(fake.requests[-1].argv)
     assert argv[:3] == ["docker", "exec", "-i"]
-    assert argv[argv.index("-w") + 1] == docker_executor.DEFAULT_CONTAINER_WORKDIR
+    assert argv[argv.index("-w") + 1] == "/workspace"
     forwarded = [argv[index + 1] for index, item in enumerate(argv) if item == "-e"]
-    assert "GPU=0" in forwarded
-    # The host paths agentshim assembled for this process must not cross over:
-    # they name directories that do not exist inside the container.
-    assert not any(entry.startswith("PATH=") for entry in forwarded)
-    assert "container-1" in argv
-    assert argv[argv.index("container-1") + 1].endswith(
+    assert "VIBESYS_ROUND=3" in forwarded
+    assert sandbox.container_id in argv
+    assert argv[argv.index(sandbox.container_id) + 1].endswith(
         agentshim.get_provider(provider).profile.binary
     )
-    # The turn's own working directory stays unset: `-w` is what carries it.
-    assert fake.requests[-1].cwd is None
-
-
-@pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
-def test_a_container_turn_carries_no_host_device_pin(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    provider: str,
-) -> None:
-    """The host GPU index is not a fact about the inside of the container.
-
-    An editor container is started with ``--gpus device=N``, which makes the
-    chosen GPU device 0 inside it, so the host's ``CUDA_VISIBLE_DEVICES``
-    would name a device that is not there. The run context keeps the pin out
-    of the session spec in container mode; the driver's part of that contract
-    is that it forwards only what the spec declared and never reads the
-    variable off the host environment.
-    """
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
-    driver, fake = _container_driver(monkeypatch, provider, scripted_turn(provider, text="ok"))
-    session = driver.create_session(_container_spec(tmp_path, provider, environment=()))
-
-    session.run_turn(AgentTurnRequest(message="Do it"))
-
-    argv = list(fake.requests[-1].argv)
-    forwarded = [argv[index + 1] for index, item in enumerate(argv) if item == "-e"]
-    assert forwarded == []
-    assert not any("CUDA_VISIBLE_DEVICES" in argument for argument in argv)
+    assert fake.requests[-1].env["HOME"] == sandbox.home
 
 
 @pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
 def test_a_container_binary_check_gets_the_container_budget(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     provider: str,
 ) -> None:
@@ -635,7 +704,10 @@ def test_a_container_binary_check_gets_the_container_budget(
     A failed health check ends the run before the first turn, so the budget
     has to survive a daemon that is busy rather than dead.
     """
-    driver, fake = _container_driver(monkeypatch, provider, scripted_turn(provider, text="ok"))
+    sandbox = _FakeDockerSandbox(workspace=tmp_path)
+    driver, fake = _driver(
+        provider, scripted_turn(provider, text="ok"), docker_sandboxes={"implementer": sandbox}
+    )
 
     driver.create_session(_container_spec(tmp_path, provider))
 
@@ -646,12 +718,15 @@ def test_a_container_binary_check_gets_the_container_budget(
 
 @pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
 def test_the_binary_check_budget_is_a_driver_option(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     provider: str,
 ) -> None:
-    driver, fake = _container_driver(
-        monkeypatch, provider, scripted_turn(provider, text="ok"), check_timeout=5
+    sandbox = _FakeDockerSandbox(workspace=tmp_path)
+    driver, fake = _driver(
+        provider,
+        scripted_turn(provider, text="ok"),
+        docker_sandboxes={"implementer": sandbox},
+        check_timeout=5,
     )
 
     driver.create_session(_container_spec(tmp_path, provider))
@@ -682,57 +757,62 @@ def _watchdog_spy(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, ...]]:
     return watched
 
 
-def test_a_container_codex_session_runs_its_turns_through_the_watchdog(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """A resumed containerized ``codex exec --json`` can finish without exiting.
-
-    The watchdog has to be in the path the session's turns actually take, not
-    merely constructible from the driver.
-    """
-    watched = _watchdog_spy(monkeypatch)
-    driver, _fake = _container_driver(monkeypatch, "codex", scripted_turn("codex", text="ok"))
-    session = driver.create_session(_container_spec(tmp_path, "codex"))
-
-    session.run_turn(AgentTurnRequest(message="Do it"))
-
-    assert watched, "the codex session's turn did not go through the watchdog"
-    assert watched[-1][0].endswith("codex")
-
-
-@pytest.mark.parametrize("provider", [name for name in SCRIPTED_PROVIDERS if name != "codex"])
-def test_a_container_session_for_another_provider_gets_no_watchdog(
+@pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
+def test_every_container_session_runs_its_turns_through_the_watchdog(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     provider: str,
 ) -> None:
-    """The watchdog compensates for one provider's behaviour, not for containers."""
+    """The watchdog wraps unconditionally: it only ever acts on a resumed Codex
+    JSON run, so wrapping every provider's container session costs nothing for
+    the rest and needs no per-provider branch in the driver."""
     watched = _watchdog_spy(monkeypatch)
-    driver, fake = _container_driver(monkeypatch, provider, scripted_turn(provider, text="ok"))
+    sandbox = _FakeDockerSandbox(workspace=tmp_path)
+    driver, _fake = _driver(
+        provider, scripted_turn(provider, text="ok"), docker_sandboxes={"implementer": sandbox}
+    )
     session = driver.create_session(_container_spec(tmp_path, provider))
 
     session.run_turn(AgentTurnRequest(message="Do it"))
 
-    assert watched == []
-    # The plain `docker exec` transport is still what carried the turn.
-    assert list(fake.requests[-1].argv)[:3] == ["docker", "exec", "-i"]
+    assert watched, "the container session's turn did not go through the watchdog"
+
+
+def test_the_watchdog_rollout_root_comes_from_the_sandbox_home(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """No ``/root`` or ``/home/agent`` literal: it is read off the sandbox."""
+    captured: dict[str, str] = {}
+    real = docker_executor.CodexRolloutWatchdogExecutor
+
+    def _spy(*args: Any, rollout_sessions_root: str, **kwargs: Any) -> Any:  # noqa: ANN401
+        captured["rollout_sessions_root"] = rollout_sessions_root
+        return real(*args, rollout_sessions_root=rollout_sessions_root, **kwargs)
+
+    monkeypatch.setattr(docker_executor, "CodexRolloutWatchdogExecutor", _spy)
+    sandbox = _FakeDockerSandbox(workspace=tmp_path, home="/home/somebody-else")
+    driver, _fake = _driver(
+        "codex", scripted_turn("codex", text="ok"), docker_sandboxes={"implementer": sandbox}
+    )
+
+    driver.create_session(_container_spec(tmp_path, "codex"))
+
+    assert captured["rollout_sessions_root"] == "/home/somebody-else/.codex/sessions"
 
 
 @pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
 def test_container_session_mcp_servers_are_installed_on_the_host_workspace(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     provider: str,
 ) -> None:
     """A container turn writes its MCP config on the bind-mounted host workspace.
 
-    The CLI runs at the container's own path, so the turn names no host
-    working directory for agentshim to derive the config directory from. The
-    driver points ``mcp_workspace`` at the host workspace instead, which the
-    container sees as ``/workspace``. As on the host, the file exists only
-    while the provider process is running, so the scripted run is the moment
-    it can be observed.
+    The session's own ``cwd`` is the real host workspace path in every mode
+    now, so agentshim's ordinary cwd-derived config directory already lands
+    on the host side of the bind mount; the CLI reads it back through
+    ``/workspace``. As on the host, the file exists only while the provider
+    process is running, so the scripted run is the moment it can be observed.
     """
     server = MCPServerSpec(name="issues", command="python", args=("-m", "issues"))
     during: list[dict[str, str]] = []
@@ -745,15 +825,13 @@ def test_container_session_mcp_servers_are_installed_on_the_host_workspace(
         installed.append(installed_mcp_servers(provider, request, tmp_path))
         return scripted_turn(provider, text="ok")
 
-    driver, _fake = _container_driver(monkeypatch, provider, run)
+    sandbox = _FakeDockerSandbox(workspace=tmp_path)
+    driver, _fake = _driver(provider, run, docker_sandboxes={"implementer": sandbox})
     session = driver.create_session(_container_spec(tmp_path, provider, mcp_servers=(server,)))
 
     session.run_turn(AgentTurnRequest(message="review"))
 
     entry = installed[-1]["issues"]
-    # The container image resolves its own interpreter: the host substitution
-    # would name a path that does not exist inside it, so the command must
-    # reach the CLI unsubstituted.
     assert entry["command"] == "python"
     assert entry["args"] == ["-m", "issues"]
 
@@ -764,6 +842,35 @@ def test_container_session_mcp_servers_are_installed_on_the_host_workspace(
     else:
         assert during[-1], f"{provider} wrote no MCP config on the host workspace"
     assert _workspace_files(tmp_path) == {}, "the MCP config outlived the turn"
+
+
+@pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
+def test_a_container_timeout_reports_no_docker_transport_in_its_message(
+    tmp_path: Path,
+    provider: str,
+) -> None:
+    """A timeout message must not carry the ``docker exec`` transform.
+
+    In container mode the argv agentshim times out on is the transformed
+    ``docker exec -e KEY=VALUE ...`` line, and ``AgentClient`` logs
+    ``str(exc)`` on a failed round.
+    """
+
+    def run(request: agentshim.CommandRequest) -> FakeRun:
+        # Every container command is scripted, the binary health check
+        # included; only the turn itself is the one that hangs.
+        return FakeRun() if "--help" in request.argv else FakeRun(timeout=True)
+
+    sandbox = _FakeDockerSandbox(workspace=tmp_path, extra_env={"ANTHROPIC_AUTH_TOKEN": "secret"})
+    driver, _fake = _driver(provider, run, docker_sandboxes={"implementer": sandbox})
+    session = driver.create_session(_container_spec(tmp_path, provider))
+
+    with pytest.raises(subprocess.TimeoutExpired) as raised:
+        session.run_turn(AgentTurnRequest(message="one", timeout=timedelta(seconds=5)))
+
+    assert raised.value.cmd == [agentshim.get_provider(provider).profile.binary]
+    assert "secret" not in str(raised.value)
+    assert "docker" not in str(raised.value)
 
 
 # ---------------------------------------------------------------------------
@@ -807,6 +914,33 @@ def test_a_native_schema_replaces_the_prompt_contract(
     # The caller parses the answer back into its response model, so the
     # schema-conformant payload is what the turn reports as its text.
     assert json.loads(result.text) == payload
+
+
+@pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
+def test_a_container_native_schema_directory_is_mapped_through_agent_path(
+    tmp_path: Path,
+    provider: str,
+) -> None:
+    """The schema file lives on the host; the CLI reads it back through the mount."""
+    profile = agentshim.get_provider(provider).profile
+    if profile.output_schema is not agentshim.OutputSchemaStyle.FILE_PATH:
+        pytest.skip(f"{provider} does not reference a schema file path")
+    payload = {"analysis": "it improved", "verdict": "accept"}
+    sandbox = _FakeDockerSandbox(workspace=tmp_path)
+    driver, fake = _driver(
+        provider,
+        scripted_turn(provider, text="", structured_output=payload),
+        docker_sandboxes={"implementer": sandbox},
+    )
+    session = driver.create_session(_container_spec(tmp_path, provider))
+
+    session.run_turn(
+        AgentTurnRequest(message="usr", instructions="sys", output_schema=JudgeResponse)
+    )
+
+    launched = " ".join(fake.requests[-1].argv) + (fake.requests[-1].stdin or "")
+    assert str(tmp_path) not in launched
+    assert "/workspace/.cache/vibesys/response-schemas" in launched
 
 
 @pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
@@ -1146,41 +1280,6 @@ def test_a_turn_that_times_out_is_reported_as_a_subprocess_timeout(
     assert raised.value.cmd == [agentshim.get_provider(provider).profile.binary]
 
 
-@pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
-def test_a_container_timeout_reports_no_forwarded_environment_value(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    provider: str,
-) -> None:
-    """A timeout message must not carry the credentials the turn was given.
-
-    In container mode the argv agentshim times out on is the transformed
-    ``docker exec -e KEY=VALUE ...`` line, and ``AgentClient`` logs
-    ``str(exc)`` on a failed round.
-    """
-
-    def run(request: agentshim.CommandRequest) -> FakeRun:
-        # Every container command is scripted, the binary health check
-        # included; only the turn itself is the one that hangs.
-        return FakeRun() if "--help" in request.argv else FakeRun(timeout=True)
-
-    driver, _fake = _container_driver(monkeypatch, provider, run)
-    session = driver.create_session(
-        _container_spec(
-            tmp_path,
-            provider,
-            environment=(("ANTHROPIC_AUTH_TOKEN", "secret-token"),),
-        )
-    )
-
-    with pytest.raises(subprocess.TimeoutExpired) as raised:
-        session.run_turn(AgentTurnRequest(message="one", timeout=timedelta(seconds=5)))
-
-    assert raised.value.cmd == [agentshim.get_provider(provider).profile.binary]
-    assert "secret-token" not in str(raised.value)
-    assert "docker" not in str(raised.value)
-
-
 def test_the_codex_thread_budget_retires_a_conversation(
     sandbox_builds: list[dict[str, Any]],
     tmp_path: Path,
@@ -1377,6 +1476,20 @@ def test_a_container_policy_on_a_host_driver_is_rejected(
         )
 
 
+@pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
+def test_a_host_policy_on_a_container_driver_is_rejected(
+    tmp_path: Path,
+    provider: str,
+) -> None:
+    sandbox = _FakeDockerSandbox(workspace=tmp_path)
+    driver, _fake = _driver(
+        provider, scripted_turn(provider, text="ok"), docker_sandboxes={"implementer": sandbox}
+    )
+
+    with pytest.raises(ValueError, match="container policy"):
+        driver.create_session(_spec(tmp_path, provider=provider))
+
+
 # ---------------------------------------------------------------------------
 # Environment hygiene
 # ---------------------------------------------------------------------------
@@ -1400,22 +1513,3 @@ def test_the_launch_drops_the_inherited_pwd(
     env = fake.requests[-1].env
     assert "PWD" not in env
     assert env["GPU"] == "1"
-
-
-@pytest.mark.parametrize("provider", SCRIPTED_PROVIDERS)
-def test_a_container_turn_does_not_forward_the_inherited_pwd(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    provider: str,
-) -> None:
-    driver, fake = _container_driver(monkeypatch, provider, scripted_turn(provider, text="ok"))
-    session = driver.create_session(
-        _container_spec(tmp_path, provider, environment=(("PWD", "/somewhere/stale"), ("GPU", "1")))
-    )
-
-    session.run_turn(AgentTurnRequest(message="Do it"))
-
-    argv = list(fake.requests[-1].argv)
-    forwarded = [argv[index + 1] for index, item in enumerate(argv) if item == "-e"]
-    assert "GPU=1" in forwarded
-    assert not any(entry.startswith("PWD=") for entry in forwarded)

--- a/tests/vibesys/agents/test_docker_executor.py
+++ b/tests/vibesys/agents/test_docker_executor.py
@@ -18,7 +18,6 @@ from agentshim.testing import FakeExecutor, FakeRun, scripted_turn
 from vibesys.agents.docker_executor import (
     _CODEX_RESUME_TERMINATION_SCRIPT,
     CodexRolloutWatchdogExecutor,
-    DockerCommandExecutor,
     _codex_resume_argv_matches,
     _codex_resume_thread_id,
     _codex_started_thread_id,
@@ -26,6 +25,8 @@ from vibesys.agents.docker_executor import (
     _discard,
     _scan_codex_rollout_completion,
 )
+
+_ROLLOUT_SESSIONS_ROOT = "/home/agent/.codex/sessions"
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -56,142 +57,6 @@ def _request(**overrides: object) -> CommandRequest:
     }
     fields.update(overrides)
     return CommandRequest(**fields)  # type: ignore[arg-type]
-
-
-class TestDockerCommandExecutor:
-    """The docker exec transport: argv shape, environment, and binary lookup."""
-
-    def test_wraps_argv_in_docker_exec_with_the_request_working_directory(self) -> None:
-        inner = FakeExecutor(FakeRun(stdout=["out\n"], stderr=["err\n"]))
-        executor = DockerCommandExecutor(lambda: "container-123", inner=inner)
-        stdout: list[str] = []
-        stderr: list[str] = []
-
-        result = executor.run(
-            _request(argv=["codex", "exec", "-"], cwd="/workspace/candidate"),
-            _sink(stdout, stderr),
-        )
-
-        assert inner.requests[0].argv == [
-            "docker",
-            "exec",
-            "-i",
-            "-w",
-            "/workspace/candidate",
-            "container-123",
-            "codex",
-            "exec",
-            "-",
-        ]
-        assert inner.requests[0].cwd is None
-        assert inner.requests[0].timeout == 17.0
-        assert stdout == ["out\n"]
-        assert stderr == ["err\n"]
-        assert result.returncode == 0
-
-    def test_falls_back_to_the_configured_workdir_when_the_request_has_no_cwd(self) -> None:
-        inner = FakeExecutor(FakeRun())
-        DockerCommandExecutor(lambda: "container-123", inner=inner).run(_request(), _sink())
-
-        assert inner.requests[0].argv[:6] == [
-            "docker",
-            "exec",
-            "-i",
-            "-w",
-            "/workspace",
-            "container-123",
-        ]
-
-    def test_forwards_only_the_nominated_environment_entries(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """The host environment describes the host, not the container.
-
-        ``PATH`` and the rest of the turn environment name directories that do
-        not exist inside the image, so only the variables the caller nominated
-        cross the boundary.
-        """
-        monkeypatch.setenv("PATH", "/host/bin")
-        inner = FakeExecutor(FakeRun())
-
-        DockerCommandExecutor(
-            lambda: "container-123",
-            forward_env=("ANTHROPIC_AUTH_TOKEN", "VIBESYS_ROUND", "ABSENT"),
-            inner=inner,
-        ).run(
-            _request(
-                env={
-                    "PATH": "/host/bin",
-                    "SHARED": "same",
-                    "ANTHROPIC_AUTH_TOKEN": "token",
-                    "VIBESYS_ROUND": "3",
-                }
-            ),
-            _sink(),
-        )
-
-        argv = inner.requests[0].argv
-        forwarded = [argv[index + 1] for index, part in enumerate(argv) if part == "-e"]
-        # A nominated variable the turn does not carry is simply absent; it is
-        # not forwarded as an empty value that would shadow the image's own.
-        assert forwarded == ["ANTHROPIC_AUTH_TOKEN=token", "VIBESYS_ROUND=3"]
-        # The docker CLI itself still runs with the host environment.
-        assert inner.requests[0].env["PATH"] == "/host/bin"
-
-    def test_forwards_nothing_when_the_caller_nominated_nothing(self) -> None:
-        inner = FakeExecutor(FakeRun())
-
-        DockerCommandExecutor(lambda: "container-123", inner=inner).run(
-            _request(env={"PATH": "/host/bin", "VIBESYS_ROUND": "3"}),
-            _sink(),
-        )
-
-        assert "-e" not in inner.requests[0].argv
-
-    def test_passes_stdin_through_untouched(self) -> None:
-        inner = FakeExecutor(FakeRun())
-        DockerCommandExecutor(lambda: "container-123", inner=inner).run(
-            _request(stdin="a long prompt"),
-            _sink(),
-        )
-
-        assert inner.requests[0].stdin == "a long prompt"
-
-    def test_reads_the_container_id_once_per_request(self) -> None:
-        containers = iter(["container-a", "container-b"])
-        inner = FakeExecutor(FakeRun())
-        executor = DockerCommandExecutor(lambda: next(containers), inner=inner)
-
-        executor.run(_request(), _sink())
-        executor.run(_request(), _sink())
-
-        assert [request.argv[5] for request in inner.requests] == [
-            "container-a",
-            "container-b",
-        ]
-
-    def test_finds_the_binary_by_name_because_it_lives_in_the_container(self) -> None:
-        executor = DockerCommandExecutor(lambda: "container-123", inner=FakeExecutor(FakeRun()))
-
-        assert executor.find_binary("codex", {"PATH": "/host/bin"}) == "codex"
-
-    def test_checks_the_binary_inside_the_container(self) -> None:
-        inner = FakeExecutor(FakeRun())
-        executor = DockerCommandExecutor(lambda: "container-123", inner=inner)
-
-        executor.check_binary("claude", {}, timeout=5)
-
-        assert inner.requests[0].argv == [
-            "docker",
-            "exec",
-            "-i",
-            "-w",
-            "/workspace",
-            "container-123",
-            "claude",
-            "--help",
-        ]
 
 
 class _BlockingHandle:
@@ -251,6 +116,7 @@ def _impatient(
     return CodexRolloutWatchdogExecutor(
         inner,
         container_id_resolver,
+        rollout_sessions_root=_ROLLOUT_SESSIONS_ROOT,
         log=log,
         tick_seconds=0.001,
         rollout_poll_seconds=0.0,
@@ -266,7 +132,9 @@ class TestCodexRolloutWatchdog:
         inner = FakeExecutor(FakeRun(stdout=["hello\n"], returncode=3))
         stdout: list[str] = []
 
-        result = CodexRolloutWatchdogExecutor(inner, lambda: "container-123").run(
+        result = CodexRolloutWatchdogExecutor(
+            inner, lambda: "container-123", rollout_sessions_root=_ROLLOUT_SESSIONS_ROOT
+        ).run(
             _request(argv=["claude", "-p", "--verbose"]),
             _sink(stdout),
         )
@@ -277,7 +145,9 @@ class TestCodexRolloutWatchdog:
     def test_leaves_the_exit_code_alone_when_it_never_intervenes(self) -> None:
         inner = FakeExecutor(FakeRun(stdout=["{}\n"], returncode=7))
 
-        result = CodexRolloutWatchdogExecutor(inner, lambda: "container-123").run(
+        result = CodexRolloutWatchdogExecutor(
+            inner, lambda: "container-123", rollout_sessions_root=_ROLLOUT_SESSIONS_ROOT
+        ).run(
             _request(argv=["codex", "exec", "resume", THREAD_ID, "-", "--json"]),
             _sink(),
         )
@@ -292,7 +162,11 @@ class TestCodexRolloutWatchdog:
         is the one test that constructs the executor with no overrides at all
         and pins what production actually runs with.
         """
-        executor = CodexRolloutWatchdogExecutor(FakeExecutor(FakeRun()), lambda: "container-123")
+        executor = CodexRolloutWatchdogExecutor(
+            FakeExecutor(FakeRun()),
+            lambda: "container-123",
+            rollout_sessions_root=_ROLLOUT_SESSIONS_ROOT,
+        )
 
         assert executor.tick_seconds == 5.0
         assert executor.rollout_poll_seconds == 15.0
@@ -301,7 +175,9 @@ class TestCodexRolloutWatchdog:
 
     def test_delegates_binary_lookup_and_the_health_check(self) -> None:
         inner = FakeExecutor(FakeRun())
-        executor = CodexRolloutWatchdogExecutor(inner, lambda: "container-123")
+        executor = CodexRolloutWatchdogExecutor(
+            inner, lambda: "container-123", rollout_sessions_root=_ROLLOUT_SESSIONS_ROOT
+        )
 
         assert executor.find_binary("codex", {}) == "/usr/local/bin/codex"
         executor.check_binary("/usr/local/bin/codex", {}, timeout=5)
@@ -518,7 +394,11 @@ class TestCodexRolloutReading:
         monkeypatch: pytest.MonkeyPatch,
         queries: _FakeDockerQueries,
     ) -> _CodexRolloutCompletion | None:
-        executor = CodexRolloutWatchdogExecutor(FakeExecutor(FakeRun()), lambda: "container-123")
+        executor = CodexRolloutWatchdogExecutor(
+            FakeExecutor(FakeRun()),
+            lambda: "container-123",
+            rollout_sessions_root=_ROLLOUT_SESSIONS_ROOT,
+        )
         monkeypatch.setattr("vibesys.agents.docker_executor.subprocess.run", queries)
         return executor._read_codex_rollout_completion("container-123", THREAD_ID)  # noqa: SLF001
 

--- a/tests/vibesys/agents/test_hostsandbox.py
+++ b/tests/vibesys/agents/test_hostsandbox.py
@@ -522,11 +522,14 @@ def test_sandbox_exposes_codex_auth_but_not_sibling_worktrees(tmp_path):  # noqa
     assert result.returncode == 0, result.stderr
 
 
-def test_the_executor_transform_wraps_only_a_workspace_command(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-    """Container executors run without a cwd; confinement must not engage there.
+def test_the_executor_transform_wraps_every_command(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    """Confinement applies to every command, cwd or none.
 
-    The driver applies the host sandbox as an executor transform, so this is
-    the chokepoint that decides whether a command is confined at all.
+    A command with no cwd is the binary health check; it is wrapped too so a
+    binary that only exists inside a container sandbox's confinement (this
+    same transform, given a ``DockerSandbox``) is still checkable there.
+    ``HostSandbox.wrap`` takes no ``cwd`` of its own, so the request's is
+    irrelevant to it either way; it always confines to its own workspace.
     """
     sandbox = hostsandbox.HostSandbox(bwrap_path="/usr/bin/bwrap", workspace=tmp_path)
     recorder = FakeExecutor([FakeRun()])
@@ -542,10 +545,10 @@ def test_the_executor_transform_wraps_only_a_workspace_command(tmp_path):  # noq
     executor.run(request, agentshim.NullSink())
     executor.run(replace(request, cwd=str(tmp_path)), agentshim.NullSink())
 
-    unconfined, confined = recorder.requests
-    assert list(unconfined.argv) == ["stub-agent", "--json"]
-    assert confined.argv[0] == "/usr/bin/bwrap"
-    assert list(confined.argv[confined.argv.index("--") + 1 :]) == ["stub-agent", "--json"]
+    no_cwd, with_cwd = recorder.requests
+    for confined in (no_cwd, with_cwd):
+        assert confined.argv[0] == "/usr/bin/bwrap"
+        assert list(confined.argv[confined.argv.index("--") + 1 :]) == ["stub-agent", "--json"]
 
 
 def _seatbelt_works() -> bool:

--- a/tests/vibesys/backends/test_cpu_backend.py
+++ b/tests/vibesys/backends/test_cpu_backend.py
@@ -13,7 +13,13 @@ from vibesys.backends import SandboxKind
 from vibesys.backends.local import LocalBackend
 from vibesys.constants import ComputeBackend
 from vibesys.profilers import ProfilerKind
-from vs_sandbox import BeforeReadyContext, DockerSandbox, SandboxLifecycleHooks
+from vs_sandbox import (
+    BeforeReadyContext,
+    DockerSandbox,
+    HostResource,
+    HostResourceAccess,
+    SandboxLifecycleHooks,
+)
 
 
 class _RecordingHooks(SandboxLifecycleHooks):
@@ -79,6 +85,21 @@ class TestCpuSandbox:
         assert sb._gpus is None  # noqa: SLF001  # tracked: #288
         assert sb._image == "sha256:" + "a" * 64  # noqa: SLF001  # tracked: #288
         assert sb._env["FOO"] == "bar"  # noqa: SLF001  # tracked: #288
+
+    def test_docker_forwards_resources_to_the_sandbox(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        impl = _make_backend(tmp_path)
+        resource = HostResource(tmp_path / "history", HostResourceAccess.READ_ONLY, "history")
+
+        sb = impl.make_sandbox(
+            SandboxKind.DOCKER,
+            host_workspace=str(tmp_path),
+            log_path=None,
+            container_image="sha256:" + "a" * 64,
+            resources=[resource],
+        )
+
+        assert isinstance(sb, DockerSandbox)
+        assert resource in sb._resources  # noqa: SLF001  # tracked: #288
 
     def test_docker_falls_back_to_the_backend_image_without_a_resolved_container_image(  # noqa: ANN201  # tracked: #288
         self,

--- a/tests/vibesys/backends/test_cuda_backend.py
+++ b/tests/vibesys/backends/test_cuda_backend.py
@@ -5,7 +5,7 @@ import pytest
 
 from vibesys.backends import SandboxKind
 from vibesys.backends.cuda import CudaBackend
-from vs_sandbox import DockerSandbox
+from vs_sandbox import DockerSandbox, HostResource, HostResourceAccess
 
 
 def test_cpu_only_control_plane_docker_skips_gpu_runtime(
@@ -42,3 +42,19 @@ def test_ephemeral_setup_sandbox_is_not_tracked_for_reselection(tmp_path: Path) 
 
     assert isinstance(sandbox, DockerSandbox)
     assert backend._sandboxes == []  # noqa: SLF001
+
+
+def test_docker_forwards_resources_to_the_sandbox(tmp_path: Path) -> None:
+    backend = CudaBackend(tmp_path)
+    resource = HostResource(tmp_path / "history", HostResourceAccess.READ_ONLY, "history")
+
+    sandbox = backend.make_sandbox(
+        SandboxKind.DOCKER,
+        host_workspace=str(tmp_path),
+        log_path=None,
+        attach_accelerator=False,
+        resources=[resource],
+    )
+
+    assert isinstance(sandbox, DockerSandbox)
+    assert resource in sandbox._resources  # noqa: SLF001  # tracked: #288

--- a/tests/vibesys/backends/test_rocm_backend.py
+++ b/tests/vibesys/backends/test_rocm_backend.py
@@ -15,7 +15,7 @@ from vibesys.constants import ComputeBackend
 from vibesys.profilers import ProfilerKind
 from vibesys.prompts import PROMPTS_DIR, RocmComputeBackendFragment
 from vibesys.prompts.renderer import _FRAGMENT_IMPLS, ComputeBackendFragment
-from vs_sandbox import DockerSandbox
+from vs_sandbox import DockerSandbox, HostResource, HostResourceAccess
 
 
 def _make_backend(tmp_path, devices=("/dev/kfd", "/dev/dri/renderD128")) -> RocmBackend:  # noqa: ANN001  # tracked: #288
@@ -61,6 +61,22 @@ class TestRocmSandbox:
         assert isinstance(sb, DockerSandbox)
         assert sb._devices == ["/dev/kfd", "/dev/dri/renderD128"]  # noqa: SLF001  # tracked: #288
         assert sb._gpus is None  # noqa: SLF001  # tracked: #288
+
+    def test_docker_forwards_resources_to_the_sandbox(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        impl = _make_backend(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        resource = HostResource(tmp_path / "history", HostResourceAccess.READ_ONLY, "history")
+
+        sb = impl.make_sandbox(
+            SandboxKind.DOCKER,
+            host_workspace=str(workspace),
+            log_path=None,
+            resources=[resource],
+        )
+
+        assert isinstance(sb, DockerSandbox)
+        assert resource in sb._resources  # noqa: SLF001  # tracked: #288
 
     def test_docker_can_skip_accelerator_for_control_plane(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)

--- a/tests/vibesys/backends/test_trainium_backend.py
+++ b/tests/vibesys/backends/test_trainium_backend.py
@@ -13,7 +13,7 @@ from vibesys.backends import SandboxKind
 from vibesys.backends.trainium import TrainiumBackend
 from vibesys.constants import ComputeBackend
 from vibesys.profilers import ProfilerKind
-from vs_sandbox import DockerSandbox
+from vs_sandbox import DockerSandbox, HostResource, HostResourceAccess
 
 
 def _make_backend(tmp_path, devices=("/dev/neuron0",)) -> TrainiumBackend:  # noqa: ANN001  # tracked: #288
@@ -69,6 +69,22 @@ class TestTrainiumSandbox:
         assert sb._auto_remove is True  # noqa: SLF001  # tracked: #288
         assert sb._env.get("TMPDIR") == "/opt/neuron-tmp"  # noqa: SLF001  # tracked: #288
         assert any(c == "/opt/neuron-tmp" for _h, c, _ro in sb._bind_mounts)  # noqa: SLF001  # tracked: #288
+
+    def test_docker_forwards_resources_to_the_sandbox(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        impl = _make_backend(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        resource = HostResource(tmp_path / "history", HostResourceAccess.READ_ONLY, "history")
+
+        sb = impl.make_sandbox(
+            SandboxKind.DOCKER,
+            host_workspace=str(workspace),
+            log_path=None,
+            resources=[resource],
+        )
+
+        assert isinstance(sb, DockerSandbox)
+        assert resource in sb._resources  # noqa: SLF001  # tracked: #288
 
     def test_modal_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)

--- a/tests/vibesys/sandbox/test_run_environment.py
+++ b/tests/vibesys/sandbox/test_run_environment.py
@@ -30,6 +30,7 @@ from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     _cli_container_env,
     _cli_provider_env_and_auth_files,
+    _container_mount_plan,
     _docker_agent_toolchains,
     _docker_evaluator_tool_mounts,
     _evaluator_container_setup,
@@ -43,9 +44,17 @@ from vibesys.sandbox.run_environment import (
     run_environment_record,
 )
 from vs_project import Project, RunEnvironmentRecord, RunResourceRequest
-from vs_sandbox import BeforeReadyContext, ProjectPathPolicy, SandboxLifecycle
+from vs_sandbox import (
+    BeforeReadyContext,
+    HostResource,
+    HostResourceAccess,
+    ProjectPathPolicy,
+    SandboxLifecycle,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
     from deepagents.backends.protocol import SandboxBackendProtocol
 
     from vibesys.backends.base import ContentionMonitor
@@ -55,6 +64,52 @@ if TYPE_CHECKING:
 # how the run environment expands and quotes nested shell argv, not any
 # particular candidate repository.
 NESTED_SHELL_PROJECT = Path(__file__).parent / "fixtures" / "nested_shell_project"
+
+
+def _as_mount_tuples(resources: Sequence[HostResource]) -> list[tuple[str, str, bool]]:
+    """Invert ``_resource_for_mount`` for assertions written against the old shape.
+
+    Lets tests keep comparing against plain ``(host, container, readonly)``
+    tuples after ``_container_mount_plan`` moved from raw bind mounts to a
+    ``HostResource`` list.
+    """
+    return [
+        (
+            str(resource.path),
+            resource.agent_path if resource.agent_path is not None else str(resource.path),
+            resource.access is HostResourceAccess.READ_ONLY,
+        )
+        for resource in resources
+    ]
+
+
+def _fake_agent_path(
+    host_workspace: str, resources: Sequence[HostResource]
+) -> Callable[[Path | str], str]:
+    """Build a lookup mirroring ``DockerSandbox.agent_path`` from the same inputs.
+
+    Longest host-prefix wins, exactly like the real sandbox, so a test can
+    assert on ``AgentPaths`` without starting a real container.
+    """
+    entries = [
+        (str(Path(host_workspace)), "/workspace"),
+        *(
+            (str(resource.path), resource.agent_path or str(resource.path))
+            for resource in resources
+        ),
+    ]
+    entries.sort(key=lambda pair: len(pair[0]), reverse=True)
+
+    def lookup(host_path: Path | str) -> str:
+        normalized = str(Path(host_path))
+        for host_prefix, container_prefix in entries:
+            if normalized == host_prefix:
+                return container_prefix
+            if normalized.startswith(host_prefix + "/"):
+                return container_prefix + normalized[len(host_prefix) :]
+        return normalized
+
+    return lookup
 
 
 class FakeBackend:
@@ -70,6 +125,13 @@ class FakeBackend:
 
     def make_sandbox(self, kind: SandboxKind, **kwargs: Any) -> SandboxBackendProtocol:  # noqa: ANN401  # tracked: #288
         self.calls.append((kind, kwargs))
+        if kind is SandboxKind.DOCKER:
+            # A real DockerSandbox derives agent_path from (host_workspace,
+            # resources); give the mock the same behavior so AgentPaths
+            # assertions exercise the real lookup instead of a bare Mock.
+            self.sandbox.agent_path.side_effect = _fake_agent_path(
+                kwargs.get("host_workspace", ""), kwargs.get("resources", ())
+            )
         return self.sandbox
 
     def make_monitor(self, log_dir: Path) -> ContentionMonitor | None:  # noqa: ARG002  # tracked: #288
@@ -495,7 +557,7 @@ def test_isolated_environment_mounts_and_translates_evaluator_package(
         str(package.root),
         "/opt/vibesys-evaluator-package",
         True,
-    ) in backend.calls[0][1]["bind_mounts"]
+    ) in _as_mount_tuples(backend.calls[0][1]["resources"])
     # The evaluator package's declared toolchains (go, rust) are baked into
     # the agent image at build time now, not installed per-run.
     assert "extra_init_commands" not in backend.calls[0][1]
@@ -665,7 +727,9 @@ def test_isolated_environments_install_and_translate_evaluator_tools(
             isinstance(hook, EvaluatorToolLifecycleHooks)
             for hook in backend.calls[0][1]["lifecycle_hooks"]
         )
-        assert (str(built_root), str(container_root), True) in backend.calls[0][1]["bind_mounts"]
+        assert (str(built_root), str(container_root), True) in _as_mount_tuples(
+            backend.calls[0][1]["resources"]
+        )
         # Cargo-git tools are prebuilt and mounted read-only; nothing installs
         # Rust in the running container.
         assert "extra_init_commands" not in backend.calls[0][1]
@@ -929,9 +993,62 @@ def test_docker_environment_mounts_effective_objective_read_only(tmp_path):  # n
         str(host_path),
         "/opt/vibesys-runtime/objective.md",
         True,
-    ) in backend.calls[0][1]["bind_mounts"]
+    ) in _as_mount_tuples(backend.calls[0][1]["resources"])
     assert "/opt/vibesys-runtime" in backend.calls[0][1]["passthrough_paths"]
     assert session.view.paths.objective == "/opt/vibesys-runtime/objective.md"
+
+
+def test_local_environment_objective_defaults_to_the_bare_workspace_relative_name(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    """The host answer for an unset objective is identity: no lookup, no rewrite."""
+    backend = FakeBackend()
+    env = build_run_environment(RunEnvironmentSpec("local"))
+
+    session = env.open(_request(tmp_path, backend))
+
+    assert session.view.paths.objective == "OBJECTIVE.md"
+
+
+def test_container_mount_plan_declares_named_resources_with_agent_paths(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    """``_container_mount_plan`` returns ``HostResource`` entries, not bind-mount
+    tuples, with ``access`` and ``agent_path`` set for every named mount."""
+    backend = FakeBackend()
+    history = tmp_path / "experiment-history"
+    history.mkdir()
+    package_root = tmp_path / "evaluator-package"
+    package_root.mkdir()
+    request = _request(
+        tmp_path,
+        backend,
+        objective="Optimize the service.\n",
+        git_history_root=history,
+        evaluator_package_root=package_root,
+        agent_backend="cli",
+        cli_provider="codex",
+    )
+
+    resources, _symlinks, passthrough = _container_mount_plan(request)
+
+    assert all(isinstance(resource, HostResource) for resource in resources)
+    by_agent_path = {resource.agent_path: resource for resource in resources}
+
+    objective_resource = by_agent_path["/opt/vibesys-runtime/objective.md"]
+    assert objective_resource.access is HostResourceAccess.READ_ONLY
+    assert objective_resource.path == tmp_path / "logs" / "effective-objective.md"
+
+    history_resource = by_agent_path["/opt/vibesys-history"]
+    assert history_resource.access is HostResourceAccess.READ_ONLY
+    assert history_resource.path == history
+
+    package_resource = by_agent_path["/opt/vibesys-evaluator-package"]
+    assert package_resource.access is HostResourceAccess.READ_ONLY
+    assert package_resource.path == package_root
+
+    framework_resource = by_agent_path["/opt/vibesys"]
+    assert framework_resource.access is HostResourceAccess.READ_ONLY
+    assert framework_resource.path == request.framework_root
+
+    assert "/opt/vibesys-runtime" in passthrough
+    assert "/opt/vibesys-history" in passthrough
 
 
 @pytest.mark.parametrize("environment_name", ["docker", "modal"])
@@ -959,7 +1076,7 @@ def test_isolated_environment_enforces_project_path_policy(tmp_path, environment
         )
     )
 
-    mounts = backend.calls[0][1]["bind_mounts"]
+    mounts = _as_mount_tuples(backend.calls[0][1]["resources"])
     assert (str(project / ".git"), "/workspace/.git", True) in mounts
     assert (str(project / ".state"), "/workspace/.state", True) in mounts
     assert (
@@ -1035,7 +1152,7 @@ def test_docker_environment_copies_cli_auth_from_readonly_staging(tmp_path, monk
     env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
 
     kwargs = backend.calls[0][1]
-    assert (str(auth_file), "/opt/vibesys-auth/0", True) in kwargs["bind_mounts"]
+    assert (str(auth_file), "/opt/vibesys-auth/0", True) in _as_mount_tuples(kwargs["resources"])
     # The plain Docker path copies staged auth files into the agent HOME as a
     # start-time DockerSandbox step, not via extra_init_commands.
     assert "extra_init_commands" not in kwargs
@@ -1101,7 +1218,7 @@ def test_docker_environment_exposes_framework_git_history_read_only(tmp_path):  
     )
 
     kwargs = backend.calls[0][1]
-    assert (str(history), "/opt/vibesys-history", True) in kwargs["bind_mounts"]
+    assert (str(history), "/opt/vibesys-history", True) in _as_mount_tuples(kwargs["resources"])
     assert "/opt/vibesys-history" in kwargs["passthrough_paths"]
     assert kwargs["extra_env"]["VIBESYS_GIT_HISTORY"] == "/opt/vibesys-history"
     assert "/opt/vibesys-history" in session.view.prompt_notes
@@ -1123,7 +1240,7 @@ def test_docker_environment_uses_environment_bind_mounts(tmp_path):  # noqa: ANN
     )
 
     kwargs = backend.calls[0][1]
-    assert (str(model_dir), "/model", True) in kwargs["bind_mounts"]
+    assert (str(model_dir), "/model", True) in _as_mount_tuples(kwargs["resources"])
     assert "/model" in kwargs["passthrough_paths"]
 
 
@@ -1143,7 +1260,9 @@ def test_docker_environment_mounts_selected_profiler_support(tmp_path):  # noqa:
     )
 
     kwargs = backend.calls[0][1]
-    assert (str(support), "/workspace/fixture_profiler", True) in kwargs["bind_mounts"]
+    assert (str(support), "/workspace/fixture_profiler", True) in _as_mount_tuples(
+        kwargs["resources"]
+    )
     assert session.view.paths.profiler_support == "fixture_profiler"
 
 
@@ -1155,8 +1274,8 @@ def test_docker_environment_does_not_infer_model_mount_from_reference_dir(tmp_pa
 
     env.open(_request(tmp_path, backend, ref_dir=ref_dir))
 
-    bind_mounts = backend.calls[0][1]["bind_mounts"]
-    assert all(container_path != "/model" for _, container_path, _ in bind_mounts)
+    mounts = _as_mount_tuples(backend.calls[0][1]["resources"])
+    assert all(container_path != "/model" for _, container_path, _ in mounts)
 
 
 def test_environment_session_context_manager_closes(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -1243,7 +1362,7 @@ def test_modal_environment_wraps_service_evaluators_with_remote_dispatch(tmp_pat
     assert session.view.framework_setup_timeout_seconds == 1200
     assert any(
         container_path == helper and read_only
-        for _, container_path, read_only in backend.calls[0][1]["bind_mounts"]
+        for _, container_path, read_only in _as_mount_tuples(backend.calls[0][1]["resources"])
     )
 
 
@@ -1312,7 +1431,7 @@ def test_modal_environment_prompt_references_runtime_document(tmp_path):  # noqa
     assert "GPU" in runtime
     assert any(
         container_path == "/opt/vibesys-runtime/environment.md" and read_only
-        for _, container_path, read_only in backend.calls[0][1]["bind_mounts"]
+        for _, container_path, read_only in _as_mount_tuples(backend.calls[0][1]["resources"])
     )
     assert "/opt/vibesys-runtime" in backend.calls[0][1]["passthrough_paths"]
     # Tell the agent where to look up volume names rather than baking them in.
@@ -1360,7 +1479,7 @@ def test_modal_environment_mounts_effective_objective_read_only(tmp_path):  # no
         str(host_path),
         "/opt/vibesys-runtime/objective.md",
         True,
-    ) in backend.calls[0][1]["bind_mounts"]
+    ) in _as_mount_tuples(backend.calls[0][1]["resources"])
     assert session.view.paths.objective == "/opt/vibesys-runtime/objective.md"
 
 
@@ -1408,7 +1527,7 @@ def test_modal_environment_documents_history_and_exact_measurement_source(tmp_pa
     kwargs = backend.calls[0][1]
     notes = _modal_runtime_document(tmp_path)
 
-    assert (str(history), "/opt/vibesys-history", True) in kwargs["bind_mounts"]
+    assert (str(history), "/opt/vibesys-history", True) in _as_mount_tuples(kwargs["resources"])
     assert kwargs["extra_env"]["VIBESYS_GIT_HISTORY"] == "/opt/vibesys-history"
     assert "git -c safe.directory=/opt/vibesys-history" in notes
     assert "ls-tree -r --name-only <commit>" in notes
@@ -1580,7 +1699,7 @@ remote_artifact_root = "/remote/vibesys"
     assert fake_ensure_pushed == ["sha256:" + "a" * 64]
     assert kwargs["container_image"] == _PUSHED_DIGEST
     assert "extra_init_commands" not in kwargs
-    mounts = kwargs["bind_mounts"]
+    mounts = _as_mount_tuples(kwargs["resources"])
     assert any(target == "/opt/vibesys-skypilot/bridge.sock" for _, target, _ in mounts)
     assert any(target == "/opt/vibesys-skypilot-evaluator.py" for _, target, _ in mounts)
     assert all(".ssh" not in source and ".sky" not in source for source, _, _ in mounts)


### PR DESCRIPTION
## Problem

The AgentShim driver had two code paths. Host: build a sandbox, wrap the executor. Container: a separate `DockerCommandExecutor`, `forward_env`, an `in_container` flag, and per-site path substitutions (`_as_mcp_server(in_container=...)`, `OutputSchema.host_dir` versus `cli_dir`, `mcp_workspace`). The host PATH and HOME reached agentshim in container mode, so the Codex shell PATH policy and the watchdog's rollout path were patched around instead of correct. Closes #678; stacked on #682 (#676), #681 (#677), #680 (#675).

## Solution

- One path: `create_session` obtains a `WorkspaceSandbox` (the host one from `build_host_sandbox`, or the run environment's started `DockerSandbox`), wraps a plain `HostCommandExecutor` through `confine_to_sandbox`, and hands `CliAgent` the sandbox's `env`. `WorkspaceSandbox.wrap` takes an optional `cwd` so the container health check is wrapped like a turn.
- Every path the agent is told about goes through `sandbox.agent_path`: MCP server command and args, the schema file directory.
- Deleted: `DockerCommandExecutor`, `forward_env`, `_container_executor`, `mcp_workspace`, the `host_dir`/`cli_dir` split, the `in_container` argument and branches, the `AGENT_HOME` literal in the watchdog.
- `CodexRolloutWatchdogExecutor` wraps container sessions unconditionally and derives the rollout directory from `sandbox.env["HOME"]` plus the Codex profile's state dir.
- `CARGO_HOME` defaults to `/workspace/.cache/cargo` in Docker runs: `/opt/cargo` is read-only in the agent image, and the evaluator's trusted-runner build needs a writable registry cache. Found by the headless Docker round.
- Driver tests run the same scenarios against a host and a Docker sandbox double; mode-specific tests are gone. "Container execution" in `docs/contributing/agent-drivers.md` describes the one path.

- Second commit: `_container_mount_plan` returns `HostResource`s (access plus `agent_path`) instead of bind-mount triples; Docker, Modal and SkyPilot environments call `make_sandbox(resources=...)` on every backend, and `AgentPaths` (objective, runtime notes, evaluator package root) come from `sandbox.agent_path` instead of literals.

### Architecture

The driver never names a backend. The sandbox interface (`wrap`, `agent_path`, `env`) is the whole contract between VibeSys policy and where the agent runs.

## Verification

### Correctness properties

- The same driver code produces a bubblewrap-wrapped launch on the host and a `docker exec` launch in a container; only the sandbox differs.
- agentshim receives the environment the agent process really has (container HOME and PATH in a container).
- A resumed Codex turn inside a container that finishes but never exits is still rescued, with the rollout looked up under the agent's HOME.

### Testing

```
uv run ruff check src tests libs            # All checks passed
uv run ruff format --check src tests libs   # 398 files already formatted
scripts/check_types.sh                      # All checks passed
uv run lint-imports                         # Contracts: 2 kept, 0 broken
uv run python scripts/check_doc_links.py    # no broken links
uv run pytest tests libs -q -n auto         # 5778 passed, 24 skipped
```

Headless rounds, codex / gpt-5.6-sol on `queue-rs` task `spsc`, `--max-rounds 1`:
- `--local`: validation, accuracy, benchmark PASS (total_ops_per_sec 24572662), exit 0, no tracebacks.
- `--local --docker`: validation, accuracy, benchmark PASS (total_ops_per_sec 41917664), exit 0, no tracebacks, every workspace file owned by the running uid. The first attempt exposed the `CARGO_HOME` issue above.
- `--local --docker` again on the second commit: PASS (total_ops_per_sec 9333490), exit 0; the agent's first tool call read `/opt/vibesys-runtime/objective.md`, the path produced by the resource-based lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
