### PR TITLE
fix(tui): stop painting an active node's outbound edges as live

### DIFF
--- a/clients/tui/src/ui/agent-graph.test.ts
+++ b/clients/tui/src/ui/agent-graph.test.ts
@@ -75,10 +75,63 @@ describe('layoutAgentGraph', () => {
   test('tones an edge by the phases it connects', () => {
     const four = [...CHAIN, phase('profiler', 'pending')];
     const graph = layoutAgentGraph(four, graphPaneBounds(four).max - 4);
-    // The frontier glows: an edge is live while either end is running. Two
-    // stages that have not run yet stay idle.
+    // Live means data has flowed: a completed source feeding an active
+    // target. A stage that has not produced anything yet, or that feeds a
+    // stage that has not started, stays idle.
     expect(graph.cells.some(cell => cell.tone === 'live')).toBe(true);
     expect(graph.cells.some(cell => cell.tone === 'idle')).toBe(true);
+  });
+
+  test('an edge from an active source to a pending target is idle, not live', () => {
+    // The active node has not produced anything yet, so its outbound edge
+    // must not be painted as live dataflow.
+    const activeToPending = [phase('implementer', 'active'), phase('judge', 'pending')];
+    const graph = layoutAgentGraph(activeToPending, graphPaneBounds(activeToPending).max - 4);
+    expect(graph.cells.every(cell => cell.tone === 'idle')).toBe(true);
+  });
+
+  test('an edge from a completed source to an active target is still live', () => {
+    const completedToActive = [phase('implementer', 'completed'), phase('judge', 'active')];
+    const graph = layoutAgentGraph(completedToActive, graphPaneBounds(completedToActive).max - 4);
+    expect(graph.cells.every(cell => cell.tone === 'live')).toBe(true);
+  });
+
+  test.each([
+    'failed',
+    'cancelled',
+    'interrupted',
+  ] as const)('a %s source still fails the edge, even into an active target', status => {
+    const badSource = [phase('implementer', status), phase('judge', 'active')];
+    const graph = layoutAgentGraph(badSource, graphPaneBounds(badSource).max - 4);
+    expect(graph.cells.every(cell => cell.tone === 'failed')).toBe(true);
+  });
+
+  test('a completed source into any non-pending target still reads as done', () => {
+    const completedToFailed = [phase('implementer', 'completed'), phase('judge', 'failed')];
+    const graph = layoutAgentGraph(completedToFailed, graphPaneBounds(completedToFailed).max - 4);
+    expect(graph.cells.every(cell => cell.tone === 'done')).toBe(true);
+  });
+
+  test('an active fan-out node leaves every outbound edge idle', () => {
+    const fanOut = [
+      phase('orchestrator', 'active'),
+      phase('implementer', 'pending'),
+      phase('implementer', 'pending'),
+      phase('implementer', 'pending'),
+    ];
+    const graph = layoutAgentGraph(fanOut, graphPaneBounds(fanOut).max - 4);
+    expect(graph.cells.every(cell => cell.tone === 'idle')).toBe(true);
+  });
+
+  test('an active fan-in node has every completed-source inbound edge live', () => {
+    const fanIn = [
+      phase('implementer', 'completed'),
+      phase('implementer', 'completed'),
+      phase('implementer', 'completed'),
+      phase('judge', 'active'),
+    ];
+    const graph = layoutAgentGraph(fanIn, graphPaneBounds(fanIn).max - 4);
+    expect(graph.cells.every(cell => cell.tone === 'live')).toBe(true);
   });
 
   test('a finished handover between finished stages reads as done', () => {

--- a/clients/tui/src/ui/agent-graph.ts
+++ b/clients/tui/src/ui/agent-graph.ts
@@ -382,7 +382,7 @@ function edgeTone(source: AgentPhase, target: AgentPhase): EdgeTone {
     source.status === 'interrupted'
   )
     return 'failed';
-  if (source.status === 'active' || (source.status === 'completed' && target.status === 'active')) {
+  if (source.status === 'completed' && target.status === 'active') {
     return 'live';
   }
   if (source.status === 'completed' && target.status !== 'pending') return 'done';


### PR DESCRIPTION
## Problem

In the agent graph (Agents pane), an edge leaving an active node renders in
the live accent color regardless of what it points at. An operator sees
`implementer -> judge` light up as though data already flowed out of the
implementer while it is still active. `edgeTone()` treats
`source.status === 'active'` alone as sufficient for `'live'`, ignoring the
target. Closes #713.

## Solution

Drop the `source.status === 'active' ||` disjunct from `edgeTone()`.
`'live'` now requires only the already-correct second clause: a completed
source feeding an active target, i.e. data that has actually flowed into
work now in progress. An active source's outbound edges fall through to
`'idle'` until the source completes. Reviewers should check the fan-out/
fan-in tests: an active node's outbound edges all go idle, while its
completed-source inbound edges stay live.

### Architecture

Change is confined to `edgeTone()` in `clients/tui/src/ui/agent-graph.ts`.
Its only consumer is `edgeColor()` in `agent-map.ts` (presentational); the
stacked-list fallback never calls `layoutAgentGraph` and there is no legend.

## Verification

| Before (`main`) | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr714-edge-tone-before.png) | ![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr714-edge-tone-after.png) |

Round 1 with `implementer` active (fixture cut after its `invocation_started`), 140x40, dark theme, cropped to the Agents pane. `implementer -> judge` goes from live to idle; `orchestrator -> implementer` stays live.

Reproduced the active-to-pending case from #713 against pre-fix code (tone
read `live`) and confirmed it reads `idle` post-fix.

### Correctness properties

- `'live'` implies a completed source and an active target.
- An active source's outbound edges are `'idle'` until it completes.
- Failed/cancelled/interrupted sources still force `'failed'` regardless of target.
- A completed source into any non-pending, non-active target still reads `'done'`.

### Testing

- `pnpm --filter @vibesys/tui test`: 832 pass, 0 fail (30 files)
- `pnpm check:clients`: clean

