### PR TITLE
fix(tui): stop a parked chat draft from disabling single-key navigation

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -6156,6 +6156,139 @@ describe('modal scrim', () => {
   });
 });
 
+describe('single-key gating by the composer that owns the keyboard', () => {
+  /** A round view with two rounds, so `[` has somewhere to go. */
+  function twoRoundController(): FakeController {
+    return new FakeController({
+      ...initialSessionState(),
+      core: {
+        ...initialSessionState().core,
+        rounds: [
+          {number: 1, status: 'completed' as const},
+          {number: 2, status: 'active' as const},
+        ],
+        transcript: [
+          {
+            id: 'live',
+            kind: 'assistant',
+            label: 'Agent',
+            content: 'live output',
+            roundNumber: 2,
+          },
+        ],
+      },
+    });
+  }
+
+  it('keeps round navigation alive after a chat draft is closed unsent', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 20});
+    const controller = twoRoundController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+
+    // Leave a half-typed question in the modal chat, then close it unsent.
+    controller.publish({...controller.state, chatOpen: true});
+    await testRenderer.waitForFrame(value => value.includes('Experiment chat'));
+    await testRenderer.mockInput.typeText('half a question');
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+    expect(controller.state.chatOpen).toBe(false);
+
+    // The keystroke cannot reach the closed composer, so the parked draft
+    // must not disable the round view's plain keys. The bracket right after
+    // a flushed ESC sits out the parser's escape-sequence timeout, which the
+    // escape helper's beat also covers.
+    testRenderer.mockInput.pressKey('[');
+    await frameAfterEscape(testRenderer);
+    expect(controller.state.selectedRound).toBe(1);
+
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('agents');
+
+    // The draft was parked, not discarded: reopening the chat shows it.
+    controller.publish({...controller.state, chatOpen: true});
+    const reopened = await testRenderer.waitForFrame(value => value.includes('half a question'));
+    expect(reopened).toContain('Experiment chat');
+  });
+
+  it('opens a hypothesis on Enter while an unfocused docked draft is parked', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    // Draft in the docked chat, then move the keys back to the table.
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    await testRenderer.mockInput.typeText('draft for later');
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.focus).toBe('left');
+
+    // The command input is empty and owns the keyboard, so Enter belongs to
+    // the table even though a draft waits in the unfocused composer beside it.
+    testRenderer.mockInput.pressEnter();
+    await frameAfter(testRenderer);
+    expect(controller.state.hypothesisDetail).not.toBeNull();
+
+    // The draft was parked, not discarded by the drilldown.
+    controller.publish({...controller.state, chatOpen: true});
+    await testRenderer.waitForFrame(value => value.includes('draft for later'));
+  });
+
+  it('keeps navigation keys inside a focused composer holding text', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 20});
+    const controller = twoRoundController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+
+    controller.publish({...controller.state, chatOpen: true});
+    await testRenderer.waitForFrame(value => value.includes('Experiment chat'));
+    await testRenderer.mockInput.typeText('inspect arr');
+    testRenderer.mockInput.pressKey('[');
+    await frameAfter(testRenderer);
+
+    // The bracket is a character of the question, not round navigation.
+    expect(controller.state.selectedRound).toBeNull();
+
+    await testRenderer.mockInput.typeText('0]');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.chatSubmissions.length === 1);
+    expect(controller.chatSubmissions).toEqual(['inspect arr[0]']);
+  });
+
+  it('leaves brackets to a typed command while a chat draft is parked', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 20});
+    const controller = twoRoundController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+
+    controller.publish({...controller.state, chatOpen: true});
+    await testRenderer.waitForFrame(value => value.includes('Experiment chat'));
+    await testRenderer.mockInput.typeText('parked draft');
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+
+    // Text in the command input still shadows navigation: the bracket is a
+    // character of the command, whatever the parked draft holds.
+    await testRenderer.mockInput.typeText('/steer fix arr');
+    testRenderer.mockInput.pressKey('[');
+    const typed = await frameAfter(testRenderer);
+    expect(typed).toContain('arr[');
+    expect(controller.state.selectedRound).toBeNull();
+
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+    expect(controller.submissions).toEqual(['/steer fix arr[']);
+  });
+});
+
 /** The renderable behind a screen region, for asserting what a scrim covers. */
 function boxOf(testRenderer: TestRendererSetup, id: string): Renderable {
   const found = testRenderer.renderer.root.findDescendantById(id);

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -8,6 +8,7 @@ import {
 import {COMMAND_NAMES} from '../commands.js';
 import type {SessionController} from '../session-controller.js';
 import {
+  chatPaneFocused,
   experimentLogVisible,
   focusedPane,
   type SessionState,
@@ -565,11 +566,20 @@ export function createOpenTuiApp(
         : chatPane.navigateSuggestions(direction),
     completeChatInput: () =>
       controller.state.chatOpen ? chat.completeSuggestion() : chatPane.completeSuggestion(),
-    // Enter belongs to a pane only when nothing is typed anywhere. Asking which
-    // box has the cursor is not enough: a question waiting in the other box is
-    // still a question, and Enter must never discard it to open a hypothesis.
+    // Enter and the single-key bindings yield to typing, and typing happens
+    // in exactly one composer: the modal chat while it is open, the focused
+    // docked chat, otherwise the command box. Only that composer's text
+    // matters. A draft parked in a closed or unfocused chat surface cannot
+    // take the keystroke, and it survives whatever the binding does, so it
+    // must not disable navigation. The ladder mirrors the key router's own
+    // early returns, so any state it routes to a chat composer is exactly a
+    // state this gate consults that composer in.
     inputIsEmpty: () =>
-      commandInput.isEmpty() && chatPane.isComposerEmpty() && chat.isComposerEmpty(),
+      controller.state.chatOpen
+        ? chat.isComposerEmpty()
+        : chatPaneFocused(controller.state)
+          ? chatPane.isComposerEmpty()
+          : commandInput.isEmpty(),
     closeChat: () => controller.closeChat(),
     toggleLatestPrompt: () => conversation.toggleLatestPrompt(),
     toggleSelectedTool: () => conversation.toggleSelectedTool(),


### PR DESCRIPTION
## Problem

The keybinding layer gates every plain-key binding on `inputIsEmpty`, built in `clients/tui/src/ui/app.ts` as a conjunction over every composer in the app: `commandInput.isEmpty() && chatPane.isComposerEmpty() && chat.isComposerEmpty()`. The two chat surfaces read the same shared `ChatDraft`, so the conjunction is really "command input empty AND chat draft empty", regardless of whether any chat surface is on screen.

The consequence is a silent, persistent loss of navigation. An operator opens experiment chat (modal on the round view, or the docked pane on the landing view), types part of a question, and closes the chat without sending. The draft is deliberately parked so it survives reopening. But from that point `inputIsEmpty()` is false forever, and every binding gated on it dies: `[` and `]` round navigation, Left/Right pane focus, Enter to open a hypothesis from the experiment table, and Enter to expand a tool card. The keystroke could never reach the hidden composer, there is no visual cue that a draft exists, and the only recovery is reopening the chat and deleting text the operator may not remember writing.

The gate asks the wrong question. Every consumer in `clients/tui/src/ui/keybindings.ts` (lines that check `actions.inputIsEmpty()` before Enter, Left/Right, `[`, `]`) needs to know one thing: would this key be swallowed by the composer the operator is currently typing into. A draft in a closed or unfocused surface cannot swallow anything.

## Solution

Replace the global conjunction with a per-surface check that consults only the composer that currently owns the keyboard. The ownership ladder already exists twice in the client: the render path's `focusTarget` (modal chat while `chatOpen`, then the focused docked chat, then the command input) and the key router's early returns in `keybindings.ts` (the `chatOpen` branch and the `chatPaneFocused` branch both return before any `inputIsEmpty` consumer runs). `inputIsEmpty` now walks the same ladder:

```ts
inputIsEmpty: () =>
  controller.state.chatOpen
    ? chat.isComposerEmpty()
    : chatPaneFocused(controller.state)
      ? chatPane.isComposerEmpty()
      : commandInput.isEmpty(),
```

Because the key router returns early in exactly the states where the first two branches apply, every reachable consumer now effectively gates on `commandInput.isEmpty()`, which is the composer the keystroke would actually land in. The chat branches keep the action's contract self-contained ("is the composer that owns the keyboard empty") rather than depending on which call sites happen to be reachable, and they use the same `chatPaneFocused` predicate as the router's own early return, so the gate and the routing can never disagree about which composer owns a state.

Rejected alternatives. Reducing the gate to bare `commandInput.isEmpty()` encodes the reachability argument into the action's definition; a future consumer called from a chat-focused state would silently get the wrong answer. Clearing the chat draft when a surface closes would fix the gate but break draft parking, which is tested behavior (drafts survive close, reopen, thread switches, and dock-to-modal resizes). Moving the branch into `keybindings.ts` would need the three composers threaded through `KeybindingActions`, widening an interface that currently exposes one predicate.

The old comment justified the conjunction by "Enter must never discard it to open a hypothesis". Entering a hypothesis does not discard the draft: it stays in the shared `ChatDraft` and reappears when any chat surface next shows, which the new tests assert. The conjunction was guarding against a loss that does not happen, at the price of dead keys.

### Architecture

The fix stays entirely in the TUI package's presentation layer, which owns focus, drafts, and keyboard routing per `docs/contributing/tui-architecture.md`. `app.ts` wires the `inputIsEmpty` action from the composers it constructs plus the `session-model` focus predicates; `keybindings.ts` consumes the action without knowing which composer answered. No change to `core-state`, `backend-client`, or any event contract.

```mermaid
flowchart TD
  K[keypress] --> R{key router\nkeybindings.ts}
  R -->|chatOpen| M[modal composer\nhandles key]
  R -->|chatPaneFocused| D[docked composer\nhandles key]
  R -->|otherwise, plain nav key| G{inputIsEmpty}
  G -->|asks the same ladder| L[chatOpen? modal draft\nchatPaneFocused? docked draft\nelse command input]
  G -->|empty| N[navigate: rounds, panes,\nhypothesis, tool cards]
  G -->|holds text| C[command input keeps the key]
```

## Verification

### Correctness properties

A draft parked in a closed or unfocused chat surface never disables a binding: after closing a modal or docked chat with text in its composer, `[`, `]`, Left/Right, and Enter behave exactly as with no draft, and the draft is still there when the chat reopens.

Typing into the composer that owns the keyboard still shadows navigation: with the modal open, brackets and letters are characters of the question; with the docked pane focused, keys reach its editor; with text in the command input, brackets and cursor keys stay in the input and Enter submits the command.

The gate and the key router derive composer ownership from the same predicates (`controller.state.chatOpen`, `chatPaneFocused`), so any state the router routes to a chat composer is a state the gate consults that composer in.

### Testing

New describe block `single-key gating by the composer that owns the keyboard` in `clients/tui/src/ui/app.test.ts`, driven through the OpenTUI test renderer and the real key router:

- `keeps round navigation alive after a chat draft is closed unsent`: round view, modal draft closed with Escape; `[` selects the previous round, Left focuses the agents pane, and reopening the chat shows the untouched draft. Fails at base (`[` and Left are dead, selectedRound stays null).
- `opens a hypothesis on Enter while an unfocused docked draft is parked`: landing view, draft typed in the docked composer, Ctrl+W back to the table; Enter opens the hypothesis detail and the draft survives. Fails at base (Enter is dead, hypothesisDetail stays null).
- `keeps navigation keys inside a focused composer holding text`: modal open with text; `[` does not navigate and the submitted question contains it.
- `leaves brackets to a typed command while a chat draft is parked`: with `/steer fix arr` typed and a parked chat draft, `[` is appended to the command and submitted, never navigation.

Fail-at-base verified by patch-revert: `git diff > /tmp/i1.patch`, `git checkout -- clients`, apply the test-only hunk, `bun test src/ui/app.test.ts --test-name-pattern "single-key gating"` gives 2 fail (the two regression tests) and 2 pass (the two guards of existing behavior), then `git apply /tmp/i1.patch` restores the fix and all 4 pass.

Commands and results at head:

- `pnpm --dir clients/tui test`: 828 pass, 0 fail (824 at base plus the 4 new tests).
- `pnpm check:ts-architecture`: no dependency violations (93 modules, 360 dependencies).
- `pnpm --dir clients/tui check`: tsc clean.
- `pnpm check:ts`: biome clean, 88 files.
