### PR TITLE
fix(tui): separate every transcript run with the divider

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -5607,7 +5607,7 @@ describe('box fills', () => {
     expect(ids).toContain('experiment-log'); // a pane, the same way
     expect(ids).toContain('theme-picker'); // an overlay, built here, never opened
     expect(ids).toContain('event-card'); // a transcript card, now a top-edge rule
-    expect(ids).toContain('event-status'); // borderless, so it keeps its own fill
+    expect(ids).toContain('event-status'); // a bare entry, tinted on a layer inside
     expect(ids.some(id => id.startsWith('agent-implementer-'))).toBe(true);
 
     expect(offenders(root)).toEqual([]);
@@ -5627,7 +5627,9 @@ describe('box fills', () => {
     // 'event-card-fill' is deliberately absent: #565 removed the transcript
     // card's border and its fill together, so there is no longer a rounded
     // corner to keep a fill out of, and nothing left to move inwards.
-    for (const id of ['header-fill', 'experiment-log-fill']) {
+    // 'event-status-fill' is here because a bare entry now draws the run
+    // divider like any other opener, so its role tint moved inwards too.
+    for (const id of ['header-fill', 'experiment-log-fill', 'event-status-fill']) {
       expect([id, isPainted(root, id)]).toEqual([id, true]);
     }
   });

--- a/clients/tui/src/ui/conversation.test.ts
+++ b/clients/tui/src/ui/conversation.test.ts
@@ -77,8 +77,9 @@ function cardOf(view: ConversationView, id: string): BoxRenderable {
  * An entry from a named agent in a named round: the pair a heading splits.
  *
  * 'analysis' because run collapsing is about entries drawn as cards. #620's
- * bare kinds ('status', and unflagged 'diagnostic'/'subprocess') keep their own
- * grammar and are covered separately below.
+ * bare kinds ('status', and unflagged 'diagnostic'/'subprocess') group into
+ * runs the same way and differ only in the frame they do not draw; they are
+ * covered separately below.
  */
 function from(
   who: {agentKind: string; roundLabel: string},
@@ -163,17 +164,13 @@ describe('conversation entry row cost (#565)', () => {
   });
 
   it('costs a divider and a heading per entry, not a margin row plus a four-sided card', async () => {
-    // Divider (1) + heading (1) + one content line (1) for an entry drawn as a
-    // card. A bordered card with its own margin row cost 5 rows for the same
-    // content.
-    //
-    // 'status' is the one kind that does not draw the divider, and that is not
-    // this change's doing: #620 demoted lifecycle chatter to bare lines, so a
-    // status entry draws no frame at all and costs a heading plus its content.
-    // Giving it the rule would undo that demotion, so the row cost is asserted
-    // per kind rather than as one number for all of them.
+    // Divider (1) + heading (1) + one content line (1) for a run opener. A
+    // bordered card with its own margin row cost 5 rows for the same content.
+    // #620's bare kinds pay the same three rows: the divider is the separator
+    // between runs, and the blank row a bare opener used to draw instead was
+    // the same separator spelled less legibly.
     const expected: Record<string, {height: number; border: boolean | 'top'[]}> = {
-      a: {height: 2, border: false},
+      a: {height: 3, border: ['top']},
       b: {height: 3, border: ['top']},
       c: {height: 3, border: ['top']},
     };
@@ -188,8 +185,7 @@ describe('conversation entry row cost (#565)', () => {
       expect([entry.id, card.border]).toEqual([entry.id, want.border]);
     }
     // No stray rows between cards either: the three entries cost exactly 9 rows
-    // end to end (2 + 3 + 3, plus the single margin row the bare status entry
-    // keeps from #620). The pre-#565 card cost 5 rows each, 15 total.
+    // end to end (3 + 3 + 3). The pre-#565 card cost 5 rows each, 15 total.
     expect(view.output.height).toBe(9);
     void testRenderer;
   });
@@ -258,11 +254,11 @@ describe('conversation entry row cost (#565)', () => {
     expect(view.output.height).toBe(3 + 1 + 3 + 3 + 3 + 1 + 3);
   });
 
-  it('collapses a run of #620 bare entries without giving one a divider', async () => {
+  it('collapses a run of #620 bare entries behind one divider', async () => {
     // Bare lifecycle lines are most of what run collapsing buys: a run of them
     // is one agent talking, and it restated the agent above every line. They
-    // lose the repeated heading like any other entry and never gain the
-    // divider, which is the half of the chrome #620's demotion is about.
+    // lose the repeated heading like any other entry, and the divider they do
+    // draw is on the opener alone.
     const entries: ConversationEntry[] = [
       {id: 'b1', kind: 'status', label: 'launcher', content: 'one'},
       {id: 'b2', kind: 'status', label: 'launcher', content: 'two'},
@@ -271,11 +267,11 @@ describe('conversation entry row cost (#565)', () => {
       from(judge, 'j2', 'five'),
     ];
     const {view} = await renderEntries(entries);
-    for (const id of ['b1', 'b2', 'b3']) expect([id, cardOf(view, id).border]).toEqual([id, false]);
-    // The opener keeps heading and content; the rest of the run is content
-    // alone, and #620's margin row goes with the heading rather than splitting
-    // the run with a blank line.
-    expect(cardOf(view, 'b1').height).toBe(2);
+    expect(cardOf(view, 'b1').border).toEqual(['top']);
+    for (const id of ['b2', 'b3']) expect([id, cardOf(view, id).border]).toEqual([id, false]);
+    // The opener keeps divider, heading and content; the rest of the run is
+    // content alone, so no blank row splits one speaker's block.
+    expect(cardOf(view, 'b1').height).toBe(3);
     expect(cardOf(view, 'b2').height).toBe(1);
     expect(cardOf(view, 'b3').height).toBe(1);
     expect(view.output.findDescendantById('event-b2-heading')).toBeUndefined();
@@ -285,8 +281,7 @@ describe('conversation entry row cost (#565)', () => {
     expect(cardOf(view, 'j1').border).toEqual(['top']);
     expect(cardOf(view, 'j1').height).toBe(3);
     expect(cardOf(view, 'j2').height).toBe(1);
-    // One margin row (b1) + 2 + 1 + 1 + 3 + 1.
-    expect(view.output.height).toBe(1 + 2 + 1 + 1 + 3 + 1);
+    expect(view.output.height).toBe(3 + 1 + 1 + 3 + 1);
   });
 
   it('shows the cursor on an entry inside a run without moving its content', async () => {
@@ -310,6 +305,52 @@ describe('conversation entry row cost (#565)', () => {
     const head = cardOf(await renderEntries(run, 'a').then(mounted => mounted.view), 'a');
     expect(head.border).toEqual(['top', 'left']);
     expect(head.getChildren()[0]?.x).toBe(cardOf(resting.view, 'a').getChildren()[0]?.x);
+  });
+});
+
+/**
+ * The rule is the separator between one run and the next, and #620's bare
+ * entries need separating like any other. Both cases below come from the tail
+ * of dev/fixtures/bad-cpp-round1.jsonl, where the judge's "Reached max_rounds"
+ * notice printed directly under the `round-1 · PASS` summary with nothing
+ * between them.
+ */
+describe('every run opener draws the divider', () => {
+  it('draws the rule on a bare entry that opens a run', async () => {
+    const entries: ConversationEntry[] = [
+      {id: 'summary', kind: 'result', label: 'round-1 · PASS', content: '1 attempt(s)'},
+      {
+        id: 'notice',
+        kind: 'diagnostic',
+        label: 'judge',
+        agentKind: 'judge',
+        roundLabel: 'round-1-retry-1-judge',
+        content: 'Reached max_rounds=1. Stopping.',
+      },
+    ];
+    const {testRenderer, view} = await renderEntries(entries);
+    // The notice is a different speaker from the summary above it, so it opens
+    // a run, and a run opener is separated from the run above whether or not
+    // #620 draws it as a bare line.
+    expect(cardOf(view, 'notice').border).toEqual(['top']);
+    // On screen, not just on the box: the rule sits above the notice's own
+    // heading. The summary's rule is drawn either way, so the row asserted is
+    // the second one, which is the row that was missing.
+    const rows = testRenderer.captureCharFrame().split('\n');
+    const notice = rows.findIndex(row => row.includes('Reached max_rounds'));
+    expect(rows[notice - 1]).toContain('judge');
+    expect(rows[notice - 2]?.trimEnd()).toMatch(/^─+$/);
+  });
+
+  it('keeps a bare entry inside a run frameless', async () => {
+    const entries: ConversationEntry[] = [
+      {id: 'b1', kind: 'diagnostic', label: 'launcher', content: 'one'},
+      {id: 'b2', kind: 'diagnostic', label: 'launcher', content: 'two'},
+    ];
+    const {view} = await renderEntries(entries);
+    expect(cardOf(view, 'b1').border).toEqual(['top']);
+    // `false`, not an empty side list (tui-conventions.md).
+    expect(cardOf(view, 'b2').border).toBe(false);
   });
 });
 

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -14,6 +14,7 @@ import {hasRunEnded} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
 import {visibleConversation} from '../session-model.js';
+import {fillLayer} from './box-fill.js';
 import {promptPreview, toolCallPreview, toolResultPreview} from './previews.js';
 import {
   conversationRole,
@@ -386,19 +387,18 @@ export class ConversationView {
     // restated the agent and the round above every line.
     const opensRun = previous === undefined || !sameSpeaker(previous, entry);
     const borderSides: ('top' | 'left')[] = [];
-    // A carded entry gets a rule on its top edge instead of a four-sided
-    // border (#565): it separates one entry from the next at a fraction of the
-    // row cost, with no bottom border and no blank margin row to hold the gap
-    // open. It is drawn only where the speaker changes: consecutive entries
-    // from one agent are one block, and a divider inside that block separates
-    // nothing.
+    // An entry that opens a run gets a rule on its top edge instead of a
+    // four-sided border (#565): it separates one run from the next at a
+    // fraction of the row cost, with no bottom border and no blank margin row
+    // to hold the gap open. It is drawn only on the opener: consecutive
+    // entries from one speaker are one block, and a divider inside that block
+    // separates nothing.
     //
-    // A bare entry never draws it, opener or not. #620 demoted lifecycle
-    // chatter to frameless tinted lines, and handing one a rule would undo that
-    // demotion; only entries that were cards trade a border for a divider here.
-    // Losing the repeated heading is the density win, keeping the frame off is
-    // #620's, and the two compose.
-    if (opensRun && !bare) borderSides.push('top');
+    // #620's bare entries draw it too. The rule is the separator between runs,
+    // and a run of lifecycle lines needs separating from the run above it as
+    // much as a card does. #620's demotion is about the frame around an entry,
+    // which a bare entry still does not draw.
+    if (opensRun) borderSides.push('top');
     // The cursor. An entry inside a run has no heading to carry a "▸ " marker,
     // so selection moves out of the heading and onto a rule down the entry's
     // left edge, which every entry can draw and which costs no row. The column
@@ -418,13 +418,6 @@ export class ConversationView {
       // does), and a card padding on top of that was a second, inconsistent
       // inset.
       ...(selected ? {} : {paddingLeft: 1}),
-      // #620's margin row above a bare status entry is separation chrome, so
-      // it is drawn where the divider would be: once, on the run opener. Inside
-      // a run it would be a blank row splitting one speaker's block.
-      marginTop: bare && entry.kind === 'status' && opensRun ? 1 : 0,
-      // A bare entry draws no frame, so its role tint goes straight on the
-      // card rather than on a border.
-      ...(bare ? {backgroundColor: palette.background} : {}),
       // OpenTUI turns a border back on if `borderStyle` or `borderColor` is
       // passed beside `border: false`, so an entry that draws neither rule has
       // to omit both (tui-conventions.md).
@@ -464,6 +457,12 @@ export class ConversationView {
             }
           : {}),
     });
+    // A bare entry draws no frame, so its role tint is what marks it as one
+    // agent's line. It goes on a layer inside the card rather than on the card
+    // itself: an opener draws a rule, and a `backgroundColor` on a bordered box
+    // paints the border row with it (tui-conventions.md, "a fill lives on an
+    // inner box").
+    if (bare) fillLayer(card, `event-${entry.id}-fill`, palette.background);
     if (opensRun) {
       const heading = new BoxRenderable(this.renderer, {
         id: `event-${entry.id}-heading`,


### PR DESCRIPTION
## Problem

The transcript separates one speaker's block (a "run") from the next with a horizontal
rule. A bare entry (#620's status, diagnostic and subprocess lines) never drew that rule,
opener or not, and the blank row that stood in for it covered only `kind === 'status'`. So
a bare diagnostic that opened a run had nothing above it at all.

In `dev/fixtures/bad-cpp-round1.jsonl` the judge's `Reached max_rounds=1. Stopping.` prints
directly under the `round-1 · PASS` round summary, with the summary's last content line and
the notice's heading on adjacent rows.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/divider-grammar-before.png) | ![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/divider-grammar-after.png) |

Both frames are bottom-anchored on the `Reached max_rounds` line, so the rows above shift up
by one. That row is the change, not a mis-set crop.

## Solution

Every run opener draws the rule, whether or not #620 draws the entry itself as a bare
tinted line. That issue demoted the frame around an entry; a run of lifecycle lines still
needs separating from the run above it as much as a card does. The blank row goes with it
rather than spelling the same separation less legibly, and the row cost is unchanged,
because the rule takes the row the margin held.

Run grouping itself is not touched. A run is still one speaker's block, keyed on the agent
and round pair the heading splits.

### Architecture

Three hunks in `clients/tui/src/ui/conversation.ts`, no cross-boundary change. The third is
forced: a bare entry's role tint moves from `backgroundColor` onto a `fillLayer`, because a
fill on a box that now draws a border paints the border row too (`tui-conventions.md`, "a
fill lives on an inner box"). That also closes a latent #642 case the `box fills` walk could
not see, where a selected bare entry already drew a left rule over an opaque card background.

## Verification

### Correctness properties

- Every run opener draws the rule; entries inside a run stay frameless.
- Run grouping is unchanged: two matching labels are one run, a differing label opens another.
- No bordered box carries a fill (#642), enforced by the `box fills` walk in `app.test.ts`.
- The incremental render paths agree with a fresh render. A 24-case probe (replace, append
  and reveal, across before/after speaker and kind combinations) compares both the shape and
  the character frame; stubbing the neighbour redraw fails 8 of the 24, so the guard is proven
  rather than assumed.

### Testing

- `bun test --max-concurrency 1 src dev` in `clients/tui`: 825 pass. The single failure,
  `launcher > returns the backend argument error for an explicitly empty runs directory`, is
  pre-existing at the merge base and unrelated.
- Four tests fail at `d363042` and pass here, including the reported symptom.
- `pnpm check:ts`, `pnpm --filter @vibesys/tui check`, `pnpm check:ts-architecture`,
  `pnpm test:ts-architecture`, `scripts/check_doc_links.py`: clean.
