### PR TITLE
refactor(tui): carry a transcript role on two channels, not four

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -78,8 +78,8 @@ import {
   ensureContrast,
   listThemes,
   mix,
+  RUN_DIVIDER_MIN_CONTRAST,
   resolveTheme,
-  SUBTLE_TEXT_MIN_CONTRAST,
   scrim,
   THEME_NAMES,
   type ThemeName,
@@ -2828,15 +2828,13 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe(light.accent);
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe(light.conversation.assistant.content);
-    // #565: the card carries its role on the divider rule, not a fill, so its
-    // body sits on the theme's canvas.
+    // #565 took the card's fill and the colour diet took the role tint behind a
+    // bare entry, so every entry's body sits on the theme's canvas.
     expect(body?.bg).toBe(light.canvas);
+    // The divider is a separator, not a role signal: it draws in the neutral
+    // resting border every other frame uses, lifted to the divider floor.
     expect(cardBorder(testRenderer, 'event-themed')).toBe(
-      ensureContrast(
-        light.conversation.assistant.border,
-        light.canvas,
-        SUBTLE_TEXT_MIN_CONTRAST,
-      ).toLowerCase(),
+      ensureContrast(light.border, light.canvas, RUN_DIVIDER_MIN_CONTRAST).toLowerCase(),
     );
     expect(spanColors(testRenderer, 'implementer')?.fg).toBe(light.conversation.assistant.label);
   });
@@ -5607,7 +5605,7 @@ describe('box fills', () => {
     expect(ids).toContain('experiment-log'); // a pane, the same way
     expect(ids).toContain('theme-picker'); // an overlay, built here, never opened
     expect(ids).toContain('event-card'); // a transcript card, now a top-edge rule
-    expect(ids).toContain('event-status'); // a bare entry, tinted on a layer inside
+    expect(ids).toContain('event-status'); // a bare entry, which now fills nothing
     expect(ids.some(id => id.startsWith('agent-implementer-'))).toBe(true);
 
     expect(offenders(root)).toEqual([]);
@@ -5627,9 +5625,9 @@ describe('box fills', () => {
     // 'event-card-fill' is deliberately absent: #565 removed the transcript
     // card's border and its fill together, so there is no longer a rounded
     // corner to keep a fill out of, and nothing left to move inwards.
-    // 'event-status-fill' is here because a bare entry now draws the run
-    // divider like any other opener, so its role tint moved inwards too.
-    for (const id of ['header-fill', 'experiment-log-fill', 'event-status-fill']) {
+    // 'event-status-fill' is absent for the same reason one step further on: an
+    // entry has no role tint left to paint, so no entry paints a fill at all.
+    for (const id of ['header-fill', 'experiment-log-fill']) {
       expect([id, isPainted(root, id)]).toEqual([id, true]);
     }
   });

--- a/clients/tui/src/ui/conversation.test.ts
+++ b/clients/tui/src/ui/conversation.test.ts
@@ -1,15 +1,22 @@
 import {afterEach, describe, expect, it} from 'bun:test';
-import {BoxRenderable, type Renderable, rgbToHex, TextRenderable} from '@opentui/core';
+import {
+  BoxRenderable,
+  type Renderable,
+  rgbToHex,
+  TextAttributes,
+  TextRenderable,
+} from '@opentui/core';
 import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
 import type {SessionController} from '../session-controller.js';
 import {type ConversationEntry, initialSessionState} from '../session-model.js';
-import {ConversationView, styleSourceTags} from './conversation.js';
+import {ConversationView, styleTranscriptText} from './conversation.js';
 import {createMarkdownStyle} from './styles.js';
 import {
   CONVERSATION_ROLES,
   contrastRatio,
   ensureContrast,
   listThemes,
+  RUN_DIVIDER_MIN_CONTRAST,
   resolveTheme,
   SUBTLE_TEXT_MIN_CONTRAST,
   type Theme,
@@ -442,24 +449,30 @@ describe('speaker runs survive incremental rendering (#565)', () => {
  * at that layer.
  */
 describe('role and selection stay distinguishable across every theme (#565)', () => {
-  it('holds every role divider to the 3:1 floor textSubtle uses for punctuation and rules', () => {
+  it('holds the run divider above the floor subtle text is held to', () => {
+    // The divider is structural, not decoration, so it does not share
+    // `textSubtle`'s floor. Pinned here because the whole point of the raise is
+    // that the two numbers differ.
+    expect(RUN_DIVIDER_MIN_CONTRAST).toBeGreaterThan(SUBTLE_TEXT_MIN_CONTRAST);
     for (const theme of listThemes()) {
-      const restingColors = CONVERSATION_ROLES.map(role => {
-        // Mirrors the `ensureContrast` call `#renderEntry` makes on
-        // `palette.border` before using it as the resting divider colour.
-        const resting = ensureContrast(
-          theme.conversation[role].border,
-          theme.canvas,
-          SUBTLE_TEXT_MIN_CONTRAST,
-        );
-        expect(contrastRatio(resting, theme.canvas)).toBeGreaterThanOrEqual(
-          SUBTLE_TEXT_MIN_CONTRAST,
-        );
-        return resting;
-      });
-      // Nudging a marginal accent toward black or white must not collapse
-      // two roles onto the same divider colour.
-      expect(new Set(restingColors).size).toBe(restingColors.length);
+      // Mirrors the `ensureContrast` call `#renderEntry` makes on `border`
+      // before using it as the resting divider colour. `border` is not run
+      // through `ensureContrast` in theme.ts the way text tokens are, and a
+      // one-row rule that no longer carries a role accent cannot lean on its
+      // own area to stay noticeable the way a four-sided border could.
+      const resting = ensureContrast(theme.border, theme.canvas, RUN_DIVIDER_MIN_CONTRAST);
+      expect([
+        theme.name,
+        contrastRatio(resting, theme.canvas) >= RUN_DIVIDER_MIN_CONTRAST,
+      ]).toEqual([theme.name, true]);
+      // Still a rule and not the cursor: selection is the one thing that
+      // replaces this colour, so the two may not resolve to the same cell.
+      expect([theme.name, resting]).not.toEqual([theme.name, theme.borderFocus]);
+      // One colour for every role, which is the point: a divider separates one
+      // run from the next and says nothing about who is speaking. Role is the
+      // heading word and the heading colour, and those stay distinct.
+      const labels = CONVERSATION_ROLES.map(role => theme.conversation[role].label);
+      expect(new Set(labels).size).toBe(labels.length);
     }
   });
 
@@ -473,58 +486,98 @@ describe('role and selection stay distinguishable across every theme (#565)', ()
 });
 
 /**
- * #647 review: a reviewer asked that the run id keep the card's colour
- * instead of fading to `textSubtle`, and that a bracketed source tag
- * (`[git-tracking]`, `[framework-validation]`) stand out from the rest of its
- * line. `styleSourceTags` is exported and tested directly for the same reason
- * `unwrapShellCommand` is in previews.ts: the line-splitting and anchoring is
- * the whole of the behaviour, and a full render obscures which case failed.
+ * `styleTranscriptText` is the one place the client styles part of a line, and
+ * it is exported and tested directly for the same reason `unwrapShellCommand`
+ * is in previews.ts: the line-splitting and anchoring is the whole of the
+ * behaviour, and a full render obscures which case failed.
+ *
+ * Both spans it draws are the colour diet, not decoration. A `[source-tag]`
+ * prefix is on nearly every subprocess line and is about 24 of ~78 cells, so it
+ * recedes into `textMuted` rather than carrying the card's label colour. `PASS`
+ * and `FAIL` are what a reader scans for, so they take the emphasis instead:
+ * the verdict role's colour and bold, with the word itself as the channel WCAG
+ * 1.4.1 asks for.
  */
-describe('styleSourceTags (#647)', () => {
-  const palette = resolveTheme(null).conversation.analysis;
+describe('styleTranscriptText', () => {
+  const theme = resolveTheme(null);
+  const palette = theme.conversation.analysis;
 
-  function styledChunks(content: string): {text: string; fg: string | undefined}[] {
-    const styled = styleSourceTags(content, palette);
+  function styledChunks(content: string): {text: string; fg: string | undefined; bold: boolean}[] {
+    const styled = styleTranscriptText(content, palette, theme);
     if (typeof styled === 'string') throw new Error('expected a styled result, got a plain string');
     return styled.chunks.map(chunk => ({
       text: chunk.text,
       fg: chunk.fg === undefined ? undefined : rgbToHex(chunk.fg).toLowerCase(),
+      // The renderer packs a chunk's styles into one bitmask.
+      bold: ((chunk.attributes ?? 0) & TextAttributes.BOLD) !== 0,
     }));
   }
 
-  it('colors a leading tag in the label color and the rest of the line in the content color', () => {
+  const body = (text: string) => ({text, fg: palette.content.toLowerCase(), bold: false});
+  const tag = (text: string) => ({text, fg: theme.textMuted.toLowerCase(), bold: false});
+
+  it('mutes a leading tag and leaves the rest of the line in the content color', () => {
     expect(styledChunks('[git-tracking] trusted input baseline: 4cf7a6767b6f')).toEqual([
-      {text: '[git-tracking]', fg: palette.label.toLowerCase()},
-      {text: ' trusted input baseline: 4cf7a6767b6f', fg: palette.content.toLowerCase()},
+      tag('[git-tracking]'),
+      body(' trusted input baseline: 4cf7a6767b6f'),
     ]);
   });
 
-  it('returns untagged content unchanged, including empty content', () => {
-    expect(styleSourceTags('plain line', palette)).toBe('plain line');
-    expect(styleSourceTags('', palette)).toBe('');
+  it('returns unremarkable content unchanged, including empty content', () => {
+    expect(styleTranscriptText('plain line', palette, theme)).toBe('plain line');
+    expect(styleTranscriptText('', palette, theme)).toBe('');
   });
 
   it('leaves a bracket that is not at the start of the line untouched', () => {
-    expect(styleSourceTags('see [x] here', palette)).toBe('see [x] here');
+    expect(styleTranscriptText('see [x] here', palette, theme)).toBe('see [x] here');
   });
 
-  it('colors a line that is only a tag, with no trailing content chunk', () => {
-    expect(styledChunks('[git-tracking]')).toEqual([
-      {text: '[git-tracking]', fg: palette.label.toLowerCase()},
-    ]);
+  it('mutes a line that is only a tag, with no trailing content chunk', () => {
+    expect(styledChunks('[git-tracking]')).toEqual([tag('[git-tracking]')]);
   });
 
-  it('colors each tagged line independently across multi-line content', () => {
+  it('styles each tagged line independently across multi-line content', () => {
     const content = '[git-tracking] one\nplain\n[framework-validation] two';
     expect(styledChunks(content)).toEqual([
-      {text: '[git-tracking]', fg: palette.label.toLowerCase()},
-      {text: ' one', fg: palette.content.toLowerCase()},
-      {text: '\n', fg: palette.content.toLowerCase()},
-      {text: 'plain', fg: palette.content.toLowerCase()},
-      {text: '\n', fg: palette.content.toLowerCase()},
-      {text: '[framework-validation]', fg: palette.label.toLowerCase()},
-      {text: ' two', fg: palette.content.toLowerCase()},
+      tag('[git-tracking]'),
+      body(' one'),
+      body('\n'),
+      body('plain'),
+      body('\n'),
+      tag('[framework-validation]'),
+      body(' two'),
     ]);
+  });
+
+  it('bolds PASS in the success colour and FAIL in the failure colour', () => {
+    expect(styledChunks('[framework-validation] PASS')).toEqual([
+      tag('[framework-validation]'),
+      body(' '),
+      {text: 'PASS', fg: theme.conversation.success.label.toLowerCase(), bold: true},
+    ]);
+    expect(styledChunks('[framework-validation] FAIL: build: exit 1')).toEqual([
+      tag('[framework-validation]'),
+      body(' '),
+      {text: 'FAIL', fg: theme.conversation.failure.label.toLowerCase(), bold: true},
+      body(': build: exit 1'),
+    ]);
+  });
+
+  it('emphasizes a verdict on an untagged line and mid-line', () => {
+    expect(styledChunks('[framework-validation] reused PASS: warmup')).toEqual([
+      tag('[framework-validation]'),
+      body(' reused '),
+      {text: 'PASS', fg: theme.conversation.success.label.toLowerCase(), bold: true},
+      body(': warmup'),
+    ]);
+  });
+
+  it('leaves a verdict that is only part of a longer word alone', () => {
+    // `\b` on both sides, so the gate's own words are emphasized and prose
+    // about them, or a path that happens to contain them, is not.
+    for (const line of ['3 PASSED, 1 skipped', 'wrote FAILURES.md', 'no failures']) {
+      expect([line, styleTranscriptText(line, palette, theme)]).toEqual([line, line]);
+    }
   });
 });
 
@@ -536,7 +589,7 @@ describe('styleSourceTags (#647)', () => {
  * helper alone, so a future refactor that stops passing the styled result to
  * either `TextRenderable` still fails here.
  */
-describe('transcript source tags and run ids take the card label color (#647)', () => {
+describe('transcript run ids take the card label color, source tags recede (#647)', () => {
   it('colors the run id exactly like the role, selected or not, in every theme', async () => {
     for (const theme of listThemes()) {
       for (const selectedId of [null, 'a'] as const) {
@@ -562,7 +615,7 @@ describe('transcript source tags and run ids take the card label color (#647)', 
     }
   });
 
-  it('colors the bracketed tag on a real diagnostic line (bad-cpp-round1.jsonl) in the label color', async () => {
+  it('mutes the bracketed tag on a real diagnostic line (bad-cpp-round1.jsonl)', async () => {
     // Shape of fixture line 4: a diagnostic entry whose content is exactly
     // one `[git-tracking]`-tagged line, trailing newline included, the way
     // `agent_output_chunk` delivers it.
@@ -578,13 +631,38 @@ describe('transcript source tags and run ids take the card label color (#647)', 
     const card = cardOf(view, 'd1');
     const text = card.getChildren().find(child => child instanceof TextRenderable);
     if (!(text instanceof TextRenderable)) throw new Error('content text missing');
-    const palette = resolveTheme(null).conversation.analysis;
+    const theme = resolveTheme(null);
+    const palette = theme.conversation.analysis;
     const [tag, rest] = text.content.chunks;
     expect(tag?.text).toBe('[git-tracking]');
     expect(rest?.text).toBe(' trusted input baseline: 4cf7a6767b6f');
     if (tag?.fg === undefined || rest?.fg === undefined) throw new Error('chunk missing a colour');
-    expect(rgbToHex(tag.fg).toLowerCase()).toBe(palette.label.toLowerCase());
+    expect(rgbToHex(tag.fg).toLowerCase()).toBe(theme.textMuted.toLowerCase());
+    // Pinned against the label directly, because the muted token is the whole
+    // point: the tag is on nearly every subprocess line and must not compete
+    // with the heading that says who is speaking.
+    expect(rgbToHex(tag.fg).toLowerCase()).not.toBe(palette.label.toLowerCase());
     expect(rgbToHex(rest.fg).toLowerCase()).toBe(palette.content.toLowerCase());
+  });
+
+  it('bolds a gate verdict on the line the gate actually prints', async () => {
+    const entries: ConversationEntry[] = [
+      {
+        id: 'd2',
+        kind: 'subprocess',
+        label: 'launcher',
+        content: '[framework-benchmark] PASS: throughput=1135\n',
+      },
+    ];
+    const {view} = await renderEntries(entries);
+    const card = cardOf(view, 'd2');
+    const text = card.getChildren().find(child => child instanceof TextRenderable);
+    if (!(text instanceof TextRenderable)) throw new Error('content text missing');
+    const theme = resolveTheme(null);
+    const verdict = text.content.chunks.find(chunk => chunk.text === 'PASS');
+    if (verdict?.fg === undefined) throw new Error('verdict chunk missing');
+    expect(rgbToHex(verdict.fg).toLowerCase()).toBe(theme.conversation.success.label.toLowerCase());
+    expect((verdict.attributes ?? 0) & TextAttributes.BOLD).not.toBe(0);
   });
 
   it('leaves an untagged line as a single content-colored chunk', async () => {

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -1,5 +1,6 @@
 import {
   BoxRenderable,
+  bold,
   type CliRenderer,
   fg,
   MarkdownRenderable,
@@ -14,16 +15,14 @@ import {hasRunEnded} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
 import {visibleConversation} from '../session-model.js';
-import {fillLayer} from './box-fill.js';
 import {promptPreview, toolCallPreview, toolResultPreview} from './previews.js';
 import {
-  conversationRole,
   createMarkdownBlockOptions,
   type EntryPalette,
   entryPalette,
   type MarkdownBlockOptions,
 } from './styles.js';
-import {ensureContrast, SUBTLE_TEXT_MIN_CONTRAST, type Theme} from './theme.js';
+import {ensureContrast, RUN_DIVIDER_MIN_CONTRAST, type Theme} from './theme.js';
 
 export interface ConversationViewOptions {
   selectConversation?: (state: SessionState) => ConversationEntry[];
@@ -375,7 +374,6 @@ export class ConversationView {
   #renderEntry(entry: ConversationEntry, previous: ConversationEntry | undefined): BoxRenderable {
     const palette = entryPalette(entry, this.#theme);
     const selected = this.#selectedId === entry.id;
-    const bare = isBareEntry(entry);
     // The first rendered entry always draws its chrome, whatever sits above it
     // in the model: the window and the scrollback both start mid-run, and the
     // topmost row on screen is the one that most has to say who is speaking.
@@ -426,15 +424,17 @@ export class ConversationView {
         : {
             border: borderSides,
             borderStyle: 'single' as const,
-            // The resting colour is held to the same 3:1 floor `textSubtle`
-            // uses for punctuation and rules: `roleAccents` in theme.ts is not
-            // run through `ensureContrast` the way the label and content
-            // derived from it are, and five of the 64 role/theme combinations
-            // sit under 3:1. A four-sided border could lean on its own area to
-            // stay noticeable at a marginal contrast; a one-row rule cannot.
+            // Neutral, not the role accent. The rule separates one run from
+            // the next; who is speaking is already said by the heading word and
+            // its colour, and a third channel pointed at the same fact is what
+            // made the transcript read as oversaturated. `border` is the token
+            // every other resting frame in the UI draws in (`paneBorderColor`),
+            // lifted to `RUN_DIVIDER_MIN_CONTRAST`: a four-sided border can lean
+            // on its own area to stay noticeable at a marginal contrast, and a
+            // one-row rule that has just given up its accent cannot.
             borderColor: selected
               ? this.#theme.borderFocus
-              : ensureContrast(palette.border, this.#theme.canvas, SUBTLE_TEXT_MIN_CONTRAST),
+              : ensureContrast(this.#theme.border, this.#theme.canvas, RUN_DIVIDER_MIN_CONTRAST),
           }),
       ...(this.#showsSelection
         ? {
@@ -457,12 +457,6 @@ export class ConversationView {
             }
           : {}),
     });
-    // A bare entry draws no frame, so its role tint is what marks it as one
-    // agent's line. It goes on a layer inside the card rather than on the card
-    // itself: an opener draws a rule, and a `backgroundColor` on a bordered box
-    // paints the border row with it (tui-conventions.md, "a fill lives on an
-    // inner box").
-    if (bare) fillLayer(card, `event-${entry.id}-fill`, palette.background);
     if (opensRun) {
       const heading = new BoxRenderable(this.renderer, {
         id: `event-${entry.id}-heading`,
@@ -519,7 +513,7 @@ export class ConversationView {
       const content = prompt ? prompt.content : (output?.content ?? entry.content);
       card.add(
         new TextRenderable(this.renderer, {
-          content: styleSourceTags(content, palette),
+          content: styleTranscriptText(content, palette, this.#theme),
           fg: palette.content,
           width: '100%',
           // A command line, a stderr trace, or a banner runs past the card;
@@ -636,48 +630,74 @@ export class ConversationView {
 const SOURCE_TAG = /^\[[A-Za-z0-9][\w-]*\]/;
 
 /**
- * Colors a leading bracketed source tag in the card's label color; the rest
- * of that line, and any line without one, stays in the content color.
- * `SOURCE_TAG` is anchored to the start of the line, so a bracket elsewhere in
- * a line (`see [x] here`) is left alone.
- *
- * Returns `content` unchanged when no line carries a tag, so an untagged
- * entry keeps rendering as the single content-colored string it always has.
- * Exported so the line-splitting and anchoring are tested directly, the way
- * previews.ts exports `unwrapShellCommand` for the same reason.
+ * The verdict a gate prints: `[framework-validation] PASS`,
+ * `[framework-benchmark] FAIL: ...`. Whole words, so `PASSED` and a path
+ * component spelled `fail` are left alone.
  */
-export function styleSourceTags(content: string, palette: EntryPalette): StyledText | string {
-  const lines = content.split('\n');
-  if (!lines.some(line => SOURCE_TAG.test(line))) return content;
-  const chunks: TextChunk[] = [];
-  lines.forEach((line, index) => {
-    const tag = SOURCE_TAG.exec(line);
-    if (tag !== null) {
-      chunks.push(fg(palette.label)(tag[0]));
-      const rest = line.slice(tag[0].length);
-      if (rest !== '') chunks.push(fg(palette.content)(rest));
-    } else if (line !== '') {
-      chunks.push(fg(palette.content)(line));
-    }
-    if (index < lines.length - 1) chunks.push(fg(palette.content)('\n'));
-  });
-  return new StyledText(chunks);
+const VERDICT = /\bPASS\b|\bFAIL\b/g;
+
+/**
+ * Emphasizes the two words in `text` a reader is actually scanning for, and
+ * draws everything around them in the entry's content color.
+ *
+ * `PASS` and `FAIL` are the outcome of a run, and after the transcript stopped
+ * spending colour on role they are close to the only saturated thing left on
+ * the line. The word is the non-colour channel: green and red alone say nothing
+ * to the ~8% of men with red-green CVD, and the two high-contrast themes barely
+ * have a palette to say it with.
+ */
+function pushBody(chunks: TextChunk[], text: string, palette: EntryPalette, theme: Theme): boolean {
+  let cursor = 0;
+  let emphasized = false;
+  for (const match of text.matchAll(VERDICT)) {
+    if (match.index > cursor) chunks.push(fg(palette.content)(text.slice(cursor, match.index)));
+    const role = match[0] === 'PASS' ? theme.conversation.success : theme.conversation.failure;
+    chunks.push(bold(fg(role.label)(match[0])));
+    cursor = match.index + match[0].length;
+    emphasized = true;
+  }
+  if (cursor < text.length) chunks.push(fg(palette.content)(text.slice(cursor)));
+  return emphasized;
 }
 
 /**
- * Whether an entry is drawn as bare lines instead of a bordered card.
+ * Colors the parts of a transcript line that are not the line's own prose.
  *
- * Provider lifecycle chatter and driver banners arrive on the diagnostic and
- * subprocess channels a line at a time, and a rounded card turns each of those
- * lines into five rows of chrome around three words. They read better as a
- * muted run of text between the cards that carry real turns. A failure is the
- * exception: whether the backend marked it or the driver's own error marker
- * did, it keeps the card so it still stops the eye.
+ * A leading bracketed source tag recedes into the theme's muted text, and any
+ * `PASS` or `FAIL` is lifted into its verdict colour and bolded. Everything
+ * else stays in the entry's content color. `SOURCE_TAG` is anchored to the
+ * start of the line, so a bracket elsewhere in a line (`see [x] here`) is left
+ * alone.
+ *
+ * The tags used to take the card's label colour, which put a saturated
+ * 24-column prefix on nearly every subprocess line. A marker that appears on
+ * almost every row marks nothing, so it is drawn as what it is: a frequent,
+ * low-information prefix that should recede.
+ *
+ * Returns `content` unchanged when no line carries a tag or a verdict, so an
+ * ordinary entry keeps rendering as the single content-colored string it always
+ * has. Exported so the line-splitting and anchoring are tested directly, the
+ * way previews.ts exports `unwrapShellCommand` for the same reason.
  */
-function isBareEntry(entry: ConversationEntry): boolean {
-  if (entry.kind === 'status') return true;
-  if (entry.kind !== 'diagnostic' && entry.kind !== 'subprocess') return false;
-  return conversationRole(entry) !== 'failure';
+export function styleTranscriptText(
+  content: string,
+  palette: EntryPalette,
+  theme: Theme,
+): StyledText | string {
+  const lines = content.split('\n');
+  const chunks: TextChunk[] = [];
+  let styled = false;
+  lines.forEach((line, index) => {
+    const tag = SOURCE_TAG.exec(line);
+    if (tag !== null) {
+      chunks.push(fg(theme.textMuted)(tag[0]));
+      styled = true;
+    }
+    const rest = tag === null ? line : line.slice(tag[0].length);
+    if (pushBody(chunks, rest, palette, theme)) styled = true;
+    if (index < lines.length - 1) chunks.push(fg(palette.content)('\n'));
+  });
+  return styled ? new StyledText(chunks) : content;
 }
 
 /**

--- a/clients/tui/src/ui/theme.test.ts
+++ b/clients/tui/src/ui/theme.test.ts
@@ -69,20 +69,20 @@ describe('theme selection', () => {
     expect(dark.accent).toBe('#22d3ee');
     expect(dark.border).toBe('#475569');
     expect(dark.conversation.assistant).toEqual({
-      border: '#0891b2',
-      // The one knock-on. A card fill is `mix(canvas, roleAccent, cardTint)`,
-      // so it follows the canvas by construction and stays the same 14% step
-      // off it that it was; pinning the old `#0e283d` here would put a lighter
-      // rectangle back on the screen, which is the thing #574 removed.
-      background: '#03192d',
+      // The canvas. A role used to tint its own fill (`#03192d`, a 14% step off
+      // the canvas); dropping it is what leaves role carried by the heading
+      // word and its colour and nothing else. Both of those are unchanged,
+      // because they already cleared the floor against the tint and so came
+      // through `ensureContrast` untouched either way.
+      background: '#020617',
       label: '#5cb6cc',
       content: '#e2e8f0',
     });
     expect(dark.conversation.failure.label).toBe('#f28484');
     // A tool call is told apart by its text colour, not by a filled band: a
     // block of background behind text reads as a selection.
-    expect(dark.toolCall.background).toBe(dark.conversation.tool.background);
-    expect(dark.toolResult.background).toBe(dark.conversation.tool.background);
+    expect(dark.toolCall.background).toBe(dark.canvas);
+    expect(dark.toolResult.background).toBe(dark.canvas);
     expect(dark.toolCall.foreground).not.toBe(dark.toolResult.foreground);
     expect(dark.markdown.code).toBe('#a5f3fc');
     expect(dark.markdown.codeBackground).toBe('#1e293b');
@@ -150,10 +150,15 @@ describe('semantic roles', () => {
 
   it.each(
     themes.map(theme => [theme.name, theme] as const),
-  )('%s keeps every conversation card label and body readable on its own fill', (_name, theme: Theme) => {
+  )('%s keeps every conversation role readable on the canvas it now draws on', (_name, theme: Theme) => {
     const minimum = theme.name.startsWith('high-contrast') ? 7 : 4.5;
     for (const role of CONVERSATION_ROLES) {
       const {label, content, background} = theme.conversation[role];
+      // No role paints a fill any more, so this is the canvas, and the floor is
+      // remade against the cell the text actually lands on. A tint coming back
+      // moves the background out from under both checks below at once, which is
+      // why it is asserted here rather than assumed.
+      expect(background).toBe(theme.canvas);
       expect(contrastRatio(label, background)).toBeGreaterThanOrEqual(minimum);
       expect(contrastRatio(content, background)).toBeGreaterThanOrEqual(minimum);
     }
@@ -268,9 +273,9 @@ describe('semantic roles', () => {
       const light = resolveTheme(lightName);
       expect(dark.canvas).not.toBe(light.canvas);
       expect(dark.textPrimary).not.toBe(light.textPrimary);
-      expect(dark.conversation.assistant.background).not.toBe(
-        light.conversation.assistant.background,
-      );
+      // The label, not the background: every role draws on the canvas now, so
+      // comparing backgrounds would only restate the line above.
+      expect(dark.conversation.assistant.label).not.toBe(light.conversation.assistant.label);
     }
   });
 });

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -36,8 +36,20 @@ export const CONVERSATION_ROLES: readonly ConversationRole[] = [
   'failure',
 ];
 
+/**
+ * What a conversation role is drawn in.
+ *
+ * Two channels for one fact, which is the whole of it: the heading word says
+ * who is speaking and `label` colours it. `background` is the canvas for every
+ * role, so it is the cell a role's text lands on rather than a surface of its
+ * own; it is here because the bands below still need a background to name.
+ *
+ * A role tint and a role-coloured run divider used to sit beside those two, so
+ * one fact carried four signals at once. The tint was the loudest of them: a
+ * screen of entries read as a field of blocks. The divider is a separator, and
+ * separators are neutral.
+ */
 export interface ConversationRoleColors {
-  border: string;
   background: string;
   label: string;
   content: string;
@@ -285,7 +297,6 @@ interface ThemeSpec {
   error: string;
   roleAccents: Record<ConversationRole, string>;
   minContrast: number;
-  cardTint: number;
   overrides?: {
     conversation?: Partial<Record<ConversationRole, Partial<ConversationRoleColors>>>;
     toolCall?: Partial<BandColors>;
@@ -298,6 +309,20 @@ interface ThemeSpec {
 export const SUBTLE_TEXT_MIN_CONTRAST = 3;
 
 /**
+ * The floor the transcript's run divider is held to, above the subtle-text one.
+ * Subtle text is decoration a reader can skip; this rule is one cell tall and
+ * is the only thing left saying where one run ends and the next begins, so it
+ * has to survive at a glance.
+ *
+ * It used to draw in the speaking role's accent and borrowed that saturated
+ * colour's own contrast, 3.84 to 4.76 across the eight themes. Neutral at 3
+ * measured 3.03 to 3.31 and the grouping read visibly weaker. 4.5 puts the rule
+ * back in the band the per-role dividers occupied without giving it a colour
+ * channel back.
+ */
+export const RUN_DIVIDER_MIN_CONTRAST = 4.5;
+
+/**
  * How far a card's label is pulled toward the theme's strongest text before the
  * contrast floor is applied. The raw role accent reads as a border but is too
  * close to the card fill to head it: lifting it keeps the role's hue while
@@ -307,11 +332,12 @@ const LABEL_LIFT = 0.35;
 
 function buildConversationRole(spec: ThemeSpec, role: ConversationRole): ConversationRoleColors {
   const accent = spec.roleAccents[role];
-  // A low tint off the canvas: enough to group a card's lines together, not so
-  // much that a screen of cards becomes a field of blocks.
-  const background = mix(spec.canvas, accent, spec.cardTint);
+  // The canvas, not a tint off it. A tint low enough to keep text readable was
+  // not seen as grouping and a tint high enough to be seen bled a rectangle
+  // around every entry, which is the same argument `canvas` above makes against
+  // a second surface.
+  const background = spec.canvas;
   const derived: ConversationRoleColors = {
-    border: accent,
     background,
     label: ensureContrast(mix(accent, spec.textStrong, LABEL_LIFT), background, spec.minContrast),
     content: ensureContrast(spec.textPrimary, background, spec.minContrast),
@@ -324,14 +350,18 @@ function buildToolBands(
   conversation: Record<ConversationRole, ConversationRoleColors>,
 ): {toolCall: BandColors; toolResult: BandColors} {
   const tool = conversation.tool;
+  // The canvas, by way of the role the bands belong to: a band is told apart by
+  // its text colour, not by a fill behind it, and both foregrounds are held to
+  // the floor against the cell they actually land on.
+  const background = tool.background;
   return {
     toolCall: {
-      background: tool.background,
-      foreground: ensureContrast(spec.roleAccents.user, tool.background, spec.minContrast),
+      background,
+      foreground: ensureContrast(spec.roleAccents.user, background, spec.minContrast),
       ...spec.overrides?.toolCall,
     },
     toolResult: {
-      background: tool.background,
+      background,
       foreground: tool.content,
       ...spec.overrides?.toolResult,
     },
@@ -421,7 +451,6 @@ const DARK: ThemeSpec = {
   warning: '#facc15',
   error: '#f87171',
   minContrast: 4.5,
-  cardTint: 0.14,
   roleAccents: {
     assistant: '#0891b2',
     user: '#2563eb',
@@ -466,7 +495,6 @@ const LIGHT: ThemeSpec = {
   warning: '#b45309',
   error: '#b91c1c',
   minContrast: 4.5,
-  cardTint: 0.1,
   roleAccents: {
     assistant: '#0e7490',
     user: '#1d4ed8',
@@ -499,7 +527,6 @@ const SOLARIZED_DARK: ThemeSpec = {
   warning: '#b58900',
   error: '#dc322f',
   minContrast: 4.5,
-  cardTint: 0.16,
   roleAccents: {
     assistant: '#2aa198',
     user: '#268bd2',
@@ -532,7 +559,6 @@ const SOLARIZED_LIGHT: ThemeSpec = {
   warning: '#b58900',
   error: '#dc322f',
   minContrast: 4.5,
-  cardTint: 0.12,
   roleAccents: {
     assistant: '#2aa198',
     user: '#268bd2',
@@ -565,7 +591,6 @@ const CATPPUCCIN_MOCHA: ThemeSpec = {
   warning: '#f9e2af',
   error: '#f38ba8',
   minContrast: 4.5,
-  cardTint: 0.16,
   roleAccents: {
     assistant: '#94e2d5',
     user: '#89b4fa',
@@ -598,7 +623,6 @@ const CATPPUCCIN_LATTE: ThemeSpec = {
   warning: '#df8e1d',
   error: '#d20f39',
   minContrast: 4.5,
-  cardTint: 0.12,
   roleAccents: {
     assistant: '#179299',
     user: '#1e66f5',
@@ -631,7 +655,6 @@ const HIGH_CONTRAST_DARK: ThemeSpec = {
   warning: '#ffd700',
   error: '#ff8080',
   minContrast: 7,
-  cardTint: 0.1,
   roleAccents: {
     assistant: '#00ffff',
     user: '#7cc7ff',
@@ -668,7 +691,6 @@ const HIGH_CONTRAST_LIGHT: ThemeSpec = {
   warning: '#7a4b00',
   error: '#b00000',
   minContrast: 7,
-  cardTint: 0.08,
   roleAccents: {
     assistant: '#006466',
     user: '#0033cc',


### PR DESCRIPTION
## Problem

The transcript encodes **role** (who is speaking) four separate ways, all derived from one
accent in `buildConversationRole`:

1. the heading word itself, `judge`, the only non-colour channel
2. `palette.label`, the heading colour
3. `palette.background`, a tint of `mix(canvas, accent, cardTint)` behind every line of the run
4. `palette.border`, the raw accent, used as the run divider's colour

One fact, four signals. That is what makes the transcript read as oversaturated, and it is
worst on the light themes, where the tint is a lavender slab over roughly a quarter of the
window. Two related counts: the `[framework-validation]` style source tags appear on nearly
every subprocess line, so they mark nothing, and they are drawn in the same purple as the
heading while taking about a third of the line. Meanwhile `PASS`, the thing an operator is
actually scanning for, is plain body text.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/colour-diet-before.png) | ![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/colour-diet-after.png) |

Dark, for consistency with the rest of the stack. The effect is larger on the light themes,
where the tint is a slab over roughly a quarter of the window:
[latte before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/colour-diet-latte-before.png)
and [latte after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/colour-diet-latte-after.png).

## Solution

Cut role from four channels to two, and spend what is reclaimed on the outcome.

- **The role background tint is gone.** Every role's background is the canvas.
- **The run divider is one neutral colour** rather than the role accent. It is a separator,
  not a role signal.
- **Source tags are muted** instead of purple, so a marker that appears on every line recedes.
- **`PASS` and `FAIL` are bold in the success and failure colours.** After the above they are
  nearly the only saturated things on screen, which is what makes them scan. The words stay:
  green against red alone fails for the ~8% of men with red-green colour vision deficiency.

Role is now the heading word plus its colour. Two channels, one of them non-colour.

### Architecture

Removing the tint cascaded into deletions rather than additions: `cardTint` (the interface and
all eight theme specs), `ConversationRoleColors.border` (the divider was its only reader),
`isBareEntry`, and the `fillLayer` call for a bare entry's tint, which was that helper's only
caller here. `box-fill.ts` itself stays; five other panes use it.

Note that call was **added by #693**, the base of this PR. It existed to keep a tint off a
bordered box. With the tint gone, so is the reason.

The divider targets a new `RUN_DIVIDER_MIN_CONTRAST` of 4.5 rather than the shared
`SUBTLE_TEXT_MIN_CONTRAST` of 3. Going neutral cost the rule about a third of its contrast,
because it no longer borrows a saturated accent's, and a one-row rule doing structural work
needs more than subtle text does. The shared constant is untouched at its four other sites.

## Verification

### Correctness properties

- Every role's `label` and `content` meet their theme's `minContrast` (4.5 normally, 7 on the
  two high-contrast themes) against the new background, in all eight themes.
- The run divider meets 4.5 against the canvas in all eight, and is never equal to
  `borderFocus`, which remains the selection cursor.
- No bordered box carries a fill (#642), still enforced by the `box fills` walk.
- `PASS`/`FAIL` match on word boundaries, so `PASSED` and `FAILURES.md` are untouched.

### Testing

- `pnpm --filter @vibesys/tui test`: 830 pass, 0 fail.
- `pnpm check:ts`, `pnpm check:clients`, `pnpm check:ts-architecture`,
  `pnpm test:ts-architecture`, `scripts/check_doc_links.py`: clean.
- Contrast is asserted programmatically per theme rather than eyeballed, and `theme.test.ts`
  now pins `background === canvas` for every role, so a tint returning fails visibly.
- Every theme's worst-case role improved, because the tint had been pulling each background
  toward its own label's hue: dark 6.45 to 7.14, solarized-light 4.66 to 5.08, catppuccin-latte
  4.91 to 5.53, high-contrast-dark 10.61 to 11.75.
