### PR TITLE
feat(tui): resize the Agents pane by columns with < > and =

### DIFF
--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -79,6 +79,7 @@ import {
   setChatThreadPending,
   setDesignLog,
   setExperiments,
+  setGraphWidthOverride,
   setPaneContent,
   setTheme,
   showDetail,
@@ -126,6 +127,8 @@ export interface SessionController {
   focusRound(focus: RoundFocus): void;
   selectNextTodo(delta: number): void;
   toggleTodos(): void;
+  /** `<`/`>`: the Agents pane's explicit column width, already clamped; `=`: null. */
+  setGraphWidthOverride(width: number | null): void;
   /** Expands the latest prompt in view; the view owns what "latest" means. */
   togglePrompt(): void;
   onTogglePrompt(handler: () => void): void;
@@ -428,6 +431,10 @@ export class SocketSessionController implements SessionController {
 
   toggleTodos(): void {
     this.#setState(toggleTodos(this.#state));
+  }
+
+  setGraphWidthOverride(width: number | null): void {
+    this.#setState(setGraphWidthOverride(this.#state, width));
   }
 
   setTheme(themeName: ThemeName): void {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -66,6 +66,17 @@ export interface SessionState {
   /** Non-null while the composer's inline command menu is open. */
   chatMenu: ChatMenu | null;
   todosExpanded: boolean;
+  /**
+   * Explicit column width for the Agents pane, set and stepped by `<`/`>` and
+   * cleared by `=`. `null` means automatic: `agent-map.ts#agentPaneWidth`
+   * decides, exactly as it always has, including its no-truncation floor and
+   * the stacked-list fallback on a narrow terminal. Once set it is sticky, so
+   * the pane stops following the terminal and stops growing with longer agent
+   * names until `=` hands it back; an explicit width that drifted would not be
+   * one, and `=` is what keeps that from being a trap. Session-only view state:
+   * it carries no `agent.toml` key and does not persist past this process.
+   */
+  graphWidthOverride: number | null;
   themeName: ThemeName;
   experimentLog: ExperimentLogState | null;
   /**
@@ -310,6 +321,7 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     chatPendingThreads: {},
     chatMenu: null,
     todosExpanded: false,
+    graphWidthOverride: null,
     themeName,
     // The experiment log is the landing view: a run's history reads as a short
     // list of claims before it reads as a long list of rounds.
@@ -1931,6 +1943,16 @@ export function visiblePhases(state: SessionState): AgentPhase[] {
 
 export function toggleTodos(state: SessionState): SessionState {
   return {...state, todosExpanded: !state.todosExpanded};
+}
+
+/**
+ * `<`/`>`: sets the Agents pane's explicit column width. `=`: clears it back
+ * to automatic (`null`). The value handed in is already clamped by the caller
+ * (`agent-map.ts#clampGraphWidthOverride`), which needs the terminal width and
+ * the visible phases to do that; this reducer only applies it.
+ */
+export function setGraphWidthOverride(state: SessionState, width: number | null): SessionState {
+  return state.graphWidthOverride === width ? state : {...state, graphWidthOverride: width};
 }
 
 /**

--- a/clients/tui/src/ui/agent-graph.test.ts
+++ b/clients/tui/src/ui/agent-graph.test.ts
@@ -112,6 +112,44 @@ describe('layoutAgentGraph', () => {
     expect(narrow.nodes[0]?.width).toBeGreaterThanOrEqual(14);
   });
 
+  test('a two-source fan-in still draws both edges, correctly routed, below the full-name floor', () => {
+    // Two implementer attempts (an interrupted one and the one that replaced
+    // it) both feed the single judge: in-degree 2 at the judge node, the case
+    // the graph/transcript-split resize has to keep drawable, however narrow
+    // an explicit override makes the pane. `graphPaneBounds` with no
+    // `labelWidth` (the default) gives the geometric floor: every column at
+    // its own 14-column minimum plus one gutter per gap, ignoring names.
+    const fanIn = [
+      phase('orchestrator', 'completed'),
+      phase('implementer', 'interrupted'),
+      phase('implementer', 'active'),
+      phase('judge', 'pending'),
+    ];
+    const graph = layoutAgentGraph(fanIn, graphPaneBounds(fanIn).min - 4);
+
+    expect(graph.nodes).toHaveLength(4);
+    const implementers = graph.nodes.filter(node => node.phase.kind === 'implementer');
+    expect(implementers).toHaveLength(2);
+    for (const node of graph.nodes) expect(node.width).toBeGreaterThanOrEqual(14);
+    // One arrow head at the judge: both attempts feed it, and a fed node gets
+    // one head regardless of how many sources reach it (also true of the
+    // orchestrator -> two-implementer edge, one head each since both
+    // implementers are themselves fed).
+    expect(graph.cells.filter(cell => cell.glyph === '▶')).toHaveLength(3);
+    // Edges still route through the gutter, never on top of a node, even
+    // though columns are not all the same width at this narrow a pane.
+    for (const cell of graph.cells) {
+      const onANode = graph.nodes.some(
+        node =>
+          cell.x >= node.x &&
+          cell.x < node.x + node.width &&
+          cell.y >= node.y &&
+          cell.y < node.y + NODE_HEIGHT,
+      );
+      expect(onANode).toBe(false);
+    }
+  });
+
   test('gives a long name the columns a short one does not need', () => {
     // 56 columns split evenly are three nodes of 15, one short of `✓ orchestrator`,
     // while `judge` leaves six of its own unused.

--- a/clients/tui/src/ui/agent-map.test.ts
+++ b/clients/tui/src/ui/agent-map.test.ts
@@ -3,7 +3,20 @@ import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing'
 import type {AgentPhase} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import {initialSessionState, type SessionState} from '../session-model.js';
-import {AgentMapView, agentPaneWidth, STACKED_WIDTH, TRANSCRIPT_MIN} from './agent-map.js';
+import {
+  AgentMapView,
+  agentGraphMinWidth,
+  agentPaneCeiling,
+  agentPaneFloor,
+  agentPaneWidth,
+  agentPaneWidthWithOverride,
+  agentsPaneVisible,
+  clampGraphWidthOverride,
+  graphFits,
+  STACKED_WIDTH,
+  TRANSCRIPT_MIN,
+} from './agent-map.js';
+import {MIN_SPLIT_WIDTH} from './right-pane.js';
 import {resolveTheme} from './theme.js';
 
 /** A round with one agent per kind, in order. */
@@ -51,6 +64,157 @@ describe('agentPaneWidth', () => {
         expect(terminalWidth - paneWidth).toBeGreaterThanOrEqual(TRANSCRIPT_MIN);
       }
     }
+  });
+});
+
+/**
+ * The geometric bounds an explicit `<`/`>` override is clamped between.
+ * Unlike `agentPaneWidth`'s own floor, these ignore whether a name fits: the
+ * low bound is a node box plus its edge column with no label at all, and the
+ * high bound is automatic sizing's own ceiling.
+ */
+describe('agentGraphMinWidth and agentPaneCeiling', () => {
+  test('the geometric minimum is every column at its 14-column floor plus one gutter per gap', () => {
+    // Three stages: 3*14 + 2 gutters(5) + PANE_CHROME(4) = 42 + 10 + 4 = 56.
+    expect(agentGraphMinWidth(THREE)).toBe(56);
+    // Four stages: 4*14 + 3*5 + 4 = 56 + 15 + 4 = 75.
+    expect(agentGraphMinWidth(FOUR)).toBe(75);
+    // Strictly below every name's own floor: there is room left to truncate.
+    expect(agentGraphMinWidth(THREE)).toBeLessThan(agentPaneFloor(THREE));
+    expect(agentGraphMinWidth(FOUR)).toBeLessThan(agentPaneFloor(FOUR));
+  });
+
+  test('the ceiling matches what agentPaneWidth already never grows past', () => {
+    // 250 columns is far past what three stages can use; agentPaneWidth's own
+    // test above pins that at 68.
+    expect(agentPaneCeiling(THREE)).toBe(68);
+    expect(agentPaneWidth(250, THREE)).toBe(agentPaneCeiling(THREE));
+  });
+
+  test("the geometric minimum keeps agentPaneFloor's STACKED_WIDTH floor", () => {
+    // One stage asks for 14 + PANE_CHROME(4) = 18 columns of geometry, and a
+    // round the run has not reached asks for the same. An override is a licence
+    // to cut agent names, not the round heading's elapsed tail or the
+    // empty-round placeholder, both of which wrap under 30 and cost a row.
+    expect(agentGraphMinWidth(round('orchestrator'))).toBe(STACKED_WIDTH);
+    expect(agentGraphMinWidth([])).toBe(STACKED_WIDTH);
+    // The floor is `agentPaneFloor`'s own, so the two agree wherever geometry
+    // does not already clear it.
+    for (const phases of [[], round('orchestrator'), THREE, FOUR]) {
+      expect(agentGraphMinWidth(phases)).toBeGreaterThanOrEqual(STACKED_WIDTH);
+      expect(agentGraphMinWidth(phases)).toBeLessThanOrEqual(agentPaneFloor(phases));
+    }
+  });
+});
+
+/**
+ * The precondition on the `<`/`>` keys: below it the pane is the stacked list
+ * whatever the override says, so a press has to store nothing rather than a
+ * width this terminal cannot draw.
+ */
+describe('graphFits', () => {
+  test('is the terminal holding the narrowest graph beside a readable transcript', () => {
+    // 56 + 42 = 98 for three stages.
+    expect(graphFits(97, THREE)).toBe(false);
+    expect(graphFits(98, THREE)).toBe(true);
+    expect(graphFits(90, THREE)).toBe(false);
+  });
+
+  test('agrees with agentPaneWidthWithOverride giving up on an override', () => {
+    for (let width = 60; width <= 140; width += 1) {
+      expect(agentPaneWidthWithOverride(width, THREE, 60) === null).toBe(!graphFits(width, THREE));
+    }
+  });
+});
+
+describe('clampGraphWidthOverride', () => {
+  test('holds the override between the geometric minimum and the ceiling, on a wide terminal', () => {
+    const width = 200; // room = 158, wider than THREE's 68-column ceiling.
+    expect(clampGraphWidthOverride(-1000, width, THREE)).toBe(agentGraphMinWidth(THREE));
+    expect(clampGraphWidthOverride(1000, width, THREE)).toBe(agentPaneCeiling(THREE));
+    // Inside the range, the request passes through unchanged.
+    expect(clampGraphWidthOverride(60, width, THREE)).toBe(60);
+  });
+
+  test('never asks the transcript for less than TRANSCRIPT_MIN, even when the ceiling would allow it', () => {
+    const width = 100; // room = 58, short of THREE's 68-column ceiling.
+    expect(clampGraphWidthOverride(1000, width, THREE)).toBe(width - TRANSCRIPT_MIN);
+  });
+});
+
+describe('agentPaneWidthWithOverride', () => {
+  test('with no override, matches automatic sizing exactly', () => {
+    for (const width of [80, 100, 105, 150, 160, 250]) {
+      expect(agentPaneWidthWithOverride(width, THREE, null)).toBe(agentPaneWidth(width, THREE));
+    }
+  });
+
+  test('an explicit override can draw a truncating graph where automatic sizing already gives up', () => {
+    const width = 100; // room = 58: under THREE's 63-column floor (automatic
+    // gives up to the stacked list), but over its 56-column geometric minimum.
+    expect(agentPaneWidth(width, THREE)).toBeNull();
+    const overridden = agentPaneWidthWithOverride(width, THREE, 1000);
+    expect(overridden).not.toBeNull();
+    expect(overridden as number).toBeLessThan(agentPaneFloor(THREE));
+  });
+
+  test('still falls back to the stacked list once not even the geometric minimum fits', () => {
+    const width = 90; // room = 48, under THREE's 56-column geometric minimum.
+    expect(agentPaneWidth(width, THREE)).toBeNull();
+    expect(agentPaneWidthWithOverride(width, THREE, 1000)).toBeNull();
+    expect(agentPaneWidthWithOverride(width, THREE, agentGraphMinWidth(THREE))).toBeNull();
+  });
+});
+
+/**
+ * The `<`/`>` keys must no-op wherever this is false, so it has to agree with
+ * `app.ts`'s own decision about whether the Agents pane holds the content row.
+ */
+describe('agentsPaneVisible', () => {
+  function baseState(): SessionState {
+    return {...initialSessionState(), experimentLog: null};
+  }
+
+  test('is visible for the plain round view', () => {
+    expect(agentsPaneVisible(baseState(), 120)).toBe(true);
+  });
+
+  test('is false while the experiment log is the landing view', () => {
+    // initialSessionState() starts on the experiment log, same as the real app.
+    expect(agentsPaneVisible(initialSessionState(), 120)).toBe(false);
+  });
+
+  test('is false when zoomed to a different pane', () => {
+    const state = baseState();
+    const zoomed = {...state, layout: {...state.layout, zoomedPane: 'transcript' as const}};
+    expect(agentsPaneVisible(zoomed, 120)).toBe(false);
+  });
+
+  test('is true when zoomed to the agents pane itself, even at a narrow width', () => {
+    const state = baseState();
+    const zoomed = {...state, layout: {...state.layout, zoomedPane: 'agents' as const}};
+    expect(agentsPaneVisible(zoomed, 50)).toBe(true);
+  });
+
+  test('is false once a visualization split has room to open beside it', () => {
+    const state = baseState();
+    const withPane = {
+      ...state,
+      layout: {
+        ...state.layout,
+        right: {
+          view: 'perf' as const,
+          title: 'Performance',
+          content: '',
+          pending: false,
+          error: null,
+        },
+      },
+    };
+    expect(agentsPaneVisible(withPane, MIN_SPLIT_WIDTH)).toBe(false);
+    // Below the split's own floor the visualization falls back to the modal it
+    // always was, so the agents pane keeps the row instead.
+    expect(agentsPaneVisible(withPane, MIN_SPLIT_WIDTH - 1)).toBe(true);
   });
 });
 
@@ -181,5 +345,153 @@ describe('agent graph row budget', () => {
     expect(frame).toContain('● implementer');
     expect(frame).toContain('○ judge');
     expect(frame).not.toContain('…');
+  });
+});
+
+/**
+ * The one behavior change this feature makes to what the pane can ever draw:
+ * an explicit override may render a graph narrower than every name, and only
+ * then. Automatic sizing (`graphWidthOverride: null`) never does, at any
+ * width: `agentPaneWidth`'s own floor already guarantees that, unchanged.
+ */
+describe('truncation under an explicit override', () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const destroy of cleanup.splice(0).reverse()) destroy();
+  });
+
+  function roundState(graphWidthOverride: number | null): SessionState {
+    const base = initialSessionState();
+    return {
+      ...base,
+      experimentLog: null,
+      selectedRound: 1,
+      graphWidthOverride,
+      core: {...base.core, rounds: [{number: 1, status: 'active'}], phases: THREE},
+    };
+  }
+
+  async function renderAt(
+    width: number,
+    graphWidthOverride: number | null,
+  ): Promise<{frame: string; paneWidth: number}> {
+    const testRenderer: TestRendererSetup = await createTestRenderer({width, height: 20});
+    const view = new AgentMapView(
+      testRenderer.renderer,
+      {} as unknown as SessionController,
+      resolveTheme(null),
+    );
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.destroy();
+      view.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    });
+    view.render(roundState(graphWidthOverride), undefined, 20);
+    await testRenderer.renderOnce();
+    return {frame: testRenderer.captureCharFrame(), paneWidth: view.output.width as number};
+  }
+
+  test('truncates under a narrow explicit override, and never under automatic sizing at the same width', async () => {
+    const width = 200;
+
+    const automatic = await renderAt(width, null);
+    expect(automatic.paneWidth).toBe(agentPaneWidth(width, THREE) as number);
+    expect(automatic.frame).not.toContain('…');
+
+    // -1000 clamps to the geometric minimum: every column pinned at its
+    // 14-column floor, the narrowest a graph can draw.
+    const overridden = await renderAt(width, -1000);
+    expect(overridden.paneWidth).toBe(agentGraphMinWidth(THREE));
+    expect(overridden.frame).toContain('…');
+    // Still a graph, not the stacked list: boxes and edges, just narrower.
+    expect(overridden.paneWidth).not.toBe(STACKED_WIDTH);
+    expect(overridden.frame).toContain('▶');
+    // `judge` is short enough to survive even the geometric minimum whole.
+    expect(overridden.frame).toContain('judge');
+  });
+
+  test('the same state re-clamps a stale override if the terminal has since narrowed', async () => {
+    // An override wide enough at 200 columns is past the ceiling `>` would
+    // ever have let it reach at 100: the render clamps again rather than
+    // trusting a number that predates the resize.
+    const {paneWidth} = await renderAt(100, 68);
+    expect(paneWidth).toBe(clampGraphWidthOverride(68, 100, THREE));
+    expect(paneWidth).toBeLessThan(68);
+  });
+});
+
+/**
+ * The case the design change was for: a stage with more than one agent
+ * feeding the next stage's single node (in-degree 2 there). The stacked list
+ * cannot represent that at all (`↓` is one line to one line); the graph can,
+ * narrowed or not, because `layoutAgentGraph` was never coupled to
+ * `agentPaneWidth`'s no-truncation floor in the first place.
+ */
+describe('fan-in at a narrowed, overridden width', () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const destroy of cleanup.splice(0).reverse()) destroy();
+  });
+
+  test('two attempts feeding one judge still draw as two boxes and two edges, not a lossy stack', async () => {
+    const phases: AgentPhase[] = [
+      {kind: 'orchestrator', status: 'completed', roundNumber: 1, roundLabel: 'round-1'},
+      {
+        kind: 'implementer',
+        status: 'interrupted',
+        roundNumber: 1,
+        roundLabel: 'round-1-retry-1-implementer',
+        executionId: 'e0',
+      },
+      {
+        kind: 'implementer',
+        status: 'active',
+        roundNumber: 1,
+        roundLabel: 'round-1-retry-2-implementer',
+        executionId: 'e1',
+      },
+      {kind: 'judge', status: 'pending', roundNumber: 1, roundLabel: null},
+    ];
+    const base = initialSessionState();
+    const state: SessionState = {
+      ...base,
+      experimentLog: null,
+      selectedRound: 1,
+      // The narrowest a graph can draw at all: stacking a second agent inside
+      // the implementer column changes its height, not its width, so this is
+      // the same 56 columns as the three-stage chain above.
+      graphWidthOverride: agentGraphMinWidth(phases),
+      core: {...base.core, rounds: [{number: 1, status: 'active'}], phases},
+    };
+
+    const testRenderer: TestRendererSetup = await createTestRenderer({width: 200, height: 20});
+    const view = new AgentMapView(
+      testRenderer.renderer,
+      {} as unknown as SessionController,
+      resolveTheme(null),
+    );
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.destroy();
+      view.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    });
+    view.render(state, undefined, 20);
+    await testRenderer.renderOnce();
+    const frame = testRenderer.captureCharFrame();
+
+    expect(view.output.width).toBe(agentGraphMinWidth(phases));
+    // Two separate implementer boxes: NODE_HEIGHT (5) + the 2-row gap between
+    // stacked agents puts the second one 7 rows under the first.
+    expect(testRenderer.renderer.root.findDescendantById('agent-implementer-0')).toBeDefined();
+    expect(testRenderer.renderer.root.findDescendantById('agent-implementer-7')).toBeDefined();
+    // Both attempts still reach the judge: one arrow head per fed node,
+    // regardless of how many sources feed it (`agent-graph.test.ts` pins the
+    // routing itself; this just confirms the wiring reaches it at this width).
+    expect(frame).toContain('▶');
+    expect(frame).toContain('judge');
   });
 });

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -8,6 +8,7 @@ import {
 import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
 import {
+  experimentLogVisible,
   focusedPane,
   scopedRounds,
   stripRounds,
@@ -26,6 +27,7 @@ import {agentRuntimeLabel} from './agent-runtime-label.js';
 import {fillLayer} from './box-fill.js';
 import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {elapsedLabel} from './previews.js';
+import {splitFits} from './right-pane.js';
 import type {Theme} from './theme.js';
 
 const STATUS_MARKER: Record<AgentPhase['status'], string> = {
@@ -47,6 +49,16 @@ const HEADING_ROWS = 1;
 export const TRANSCRIPT_MIN = 42;
 /** Share of the terminal the graph takes when there is room for it. */
 const GRAPH_SHARE = 0.4;
+/**
+ * Columns `<`/`>` move the Agents pane by on each press. 2 rather than 1: a
+ * node's width ranges from the 14-column floor to roughly 90 for a wide
+ * multi-stage round, and at 1 column a press would rarely change which
+ * characters of a name are visible, only pad or shave whitespace no label
+ * uses. 2 halves the number of presses to cross that range while still
+ * landing on most of the widths where a label's next character appears or
+ * disappears.
+ */
+export const GRAPH_WIDTH_STEP = 2;
 
 function statusColor(theme: Theme, status: AgentPhase['status']): string {
   if (status === 'active') return theme.success;
@@ -85,21 +97,132 @@ function selectedLabelWidth(phase: AgentPhase): number {
 }
 
 /**
+ * The width at which every agent is already named in full: `graphPaneBounds`'s
+ * floor, using the selected-label width every node is sized for. Never
+ * narrower than the pane used to be: a one-stage round needs less room than
+ * the heading above it, and a wrapped heading reads worse than slack. Below
+ * this width a label starts losing characters to `…`.
+ */
+export function agentPaneFloor(phases: AgentPhase[]): number {
+  return Math.max(graphPaneBounds(phases, selectedLabelWidth).min, STACKED_WIDTH);
+}
+
+/**
+ * The width past which more columns stop being information: `graphPaneBounds`'s
+ * own `max`, the point its docstring already names as "extra columns add
+ * padding rather than information." Automatic sizing (`agentPaneWidth`) never
+ * grows past this either, so it is the natural ceiling for an explicit
+ * `<`/`>` override too (`clampGraphWidthOverride`): `>` stops here rather than
+ * padding, and never asks for less than automatic sizing would already give on
+ * the same terminal.
+ */
+export function agentPaneCeiling(phases: AgentPhase[]): number {
+  return Math.max(graphPaneBounds(phases, selectedLabelWidth).max, STACKED_WIDTH);
+}
+
+/**
+ * The narrowest pane an explicit `<`/`>` override may ask for: the wider of two
+ * floors, so this is not in general the narrowest a graph can be laid out in.
+ *
+ * The geometric floor is that width: every stage column at its own 14-column
+ * minimum (`NODE_WIDTH_MIN` in `agent-graph.ts`) plus one gutter of
+ * edge-routing room between each pair of columns, ignoring names entirely
+ * (`graphPaneBounds` with no `labelWidth` gives exactly this). Under it
+ * `fitNodeWidths` still refuses to shrink a column past its own minimum, so the
+ * columns plus gutters would add up to more than the pane was given and
+ * overflow its border instead of fitting inside it.
+ *
+ * `STACKED_WIDTH` is the other floor, carried for the same reason
+ * `agentPaneFloor` carries it: what an override buys is truncated agent names,
+ * and nothing else in the pane. Geometry alone asks for 18 columns at one stage
+ * and at a round that has not run, narrow enough to drop the heading's elapsed
+ * tail and wrap the empty-round placeholder onto a second row, which costs a
+ * graph row rather than revealing anything. From two stages up the geometric
+ * floor is the wider of the two and this one never binds.
+ */
+export function agentGraphMinWidth(phases: AgentPhase[]): number {
+  return Math.max(graphPaneBounds(phases).min, STACKED_WIDTH);
+}
+
+/**
+ * True while the terminal can carry a graph at all: even the narrowest one
+ * needs `TRANSCRIPT_MIN` columns left over for the transcript beside it. When
+ * this is false the stacked list is the pane, no override can change that, and
+ * `<`/`>` therefore store nothing rather than leaving behind a width this
+ * terminal was never allowed to draw.
+ */
+export function graphFits(terminalWidth: number, phases: AgentPhase[]): boolean {
+  return terminalWidth - TRANSCRIPT_MIN >= agentGraphMinWidth(phases);
+}
+
+/**
  * Width for the Agents pane, or null when the terminal cannot carry a graph
  * that names every agent in full beside a readable transcript; the stacked list
  * takes over then. Derived from the terminal rather than fixed, so a wide
  * terminal gives the graph room while the transcript keeps its floor.
  */
 export function agentPaneWidth(terminalWidth: number, phases: AgentPhase[]): number | null {
-  const bounds = graphPaneBounds(phases, selectedLabelWidth);
-  // Never narrower than the pane used to be: a one-stage round needs less room
-  // than the heading above it, and a wrapped heading reads worse than slack.
-  const floor = Math.max(bounds.min, STACKED_WIDTH);
-  const ceiling = Math.max(bounds.max, STACKED_WIDTH);
+  const floor = agentPaneFloor(phases);
+  const ceiling = agentPaneCeiling(phases);
   const room = terminalWidth - TRANSCRIPT_MIN;
   if (room < floor) return null;
   const share = Math.round(terminalWidth * GRAPH_SHARE);
   return Math.min(ceiling, room, Math.max(floor, share));
+}
+
+/**
+ * Clamps a requested `<`/`>` override to a range that can actually be drawn:
+ * never narrower than `agentGraphMinWidth` (a node box plus its edge column),
+ * never wider than `agentPaneCeiling` (automatic sizing's own ceiling, past
+ * which more width is padding, not information), and never so wide the
+ * transcript would drop under `TRANSCRIPT_MIN`. The low and high bounds can
+ * invert on a terminal too narrow to hold even the low bound beside a
+ * readable transcript; the high bound then collapses to the low one rather
+ * than under it, and it is `agentPaneWidthWithOverride`'s job to notice the
+ * terminal cannot draw a graph at all in that case and fall back to the
+ * stacked list.
+ */
+export function clampGraphWidthOverride(
+  requested: number,
+  terminalWidth: number,
+  phases: AgentPhase[],
+): number {
+  const low = agentGraphMinWidth(phases);
+  const high = Math.max(low, Math.min(agentPaneCeiling(phases), terminalWidth - TRANSCRIPT_MIN));
+  return Math.min(high, Math.max(low, requested));
+}
+
+/**
+ * The Agents pane's width honoring an explicit `<`/`>` override, or `null`
+ * for #686's automatic sizing (`agentPaneWidth`) when there is none. `null`
+ * also covers the terminal being too narrow to draw a graph at all (not even
+ * `agentGraphMinWidth` fits beside a readable transcript), in which case an
+ * override cannot rescue it either, and the stacked list takes over exactly
+ * as it does automatically.
+ */
+export function agentPaneWidthWithOverride(
+  terminalWidth: number,
+  phases: AgentPhase[],
+  override: number | null,
+): number | null {
+  if (override === null) return agentPaneWidth(terminalWidth, phases);
+  if (!graphFits(terminalWidth, phases)) return null;
+  return clampGraphWidthOverride(override, terminalWidth, phases);
+}
+
+/**
+ * True while the Agents pane holds a slot in the content row: not eclipsed by
+ * the experiment log, not zoomed to a different pane, and not squeezed out by
+ * a visualization split that has room to open beside it. `app.ts`'s own
+ * `showAgents` and the `<`/`>` resize keys both read this, so a layout change
+ * cannot leave the render and the keybinding guard disagreeing about whether
+ * there is a pane on screen to resize.
+ */
+export function agentsPaneVisible(state: SessionState, terminalWidth: number): boolean {
+  if (experimentLogVisible(state)) return false;
+  const {zoomedPane, right} = state.layout;
+  if (zoomedPane !== null) return zoomedPane === 'agents';
+  return !(right !== null && splitFits(terminalWidth));
 }
 
 const AGENTS_TITLE = 'Agents';
@@ -166,14 +289,15 @@ export class AgentMapView {
   render(state: SessionState, widthOverride?: number, rows = Number.POSITIVE_INFINITY): void {
     const phases = visiblePhases(state);
     // The pane's width follows the terminal, so a resize has to redraw even
-    // when the state is unchanged. A zoom hands the pane the whole terminal,
-    // and one narrower than the graph needs stacks the agents rather than cut a
-    // name.
+    // when the state is unchanged. A zoom hands the pane the whole terminal
+    // (`widthOverride`, this method's own parameter for that, distinct from
+    // `state.graphWidthOverride` below), and one narrower than the graph needs
+    // stacks the agents rather than cut a name.
     // Null either way means the stacked list: the pane is drawn at `paneWidth`
     // whatever that decides.
     const graphWidth =
       widthOverride === undefined
-        ? agentPaneWidth(this.renderer.terminalWidth, phases)
+        ? agentPaneWidthWithOverride(this.renderer.terminalWidth, phases, state.graphWidthOverride)
         : widthOverride >= graphPaneBounds(phases, selectedLabelWidth).min
           ? widthOverride
           : null;

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -512,7 +512,7 @@ describe('OpenTUI presentation', () => {
     const lines = active.split('\n');
     const promptLine = lines.findIndex(line => line.includes('Implement the queue'));
     const activityLineIndex = lines.findIndex(line => line.includes('Implementer · Working'));
-    const helpLine = lines.findIndex(line => line.includes('[/] or click: round'));
+    const helpLine = lines.findIndex(line => line.includes('[/]: round'));
     // The command box is the foot of the transcript pane, so the pane's own
     // bottom border is below it and the row the activity line is measured
     // against is where that box starts.
@@ -920,6 +920,330 @@ describe('OpenTUI presentation', () => {
 
     const at = await agentPaneText(105, threeStageRound());
     expect(at).toContain('▶');
+  });
+
+  /**
+   * `<`/`>` resize the Agents pane by columns, the way a vim/LazyVim window
+   * resize does: the pane's actual on-screen width changes, not a share of
+   * the terminal a floor could override into doing nothing. Measured on the
+   * laid-out boxes, like the fixed-width table above, since a layout
+   * regression only shows up there.
+   */
+  it('changes the pane by exactly one step per press, seeded from the current width on the first press', async () => {
+    const width = 160; // automatic sizing renders 64 here (fixed-width table).
+    const testRenderer = await createTestRenderer({width, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const agentsBox = () => testRenderer.renderer.root.findDescendantById('agent-map');
+
+    expect(controller.state.graphWidthOverride).toBeNull();
+    expect(agentsBox()?.width).toBe(64);
+
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(agentsBox()?.width).toBe(62); // seeded from 64, one step down.
+
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(agentsBox()?.width).toBe(60);
+
+    testRenderer.mockInput.pressKey('>');
+    testRenderer.mockInput.pressKey('>');
+    await frameAfter(testRenderer);
+    expect(agentsBox()?.width).toBe(64); // back to where it started.
+  });
+
+  it("> stops at the graph's natural ceiling instead of padding past it", async () => {
+    const width = 160;
+    const testRenderer = await createTestRenderer({width, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const agentsBox = () => testRenderer.renderer.root.findDescendantById('agent-map');
+    const transcriptBox = () => testRenderer.renderer.root.findDescendantById('viewport');
+
+    for (let step = 0; step < 15; step += 1) testRenderer.mockInput.pressKey('>');
+    await frameAfter(testRenderer);
+
+    // 68 is three stages' own ceiling (the fixed-width table's 250-column
+    // case): past it, more width is blank padding, not more name.
+    expect(agentsBox()?.width).toBe(68);
+    expect(transcriptBox()?.width).toBe(width - 68);
+    expect(transcriptBox()?.width as number).toBeGreaterThanOrEqual(TRANSCRIPT_MIN);
+  });
+
+  it('< stops at the geometric minimum instead of collapsing to the stacked list', async () => {
+    const width = 160;
+    const testRenderer = await createTestRenderer({width, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const agentsBox = () => testRenderer.renderer.root.findDescendantById('agent-map');
+    const transcriptBox = () => testRenderer.renderer.root.findDescendantById('viewport');
+
+    for (let step = 0; step < 15; step += 1) testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+
+    // 56 is three stages at their own 14-column floor plus two gutters plus
+    // chrome: the narrowest a graph (not the 30-column stacked list) can draw.
+    expect(agentsBox()?.width).toBe(56);
+    expect(agentsBox()?.width).not.toBe(30);
+    expect(transcriptBox()?.width).toBe(width - 56);
+    expect(transcriptBox()?.width as number).toBeGreaterThanOrEqual(TRANSCRIPT_MIN);
+  });
+
+  it('> jumps from the automatic stacked fallback straight to the geometric minimum', async () => {
+    // Automatic sizing already gives up to the stacked list at 100 columns
+    // (three stages need 63 to name every agent in full, and only 58 columns
+    // are on offer beside the transcript floor), so the pane is showing the
+    // fixed 30-column list, not a narrow graph, before the first press.
+    const width = 100;
+    const testRenderer = await createTestRenderer({width, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const agentsBox = () => testRenderer.renderer.root.findDescendantById('agent-map');
+
+    expect(agentsBox()?.width).toBe(30);
+
+    testRenderer.mockInput.pressKey('>');
+    await frameAfter(testRenderer);
+
+    // A step of 2 from 30 would still be 32, under the 56-column geometric
+    // minimum: the clamp, not the step, decides where the first press lands.
+    expect(agentsBox()?.width).toBe(56);
+  });
+
+  it('< is inert on the automatic stacked fallback, which is already the narrowest pane', async () => {
+    // The mirror of the `>` case above, and the reason it cannot share its
+    // code: seeding from `STACKED_WIDTH` and clamping sends `<` to the same
+    // 56 as `>`, so a shrink key widened the pane by 26 columns. The stacked
+    // list is the floor, so `<` has nowhere to go from it.
+    const width = 100;
+    const testRenderer = await createTestRenderer({width, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const agentsBox = () => testRenderer.renderer.root.findDescendantById('agent-map');
+
+    expect(agentsBox()?.width).toBe(30);
+
+    testRenderer.mockInput.pressKey('<');
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+
+    expect(agentsBox()?.width).toBe(30);
+    expect(controller.state.graphWidthOverride).toBeNull();
+  });
+
+  it('stores nothing on a terminal too narrow to draw any graph, so a later widening is still automatic', async () => {
+    // 90 columns leaves 48 beside the transcript floor, under the 56 the
+    // narrowest three-stage graph needs, so no override is drawable here at
+    // all. A press that stored the clamp's inverted low bound anyway left 56
+    // behind: invisible now, but it outlived the narrow terminal and pinned
+    // the pane to a truncating 56 once the terminal grew.
+    const width = 90;
+    const testRenderer = await createTestRenderer({width, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const agentsBox = () => testRenderer.renderer.root.findDescendantById('agent-map');
+
+    expect(agentsBox()?.width).toBe(30);
+
+    testRenderer.mockInput.pressKey('>');
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+
+    // 56 beside a 90-column terminal would have left the transcript 34
+    // columns, under its own floor. `agent-map.test.ts` pins that the clamp
+    // never hands such a width back for this terminal; this pins that no key
+    // press stores one anyway.
+    expect(agentsBox()?.width).toBe(30);
+    expect(controller.state.graphWidthOverride).toBeNull();
+  });
+
+  it('stores nothing on a round whose clamp band is one width wide, leaving later rounds automatic', async () => {
+    // Round 1 predates every phase the state carries, so it has none, and with
+    // no stages `agentGraphMinWidth`, `agentPaneFloor` and `agentPaneCeiling`
+    // all collapse to STACKED_WIDTH: there is no other width for a press to
+    // reach. The terminal is wide, so `graphFits` cannot catch this; only
+    // comparing the next width against the current one does. A press that
+    // stored anyway armed an override nothing on screen showed, and every
+    // later round in the session was then pinned to it.
+    const width = 160;
+    const testRenderer = await createTestRenderer({width, height: 30});
+    const controller = new FakeController({...threeStageRound(), selectedRound: 1});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+    const agentsBox = () => testRenderer.renderer.root.findDescendantById('agent-map');
+    expect(agentsBox()?.width).toBe(30);
+
+    testRenderer.mockInput.pressKey('>');
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+
+    expect(agentsBox()?.width).toBe(30);
+    expect(controller.state.graphWidthOverride).toBeNull();
+
+    // The round that does have stages is still sized automatically, rather
+    // than pinned to the 56-column narrowest graph with its names cut.
+    testRenderer.mockInput.pressKey(']');
+    testRenderer.mockInput.pressKey(']');
+    const round3 = await testRenderer.waitForFrame(value => value.includes('live output'));
+    expect(agentsBox()?.width).toBe(64);
+    expect(round3).not.toContain('…');
+  });
+
+  it('does not convert automatic sizing into an override when > is already at the ceiling', async () => {
+    // 250 columns puts automatic sizing on three stages' own 68-column ceiling,
+    // so `>` has nowhere to go. Storing 68 would look identical this frame and
+    // then stop the pane following the terminal for the rest of the session.
+    const testRenderer = await createTestRenderer({width: 250, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const agentsBox = () => testRenderer.renderer.root.findDescendantById('agent-map');
+    expect(agentsBox()?.width).toBe(68);
+
+    testRenderer.mockInput.pressKey('>');
+    await frameAfter(testRenderer);
+
+    expect(agentsBox()?.width).toBe(68);
+    expect(controller.state.graphWidthOverride).toBeNull();
+  });
+
+  it('no-ops the resize keys while a visualization split holds the row beside the transcript', async () => {
+    // The experiment-log case never reaches the resize block: that branch of
+    // `bindKeybindings` returns first. This one does reach it, so it is what
+    // actually covers the `agentsPaneVisible` guard. Without the guard the
+    // presses land on a pane that is not on screen, and the width they stored
+    // appears the moment the split closes.
+    const testRenderer = await createTestRenderer({width: 160, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const agentsBox = () => testRenderer.renderer.root.findDescendantById('agent-map');
+    expect(agentsBox()?.width).toBe(64);
+
+    await controller.openPane('perf');
+    await frameAfter(testRenderer);
+    // 160 clears MIN_SPLIT_WIDTH, so the split takes the row and the agents
+    // pane gives it up rather than falling back to its modal.
+    expect(controller.state.layout.right).not.toBeNull();
+    expect(agentsBox()?.visible).toBe(false);
+
+    testRenderer.mockInput.pressKey('>');
+    testRenderer.mockInput.pressKey('>');
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(controller.state.graphWidthOverride).toBeNull();
+
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+    expect(controller.state.layout.right).toBeNull();
+    expect(agentsBox()?.width).toBe(64);
+  });
+
+  it('= hands the pane back to automatic sizing after a resize', async () => {
+    // Without a reset key an override is permanent for the life of the
+    // process: the pane stops following the terminal and keeps truncating
+    // names automatic sizing guarantees never to cut.
+    const width = 160;
+    const testRenderer = await createTestRenderer({width, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const agentsBox = () => testRenderer.renderer.root.findDescendantById('agent-map');
+
+    for (let step = 0; step < 15; step += 1) testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(agentsBox()?.width).toBe(56);
+    expect(controller.state.graphWidthOverride).toBe(56);
+
+    testRenderer.mockInput.pressKey('=');
+    const reset = await frameAfter(testRenderer);
+
+    expect(controller.state.graphWidthOverride).toBeNull();
+    expect(agentsBox()?.width).toBe(64); // automatic sizing at 160, as before any press.
+    // And with it the no-truncation guarantee: 56 cut `orchestrator` short.
+    expect(reset).toContain('orchestrator');
+    expect(reset).not.toContain('…');
+  });
+
+  it('leaves < and > to a typed command, and resumes resizing once it empties', async () => {
+    const testRenderer = await createTestRenderer({width: 160, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+
+    // With text in the command input, `<` and `>` are characters.
+    await testRenderer.mockInput.typeText('/steer a < b > c');
+    const typed = await frameAfter(testRenderer);
+    expect(typed).toContain('a < b > c');
+    expect(controller.state.graphWidthOverride).toBeNull();
+
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+
+    // With the input empty again, the same key resizes.
+    testRenderer.mockInput.pressKey('>');
+    await frameAfter(testRenderer);
+    expect(controller.state.graphWidthOverride).toBe(66);
+  });
+
+  it('leaves graphWidthOverride untouched while the agents pane is zoomed', async () => {
+    const testRenderer = await createTestRenderer({width: 160, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    testRenderer.mockInput.pressKey('F4');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.zoomedPane).toBe('agents');
+
+    // Before the zoom guard, these keys still seeded and mutated
+    // `graphWidthOverride` here with no visible effect, since the zoomed pane
+    // ignores it for its own full-width rule; the state itself has to stay
+    // put, not just the frame.
+    // `=` first, so the `<`/`>` presses are the ones the assertion rests on:
+    // `=` writes null onto null, which an unguarded run would not distinguish.
+    testRenderer.mockInput.pressKey('=');
+    testRenderer.mockInput.pressKey('<');
+    testRenderer.mockInput.pressKey('<');
+    testRenderer.mockInput.pressKey('>');
+    await frameAfter(testRenderer);
+
+    expect(controller.state.graphWidthOverride).toBeNull();
+  });
+
+  it('no-ops the resize keys while the experiment log holds the row instead of the agents pane', async () => {
+    const testRenderer = await createTestRenderer({width: 160, height: 30});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    const frame = await frameAfter(testRenderer);
+    expect(frame).not.toContain('Agents');
+
+    testRenderer.mockInput.pressKey('=');
+    testRenderer.mockInput.pressKey('>');
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(controller.state.graphWidthOverride).toBeNull();
   });
 
   it("reads the tabs' measured delta from the experiment log, not the design log", async () => {
@@ -6457,6 +6781,14 @@ class FakeController implements SessionController {
   }
   toggleTodos(): void {
     this.publish({...this.state, todosExpanded: !this.state.todosExpanded});
+  }
+  setGraphWidthOverride(width: number | null): void {
+    // The same dedup the real reducer does
+    // (`session-model.ts#setGraphWidthOverride`): an unchanged width keeps the
+    // same state object, so a lost dedup is visible here rather than papered
+    // over by a double that always publishes.
+    if (this.state.graphWidthOverride === width) return;
+    this.publish({...this.state, graphWidthOverride: width});
   }
 
   /** Rows the fake server returns for query.experiments. */

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -15,7 +15,7 @@ import {
   visibleRoundNumber,
 } from '../session-model.js';
 import {ActivityBarView} from './activity-bar.js';
-import {AgentMapView} from './agent-map.js';
+import {AgentMapView, agentsPaneVisible} from './agent-map.js';
 import {fillLayer} from './box-fill.js';
 import {createChatDraft} from './chat-composer.js';
 import {ChatOverlayView} from './chat-overlay.js';
@@ -49,8 +49,13 @@ export interface OpenTuiApp {
 /** Which of the client's editors currently holds the cursor. */
 type FocusTarget = 'command' | 'chat' | 'modal';
 
-const KEY_HELP = `←→: agents/transcript · ↑↓: within · [/] or click: round · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Ctrl+L: live`;
-const SCOPED_KEY_HELP = `←→: agents/transcript · ↑↓: within · [/] or click: round · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Esc: back`;
+// `help` is one row and clips rather than wraps, so a hint added here costs the
+// hints behind it on a narrow terminal, which is exactly where the resize keys
+// matter most. All three ride one token, and the round tabs gave up `or click`
+// to pay for it: a tab is the most clickable-looking thing on the screen, while
+// `<>=` is advertised nowhere else.
+const KEY_HELP = `←→: agents/transcript · ↑↓: within · [/]: round · <>=: width · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Ctrl+L: live`;
+const SCOPED_KEY_HELP = `←→: agents/transcript · ↑↓: within · [/]: round · <>=: width · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Esc: back`;
 const LOG_KEY_HELP = `↑↓ or scroll: select · Enter/click: open hypothesis · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
 const LOG_CHAT_KEY_HELP = `↑↓: select · Enter/click: hypothesis · Ctrl+W: chat · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
 const HYPOTHESIS_KEY_HELP =
@@ -423,8 +428,10 @@ export function createOpenTuiApp(
           : SCOPED_KEY_HELP;
     help.content = transientStatus ?? renderedKeyHelp;
     // The round tabs and agent map are per-round detail. They belong to a
-    // hypothesis trajectory, not to the list of claims.
-    const showAgents = !showLog && (zoomedPane === null ? !showSplit : zoomedPane === 'agents');
+    // hypothesis trajectory, not to the list of claims. `agentsPaneVisible` is
+    // this same decision, shared with the `<`/`>` resize keys so a layout
+    // change cannot leave the render and the keybinding guard disagreeing.
+    const showAgents = agentsPaneVisible(state, renderer.terminalWidth);
     const showTranscript = !showLog && (zoomedPane === null || zoomedPane === 'transcript');
     // The tabs head the whole round view, so they give way wherever it is not
     // on screen whole: a zoomed pane, or a split that takes the row's right side.
@@ -583,6 +590,7 @@ export function createOpenTuiApp(
     selectNextRound: () => controller.selectNextRound(),
     selectPreviousRound: () => controller.selectPreviousRound(),
     toggleTodos: () => controller.toggleTodos(),
+    setGraphWidthOverride: width => controller.setGraphWidthOverride(width),
     scrollRightPane: delta => rightPane.scrollBy(delta),
     scrollChatPane: delta => chatPane.scrollBy(delta),
     scrollExperimentDetail: delta => experimentLog.scrollBy(delta),

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -5,7 +5,17 @@ import {
   chatPaneVisible,
   experimentLogVisible,
   todoListFocused,
+  visiblePhases,
 } from '../session-model.js';
+import {
+  agentGraphMinWidth,
+  agentPaneWidthWithOverride,
+  agentsPaneVisible,
+  clampGraphWidthOverride,
+  GRAPH_WIDTH_STEP,
+  graphFits,
+  STACKED_WIDTH,
+} from './agent-map.js';
 import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 
 export interface KeybindingActions {
@@ -28,6 +38,8 @@ export interface KeybindingActions {
   selectNextRound(): void;
   selectPreviousRound(): void;
   toggleTodos(): void;
+  /** `<`/`>`: the Agents pane's explicit column width, already clamped; `=`: null. */
+  setGraphWidthOverride(width: number | null): void;
   scrollRightPane(delta: number): void;
   scrollChatPane(delta: number): void;
   scrollExperimentDetail(delta: number): void;
@@ -326,6 +338,77 @@ export function bindKeybindings(
     if (key.name === '[' && actions.inputIsEmpty()) {
       actions.selectPreviousRound();
       viewport.scrollTo(viewport.scrollHeight);
+      key.preventDefault();
+      return;
+    }
+    // Resizes the Agents pane by columns, the way a vim/LazyVim window resize
+    // does: `<` shrinks and `>` grows by `GRAPH_WIDTH_STEP` each press, and `=`
+    // drops the override so the pane follows the terminal again, which is
+    // vim's `<C-w>=`. An override is otherwise sticky for the life of the
+    // process, so without `=` a single press would cost the pane its automatic
+    // sizing, its no-truncation guarantee, and its growth as agent names get
+    // longer, with no way back.
+    //
+    // The keys belong to the Agents pane, so they are claimed wherever it holds
+    // the content row (`agentsPaneVisible` is the same test `app.ts` renders
+    // `showAgents` from) and left alone everywhere else, rather than typing a
+    // stray character into the command input. While the pane is zoomed they are
+    // claimed by nobody: a zoomed pane takes the whole terminal and ignores
+    // `graphWidthOverride`, so the key must not mutate a number that would
+    // change nothing on screen.
+    if (
+      (key.name === '>' || key.name === '<' || key.name === '=') &&
+      actions.inputIsEmpty() &&
+      controller.state.layout.zoomedPane === null &&
+      agentsPaneVisible(controller.state, renderer.terminalWidth)
+    ) {
+      const phases = visiblePhases(controller.state);
+      const terminalWidth = renderer.terminalWidth;
+      if (key.name === '=') actions.setGraphWidthOverride(null);
+      // A terminal too narrow for even the narrowest graph is the stacked list
+      // whatever the override says, so a press there would store a width this
+      // terminal never drew and then surprise the operator with it on the next
+      // resize. Nothing is stored instead.
+      else if (graphFits(terminalWidth, phases)) {
+        const current = agentPaneWidthWithOverride(
+          terminalWidth,
+          phases,
+          controller.state.graphWidthOverride,
+        );
+        // `null` is the stacked list, which is both what the pane is drawn at
+        // and the narrowest it goes. The gap up to a graph is 26 columns at
+        // three stages, 7 at two, and none at one, so it is never a step.
+        const width = current ?? STACKED_WIDTH;
+        const step = key.name === '>' ? GRAPH_WIDTH_STEP : -GRAPH_WIDTH_STEP;
+        // From the stacked list, `>` is the operator asking for the graph that
+        // automatic sizing declined to draw, at the only width it has.
+        const next =
+          current === null
+            ? step > 0
+              ? agentGraphMinWidth(phases)
+              : width
+            : clampGraphWidthOverride(current + step, terminalWidth, phases);
+        // A press that moves nothing stores nothing, so trying the keys can
+        // never arm an override the operator cannot see. That is the whole rule
+        // and it covers more than a shrink key at its floor: a round with no
+        // phases yet and a round of one short-named stage both have a clamp
+        // band one width wide, and a terminal wide enough that automatic sizing
+        // already sits at the ceiling has nowhere for `>` to go. Each of those
+        // would otherwise convert automatic sizing into a sticky override at
+        // the identical width, and pin every later round in the session to it.
+        //
+        // This compares widths, and it stands for "nothing changes on screen"
+        // only because `agentGraphMinWidth(phases) > STACKED_WIDTH` wherever the
+        // stacked fallback can appear at all. The two come apart in one
+        // transition, list to graph at an unchanged width, which needs the two
+        // to be equal while the list is showing: one stage whose kind name runs
+        // past 20 characters. The role vocabulary is closed and its longest name
+        // is 12 (`src/vibesys/loops/roles.py`), so that state is unreachable.
+        // Adding a long role, lowering `NODE_WIDTH_MIN`, or raising
+        // `STACKED_WIDTH` is what would make this a presentation test that has
+        // to be written as one.
+        if (next !== width) actions.setGraphWidthOverride(next);
+      }
       key.preventDefault();
       return;
     }

--- a/docs/contributing/tui-conventions.md
+++ b/docs/contributing/tui-conventions.md
@@ -98,6 +98,62 @@ as its own contents, so `F4` over it leaves the layout alone.
 focus to the left column. It never quits the application. This is CUA, and it is
 the one movement rule the current bindings already keep.
 
+### A resize moves columns, and only columns
+
+`<` and `>` change the Agents pane's width by whole columns
+(`GRAPH_WIDTH_STEP`), the way a window resize does in vim and LazyVim. Not a
+ratio: a share of the terminal that a floor then rounds away is a key press
+that did nothing, and the width the operator sees is what they are aiming at.
+
+An explicit width is sticky, so `=` gives it back, the way `<C-w>=` does in vim.
+Without it one press would cost the pane its automatic sizing for the life of
+the process: it would stop following the terminal, stop widening as agent names
+get longer, and keep cutting names automatic sizing promises never to cut. A
+resize pair with no way home is a trap, not a feature. `=` shares the guards
+that decide whether the keys belong to the Agents pane at all (an empty command
+input, no zoom, the pane on screen), but alone among the three it is not also
+gated on the pane being resizable: it is the way out, and a terminal or a round
+where `<` and `>` do nothing is exactly where an override left over from a wider
+terminal has to be clearable.
+
+A resize key also never swaps a pane's contents for a different presentation.
+The Agents pane's stacked list is an automatic fallback for a terminal too
+narrow to draw a graph, not the next step down from the narrowest graph: it
+cannot draw a node with in-degree above one, so reaching it by pressing `<`
+would lose edges the operator was resizing in order to see. `<` stops at
+`agentGraphMinWidth`, the narrowest pane an override may ask for, and `>` stops
+at `agentPaneCeiling`, past which the extra columns are padding rather than
+name.
+
+The stacked list is therefore a floor `<` cannot cross in either direction. From
+it `>` opens the narrowest graph, because asking for the graph is the only thing
+`>` can mean there, while `<` stays put: it is already at the narrowest the pane
+goes, and the gap up to `agentGraphMinWidth` is not a step a shrink key may take
+(26 columns at three stages, 7 at two, none at all at one).
+
+That last case generalizes, and the general rule is the one the code keeps: a
+press that would not change the rendered width stores nothing. A round with no
+phases yet, a round of one short-named stage, and a terminal wide enough that
+automatic sizing already sits at the ceiling each leave `<` or `>` with nowhere
+to go, and a press that stored an override anyway would arm one the operator
+cannot see and pin every later round in the session to it. A terminal too narrow
+for any graph is the same rule reached through the terminal instead of the
+round.
+
+Storing nothing means storing nothing, not storing the bound the press ran into,
+so an explicit width outlives a narrowing. A pane set to 64 columns on a wide
+terminal renders at whatever a narrower one allows, and a dead press there
+leaves the stored 64 alone, so widening back restores 64 rather than the
+narrowed width. That also keeps a dead press on one round from overwriting the
+width the operator chose on a round of a different shape.
+
+Automatic sizing keeps its own rule, that no agent name is ever cut. Truncation
+is what an explicit override buys, and it buys only that: `agentGraphMinWidth`
+keeps the same `STACKED_WIDTH` floor `agentPaneFloor` does, so an override
+narrows the agent names and never the round heading or the empty-round
+placeholder. An operator who asks for a narrower pane than the names need has
+said which of the two they want.
+
 ### Nothing moves that does not have to
 
 Reserve space for anything that appears conditionally: focus markers, status


### PR DESCRIPTION
## Problem

The Agents graph and the transcript beside it split the row at whatever width automatic
sizing picks. An operator who wants to read a wide graph, or wants the graph out of the way
to read a long transcript, has no way to say so.

This replaces the design in the first revision of this PR, which stepped a ratio and, once
the graph hit its floor, swapped the pane to the stacked agent list. Both halves were wrong:
a resize should change a width in columns, and the stacked list cannot draw a node with
in-degree above one, so it is not a view the graph can degrade into.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/graph-resize-before.png) | ![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/graph-resize-after.png) |

Both at 160x40, the after taken with six `>` presses. What to look at: the pane boundary moves
from column 82 to 91, each node box gains two columns of interior, the transcript rewraps, and
the key-help line gains `<>=: width`. The range is deliberately modest, since a step is two
columns and the clamp stops at this round's natural ceiling; six presses is already past it.

## Solution

`<` and `>` step the pane by two columns and store the result in `graphWidthOverride`, a
session-only piece of UI state. `=` clears it, the way vim's `<C-w>=` does. `null` keeps
#686's automatic sizing untouched, including its rule that no agent name is ever cut, and
its stacked-list fallback on a narrow terminal.

An explicit width is sticky, which is the point of asking for one and the reason `=` exists:
without a reset, one press would cost the pane its automatic sizing for the life of the
process. Truncation is what the override buys. Below the full-name floor a label loses
characters to `…`, and only ever under an explicit override.

### Architecture

The override is clamped to what can actually be drawn: `agentGraphMinWidth` at the low end
(every stage column at its 14-column floor plus a gutter per gap, never under
`STACKED_WIDTH`, so an override cuts agent names and not the round heading), and
`agentPaneCeiling` at the high end, past which more columns are padding rather than name.
The transcript keeps `TRANSCRIPT_MIN` either way.

**A press that would not change the rendered width stores nothing.** This one rule replaces
four special cases, each of which would otherwise arm an invisible override and pin every
later round to it: the stacked list, a round with no phases yet, a round of one short-named
stage, and a terminal where automatic sizing already sits at the ceiling.

## Verification

### Correctness properties

- Automatic sizing is byte-for-byte unchanged and still never truncates.
- `<` can never reach the stacked list, which stays a narrow-terminal fallback: from the list
  `<` is inert and `>` opens the narrowest graph.
- The clamp never yields a pane wider than the terminal, narrower than `STACKED_WIDTH`, or
  one that leaves the transcript under `TRANSCRIPT_MIN`; it is idempotent and re-runs against
  the current round, so a stale override survives neither a resize nor a stage-count change.
- The keys are inert while a pane is zoomed, while the experiment log holds the row, while a
  visualization split has room beside the transcript, and while the command input has text.
- Fan-in (in-degree above one) still draws every edge at a narrowed width.

### Testing

- `pnpm test:clients`: 856 pass, 0 fail.
- `pnpm check:ts`, `pnpm check:clients`, `pnpm check:ts-architecture`,
  `pnpm test:ts-architecture`, `scripts/check_doc_links.py`: clean.
- Clamp invariants checked by exhaustive sweep over stage counts 0-5, agent-name lengths
  1-40, terminal widths 20-300 and overrides, comparing the rendered result against storing
  nothing; plus BFS reachability of the clamp band and key sequences across a terminal resize
  and a round switch. Each guard was mutation-checked: reverting it fails a named test.
