### PR TITLE
fix(tui): open the chat modal while another pane is zoomed

### DIFF
--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -351,11 +351,14 @@ export function experimentLogVisible(state: SessionState): boolean {
  * The chat is docked on the landing view: it is part of that view rather than a
  * dialog over it, so a question never hides the table it is about. Inside a
  * hypothesis, and in a terminal too narrow for two columns, it stays the modal
- * it was.
+ * it was. Zoom hands the content row to one pane, so while any other pane is
+ * zoomed the dock is off screen and the chat is the modal again; otherwise
+ * ``/chat`` would put the keys on a composer the operator cannot see.
  */
 export function chatDocked(state: SessionState): boolean {
   return (
     state.chatDockFits &&
+    (state.layout.zoomedPane === null || state.layout.zoomedPane === 'chat') &&
     state.experimentLog !== null &&
     state.hypothesisDetail === null &&
     state.hypothesisScope === null

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -39,6 +39,7 @@ import {
   moveHypothesisRoundSelection,
   moveThemeSelection,
   normalizeFocus,
+  openChat,
   openChatModelMenu,
   openChatResumeMenu,
   openExperimentLog,
@@ -6535,3 +6536,90 @@ class FakeController implements SessionController {
     for (const listener of this.#listeners) listener(this.state);
   }
 }
+
+describe('chat while a pane is zoomed', () => {
+  /** The landing view with the experiments pane zoomed over the whole row. */
+  async function zoomedLog(): Promise<{
+    testRenderer: TestRendererSetup;
+    controller: FakeController;
+  }> {
+    const testRenderer = await createTestRenderer({width: 200, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+    testRenderer.mockInput.pressKey('F4');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.zoomedPane).toBe('experiments');
+    return {testRenderer, controller};
+  }
+
+  it('opens the modal over the zoomed pane and takes the typing', async () => {
+    // Zoom gives the whole content row to one pane, so the docked chat is off
+    // screen. `chatDocked` used to ignore that and route /chat's focus to the
+    // hidden pane: no chat appeared, and keystrokes went where the operator
+    // could not see them.
+    const {testRenderer, controller} = await zoomedLog();
+    const zoomed = await frameAfter(testRenderer);
+    expect(zoomed).not.toContain('Experiment chat');
+
+    // What the real controller's /chat dispatch runs.
+    controller.publish(openChat(controller.state));
+    const opened = await frameAfter(testRenderer);
+    expect(controller.state.chatOpen).toBe(true);
+    expect(opened).toContain('Experiment chat');
+    expect(boxOf(testRenderer, 'chat-overlay').visible).toBe(true);
+
+    // The cursor landed on the visible composer: the question reaches the
+    // chat, not the command bar behind the modal.
+    await testRenderer.mockInput.typeText('why is r41 slow?');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.chatSubmissions.length === 1);
+    expect(controller.chatSubmissions).toEqual(['why is r41 slow?']);
+    expect(controller.submissions).toEqual([]);
+  });
+
+  it('restores the zoomed pane and its keys when the modal closes', async () => {
+    const {testRenderer, controller} = await zoomedLog();
+    controller.publish(openChat(controller.state));
+    await frameAfter(testRenderer);
+    expect(controller.state.chatOpen).toBe(true);
+
+    testRenderer.mockInput.pressKey('ESCAPE');
+    const closed = await frameAfterEscape(testRenderer);
+    expect(controller.state.chatOpen).toBe(false);
+    // Escape closes only the modal: the zoom and the pane keys are exactly
+    // where /chat found them.
+    expect(controller.state.layout.zoomedPane).toBe('experiments');
+    expect(controller.state.layout.focus).toBe('left');
+    expect(closed).toContain('H-07');
+    expect(closed).not.toContain('Experiment chat');
+  });
+
+  it('carries the modal and its draft through a zoom exit into the dock', async () => {
+    const {testRenderer, controller} = await zoomedLog();
+    controller.publish(openChat(controller.state));
+    await frameAfter(testRenderer);
+    expect(controller.state.chatOpen).toBe(true);
+    await testRenderer.mockInput.typeText('draft for the dock');
+
+    // F4 stands down while the modal is open, but zoom can still end under
+    // it. The modal stays the one chat surface until it is dismissed rather
+    // than jumping into the dock mid-question.
+    controller.togglePaneZoom();
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.zoomedPane).toBeNull();
+    expect(controller.state.chatOpen).toBe(true);
+    expect(boxOf(testRenderer, 'chat-overlay').visible).toBe(true);
+    expect(boxOf(testRenderer, 'chat-pane').visible).toBe(false);
+
+    testRenderer.mockInput.pressKey('ESCAPE');
+    const docked = await frameAfterEscape(testRenderer);
+    expect(controller.state.chatOpen).toBe(false);
+    expect(boxOf(testRenderer, 'chat-pane').visible).toBe(true);
+    // One shared draft: the words typed into the modal are waiting in the
+    // docked composer rather than lost with the surface that closed.
+    expect(docked).toContain('draft for the dock');
+  });
+});


### PR DESCRIPTION
## Problem

On the landing view, `chatDocked` (`clients/tui/src/session-model.ts`) decides whether experiment chat is the docked pane or the modal purely from measured dock fit and the active view, ignoring `layout.zoomedPane`. The renderer already knows better: `app.ts` computes `showChatPane` with `zoomedPane === null || zoomedPane === 'chat'`, so while any other pane is zoomed the docked chat is not drawn. The model and the renderer therefore disagreed exactly on the zoom dimension.

The observable failure: zoom a pane on the landing view (F4), then run `/chat`. `openChat` consults `chatDocked`, concludes the chat is docked, and routes focus to the docked pane with `layout.focus = 'chat'`. That pane is not on screen. No chat UI appears, the cursor stays in the command bar so typed text lands there (a question then produces "Commands start with /"), and `chatPaneFocused` routes Escape and PageUp/PageDown to the invisible pane. The operator perceives `/chat` as doing nothing. The same predicate misroutes `/chat <question>` typed in the command bar: `sendChat` uses `chatDocked` to decide whether the answer needs the modal, so the answer landed in a surface the operator could not see. It also wrongly hid `/chat` from the command suggestions (`hiddenWhen: chatDocked`).

## Solution

Make `chatDocked` zoom-aware in the model layer, which is the single authority every consumer already reads: the chat is docked only while no pane is zoomed or the zoomed pane is the chat itself. This is the same shape as the existing narrow-terminal case, where `chatDockFits === false` already sends `/chat` down the modal path.

Every consumer then agrees without further changes. `openChat` opens the modal while another pane is zoomed, `sendChat` opens the modal for a command-bar question so the answer is visible, `chatPaneVisible` and `chatPaneFocused` stop claiming the hidden pane so key routing follows what is on screen, `visiblePaneOrder` and `visiblePaneIds` drop the chat column so `normalizeFocus` (run on every state change) repairs any stale `'chat'` focus, and the command suggestions list `/chat` again because it now does something visible.

Edge cases and the behavior chosen for each:

- Docked chat focused, F4 pressed: `focusedPane` is `'chat'`, so zoom zooms the chat itself. `chatDocked` stays true for `zoomedPane === 'chat'`, keeping the full-row chat a dock with its own composer, unchanged from before.
- Docked chat on screen, another pane zoomed: the dock hides with the rest of the split, as the renderer already did. It does not pop into a modal, matching the narrow-terminal precedent where losing dock fit hides the pane rather than opening a dialog over the operator's zoom. `/chat` then presents the modal.
- Zoom exits while the modal is open: the modal stays the one chat surface until dismissed, consistent with modal state being authoritative over pane focus. Dismissing it lands on the landing view with the docked pane back. The composer draft is one shared `ChatDraft` object passed to both `ChatOverlayView` and `ChatPaneView`, and `ChatComposerView.activate` copies it into the newly visible editor, so a question typed in the modal is waiting in the dock.
- Closing the modal over a still-zoomed pane: Escape closes only the modal; the zoom and the pane keys are exactly where `/chat` found them.

### Architecture

Per the ownership table in `docs/contributing/tui-architecture.md`, focus, layout, and zoom policy belong to the TUI's session model; `app.ts` is a projection that additionally measures terminal width and reports `chatDockFits` back, and the controller and keybindings consult the same model predicates. The fix lives at the model predicate `chatDocked` so the renderer's zoom knowledge and the model's focus routing can no longer disagree: the renderer keeps its own `showChatPane` arithmetic (it must, because it folds in the live width measurement), and the model now implies it.

```mermaid
flowchart TD
  fits[chatDockFits, measured and reported by the renderer] --> pred{chatDocked in session-model.ts}
  zoom[layout.zoomedPane is null or chat] --> pred
  view[landing view without hypothesis detail or scope] --> pred
  pred -->|true| dock[openChat puts pane keys on the dock, chatPaneVisible routes keys, /chat hidden from suggestions]
  pred -->|false| modal[openChat and sendChat set chatOpen]
  dock --> rdock[app.ts renders the chat pane beside the log]
  modal --> rmodal[app.ts renders the chat overlay and focuses its composer]
```

## Verification

### Correctness properties

1. A chat surface the model routes focus or keys to is rendered. `chatPaneVisible` now implies the renderer's `showChatPane` under an agreeing width measurement, because both require dock fit, the landing view, no open modal, and a zoom that is absent or on the chat itself.
2. `/chat` always presents a visible chat surface: the docked pane when it is on screen, the modal otherwise (narrow terminal, hypothesis views, and now a zoomed pane).
3. Zoom remains presentation-only: toggling it does not create, destroy, or duplicate chat state, and the shared draft survives dock-modal migration in both directions.
4. Focus never names an off-screen column: `normalizeFocus` runs on every controller state change, and the chat column is absent from `visiblePaneOrder` while another pane is zoomed, so a stale `'chat'` focus is repaired to `'left'`.

### Testing

New self-contained `describe('chat while a pane is zoomed')` in `clients/tui/src/ui/app.test.ts`, driven through the OpenTUI test renderer and the real model transitions (`openChat`, `togglePaneZoom` via the controller): the modal opens over the zoomed experiments pane and the typed question reaches the chat rather than the command bar; Escape closes only the modal and restores the zoom and pane keys; a zoom exit under the open modal keeps the modal as the sole chat surface and, once dismissed, the dock shows the draft typed into the modal.

Fail-at-base verified by patch-revert: with only the test hunk applied on the merge base, `bun test src/ui/app.test.ts` reports 198 pass, 3 fail, and the three failures are exactly the new tests; with the fix, 201 pass, 0 fail.

Commands run in `clients/tui` and the repo root: `pnpm --dir clients/tui test` passes 827 tests, 0 fail (824 at base plus the three new); `pnpm check:ts-architecture`, `pnpm --dir clients/tui check`, and `pnpm check:ts` all pass.
