### PR TITLE
fix(tui): keep round focus and the agent filter off hidden panes

### DIFF
--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -1271,8 +1271,34 @@ export function normalizeFocus(state: SessionState): SessionState {
     visiblePaneIds({...state, layout: {...state.layout, focus}}).includes(state.layout.zoomedPane)
       ? state.layout.zoomedPane
       : null;
-  if (focus === state.layout.focus && zoomedPane === state.layout.zoomedPane) return state;
-  return {...state, layout: {...state.layout, focus, zoomedPane}};
+  const next =
+    focus === state.layout.focus && zoomedPane === state.layout.zoomedPane
+      ? state
+      : {...state, layout: {...state.layout, focus, zoomedPane}};
+  return normalizeRoundFocus(next);
+}
+
+/**
+ * The round view's focus obeys the same rule as the columns above: it has to
+ * name a pane that is on screen. Beside a visualization a stored 'agents'
+ * focus is a parked value that `focusedPane` and the key routing both ignore
+ * and closing the pane restores, so it stays. A zoom has no restore point, so
+ * focus stranded behind one is repaired: the keys move to the pane the zoom
+ * kept, and an agent filter whose only cue the zoom removed turns off rather
+ * than silently narrowing the transcript.
+ */
+function normalizeRoundFocus(state: SessionState): SessionState {
+  if (experimentLogVisible(state) || state.layout.right !== null) return state;
+  if (
+    !roundPaneVisible(state, 'agents') &&
+    (state.roundFocus === 'agents' || state.selectedAgentKind !== null)
+  ) {
+    return {...state, roundFocus: 'transcript', selectedAgentKind: null};
+  }
+  if (!roundPaneVisible(state, 'transcript') && state.roundFocus === 'transcript') {
+    return {...state, roundFocus: 'agents'};
+  }
+  return state;
 }
 
 /** Escape from a round view: close whatever is layered over it, all of it. */
@@ -1307,6 +1333,23 @@ export function focusPane(state: SessionState, focus: PaneFocus): SessionState {
 export function todoListFocused(state: SessionState): boolean {
   if (experimentLogVisible(state) || !state.todosExpanded) return false;
   return visibleTodos(state).length > 0;
+}
+
+/**
+ * True while the named round pane is on screen, mirroring the render path: a
+ * zoom on the other pane hides it, and a visualization takes the agents pane's
+ * place (in a terminal too narrow to split, the visualization's fallback modal
+ * covers the pane and takes the keys, so it is unavailable either way). Round
+ * focus only moves to a pane this returns true for, so the keys and the agent
+ * filter can never land on a pane the operator cannot see.
+ */
+export function roundPaneVisible(state: SessionState, pane: RoundFocus): boolean {
+  if (experimentLogVisible(state)) return false;
+  const zoomed = state.layout.zoomedPane;
+  if (pane === 'agents') {
+    return state.layout.right === null && (zoomed === null || zoomed === 'agents');
+  }
+  return zoomed === null || zoomed === 'transcript';
 }
 
 /**
@@ -1701,6 +1744,11 @@ export function selectNextEntry(state: SessionState, delta: number, id?: string)
  */
 export function focusRound(state: SessionState, focus: RoundFocus): SessionState {
   if (state.roundFocus === focus) return state;
+  // The move happens only between panes that are on screen. Focus landing on
+  // a hidden pane would route the keys, and the auto-selected filter below,
+  // into a surface with no visible cue. The round view has no third pane to
+  // skip to, so at a hidden neighbour the keys stay where they are.
+  if (!roundPaneVisible(state, focus)) return state;
   // Arriving at the graph with nothing picked out puts the cursor on the agent
   // whose turns are on screen, so Tab starts from where the operator is looking.
   if (focus === 'agents' && state.selectedAgentKind === null) {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -6535,3 +6535,147 @@ class FakeController implements SessionController {
     for (const listener of this.#listeners) listener(this.state);
   }
 }
+
+describe('round focus on hidden panes', () => {
+  // Key routing consulted `roundFocus` while the border consulted
+  // `focusedPane`, so with the agents pane off screen Left could move the keys
+  // and an auto-selected agent filter onto a pane that was not there,
+  // silently narrowing the transcript.
+  function twoAgentRound(): SessionState {
+    const base = initialSessionState();
+    return {
+      ...base,
+      selectedRound: 1,
+      core: {
+        ...base.core,
+        rounds: [{number: 1, status: 'active' as const}],
+        phases: [
+          {
+            kind: 'implementer',
+            status: 'completed' as const,
+            roundNumber: 1,
+            roundLabel: 'round-1-impl',
+          },
+          {kind: 'judge', status: 'active' as const, roundNumber: 1, roundLabel: 'round-1-judge'},
+        ],
+        transcript: [
+          {
+            id: 'e1',
+            kind: 'assistant' as const,
+            label: 'implementer',
+            content: 'edited the kernel',
+            agentKind: 'implementer',
+            roundNumber: 1,
+          },
+          {
+            id: 'e2',
+            kind: 'assistant' as const,
+            label: 'implementer',
+            content: 'guarded the tail tile',
+            agentKind: 'implementer',
+            roundNumber: 1,
+          },
+          {
+            id: 'e3',
+            kind: 'assistant' as const,
+            label: 'judge',
+            content: 'checking the diff',
+            agentKind: 'judge',
+            roundNumber: 1,
+          },
+        ],
+      },
+    };
+  }
+
+  it('keeps Left from filtering the zoomed transcript through the hidden agents pane', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 26});
+    const controller = new FakeController(twoAgentRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('edited the kernel'));
+
+    testRenderer.mockInput.pressKey('F4');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.zoomedPane).toBe('transcript');
+
+    // Left names the agents pane, but the zoom took it off screen: the keys
+    // hold on the transcript and no invisible agent filter appears.
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    const frame = await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('transcript');
+    expect(controller.state.selectedAgentKind).toBeNull();
+    expect(frame).toContain('edited the kernel');
+    expect(frame).toContain('checking the diff');
+
+    // Up still moves the transcript cursor, not an invisible agent selection.
+    testRenderer.mockInput.pressKey('ARROW_UP');
+    await frameAfter(testRenderer);
+    expect(controller.state.selectedEntryId).not.toBeNull();
+    expect(controller.state.selectedAgentKind).toBeNull();
+  });
+
+  it('still reaches the agents pane with Left while it is on screen', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 26});
+    const controller = new FakeController(twoAgentRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('edited the kernel'));
+
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    const frame = await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('agents');
+    // Arriving auto-selects the active agent, with the pane there to show it.
+    expect(controller.state.selectedAgentKind).toBe('judge');
+    expect(frame).toContain('▸ Agents');
+
+    // Zoomed onto the agents pane, Right has no visible transcript to move
+    // to: the keys stay on the one pane that is on screen.
+    testRenderer.mockInput.pressKey('F4');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.zoomedPane).toBe('agents');
+    testRenderer.mockInput.pressKey('ARROW_RIGHT');
+    await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('agents');
+
+    // Unzoomed, the same key moves them again.
+    testRenderer.mockInput.pressKey('F4');
+    testRenderer.mockInput.pressKey('ARROW_RIGHT');
+    await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('transcript');
+  });
+
+  it('repairs focus and filter parked on the agents pane when a zoom hides it', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 26});
+    const controller = new FakeController(twoAgentRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('edited the kernel'));
+
+    // The agents pane holds the keys and an agent filters the transcript.
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('agents');
+    expect(controller.state.selectedAgentKind).toBe('judge');
+
+    // A zoom leaves only the transcript on screen while the agents pane held
+    // the keys. Normalization moves the keys to the visible pane and turns
+    // the filter off with its cue: the transcript shows every agent again and
+    // wears the focus border.
+    controller.publish({
+      ...controller.state,
+      layout: {...controller.state.layout, zoomedPane: 'transcript'},
+    });
+    const frame = await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('transcript');
+    expect(controller.state.selectedAgentKind).toBeNull();
+    expect(frame).toContain('▸ Transcript');
+    expect(frame).toContain('edited the kernel');
+    expect(frame).toContain('checking the diff');
+
+    // The keys followed: Up moves the transcript cursor.
+    testRenderer.mockInput.pressKey('ARROW_UP');
+    await frameAfter(testRenderer);
+    expect(controller.state.selectedEntryId).not.toBeNull();
+  });
+});

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -4,6 +4,7 @@ import {
   chatPaneFocused,
   chatPaneVisible,
   experimentLogVisible,
+  focusedPane,
   todoListFocused,
 } from '../session-model.js';
 import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
@@ -279,12 +280,15 @@ export function bindKeybindings(
     }
     if (key.name === 'up' || key.name === 'down') {
       if (!actions.navigateSuggestions(key.name === 'up' ? -1 : 1)) {
-        if (controller.state.roundFocus === 'transcript') {
-          controller.selectNextEntry(key.name === 'down' ? 1 : -1);
-          actions.revealSelectedEntry();
-        } else {
+        // `roundFocus` can sit parked on the agents pane while a visualization
+        // hides it, so the keys follow the pane that is actually on screen:
+        // the same authority the focus border reads.
+        if (focusedPane(controller.state) === 'agents') {
           if (key.name === 'down') controller.selectNextAgent();
           else controller.selectPreviousAgent();
+        } else {
+          controller.selectNextEntry(key.name === 'down' ? 1 : -1);
+          actions.revealSelectedEntry();
         }
       }
       key.preventDefault();
@@ -292,7 +296,7 @@ export function bindKeybindings(
     }
     if (
       (key.name === 'return' || key.name === 'enter') &&
-      controller.state.roundFocus === 'transcript' &&
+      focusedPane(controller.state) !== 'agents' &&
       actions.inputIsEmpty() &&
       actions.toggleSelectedTool()
     ) {


### PR DESCRIPTION
## Problem

The round view keeps two focus models. `roundFocus` in `SessionState` names which round pane, agents or transcript, the arrow keys act on, and `keybindings.ts` routed Up/Down and Enter by reading it directly. The focus border reads `focusedPane(state)` instead, which overrides `roundFocus` while a visualization holds the right of the row but knows nothing about zoom. The two diverge exactly when the agents pane is not rendered: under a transcript zoom (F4), or beside a visualization, the render path hides the agents pane while `roundFocus` can still name it or move onto it.

Pressing Left in those states called `focusRound(state, 'agents')`, which moved `roundFocus` onto the hidden pane and auto-selected the active phase's agent kind. `selectedAgentKind` filters `visibleConversation`, so the transcript silently dropped every other agent's entries with no cue anywhere on screen: the transcript title does not name the filter and the pane that shows the selection was not rendered. Up/Down then moved that invisible selection instead of the transcript cursor. The wrong result is a content change, the transcript quietly means something else, not just a dead key.

## Solution

`session-model.ts` gains `roundPaneVisible(state, pane)`, one predicate that mirrors the render path's `showAgents` and `showTranscript` conditions: a zoom on the other pane hides a round pane, and a visualization takes the agents pane's place. In a terminal too narrow to split, the visualization's fallback modal covers the agents pane and takes the keys, so it is unavailable either way, which is how `focusedPane` already treats it.

Three consumers enforce the rule:

- `focusRound` refuses a move to a pane that is not on screen. Left under a transcript zoom, and Right under an agents zoom, hold where they are: the round view has only two panes, so there is no visible target to skip to and the auto-select never runs against a hidden pane.
- `normalizeFocus`, which already runs on every state change to keep column focus and zoom on visible surfaces, repairs round focus the same way. When a zoom hides the agents pane while it held the keys, focus falls back to the transcript and `selectedAgentKind` is cleared; when a zoom hides the transcript while it held the keys, focus falls back to the agents pane. Because it runs on every state change, no action can leave the state incoherent: `selectNextAgent` under a transcript zoom, for example, is undone in the same state transition.
- `keybindings.ts` routes Up/Down and Enter by `focusedPane(state)` instead of raw `roundFocus`. That is the same authority every pane border reads, so the keys and the focus marker can no longer disagree about which surface is active.

The edge case, focus already held on a pane that goes invisible, has two situations with different answers. Beside a visualization, `roundFocus === 'agents'` stays a parked value: this is existing, tested behavior (`focusedPane` overrides it and closing the pane restores it), and this change makes the parked value inert for key routing the way it already was for the border. Under a zoom there is no closing action to restore from, so the state is repaired rather than parked: the keys move to the pane the zoom kept, and the agent filter turns off together with its only cue. The visible consequence is that zooming the transcript while an agent filter is active now shows the whole round's transcript; previously the zoomed transcript stayed filtered with nothing on screen saying so, which is the reported hazard.

### Architecture

The TUI owns focus, selection, layout, and zoom (`docs/contributing/tui-architecture.md`), and within the TUI the session model owns focus policy while `app.ts` renders it and `keybindings.ts` translates keys into controller intents. The fix stays inside that ownership: pane visibility is derived in `session-model.ts` from model state the renderer already keys off (zoom and split), `focusRound` and `normalizeFocus` enforce it, and `keybindings.ts` only changes which model selector it consults. No renderer-measured state, backend contract, or core-state fold changes.

```mermaid
flowchart LR
    K[keybindings.ts\nUp/Down/Enter] -->|focusedPane| M[session-model.ts]
    K -->|Left/Right via focusRound| M
    M -->|roundPaneVisible gates the move| M
    C[session-controller\nsetState] -->|normalizeFocus repairs\nroundFocus and filter| M
    M -->|focusedPane| B[pane borders]
    M -->|same visibility conditions| R[app.ts showAgents/showTranscript]
```

## Verification

### Correctness properties

- Round focus never lands on a hidden pane: `focusRound` only moves between panes `roundPaneVisible` reports as on screen, in both directions.
- With no visualization open, `roundFocus === 'agents'` implies the agents pane is rendered: `normalizeFocus` restores the implication on every state change, so no action sequence can strand the keys or the border on a pane a zoom removed.
- Under any zoom, what filters the transcript is visible or the filter is off: a zoom that hides the agents pane clears `selectedAgentKind` in the same normalization, so a filtered transcript always has its filter's cue on screen. Beside a visualization the previously chosen filter stays applied, unchanged by this PR: it was chosen while its cue was on screen, closing the pane shows the cue again, and the parked focus that carries it is now inert for key routing.
- Key routing and the focus border read the same selector (`focusedPane`), so a keystroke acts on the pane the border marks in every round-view state, including the parked state beside a visualization.

### Testing

New regression tests in `clients/tui/src/ui/app.test.ts`, appended as the self-contained `round focus on hidden panes` describe block, all through `createTestRenderer` since the symptom is on-screen content and borders: (1) with the transcript zoomed, Left leaves `roundFocus` on the transcript, creates no `selectedAgentKind`, every agent's entries stay in the frame, and Up moves the transcript cursor; (2) with the pane on screen, Left still reaches it and auto-selects the active agent, and with the agents pane zoomed Right holds until the zoom lifts; (3) publishing a state whose zoom hides the pane that held focus and its filter normalizes to a focused, unfiltered, border-marked transcript whose cursor keys work.

Fail-before evidence: with only the test hunk applied onto the merge base (`git checkout -- clients`, then `git apply` of the `app.test.ts` hunk), `bun test src/ui/app.test.ts -t 'round focus on hidden panes'` fails all three tests (0 pass, 3 fail; for example `expect(controller.state.roundFocus).toBe('transcript')` receives `'agents'` after Left under a transcript zoom). With the full patch restored the same command passes 3 of 3.

Full checks at head: `pnpm --dir clients/tui test` passes 827 tests across 30 files (base suite 824 plus the 3 new), `pnpm check:ts-architecture` reports no dependency violations, `pnpm --dir clients/tui check` (tsc) passes, and root `pnpm check:ts` (biome, 88 files) reports no issues.
