### PR TITLE
fix(tui): pad and truncate log columns by display cells, not code units

### DIFF
--- a/clients/tui/src/ui/experiment-log.test.ts
+++ b/clients/tui/src/ui/experiment-log.test.ts
@@ -26,6 +26,7 @@ import {
   selectionCaret,
   sentenceCase,
 } from './experiment-log.js';
+import {displayWidth} from './text-width.js';
 import {resolveTheme, THEME_NAMES} from './theme.js';
 
 const WIDE = 120;
@@ -347,6 +348,48 @@ describe('experiment log rows', () => {
   });
 });
 
+/**
+ * Column arithmetic in cells, not code units: a CJK character is one code
+ * unit but two terminal cells, so `padEnd`/`slice` layouts drift as soon as a
+ * title or id carries one.
+ */
+describe('experiment log CJK column alignment', () => {
+  function columnOf(row: string, needle: string): number {
+    const index = row.indexOf(needle);
+    expect(index, `${needle} in ${row}`).toBeGreaterThanOrEqual(0);
+    return displayWidth(row.slice(0, index));
+  }
+
+  it('keeps the outcome column aligned when the claim is CJK', () => {
+    const columns = resolveColumns(WIDE);
+    const ascii = entryRow(entry(), columns);
+    const cjk = entryRow(entry({title: '缓存优化提升吞吐'}), columns);
+
+    expect(displayWidth(cjk)).toBe(displayWidth(ascii));
+    expect(columnOf(cjk, 'Accepted')).toBe(columnOf(ascii, 'Accepted'));
+  });
+
+  it('truncates a CJK claim by cells and never splits a wide character', () => {
+    const columns = resolveColumns(WIDE);
+    const cells = entryCells(entry({title: '性'.repeat(60)}), columns);
+
+    // The claim budget is odd here, so the last ideograph would straddle it:
+    // it is dropped whole and the ellipsis marks the cut.
+    expect(cells.leading).toContain(`${'性'.repeat(25)}…`);
+    expect(cells.leading).not.toContain('性'.repeat(26));
+    expect(displayWidth(cells.leading)).toBe(displayWidth(entryCells(entry(), columns).leading));
+  });
+
+  it('truncates a CJK hypothesis id by cells so the rounds column stays put', () => {
+    const columns = resolveColumns(WIDE);
+    const ascii = entryRow(entry(), columns);
+    const cjk = entryRow(entry({hypothesis_id: '缓存优化假设编号很长'}), columns);
+
+    expect(cjk).toContain('缓存优化假设…');
+    expect(columnOf(cjk, '41')).toBe(columnOf(ascii, '41'));
+  });
+});
+
 describe('selectionCaret', () => {
   it('renders a caret for the selected row and a matching blank otherwise', () => {
     expect(selectionCaret(true)).toBe('›');
@@ -549,6 +592,32 @@ describe('experiment log rendered selection glyph', () => {
     expect(h02Selected[rowH02AfterMove]?.indexOf('H-02')).toBe(colH02);
     expect(h02Selected[rowH01AfterMove]?.[colH01 - 2]).toBe(' ');
     expect(h02Selected[rowH02AfterMove]?.[colH02 - 2]).toBe('›');
+  });
+
+  it('keeps the outcome column aligned on screen when a claim is CJK', async () => {
+    const frame = (
+      await renderLog(
+        logState([
+          entry({hypothesis_id: 'H-01', first_round: 1, last_round: 1}),
+          entry({hypothesis_id: 'H-02', first_round: 2, last_round: 2, title: '缓存优化提升吞吐'}),
+        ]),
+      )
+    ).split('\n');
+    const asciiRow = frame.find(line => line.includes('H-01'));
+    const cjkRow = frame.find(line => line.includes('H-02'));
+    expect(asciiRow).toBeDefined();
+    expect(cjkRow).toBeDefined();
+    if (asciiRow === undefined || cjkRow === undefined) throw new Error('rows did not render');
+
+    // The frame stores a wide character once per grapheme, so the on-screen
+    // column of a cell is the display width of everything before it, not its
+    // string index.
+    const columnOf = (line: string, needle: string): number => {
+      const index = line.indexOf(needle);
+      expect(index, `${needle} in ${line}`).toBeGreaterThanOrEqual(0);
+      return displayWidth(line.slice(0, index));
+    };
+    expect(columnOf(cjkRow, 'Accepted')).toBe(columnOf(asciiRow, 'Accepted'));
   });
 
   it('marks the selected unowned round row with the same caret, in its own reserved column', async () => {

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -19,6 +19,7 @@ import {fillLayer} from './box-fill.js';
 import {formatFileChange} from './design-log.js';
 import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {elapsedLabel} from './previews.js';
+import {displayWidth, padToWidth, truncateToWidth} from './text-width.js';
 import type {Theme} from './theme.js';
 
 const MIN_BODY_WIDTH = 40;
@@ -597,17 +598,17 @@ export function resolveColumns(width: number): Columns {
 }
 
 export function headerRow(columns: Columns, direction: 'max' | 'min' | null = null): string {
-  const parts = [' Hypothesis'.padEnd(ID_WIDTH), 'Rounds'.padEnd(ROUNDS_WIDTH)];
-  if (columns.claim) parts.push('Implementation Details'.padEnd(columns.claimWidth));
+  const parts = [padToWidth(' Hypothesis', ID_WIDTH), padToWidth('Rounds', ROUNDS_WIDTH)];
+  if (columns.claim) parts.push(padToWidth('Implementation Details', columns.claimWidth));
   if (columns.measured) {
     // The glyph is the way improvement points, so a signed delta below reads
     // as good or bad without task knowledge. A glyph rather than color, which
     // the outcome column already spends; the drill-down spells out the word.
     const label = direction === null ? 'Measured' : `Measured ${direction === 'max' ? '↑' : '↓'}`;
-    parts.push(label.padEnd(MEASURED_WIDTH));
+    parts.push(padToWidth(label, MEASURED_WIDTH));
   }
-  parts.push('Outcome'.padEnd(OUTCOME_WIDTH));
-  if (columns.kept) parts.push('Kept'.padEnd(KEPT_WIDTH));
+  parts.push(padToWidth('Outcome', OUTCOME_WIDTH));
+  if (columns.kept) parts.push(padToWidth('Kept', KEPT_WIDTH));
   return parts.join(COLUMN_GAP);
 }
 
@@ -651,7 +652,10 @@ export function entryCells(
 ): EntryCells {
   const marker = entryLeadingMarker(entry, isSelected);
   const leading = [
-    fitColumn(`${marker}${truncate(entry.hypothesis_id, ID_WIDTH - marker.length)}`, ID_WIDTH),
+    fitColumn(
+      `${marker}${truncate(entry.hypothesis_id, ID_WIDTH - displayWidth(marker))}`,
+      ID_WIDTH,
+    ),
     fitColumn(formatRounds(entry), ROUNDS_WIDTH),
   ];
   if (columns.claim) {
@@ -678,8 +682,9 @@ export function entryCells(
   };
 }
 
+/** Exactly `width` cells: truncated if over, space-padded if under. */
 function fitColumn(value: string, width: number): string {
-  return truncate(value, width).padEnd(width);
+  return padToWidth(truncate(value, width), width);
 }
 
 export function entryRow(entry: HypothesisEntry, columns: Columns, isSelected = false): string {
@@ -896,9 +901,15 @@ function rowId(index: number): string {
   return `experiment-row-${index}`;
 }
 
+/**
+ * At most `width` cells, ellipsized. Measured in cells, not code units: a CJK
+ * value that fits its column by `String.length` can still be twice as wide on
+ * screen, and slicing by code units can land inside a wide character.
+ */
 function truncate(value: string, width: number): string {
   if (width <= 1) return '';
-  return value.length <= width ? value : `${value.slice(0, Math.max(1, width - 1))}…`;
+  if (displayWidth(value) <= width) return value;
+  return `${truncateToWidth(value, width - 1)}…`;
 }
 
 function trimNumber(value: number): string {

--- a/clients/tui/src/ui/text-width.test.ts
+++ b/clients/tui/src/ui/text-width.test.ts
@@ -1,0 +1,27 @@
+import {describe, expect, it} from 'bun:test';
+import {displayWidth, padToWidth, truncateToWidth} from './text-width.js';
+
+describe('padToWidth', () => {
+  it('pads by cells, not code units, so CJK text fills the same column', () => {
+    expect(padToWidth('abc', 6)).toBe('abc   ');
+    // Two ideographs are two code units but four cells: padEnd would add four
+    // spaces here and make the cell eight cells wide.
+    expect(padToWidth('漢字', 6)).toBe('漢字  ');
+    expect(displayWidth(padToWidth('漢字', 6))).toBe(6);
+  });
+
+  it('returns text at or past the budget unchanged', () => {
+    expect(padToWidth('abcdef', 6)).toBe('abcdef');
+    expect(padToWidth('漢字漢字', 6)).toBe('漢字漢字');
+    expect(padToWidth('x', 0)).toBe('x');
+  });
+
+  it('fills the cell a truncation left short of a wide character', () => {
+    // '字' would straddle the four-cell budget, so truncateToWidth stops one
+    // cell short; padding restores the exact column width.
+    const cut = truncateToWidth('a漢字', 4);
+    expect(cut).toBe('a漢');
+    expect(padToWidth(cut, 4)).toBe('a漢 ');
+    expect(displayWidth(padToWidth(cut, 4))).toBe(4);
+  });
+});

--- a/clients/tui/src/ui/text-width.ts
+++ b/clients/tui/src/ui/text-width.ts
@@ -80,6 +80,18 @@ export function truncateToWidth(text: string, maxWidth: number): string {
 }
 
 /**
+ * `text` followed by the spaces that bring it to exactly `width` cells.
+ *
+ * The column-alignment counterpart of `truncateToWidth`: `String.padEnd`
+ * counts code units, so a cell holding CJK text comes out short of its column
+ * and pushes every later column out of line. Text already at or past the
+ * budget is returned unchanged; trimming it is `truncateToWidth`'s job.
+ */
+export function padToWidth(text: string, width: number): string {
+  return text + ' '.repeat(Math.max(0, width - displayWidth(text)));
+}
+
+/**
  * A cluster is as wide as the character it is built around: the code points
  * after the first are marks, joiners and selectors that render into the same
  * cells.

--- a/clients/tui/src/ui/todo-strip.test.ts
+++ b/clients/tui/src/ui/todo-strip.test.ts
@@ -4,6 +4,7 @@ import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing'
 import type {TodoItem} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import {initialSessionState, type SessionState} from '../session-model.js';
+import {displayWidth} from './text-width.js';
 import {resolveTheme} from './theme.js';
 import {TodoStripView, todoItemLine, todoSummaryLine} from './todo-strip.js';
 
@@ -43,6 +44,23 @@ describe('todo strip formatting', () => {
     const line = todoItemLine({content: 'x'.repeat(50), status: 'pending'}, 20);
     expect(line).toHaveLength(20);
     expect(line.endsWith('…')).toBe(true);
+  });
+
+  it('truncates a CJK label by display cells, not code units', () => {
+    // Nine ideographs are nine code units but eighteen cells: measured by
+    // `String.length` this line fits a 13-cell budget and overflows it on
+    // screen by seven cells.
+    const line = todoItemLine({content: '优化内核向量化路径', status: 'in_progress'}, 13);
+    expect(line).toBe('▶ 优化内核向…');
+    expect(displayWidth(line)).toBe(13);
+  });
+
+  it('drops a wide character that would straddle the budget instead of splitting it', () => {
+    const line = todoItemLine({content: '优化内核向量化路径', status: 'in_progress'}, 14);
+    // One cell short of the budget: the next ideograph needs two cells and
+    // only one is left, so it goes whole rather than as half a glyph.
+    expect(line).toBe('▶ 优化内核向…');
+    expect(displayWidth(line)).toBe(13);
   });
 });
 
@@ -137,6 +155,17 @@ describe('todo strip rendering', () => {
     expect(item.width).toBe(BOX_WIDTH - 6);
     expect(item.text).toHaveLength(item.width);
     expect(item.text.endsWith('…')).toBe(true);
+  });
+
+  it('fills the collapsed summary to the box edge in display cells for a CJK todo', async () => {
+    const cjkTodo: TodoItem = {content: '优'.repeat(200), status: 'in_progress'};
+    const {lines} = await renderStrip([cjkTodo], false, BOX_WIDTH);
+    const summary = onlyLine(lines);
+    expect(summary.width).toBe(BOX_WIDTH - 2);
+    // Cells, not code units: sliced by code units this line would occupy
+    // almost twice its slot and spill past the box edge.
+    expect(displayWidth(summary.text)).toBe(summary.width);
+    expect(summary.text.endsWith('…')).toBe(true);
   });
 
   it('survives a box narrower than its own chrome', async () => {

--- a/clients/tui/src/ui/todo-strip.ts
+++ b/clients/tui/src/ui/todo-strip.ts
@@ -4,6 +4,7 @@ import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
 import {focusedPane, visibleTodos} from '../session-model.js';
 import {paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
+import {displayWidth, truncateToWidth} from './text-width.js';
 import type {Theme} from './theme.js';
 
 const STATUS_MARKER: Record<string, string> = {
@@ -79,9 +80,15 @@ export function todoItemLine(todo: TodoItem, maxWidth: number): string {
   return truncate(`${todoMarker(todo.status)} ${todo.content}`, maxWidth);
 }
 
+/**
+ * At most `width` cells, ellipsized. Measured in cells, not code units: a CJK
+ * todo that fits by `String.length` can still be twice as wide on screen, and
+ * slicing by code units can land inside a wide character.
+ */
 function truncate(line: string, maxWidth: number): string {
   const width = Math.max(8, maxWidth);
-  return line.length <= width ? line : `${line.slice(0, width - 1)}…`;
+  if (displayWidth(line) <= width) return line;
+  return `${truncateToWidth(line, width - 1)}…`;
 }
 
 /**


### PR DESCRIPTION
## Problem

The experiment log table and the todo strip pad and truncate by JS string length, which counts UTF-16 code units, not terminal cells. A CJK ideograph is one code unit but two cells, so any hypothesis title, hypothesis id, or todo label carrying wide characters breaks the layout in two ways: `padEnd(width)` stops as soon as the string holds `width` code units, leaving the cell up to twice as wide on screen and pushing every later column out of line, and `slice(0, width - 1)` under-truncates for the same reason and can also cut a surrogate pair in half.

Concrete example, `entryRow` at a 100-column table. Before, the CJK claim is 8 code units but 16 cells, so `padEnd(38)` leaves the cell 8 cells too wide and Measured, Outcome, and Kept all shift right and overflow the row into the renderer's truncation:

```
 Hypothesis      Rounds    Implementation Details                  Measured              Outcome
  H-01           41        Batch the prefill step                  +12%                  Accepted
  H-02           42        缓存优化提升吞吐                                -3.0%                 Rejected
```

After, every cell is budgeted in cells and the columns line up:

```
 Hypothesis      Rounds    Implementation Details                  Measured              Outcome
  H-01           41        Batch the prefill step                  +12%                  Accepted
  H-02           42        缓存优化提升吞吐                        -3.0%                 Rejected
```

The repo already has the correct primitives in `clients/tui/src/ui/text-width.ts` (`displayWidth`, `truncateToWidth`), and `header.ts` and `round-tabs.ts` already route through them. These two files predate that module and were missed.

## Solution

Route both files through `text-width.ts` and add the missing third primitive there, `padToWidth`, which pads with the spaces that bring a string to exactly `width` cells. Sites fixed:

- `experiment-log.ts` `truncate`: length check and slice replaced with `displayWidth` and `truncateToWidth(value, width - 1)` plus the ellipsis, so a wide character that would straddle the budget is dropped whole rather than split.
- `experiment-log.ts` `fitColumn`: `padEnd(width)` replaced with `padToWidth`, so every cell occupies exactly its column's cells. This also absorbs the case where truncation stops one cell short of the budget at a wide-character boundary.
- `experiment-log.ts` `entryCells`: the id budget `ID_WIDTH - marker.length` now uses `displayWidth(marker)`.
- `experiment-log.ts` `headerRow`: the six label `padEnd` calls now use `padToWidth`. The labels are all narrow today, so this changes nothing observable, but it puts the header and the rows on one primitive so their columns agree by construction.
- `todo-strip.ts` `truncate`: same replacement as the experiment-log `truncate`; it serves both `todoSummaryLine` and `todoItemLine`.

Sites inspected in these two files and deliberately left alone: `sentenceCase` (slice at a regex-found index to change case, a character transformation on a string returned whole, not column math), `perf_baseline_commit.slice(0, 7)` (abbreviating a hex hash, ASCII by construction), `COLUMN_GAP.length` (a literal two-space gap whose length equals its display width), and every `.length` or `.slice` over arrays (entries, rounds, files, todos), which count items, not cells.

### Architecture

`text-width.ts` owns terminal cell measurement for the TUI: grapheme segmentation, East Asian width, and emoji presentation live there and nowhere else. Renderers own their column budgets and compose the module's primitives. This change adds `padToWidth` beside `displayWidth` and `truncateToWidth` with the same doc style, and moves `experiment-log.ts` and `todo-strip.ts` from raw `String` methods onto the module, matching the existing consumers `header.ts` and `round-tabs.ts`. Backend payloads stay semantic (ids, titles, todo content); all formatting stays in the client, per the frontend-contract rule in coding-best-practices.

```mermaid
flowchart LR
  H["HypothesisEntry: id, title, claim"] --> EL["experiment-log.ts: truncate, fitColumn, headerRow"]
  T["TodoItem: content"] --> TS["todo-strip.ts: truncate"]
  EL --> TW["text-width.ts: displayWidth, truncateToWidth, padToWidth"]
  TS --> TW
  EL --> R["table rows: every cell exactly its column's cells"]
  TS --> S["todo lines: never past the cell budget"]
```

## Verification

### Correctness properties

- Every cell `fitColumn` emits occupies exactly its column's width in terminal cells, for any input text, so header and row columns coincide for all scripts.
- Truncation never splits a wide grapheme: a character that would straddle the budget is dropped whole and the ellipsis marks the cut, exactly the `truncateToWidth` contract. A todo line may therefore end one cell short of its budget; a table cell cannot, because `padToWidth` fills the difference.
- The header and every row are padded by the same primitive, so a future non-ASCII header label cannot silently misalign them.
- Narrow-only text renders byte-for-byte as before: when every character is one code unit and one cell, `padToWidth` equals `padEnd` and the new `truncate` equals the old one. All 824 pre-existing tests pass unmodified.

### Testing

Regression tests, all failing at the merge base and passing at head (verified by patch-revert: `git diff` of the three source files saved, `git checkout --` of them with the new tests kept in place, test run, patch re-applied):

- `experiment-log.test.ts`: pure-formatter cases asserting the Outcome column of a CJK row sits at the same display column as an ASCII row's, that a long CJK claim truncates on a whole-character boundary with the leading segment at the exact ASCII segment width, and that a CJK hypothesis id truncates by cells with the rounds column unmoved; plus an OpenTUI test-renderer case (per the coding-best-practices rule for terminal-geometry symptoms) asserting on-screen Outcome alignment between an ASCII and a CJK row in the captured frame.
- `todo-strip.test.ts`: exact-string cases for `todoItemLine` with CJK content (13-cell budget yields `▶ 优化内核向…` at exactly 13 cells; a 14-cell budget drops the straddling ideograph whole and stops at 13); plus a test-renderer case asserting the collapsed summary fills its slot to exactly the slot's display width.
- `text-width.test.ts` (new): `padToWidth` pads by cells not code units, leaves at-budget text unchanged, and restores the exact column after a truncation that stopped short of a wide character.

At the base, with only the source files reverted, the run reports 8 fail (the seven CJK tests above plus the `padToWidth` unit tests erroring on the missing export); with the fix re-applied all 54 tests across the three files pass.

Commands run, from the repo root:

- `pnpm --dir clients/tui test`: 833 pass, 1 fail out of 834. The failure is `launcher > makes a successful frontend authoritative only in release smoke mode` in `src/launcher.test.ts`, which also failed once on the unmodified base, passes when the file runs alone, and touches nothing in this change; it is an environmental flake.
- `pnpm check:ts-architecture`: no dependency violations (94 modules, 366 dependencies cruised).
- `pnpm --dir clients/tui check`: tsc clean.
- `pnpm check:ts`: biome, 89 files checked, no fixes.
