### PR TITLE
Journal: replace translated legacy phase events instead of duplicating them

### DIFF
--- a/src/server/journal.py
+++ b/src/server/journal.py
@@ -484,15 +484,17 @@ def _canonical_execution_events(
                 )
             )
             continue
-        if event.type in {EventType.PHASE_STARTED, EventType.PHASE_FINISHED} and isinstance(
-            event.data, PhaseData
+        if (
+            event.type in {EventType.PHASE_STARTED, EventType.PHASE_FINISHED}
+            and isinstance(event.data, PhaseData)
+            and event.execution_id is not None
+            and event.execution_id not in invocation_lifecycle_ids
+            and event.execution_id not in canonical_lifecycle_ids
         ):
-            if (
-                event.execution_id is not None
-                and event.execution_id not in invocation_lifecycle_ids
-                and event.execution_id not in canonical_lifecycle_ids
-                and event.type is EventType.PHASE_STARTED
-            ):
+            # The phase pair is this execution's only lifecycle record. The
+            # translated copy keeps the stored sequence, so it must replace the
+            # phase event: emitting both would duplicate one cursor position.
+            if event.type is EventType.PHASE_STARTED:
                 canonical.append(
                     event.model_copy(
                         update={
@@ -508,11 +510,7 @@ def _canonical_execution_events(
                         }
                     )
                 )
-            elif (
-                event.execution_id is not None
-                and event.execution_id not in invocation_lifecycle_ids
-                and event.execution_id not in canonical_lifecycle_ids
-            ):
+            else:
                 canonical.append(
                     event.model_copy(
                         update={
@@ -521,7 +519,6 @@ def _canonical_execution_events(
                         }
                     )
                 )
-            canonical.append(event)
             continue
         canonical.append(event)
     return canonical

--- a/tests/server/test_journal.py
+++ b/tests/server/test_journal.py
@@ -1,8 +1,10 @@
-"""Durable journal attachment, diagnostics, and failure-helper tests."""
+"""Durable journal attachment, replay translation, diagnostics, and failure-helper tests."""
 
 from __future__ import annotations
 
+import itertools
 import json
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import pytest
@@ -17,17 +19,41 @@ from server.diagnostics import (
     DiagnosticSeverity,
 )
 from server.events import (
+    AgentExecutionActivityData,
     AgentExecutionFinishedData,
+    AgentExecutionStartedData,
     EventStatus,
     EventType,
     JudgeResultData,
     PhaseData,
     RoundFinishedData,
+    RunEvent,
 )
 
 
 def _events(path):  # noqa: ANN001, ANN202
     return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def _write_stored_events(log_dir, events):  # noqa: ANN001, ANN202
+    log_dir.mkdir()
+    (log_dir / "run-events.jsonl").write_text(
+        "".join(event.model_dump_json() + "\n" for event in events)
+    )
+
+
+def _stored_event(sequence, event_type, status, data):  # noqa: ANN001, ANN202
+    return RunEvent(
+        sequence=sequence,
+        run_id="persisted-run",
+        timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+        type=event_type,
+        status=status,
+        agent_kind="implementer",
+        round_label="round 1",
+        execution_id="exec-1",
+        data=data,
+    )
 
 
 def test_bootstrap_events_join_durable_history(tmp_path):  # noqa: ANN001, ANN201
@@ -54,6 +80,86 @@ def test_bootstrap_events_join_durable_history(tmp_path):  # noqa: ANN001, ANN20
     assert [event.type for event in current.journal.read()] == expected
     assert [event["type"] for event in _events(tmp_path / "durable/run-events.jsonl")] == [
         event.value for event in expected
+    ]
+
+
+def test_phase_only_legacy_replay_translates_in_place(tmp_path):  # noqa: ANN001, ANN201
+    """A translated phase event replaces the original at its stored sequence."""
+    log_dir = tmp_path / "legacy"
+    _write_stored_events(
+        log_dir,
+        [
+            _stored_event(
+                1,
+                EventType.PHASE_STARTED,
+                EventStatus.ACTIVE,
+                PhaseData(phase="implementer", attempt=1),
+            ),
+            _stored_event(
+                2,
+                EventType.PHASE_FINISHED,
+                EventStatus.COMPLETED,
+                PhaseData(phase="implementer", attempt=1),
+            ),
+        ],
+    )
+
+    parts = build_server_parts(log_dir)
+    events = parts.journal.read()
+
+    sequences = [event.sequence for event in events]
+    assert all(left < right for left, right in itertools.pairwise(sequences)), sequences
+    started, finished = events[0], events[1]
+    assert started.type is EventType.AGENT_EXECUTION_STARTED
+    assert started.sequence == 1
+    assert isinstance(started.data, AgentExecutionStartedData)
+    assert started.data.stage == "implementer"
+    assert started.data.attempt == 1
+    assert finished.type is EventType.AGENT_EXECUTION_FINISHED
+    assert finished.sequence == 2
+    assert finished.status is EventStatus.COMPLETED
+    assert not any(
+        event.type in {EventType.PHASE_STARTED, EventType.PHASE_FINISHED} for event in events
+    )
+
+
+def test_modern_phase_events_replay_unchanged(tmp_path):  # noqa: ANN001, ANN201
+    """Phase events with a canonical lifecycle sibling pass through untouched."""
+    log_dir = tmp_path / "modern"
+    activity = AgentExecutionActivityData(mode="thinking", summary="Implementing")
+    stored = [
+        _stored_event(
+            1,
+            EventType.AGENT_EXECUTION_STARTED,
+            EventStatus.ACTIVE,
+            AgentExecutionStartedData(stage="implementer", attempt=1, activity=activity),
+        ),
+        _stored_event(
+            2,
+            EventType.PHASE_STARTED,
+            EventStatus.ACTIVE,
+            PhaseData(phase="implementer", attempt=1),
+        ),
+        _stored_event(
+            3,
+            EventType.AGENT_EXECUTION_FINISHED,
+            EventStatus.COMPLETED,
+            AgentExecutionFinishedData(result={"ok": True}),
+        ),
+        _stored_event(
+            4,
+            EventType.PHASE_FINISHED,
+            EventStatus.COMPLETED,
+            PhaseData(phase="implementer", attempt=1),
+        ),
+    ]
+    _write_stored_events(log_dir, stored)
+
+    parts = build_server_parts(log_dir)
+    events = parts.journal.read()
+
+    assert [event.model_dump_json() for event in events[: len(stored)]] == [
+        event.model_dump_json() for event in stored
     ]
 
 


### PR DESCRIPTION
## Problem

`_canonical_execution_events` in `src/server/journal.py` translates legacy journals on read. For the oldest journal generation, where `phase_started`/`phase_finished` are an execution's only lifecycle record, the translation appended a synthesized `agent_execution_started`/`agent_execution_finished` copy built with `model_copy` (which retains the original event's sequence number) and then also appended the original phase event. A legacy replay therefore emitted two events with the same sequence, so the canonical stream was not strictly increasing.

Sequence numbers are the subscription cursor: `checkpoint_locked` reports a `through_sequence` watermark and clients resume with `after_sequence` floors that index the durable store. Duplicate sequences break any consumer that treats the stream as a valid cursor space. The TypeScript client's `foldEvent` has a monotonic guard (`sequence <= state.sequence` returns the state unchanged) that silently drops the second event of each pair, which masked the bug: the client never actually folded the original phase event, and any consumer without that guard double-processes the cursor position. In the client, experiment-log entry ids are also derived from sequences, so duplicates would collide.

The double append tried to mirror the modern journal shape, where `ExecutionTracker` records `agent_execution_*`, `phase_*`, and `invocation_*` events per execution, each with its own sequence. On the read path there is no second sequence to give the synthesized twin, so mirroring that shape cannot be done without corrupting the cursor space.

## Solution

Translate in place: when a phase event belongs to an execution with no other lifecycle record, the synthesized `agent_execution_*` copy replaces it, exactly as the `invocation_started`/`invocation_finished` branches already do. Each durable sequence now maps to at most one canonical event, and the translated copy keeps the stored sequence, so resume floors and watermarks still index the durable store.

Nothing a consumer needs is lost. The synthesized copy carries the phase payload forward (`PhaseData.phase` becomes `stage`, `attempt` is preserved on started events) and `model_copy` keeps `status`, `diagnostic`, `agent_kind`, `round_label`, `execution_id`, and `timestamp`. In `clients/core-state/src/run-map.ts`, `applyPhaseEvent` and `updateRoundAgentElapsed` treat `phase_started`/`agent_execution_started` (and the finished pair) interchangeably, and their phase-specific dedup exists precisely because modern journals emit both families per execution. Since the client's monotonic guard already dropped the original phase event on every legacy replay, the client-observed stream is unchanged by this fix; it only becomes valid for consumers without such a guard.

The alternative, emitting both events under fresh strictly increasing sequences, was rejected: sequences are integers assigned by the durable store, canonicalization runs after the store's range filter, and there is no integer between two adjacent stored sequences. Any renumbering scheme desynchronizes client cursors from the store, so a resumed subscription would skip or replay durable events.

Modern journals are untouched: their phase events carry an execution id indexed as canonical lifecycle (from the `agent_execution_*` headers), so the translation guard never fires and they pass through byte-identical. Invocation-era journals are also untouched, since their phase execution ids are in the invocation index.

### Architecture

The fix stays inside `EventJournal`'s read-side compatibility layer, which owns replay translation (`src/server/journal.py`). The durable log is never rewritten, the wire protocol is unchanged, and no client code changes: the client keeps folding the same canonical event types it already handles.

```mermaid
flowchart LR
    store["EventStore\nrun-events.jsonl\nassigns sequences"] -->|"read(after_sequence)"| canon["_canonical_execution_events\nlegacy translation\nfix: replace, not duplicate"]
    canon --> api["RunApi\ncheckpoint_locked\nthrough_sequence watermark"]
    api -->|"wire events"| fold["core-state foldEvent\nmonotonic sequence guard"]
```

## Verification

### Correctness properties

- Canonical replay of a phase-only legacy journal is strictly increasing in sequence: each durable record yields at most one canonical event.
- Every emitted event keeps its stored sequence, so `after_sequence` floors and `through_sequence` watermarks continue to index the durable store.
- Translation fires only for executions with no `invocation_*` or `agent_execution_*` lifecycle record; modern and invocation-era journals replay byte-identical to before the change.
- The translated copy preserves the phase payload and header fields (stage, attempt, status, diagnostic, agent kind, round label, execution id, timestamp).

### Testing

Two regression tests in `tests/server/test_journal.py`:

- `test_phase_only_legacy_replay_translates_in_place` attaches to a pre-written phase-only legacy log and asserts the canonical stream is strictly increasing, the pair is translated to `agent_execution_started`/`agent_execution_finished` at their stored sequences 1 and 2, and no phase events remain.
- `test_modern_phase_events_replay_unchanged` attaches to a modern-shaped log (`agent_execution_*` plus `phase_*` sharing one execution id) and asserts the replay is byte-identical to the stored events, guarding the zero-change property for modern journals.

Fail-before evidence: with the `src/` change reverted, `uv run pytest tests/server/test_journal.py -q -k replay` fails `test_phase_only_legacy_replay_translates_in_place` (the replay emitted sequences `[1, 1, 2, 2, ...]` with the phase originals still present) and passes the modern-journal test (1 failed, 1 passed). With the fix applied the module passes in full.

- `uv run pytest tests/server/test_journal.py tests/server/test_lazy_event_store.py -q`: 36 passed.
- `uv run pytest tests/server/ -q`: 308 passed.
- `uv run ruff check src/server/journal.py tests/server/test_journal.py`: all checks passed.
- `uv run ty check src/server/journal.py tests/server/test_journal.py`: all checks passed.
