### PR TITLE
fix(tui): pick the perf pane's best round by objective direction

### DIFF
--- a/clients/tui/src/performance-chart.test.ts
+++ b/clients/tui/src/performance-chart.test.ts
@@ -74,6 +74,27 @@ describe('renderPerformanceCurve', () => {
     expect(chart).toContain('Metric    p99_latency_us · minimize ↓');
   });
 
+  it('names the lowest round best for a minimizing objective', () => {
+    const chart = renderPerformanceCurve(
+      [performance(1, 1000), performance(2, 2000), performance(3, 1500)],
+      [],
+      context({objective_metric: 'p99_latency_us', objective_direction: 'min'}),
+    );
+
+    expect(chart).toContain('best r1 1k total_ops_per_sec');
+    expect(chart).toContain('latest r3 1.5k total_ops_per_sec');
+  });
+
+  it('keeps the highest round best for a maximizing objective', () => {
+    const chart = renderPerformanceCurve(
+      [performance(1, 1000), performance(2, 2000), performance(3, 1500)],
+      [],
+      context({objective_direction: 'max'}),
+    );
+
+    expect(chart).toContain('best r2 2k total_ops_per_sec');
+  });
+
   it('drops the lines for facts the run never recorded', () => {
     const chart = renderPerformanceCurve([performance(1, 1000)], [], context({}));
 

--- a/clients/tui/src/performance-chart.ts
+++ b/clients/tui/src/performance-chart.ts
@@ -64,7 +64,13 @@ export function renderPerformanceCurve(
   const maxLabel = `r${maxRound}`;
   lines.push(`${''.padStart(10)}${minLabel}${maxLabel.padStart(PLOT_WIDTH - minLabel.length)}`);
 
-  const best = visible.reduce((current, point) => (point.value > current.value ? point : current));
+  // "best" follows the objective direction: for a minimizing objective the
+  // lowest value wins. Without a recorded direction the historical
+  // higher-is-better reading stands.
+  const minimize = context?.objective_direction === 'min';
+  const best = visible.reduce((current, point) =>
+    (minimize ? point.value < current.value : point.value > current.value) ? point : current,
+  );
   const latest = visible.at(-1);
   if (latest) {
     lines.push(


### PR DESCRIPTION
## Problem

The `/perf` pane's summary line always names the round with the highest value `best`: `renderPerformanceCurve` reduces the visible points with `point.value > current.value`. For a minimizing objective the pane therefore contradicts itself: the context header prints `minimize ↓` (from `objective_direction`), while the summary names the worst round best. On a latency-style run the operator reads `best rN` for the round with the highest latency, which is exactly the misinformation class the backend side just fixed for round selection (#583).

## Solution

The reduce now follows `objective_direction`: for `min` the lowest value wins, for `max` (and for runs recorded without a direction) the highest wins, preserving the historical reading for old journals whose context carries no direction. The direction was already in scope: the same function renders the `maximize ↑`/`minimize ↓` glyph from `context.objective_direction` two sections above the summary line, so the fix consults the fact the pane already displays instead of introducing a new input.

### Architecture

The performance pane is presentation logic owned by `@vibesys/tui`: `renderPerformanceCurve` in `clients/tui/src/performance-chart.ts` is a pure formatter over the backend's `query.performance` response, and `objective_direction` is a backend-authoritative fact delivered in `performance_context`. The fix keeps that ownership: no protocol change, no core-state change, one formatter consults one more field of the context it already receives.

```mermaid
flowchart LR
    Q[query.performance response] --> P[performance points by round]
    Q --> C[performance_context incl. objective_direction]
    P --> R[renderPerformanceCurve]
    C --> R
    R --> H["Metric line: maximize ↑ / minimize ↓"]
    R --> B["best rN summary: now reduced by the same direction"]
```

## Verification

Pure-function regression tests on the formatter, plus the package checks.

### Correctness properties

- For `objective_direction: 'min'` the summary names the round with the lowest value best; for `'max'` the highest, unchanged.
- A context without a recorded direction keeps the historical higher-is-better reading, so old journals render exactly as before.
- The `latest` half of the summary line, the plot, the axes, and the context section are untouched.

### Testing

- New test `names the lowest round best for a minimizing objective` fails at the merge base (`best r2 2k` for a minimize run) and passes with the fix (`best r1 1k`); companion test pins the maximize behavior. Both live in `clients/tui/src/performance-chart.test.ts` beside the existing direction-glyph test.
- `bun test src/performance-chart.test.ts`: 15 pass, 0 fail. Full `pnpm --dir clients/tui test`: 826 pass, 0 fail. `pnpm check:ts-architecture` and the package `check` (tsc) pass; `pnpm check:ts` (biome) clean on the changed files.
