### PR TITLE
Fix the two failures the first real Modal round hit after the agent-image stack

### DIFF
--- a/src/vibesys/sandbox/images.py
+++ b/src/vibesys/sandbox/images.py
@@ -388,20 +388,25 @@ def push_agent_image(
 
     inspect_result = _run_registry_command(
         runner,
-        ("docker", "inspect", "--format", "{{index .RepoDigests 0}}", tag),
+        ("docker", "inspect", "--format", "{{json .RepoDigests}}", tag),
         cwd=cwd,
         timeout=timeout,
         action="inspecting",
     )
-    digest_reference = inspect_result.stdout.strip()
-    if inspect_result.returncode != 0 or not digest_reference:
+    if inspect_result.returncode != 0 or not inspect_result.stdout.strip():
         detail = (inspect_result.stderr or inspect_result.stdout or "no output").strip()
         raise ImagePushError(  # noqa: TRY003
             f"Pushed {tag} but Docker returned no repo digest for it: {detail[:_DIAGNOSTIC_LIMIT]}"
         )
-    if not digest_reference.startswith(f"{repository}@sha256:"):
+    # An image carries one repo digest per repository it has been pushed to
+    # or pulled from, and the build tag's own digest can come first under the
+    # containerd image store, so pick the entry for *repository* rather than
+    # the first one.
+    digest_reference = _repo_digest_for(inspect_result.stdout, repository)
+    if digest_reference is None:
         raise ImagePushError(  # noqa: TRY003
-            f"Docker returned an unexpected repo digest for {tag}: {digest_reference!r}"
+            f"Docker returned no repo digest for {tag} under {repository}: "
+            f"{inspect_result.stdout.strip()[:_DIAGNOSTIC_LIMIT]!r}"
         )
     return digest_reference
 
@@ -497,13 +502,21 @@ def _cached_repo_digest(
         return None
     if result.returncode != 0:
         return None
+    return _repo_digest_for(result.stdout, repository)
+
+
+def _repo_digest_for(repo_digests_json: str, repository: str) -> str | None:
+    """Pick the ``repository@sha256:...`` entry out of a ``RepoDigests`` JSON list.
+
+    Absent, malformed, or non-list output resolves to ``None``.
+    """
     try:
-        digests = json.loads(result.stdout.strip() or "null")
+        digests = json.loads(repo_digests_json.strip() or "null")
     except json.JSONDecodeError:
         return None
     if not isinstance(digests, list):
         return None
-    prefix = f"{repository}@"
+    prefix = f"{repository}@sha256:"
     return next(
         (entry for entry in digests if isinstance(entry, str) and entry.startswith(prefix)),
         None,

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -64,6 +64,7 @@ from vibesys.skypilot.config import load_cluster_profiles, resolve_profile
 from vibesys.skypilot.runner import SkyPilotJobRunner, stable_cluster_name
 from vs_project import RunEnvironmentRecord, RunResourceRequest
 from vs_sandbox import (
+    AGENT_HOME,
     BeforeReadyContext,
     HostResource,
     HostResourceAccess,
@@ -866,16 +867,18 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
         )
 
         # Mount host Modal auth so `modal run` inside the container
-        # authenticates as the host user.
+        # authenticates as the host user. The Modal SDK reads them from the
+        # HOME of the user the container runs as, the agent image's
+        # non-root ``agent`` user, not root.
         modal_auth = Path.home() / ".modal.toml"
         if modal_auth.exists():
             resources.append(
-                _resource_for_mount(str(modal_auth), "/root/.modal.toml", read_only=True)
+                _resource_for_mount(str(modal_auth), f"{AGENT_HOME}/.modal.toml", read_only=True)
             )
         modal_config_dir = Path.home() / ".modal"
         if modal_config_dir.is_dir():
             resources.append(
-                _resource_for_mount(str(modal_config_dir), "/root/.modal", read_only=True)
+                _resource_for_mount(str(modal_config_dir), f"{AGENT_HOME}/.modal", read_only=True)
             )
 
         resources = _dedupe_resources(resources)

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -64,7 +64,6 @@ from vibesys.skypilot.config import load_cluster_profiles, resolve_profile
 from vibesys.skypilot.runner import SkyPilotJobRunner, stable_cluster_name
 from vs_project import RunEnvironmentRecord, RunResourceRequest
 from vs_sandbox import (
-    AGENT_HOME,
     BeforeReadyContext,
     HostResource,
     HostResourceAccess,
@@ -869,7 +868,10 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
         # Mount host Modal auth so `modal run` inside the container
         # authenticates as the host user. The Modal SDK reads them from the
         # HOME of the user the container runs as, the agent image's
-        # non-root ``agent`` user, not root.
+        # non-root ``agent`` user, not root. Deferred: the Docker sandbox
+        # module imports the agent stack, which this module must not load.
+        from vs_sandbox import AGENT_HOME  # noqa: PLC0415  # tracked: #288
+
         modal_auth = Path.home() / ".modal.toml"
         if modal_auth.exists():
             resources.append(

--- a/tests/vibesys/sandbox/test_image_push.py
+++ b/tests/vibesys/sandbox/test_image_push.py
@@ -30,6 +30,10 @@ _IMAGE_ID = "sha256:" + "c" * 64
 _SHORT_ID = "c" * 12
 _TAG = f"{DEFAULT_AGENT_IMAGE_REGISTRY}:{_SHORT_ID}"
 _DIGEST = f"{DEFAULT_AGENT_IMAGE_REGISTRY}@sha256:" + "d" * 64
+# What `docker inspect --format {{json .RepoDigests}}` prints for an image
+# that was built under a local tag and then pushed: the build tag's own
+# digest comes first, the registry's second.
+_REPO_DIGESTS = f'["vibesys-agent-build@sha256:{"c" * 64}", "{_DIGEST}"]'
 
 
 class _FakeRegistryRunner:
@@ -41,7 +45,7 @@ class _FakeRegistryRunner:
         tag_returncode: int = 0,
         push_returncode: int = 0,
         push_stderr: str = "",
-        inspect_stdout: str = _DIGEST,
+        inspect_stdout: str = _REPO_DIGESTS,
         inspect_returncode: int = 0,
         manifest_returncode: int = 0,
         unverifiable_references: frozenset[str] = frozenset(),
@@ -94,7 +98,7 @@ class _FakeRegistryRunner:
             return subprocess.CompletedProcess(normalized, 0, stdout, "")
         if normalized[1] == "inspect":
             # The post-push digest resolution: `docker inspect --format
-            # {{index .RepoDigests 0}} <tag>`.
+            # {{json .RepoDigests}} <tag>`.
             return subprocess.CompletedProcess(
                 normalized, self.inspect_returncode, self.inspect_stdout, ""
             )
@@ -114,7 +118,7 @@ class TestPushAgentImage:
             "docker",
             "inspect",
             "--format",
-            "{{index .RepoDigests 0}}",
+            "{{json .RepoDigests}}",
             _TAG,
         )
 
@@ -127,7 +131,7 @@ class TestPushAgentImage:
         runner = _FakeRegistryRunner()
         repository = "ghcr.io/example/other-agent"
         digest = f"{repository}@sha256:" + "e" * 64
-        runner.inspect_stdout = digest
+        runner.inspect_stdout = f'["{digest}"]'
 
         reference = push_agent_image(_IMAGE_ID, repository=repository, command_runner=runner)
 
@@ -171,10 +175,16 @@ class TestPushAgentImage:
         with pytest.raises(ImagePushError, match="no repo digest"):
             push_agent_image(_IMAGE_ID, command_runner=runner)
 
-    def test_unexpected_repo_digest_raises(self) -> None:
-        runner = _FakeRegistryRunner(inspect_stdout="some-other-repo@sha256:" + "f" * 64)
-        with pytest.raises(ImagePushError, match="unexpected repo digest"):
+    def test_repo_digest_for_another_repository_is_not_accepted(self) -> None:
+        runner = _FakeRegistryRunner(inspect_stdout='["some-other-repo@sha256:' + "f" * 64 + '"]')
+        with pytest.raises(ImagePushError, match=r"no repo digest .* under"):
             push_agent_image(_IMAGE_ID, command_runner=runner)
+
+    def test_picks_the_target_repository_digest_not_the_first_entry(self) -> None:
+        # Under the containerd image store the local build tag's digest is
+        # listed before the registry's; the first entry is the wrong one.
+        runner = _FakeRegistryRunner(inspect_stdout=_REPO_DIGESTS)
+        assert push_agent_image(_IMAGE_ID, command_runner=runner) == _DIGEST
 
     def test_missing_docker_binary_raises(self) -> None:
         runner = _FakeRegistryRunner(raise_on={"tag": FileNotFoundError()})

--- a/tests/vibesys/sandbox/test_run_environment.py
+++ b/tests/vibesys/sandbox/test_run_environment.py
@@ -1410,6 +1410,28 @@ def test_modal_environment_installs_nothing_at_container_start(tmp_path):  # noq
     assert backend.calls[0][1]["extra_env"]["UV_CACHE_DIR"] == "/workspace/.cache/uv"
 
 
+def test_modal_environment_mounts_modal_auth_under_the_agent_home(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    """The Modal SDK inside the editor container reads its token from the
+    HOME of the ``agent`` user the image runs as, so the host's
+    ``~/.modal.toml`` must land there, not under ``/root``. The first real
+    Modal round after #675 failed its accuracy gate with "Token missing"
+    because the mount still targeted root's HOME."""
+    backend = FakeBackend()
+    env = build_run_environment(RunEnvironmentSpec("modal"))
+    home = tmp_path / "synthetic-home"
+    home.mkdir()
+    (home / ".modal.toml").write_text("[profile]\ntoken_id = 'synthetic'\n")
+    (home / ".modal").mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+
+    env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
+
+    mounts = _as_mount_tuples(backend.calls[0][1]["resources"])
+    assert (str(home / ".modal.toml"), "/home/agent/.modal.toml", True) in mounts
+    assert (str(home / ".modal"), "/home/agent/.modal", True) in mounts
+    assert not any(container.startswith("/root/") for _host, container, _ro in mounts)
+
+
 def test_modal_environment_prompt_references_runtime_document(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Prompts name the runtime manual instead of embedding it in every role."""
     backend = FakeBackend()


### PR DESCRIPTION
## Problem

The first real headless Modal round after the #674 stack (#680 to #684) failed twice before the agent could do any work, in code the stack had verified only with unit tests:

1. `push_agent_image` read the first `RepoDigests` entry after `docker push`. Under the containerd image store the local build tag's digest is listed before the registry's, so a successful push to GHCR was reported as "unexpected repo digest" and the run aborted.
2. The Modal editor container mounted the host's `~/.modal.toml` and `~/.modal` at `/root`. Since #675 the container runs as the non-root `agent` user with HOME `/home/agent`, so `modal run` and the Modal evaluator inside the container reported "Token missing" and the accuracy gate failed.

## Solution

- After the push, inspect `{{json .RepoDigests}}` and select the entry for the repository that was pushed to. The selection is shared with the cached-digest fast path in `ensure_pushed`, which already did this correctly.
- Mount the Modal auth files under `AGENT_HOME` instead of `/root`.

### Architecture

No boundary changes. Both fixes keep the resource-list and digest-by-content design; they correct two literals that assumed root and a single-repository image.

## Verification

### Correctness properties

- A pushed agent image resolves to `ghcr.io/uw-syfi/vibesys-agent@sha256:...` regardless of which other repositories the local image store lists first.
- A digest for a different repository is still rejected.
- The Modal editor container sees the host's Modal token at the HOME of the user it runs as, and nothing is mounted under `/root`.

### Testing

```
uv run ruff check src tests libs            # All checks passed
uv run ruff format --check src tests libs   # already formatted
scripts/check_types.sh                      # All checks passed
uv run lint-imports                         # Contracts: 2 kept, 0 broken
uv run pytest tests/vibesys/sandbox -q -n auto   # 207 passed
```

Headless Modal rounds, codex / gpt-5.6-sol on `queue-rs` task `spsc`, `--max-rounds 1`, with a GHCR login on the host:
- Before the first fix: aborted at `ImagePushError` although the registry held the digest.
- After the first fix: image pushed and verified, editor container started from the resource list (the agent's first tool call read `/opt/vibesys-runtime/objective.md`), validation PASS, accuracy FAIL with "Token missing".
- After both fixes: image verified in GHCR without a new push, validation PASS, accuracy PASS through the Modal evaluator, benchmark PASS (total_ops_per_sec 10967868), exit 0, no "Token missing" and no framework traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
