### PR TITLE
ci: narrow python change-filter and gate queue-native by evaluator paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
       tui: ${{ steps.filter.outputs.tui }}
       examples: ${{ steps.filter.outputs.examples }}
       agent_image: ${{ steps.filter.outputs.agent_image }}
+      evaluators: ${{ steps.filter.outputs.evaluators }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,12 +52,25 @@ jobs:
         id: filter
         with:
           filters: |
-            # Ruff and ty never read clients/, so a change confined to the
-            # TypeScript workspace cannot change their verdict. Everything else
-            # (including this workflow) does.
+            # What `python-checks` actually reads: `ruff`/`lint-imports`'s
+            # source roots (`[tool.ruff] src` in pyproject.toml), the dirs
+            # `check_format.sh` also formats, and dependency/lint config.
+            # Deliberately coarse rather than chasing every edge case (e.g.
+            # `check_doc_links.py` also covers Markdown under `clients/`): the
+            # job is cheap, so an occasional unnecessary run costs less than
+            # the upkeep of a fully precise filter.
             python:
-              - '**'
-              - '!clients/**'
+              - 'src/**'
+              - 'tests/**'
+              - 'libs/**'
+              - 'sdk/**'
+              - 'scripts/**'
+              - 'examples/**'
+              - 'resources/**'
+              - '*.py'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/test.yml'
             # Mirrors the rebuild watch set the repository launcher uses in
             # src/entrypoints/launcher.py: the TUI is affected by the TypeScript
             # workspace itself and by the Python modules that feed the
@@ -97,6 +111,17 @@ jobs:
               - 'src/vibesys/sandbox/images/**'
               - 'src/vibesys/sandbox/images.py'
               - 'src/vibesys/agents/provider_policy.py'
+              - '.github/workflows/test.yml'
+            # What `queue-native` builds and tests: the queue evaluator and its
+            # native runner, the queue and priority-queue reference
+            # candidates, the evaluator SDK, and the microservice evaluator.
+            evaluators:
+              - 'resources/evaluators/queue/**'
+              - 'resources/evaluators/microservice/**'
+              - 'examples/data-structures/repositories/queue-rs/**'
+              - 'examples/evaluators/priority-queue/**'
+              - 'examples/starters/priority-queue-rs/**'
+              - 'sdk/vs-evaluator/vseval/**'
               - '.github/workflows/test.yml'
 
   # One environment setup for every cheap Python check. Issue #89 split these
@@ -264,6 +289,8 @@ jobs:
           bun "$deploy_dir/dist/self-test.js"
 
   queue-native:
+    needs: changes
+    if: needs.changes.outputs.evaluators == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Problem

[PR #646](https://github.com/uw-syfi/vibesys/pull/646) touched only
`clients/tui/**` and one file under `docs/`, but triggered nearly every job
in `test.yml` plus the full `publish.yml` wheel matrix. Investigating showed
two independent causes in `.github/workflows/test.yml`'s `changes` job:

1. The `python` filter was defined as `'**' minus '!clients/**'`, so *any*
   non-`clients/` file change trips `python-checks` — including a pure docs
   addition, even though nothing that job runs (`ruff`, `lint-imports`, the
   doc-link checker) depends on most of the tree.
2. `queue-native` (the Go/Rust evaluator build+test job) had no filter at
   all — it ran unconditionally on every PR, unlike the other expensive jobs
   (`agent-image`, `validate-examples`) which are already gated by the
   `changes` job.

Neither is a correctness bug in what each job checks; both are unnecessary
CI cost on PRs that can't affect their verdict.

## Solution

- Narrow `python` to the paths those checks actually read: `[tool.ruff] src`
  in `pyproject.toml` (`src/`, `tests/`, `libs/`, `sdk/`), the dirs
  `check_format.sh` also formats (`examples/`, `resources/`, on top of the
  above), `scripts/`, root `*.py`, and the lint/dependency config files.
  Deliberately coarse rather than chasing every edge case (e.g.
  `check_doc_links.py` also covers Markdown under `clients/`) — the job is
  cheap, so an occasional unnecessary run costs less than the upkeep of a
  fully precise filter.
- Add a new `evaluators` filter output covering what `queue-native` builds
  and tests (`resources/evaluators/queue/**`, `resources/evaluators/microservice/**`,
  the queue/priority-queue reference candidates under `examples/`, and
  `sdk/vs-evaluator/vseval/**`), and gate `queue-native` on it the same way
  `agent-image` and `validate-examples` are already gated.

### Architecture

No architecture change — this only edits `changes` job filter definitions
and adds `needs`/`if` gating to one existing job in `test.yml`. No job's
internal steps changed.

## Verification

This is CI-configuration-only; there's no application code path to unit
test. Verified the YAML is well-formed and re-derived each new filter
pattern from the actual commands each gated job runs (`check_format.sh`,
`check_lint.sh`, `lint-imports` config in `pyproject.toml`, and the
`queue-native` job's own working directories), rather than guessing.

### Correctness properties

- A change to any path now covered by `python`/`evaluators` still triggers
  the corresponding job (no under-triggering introduced).
- `python-checks`, `queue-native`, `tui`, `agent-image`, and
  `validate-examples` remain independently gated; none of their internal
  steps changed.
- Editing `.github/workflows/test.yml` itself still trips every filter, so a
  future filter change can't silently stop being exercised by CI on itself.

### Testing

```bash
uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"
```
Confirms the workflow YAML parses. Because both `python` and `evaluators`
list `.github/workflows/test.yml` itself, this PR trips every filter and
runs the full matrix — by design, so a filter change is always exercised by
CI on itself. The narrowing only shows up on a *subsequent* PR: e.g.
re-running #646's diff (TUI + docs only, no workflow edit) against this
change should now skip `python-checks` and `queue-native`, which I'll spot
check once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
