### PR TITLE
fix(tui): align the unowned-round row to the Experiments table's own columns

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -5260,7 +5260,13 @@ describe('theming', () => {
     const kickoff = await frameAfter(testRenderer);
     expect(kickoff).toContain('Planning Hypothesis 1');
     expect(kickoff).toContain('Round 2');
-    expect(kickoff).toContain('Round 1 · recorded agent turns · no hypothesis');
+    // The round row now lands on the same column grid a hypothesis row uses
+    // (see experiment-log.test.ts), so its cells are checked rather than the
+    // single string the row used to be. "(no hypothes…" is the ID column,
+    // which never drops at a narrow width, unlike the claim column.
+    const unassociatedLine = kickoff.split('\n').find(line => line.includes('(no hypothes'));
+    expect(unassociatedLine).toBeDefined();
+    expect(unassociatedLine).toMatch(/\b1\b/);
 
     testRenderer.mockInput.pressEnter();
     const round = await frameAfter(testRenderer);
@@ -5285,9 +5291,10 @@ describe('theming', () => {
     registerCleanup(testRenderer.renderer, app);
     await controller.openExperimentLog();
 
-    expect(await frameAfter(testRenderer)).toContain(
-      'Round 7 · recorded agent turns · no hypothesis',
-    );
+    const indexed = await frameAfter(testRenderer);
+    const indexedLine = indexed.split('\n').find(line => line.includes('(no hypothes'));
+    expect(indexedLine).toBeDefined();
+    expect(indexedLine).toMatch(/\b7\b/);
 
     testRenderer.mockInput.pressEnter();
     const detail = await frameAfter(testRenderer);
@@ -5296,9 +5303,10 @@ describe('theming', () => {
     expect(detail).not.toContain('other round');
 
     testRenderer.mockInput.pressKey('ESCAPE');
-    expect(await frameAfterEscape(testRenderer)).toContain(
-      'Round 7 · recorded agent turns · no hypothesis',
-    );
+    const reopened = await frameAfterEscape(testRenderer);
+    const reopenedLine = reopened.split('\n').find(line => line.includes('(no hypothes'));
+    expect(reopenedLine).toBeDefined();
+    expect(reopenedLine).toMatch(/\b7\b/);
   });
 
   it('keeps later hypothesis planning below the existing history', async () => {
@@ -5352,12 +5360,22 @@ describe('theming', () => {
     await controller.openExperimentLog();
 
     const frame = await frameAfter(testRenderer);
+    const lines = frame.split('\n');
+    // Round rows no longer carry "Round N" as literal text (see
+    // experiment-log.test.ts), so the two unowned-round rows are told apart
+    // by their line order instead: ascending by round number, round 2 first.
+    // "(no hypothes…" is the ID column, which never drops at a narrow width,
+    // unlike the claim column "recorded agent turns" sits in.
+    const unownedRoundLineIndices = lines
+      .map((line, index) => (line.includes('(no hypothes') ? index : -1))
+      .filter(index => index >= 0);
+    expect(unownedRoundLineIndices).toHaveLength(2);
     const positions = [
-      frame.indexOf('H-01'),
-      frame.indexOf('Round 2 · recorded'),
-      frame.indexOf('H-03'),
-      frame.indexOf('Round 4 · recorded'),
-      frame.indexOf('Planning Hypothesis 3'),
+      lines.findIndex(line => line.includes('H-01')),
+      unownedRoundLineIndices[0] ?? -1,
+      lines.findIndex(line => line.includes('H-03')),
+      unownedRoundLineIndices[1] ?? -1,
+      lines.findIndex(line => line.includes('Planning Hypothesis 3')),
     ];
     expect(positions.every(position => position >= 0)).toBe(true);
     expect(positions).toEqual([...positions].sort((left, right) => left - right));

--- a/clients/tui/src/ui/experiment-log.test.ts
+++ b/clients/tui/src/ui/experiment-log.test.ts
@@ -25,6 +25,7 @@ import {
   resolveColumns,
   selectionCaret,
   sentenceCase,
+  unownedRoundCells,
 } from './experiment-log.js';
 import {resolveTheme, THEME_NAMES} from './theme.js';
 
@@ -287,10 +288,16 @@ describe('experiment log rows', () => {
     const header = headerRow(columns);
     const row = entryRow(entry({hypothesis_id: 'm1-preallocated-spsc-ring'}), columns);
     const roundsStart = header.indexOf('Rounds');
+    const claimStart = header.indexOf('Implementation Details');
 
-    expect(row).toContain('m1-prealloca…  41');
+    expect(row).toContain('m1-prealloca…');
+    // Rounds right-aligns (see "right-aligns the numeric columns" below), so
+    // the gutter before it is padding, not the fixed single space a
+    // left-aligned column would have kept.
     expect(row[roundsStart - 1]).toBe(' ');
-    expect(row.slice(roundsStart).startsWith('41')).toBe(true);
+    // The two-digit round number lands flush against the next column's gutter
+    // (the fixed two-space gap) rather than at the start of its own column.
+    expect(row.slice(roundsStart, claimStart - 2).endsWith('41')).toBe(true);
   });
 
   it('keeps the ? marker readable when a long unit truncates at MEASURED_WIDTH', () => {
@@ -344,6 +351,97 @@ describe('experiment log rows', () => {
       resolveColumns(WIDE),
     );
     expect(withActionOnly.leading).toContain('Batch prefill');
+  });
+});
+
+/**
+ * A round with agent turns but no owning hypothesis (a profiling round before
+ * hypothesis 1, or any round the orchestrator has not yet attached to a
+ * claim) is the default landing state, not an edge case: a task profiles
+ * before proposing its first hypothesis, so nearly every run shows this row
+ * first. `unownedRoundCells` has to land on the same column grid
+ * `entryCells` does, or the columns above it read as unused chrome.
+ */
+describe('unownedRoundCells', () => {
+  it('lands on the same column offsets as a hypothesis row at every width the panel degrades through', () => {
+    // Real recorded round, not an invented fixture: hypothesis
+    // M1-superlinear-elimination, round 1, 562.9504 total_ms, from
+    // ~/dev/vibesys-runs/bad-cpp/.../agent/rounds/0001.json.
+    const recorded = entry({
+      hypothesis_id: 'M1-superlinear-elimination',
+      first_round: 1,
+      last_round: 1,
+      perf_metric: 562.9504,
+      perf_unit: 'total_ms',
+      perf_delta_pct: null,
+      resolved_outcome: 'proven',
+    });
+    for (const width of [120, 104, 103, 90, 89, 72, 62, 61, 54, 40]) {
+      const columns = resolveColumns(width);
+      const hypothesisCells = entryCells(recorded, columns);
+      const roundCells = unownedRoundCells(2, columns);
+      expect(roundCells.leading.length, `leading at ${width}`).toBe(hypothesisCells.leading.length);
+      expect(roundCells.outcome.length, `outcome at ${width}`).toBe(hypothesisCells.outcome.length);
+      expect(roundCells.trailing.length, `trailing at ${width}`).toBe(
+        hypothesisCells.trailing.length,
+      );
+      // Same columns dropped, not just the same total width.
+      expect(roundCells.trailing === '').toBe(hypothesisCells.trailing === '');
+    }
+  });
+
+  it('renders absent measured, outcome, and kept values as the existing placeholder, not empty strings', () => {
+    const columns = resolveColumns(WIDE);
+    const cells = unownedRoundCells(3, columns);
+    expect(cells.outcome.trim()).toBe('—');
+    expect(cells.trailing.trim()).toBe('—');
+    expect(cells.leading.trimEnd().endsWith('—')).toBe(true);
+  });
+
+  it('carries a real round number and the honest "recorded agent turns" text, never an invented claim', () => {
+    const cells = unownedRoundCells(7, resolveColumns(WIDE));
+    expect(cells.leading).toContain('(no hypothes');
+    expect(cells.leading).toContain('7');
+    expect(cells.leading).toContain('recorded agent turns');
+  });
+
+  it('keeps the selection caret in the same reserved column a hypothesis row uses', () => {
+    const columns = resolveColumns(WIDE);
+    const selected = unownedRoundCells(1, columns, true);
+    const unselected = unownedRoundCells(1, columns, false);
+    expect(selected.leading.startsWith('›')).toBe(true);
+    expect(unselected.leading.startsWith(' ')).toBe(true);
+    expect(selected.leading.slice(1)).toBe(unselected.leading.slice(1));
+  });
+});
+
+describe('right-aligned numeric columns', () => {
+  it('right-aligns Rounds so it ends flush at the column boundary regardless of digit count', () => {
+    // At a width below CLAIM_MIN_WIDTH and MEASURED_MIN_WIDTH, Rounds is the
+    // trailing segment of `leading`, so a right-aligned cell makes `leading`
+    // end with the value itself; a left-aligned one would end with padding.
+    const columns = resolveColumns(NARROW);
+    expect(columns.claim).toBe(false);
+    expect(columns.measured).toBe(false);
+    const short = entryCells(entry({first_round: 2, last_round: 2}), columns);
+    const long = entryCells(entry({first_round: 10, last_round: 99}), columns);
+    expect(short.leading.endsWith('2')).toBe(true);
+    expect(long.leading.endsWith('10-99')).toBe(true);
+  });
+
+  it('right-aligns Measured so it ends flush at the column boundary regardless of value length', () => {
+    const columns = resolveColumns(WIDE);
+    const short = entry({perf_delta_pct: null, perf_metric: 5});
+    const long = entry({perf_delta_pct: null, perf_metric: 123456.78, perf_unit: 'tokens/s'});
+    expect(entryCells(short, columns).leading.endsWith(formatMeasured(short))).toBe(true);
+    expect(entryCells(long, columns).leading.endsWith(formatMeasured(long))).toBe(true);
+  });
+
+  it('right-aligns Kept so "Yes" and "No" both end flush at the column boundary', () => {
+    const columns = resolveColumns(WIDE);
+    expect(columns.kept).toBe(true);
+    expect(entryCells(entry({kept: true}), columns).trailing.endsWith('Yes')).toBe(true);
+    expect(entryCells(entry({kept: false}), columns).trailing.endsWith('No')).toBe(true);
   });
 });
 
@@ -482,13 +580,14 @@ describe('experiment log selection', () => {
 });
 
 /**
- * The pure helpers above prove the caret occupies a reserved column; these
- * tests reproduce the symptom the issue reported (selection legible only by a
- * background swap) through the real OpenTUI test renderer, per
+ * The pure helpers above prove the caret occupies a reserved column and that
+ * an unowned round's cells share a hypothesis row's widths; these tests
+ * reproduce both the original selection symptom and the column-alignment
+ * defect through the real OpenTUI test renderer, per
  * coding-best-practices.md's rule that a terminal-geometry symptom needs the
  * renderer, not just a formatter test.
  */
-describe('experiment log rendered selection glyph', () => {
+describe('experiment log rendered rows', () => {
   const cleanup: Array<() => void> = [];
 
   afterEach(() => {
@@ -566,15 +665,113 @@ describe('experiment log rendered selection glyph', () => {
       [],
     );
     const frame = (await renderLog(withActivity)).split('\n');
-    const rowSelected = frame.findIndex(line => line.includes('Round 3'));
-    const rowUnselected = frame.findIndex(line => line.includes('Round 4'));
-    const colSelected = frame[rowSelected]?.indexOf('Round 3') ?? -1;
-    const colUnselected = frame[rowUnselected]?.indexOf('Round 4') ?? -1;
+    // "recorded agent turns" is the round row's Implementation Details cell;
+    // both round rows carry it, in ascending round order (3, then 4), and
+    // round 3 is selected by default since it is the first unowned round.
+    const roundLines = frame.filter(line => line.includes('recorded agent turns'));
+    expect(roundLines).toHaveLength(2);
+    const [selectedLine, unselectedLine] = roundLines as [string, string];
+    const colSelected = selectedLine.indexOf('(no hypothes');
+    const colUnselected = unselectedLine.indexOf('(no hypothes');
     expect(colSelected).toBeGreaterThan(0);
     expect(colSelected).toBe(colUnselected);
-    // The caret sits two columns before "Round": one column for itself, one
-    // for the space that always follows it.
-    expect(frame[rowSelected]?.[colSelected - 2]).toBe('›');
-    expect(frame[rowUnselected]?.[colUnselected - 2]).toBe(' ');
+    // The caret sits two columns before the identity text: one column for
+    // itself, one for the space that always follows it, exactly like a
+    // hypothesis row's marker.
+    expect(selectedLine[colSelected - 2]).toBe('›');
+    expect(unselectedLine[colUnselected - 2]).toBe(' ');
+  });
+
+  it('aligns an unowned round row to the same column offsets as a hypothesis row sharing the same frame', async () => {
+    const state = setExperiments(
+      openExperimentLog({
+        ...initialSessionState(),
+        core: {...initialSessionState().core, rounds: [{number: 5, status: 'completed'}]},
+      }),
+      [entry({hypothesis_id: 'H-01', first_round: 1, last_round: 1})],
+    );
+    const frame = (await renderLog(state)).split('\n');
+    const hypothesisLine = frame.find(line => line.includes('H-01'));
+    const roundLine = frame.find(line => line.includes('recorded agent turns'));
+    if (hypothesisLine === undefined || roundLine === undefined) {
+      throw new Error('expected both a hypothesis row and an unowned round row');
+    }
+    // Both rows reserve the same two-character marker slot before their
+    // identity text: this is the defect the issue reported, restated as a
+    // column offset rather than as a screenshot.
+    expect(roundLine.indexOf('(no hypothes')).toBe(hypothesisLine.indexOf('H-01'));
+  });
+
+  it('draws a rule under the header that reserves its row regardless of how many rows follow', async () => {
+    const oneRound = setExperiments(
+      openExperimentLog({
+        ...initialSessionState(),
+        core: {...initialSessionState().core, rounds: [{number: 1, status: 'completed'}]},
+      }),
+      [],
+    );
+    const twoRounds = setExperiments(
+      openExperimentLog({
+        ...initialSessionState(),
+        core: {
+          ...initialSessionState().core,
+          rounds: [
+            {number: 1, status: 'completed'},
+            {number: 2, status: 'completed'},
+          ],
+        },
+      }),
+      [],
+    );
+    const frameOne = (await renderLog(oneRound)).split('\n');
+    const frameTwo = (await renderLog(twoRounds)).split('\n');
+    const headerIndexOne = frameOne.findIndex(
+      line => line.includes('Hypothesis') && line.includes('Rounds'),
+    );
+    const headerIndexTwo = frameTwo.findIndex(
+      line => line.includes('Hypothesis') && line.includes('Rounds'),
+    );
+    expect(headerIndexOne).toBeGreaterThanOrEqual(0);
+    // The rule sits at a fixed offset from the header whether one row follows
+    // it or two: nothing above the rows moves when a row appears.
+    expect(headerIndexOne).toBe(headerIndexTwo);
+    const ruleOne = frameOne[headerIndexOne + 1] ?? '';
+    const ruleTwo = frameTwo[headerIndexTwo + 1] ?? '';
+    // The pane's own border/padding sit either side of the line; the rule
+    // itself is the contiguous run of the rule glyph in the middle.
+    const ruleRun = ruleOne.match(/─+/)?.[0] ?? '';
+    expect(ruleRun.length).toBeGreaterThan(40);
+    expect(ruleOne).toBe(ruleTwo);
+  });
+
+  it('gives the unowned-round state a next-step line distinct from the zero-row wording', async () => {
+    const zeroRows = logState([]);
+    const zeroFrame = (await renderLog(zeroRows)).split('\n');
+    // Unchanged: the existing zero-row empty state keeps its own wording.
+    expect(zeroFrame.some(line => line.includes('No hypotheses have been recorded yet.'))).toBe(
+      true,
+    );
+    expect(
+      zeroFrame.some(line =>
+        line.includes('The first one appears once the orchestrator has planned a round.'),
+      ),
+    ).toBe(true);
+
+    const unownedRound = setExperiments(
+      openExperimentLog({
+        ...initialSessionState(),
+        core: {...initialSessionState().core, rounds: [{number: 1, status: 'completed'}]},
+      }),
+      [],
+    );
+    const roundFrame = (await renderLog(unownedRound)).split('\n');
+    // A round has genuinely run here, unlike the zero-row case, so the
+    // wording does not repeat "No hypotheses have been recorded yet."
+    expect(roundFrame.some(line => line.includes('No hypotheses have been recorded yet.'))).toBe(
+      false,
+    );
+    expect(
+      roundFrame.some(line => line.includes('The first hypothesis appears once the orchestrator')),
+    ).toBe(true);
   });
 });

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -61,6 +61,7 @@ export class ExperimentLogView {
   readonly output: BoxRenderable;
   readonly #fill: BoxRenderable;
   readonly #header: TextRenderable;
+  readonly #headerRule: TextRenderable;
   readonly #rows: ScrollBoxRenderable;
   readonly #footerLine: TextRenderable;
   #theme: Theme;
@@ -102,6 +103,22 @@ export class ExperimentLogView {
       wrapMode: 'none',
       truncate: true,
     });
+    // Meaningful only under the table's column header, so it costs no row in
+    // every other view (kickoff, drill-down, loading, error, empty): `#clear`
+    // collapses it to height 0 before every render, and only `#renderTable`
+    // opens it back to 1. Inside the table view that height is fixed
+    // regardless of how many rows follow, so it is a permanent row there
+    // (tui-conventions.md, "nothing moves that does not have to") without
+    // taxing views that have no header row to rule under.
+    this.#headerRule = new TextRenderable(renderer, {
+      content: '',
+      fg: theme.border,
+      width: '100%',
+      height: 0,
+      flexShrink: 0,
+      wrapMode: 'none',
+      truncate: true,
+    });
     // A scroll box rather than a hand-rolled window: it gives wheel and
     // trackpad scrolling for free, and keeps the whole log reachable instead
     // of only the rows around the selection.
@@ -126,6 +143,7 @@ export class ExperimentLogView {
       truncate: true,
     });
     this.output.add(this.#header);
+    this.output.add(this.#headerRule);
     this.output.add(this.#rows);
     this.output.add(this.#footerLine);
   }
@@ -144,6 +162,7 @@ export class ExperimentLogView {
     this.output.borderColor = theme.border;
     this.#fill.backgroundColor = theme.canvas;
     this.#header.fg = theme.textSubtle;
+    this.#headerRule.fg = theme.border;
     this.#footerLine.fg = theme.textSubtle;
     this.#renderedState = null;
   }
@@ -232,9 +251,10 @@ export class ExperimentLogView {
     );
     const unowned = unownedExperimentRounds(state);
     if (unowned.length > 0) {
+      const columns = resolveColumns(this.#bodyWidth());
       this.#line('UNASSOCIATED ROUNDS', this.#theme.textSubtle);
       for (const [index, roundNumber] of unowned.entries()) {
-        this.#roundRow(roundNumber, selectedUnownedRound === roundNumber, index + 1);
+        this.#roundRow(roundNumber, columns, selectedUnownedRound === roundNumber, index + 1);
       }
     }
     this.#footerLine.content =
@@ -250,6 +270,12 @@ export class ExperimentLogView {
     const items = experimentIndexItems(state);
     const selected = selectedExperimentIndexItem(state);
     this.#header.content = headerRow(columns, measuredDirection(log.entries));
+    // A permanent rule under the header (tui-conventions.md, "nothing moves
+    // that does not have to"): fixed at height 1 regardless of row count, so
+    // it reads as a header rather than as one more line of text that happens
+    // to sit above the rows.
+    this.#headerRule.height = 1;
+    this.#headerRule.content = '─'.repeat(this.#bodyWidth());
     let selectedRenderIndex = 0;
     let renderedRows = 0;
     for (const [navigationIndex, item] of items.entries()) {
@@ -260,7 +286,7 @@ export class ExperimentLogView {
         if (isSelected) selectedRenderIndex = renderedRows;
         renderedRows += 1;
       } else if (item.kind === 'round') {
-        this.#roundRow(item.roundNumber, isSelected, navigationIndex);
+        this.#roundRow(item.roundNumber, columns, isSelected, navigationIndex);
         if (isSelected) selectedRenderIndex = renderedRows;
         renderedRows += 1;
       } else {
@@ -285,7 +311,15 @@ export class ExperimentLogView {
       this.#bodyWidth() >= HINT_MIN_WIDTH
         ? '↑↓ or scroll: select · Enter or click: open hypothesis'
         : '↑↓ · Enter';
-    this.#footerLine.content = `${position} · ${hint}`;
+    // The common landing state: a round has run (unlike the zero-row empty
+    // state above) but the orchestrator has not yet attached a hypothesis to
+    // it. The position/hint pair describes navigating a hypothesis list that
+    // does not exist yet here, so the next-step sentence replaces it instead
+    // of competing with it.
+    this.#footerLine.content =
+      log.entries.length === 0
+        ? 'The first hypothesis appears once the orchestrator forms one.'
+        : `${position} · ${hint}`;
   }
 
   #renderDetail(entry: HypothesisEntry, state: SessionState): void {
@@ -412,7 +446,12 @@ export class ExperimentLogView {
     this.#rows.add(row);
   }
 
-  #roundRow(roundNumber: number, isSelected: boolean, navigationIndex: number): void {
+  #roundRow(
+    roundNumber: number,
+    columns: Columns,
+    isSelected: boolean,
+    navigationIndex: number,
+  ): void {
     const row = new BoxRenderable(this.renderer, {
       id: `unowned-round-${roundNumber}`,
       width: '100%',
@@ -424,9 +463,13 @@ export class ExperimentLogView {
         this.controller.moveExperimentSelection(navigationIndex - this.#selectedNavigationIndex());
       },
     });
+    // One cell on the same column grid `entryCells` uses, not a single
+    // unstructured string: the round has a real round number and genuinely
+    // recorded agent turns, but no hypothesis, measurement, or outcome yet,
+    // so it lands under the same headers a hypothesis row would.
     row.add(
       this.#cell(
-        `${selectionCaret(isSelected)} Round ${roundNumber} · recorded agent turns · no hypothesis`,
+        unownedRoundRow(roundNumber, columns, isSelected),
         this.#theme.textPrimary,
         isSelected,
       ),
@@ -536,6 +579,8 @@ export class ExperimentLogView {
 
   #clear(): void {
     this.#activeActivityLine = null;
+    this.#headerRule.height = 0;
+    this.#headerRule.content = '';
     this.#stopElapsedTimer();
     for (const child of [...this.#rows.getChildren()]) {
       this.#rows.remove(child);
@@ -573,6 +618,8 @@ const MEASURED_WIDTH = 20;
 const OUTCOME_WIDTH = 11;
 const KEPT_WIDTH = 4;
 const COLUMN_GAP = '  ';
+/** The one glyph the file uses for a value that is genuinely absent. */
+const PLACEHOLDER = '—';
 
 export function resolveColumns(width: number): Columns {
   const claim = width >= CLAIM_MIN_WIDTH;
@@ -652,17 +699,17 @@ export function entryCells(
   const marker = entryLeadingMarker(entry, isSelected);
   const leading = [
     fitColumn(`${marker}${truncate(entry.hypothesis_id, ID_WIDTH - marker.length)}`, ID_WIDTH),
-    fitColumn(formatRounds(entry), ROUNDS_WIDTH),
+    fitColumn(formatRounds(entry), ROUNDS_WIDTH, 'right'),
   ];
   if (columns.claim) {
     leading.push(
       fitColumn(
-        sentenceCase(entry.title ?? entry.claim ?? entry.action ?? '—'),
+        sentenceCase(entry.title ?? entry.claim ?? entry.action ?? PLACEHOLDER),
         columns.claimWidth,
       ),
     );
   }
-  if (columns.measured) leading.push(fitColumn(formatMeasured(entry), MEASURED_WIDTH));
+  if (columns.measured) leading.push(fitColumn(formatMeasured(entry), MEASURED_WIDTH, 'right'));
   return {
     leading: leading.join(COLUMN_GAP),
     // These are separate renderables so outcome can carry semantic color.
@@ -671,15 +718,64 @@ export function entryCells(
     outcome: `${COLUMN_GAP}${fitColumn(outcomeLabel(entry), OUTCOME_WIDTH)}`,
     trailing: columns.kept
       ? `${COLUMN_GAP}${fitColumn(
-          entry.kept === true ? 'Yes' : entry.kept === false ? 'No' : '—',
+          entry.kept === true ? 'Yes' : entry.kept === false ? 'No' : PLACEHOLDER,
           KEPT_WIDTH,
+          'right',
         )}`
       : '',
   };
 }
 
-function fitColumn(value: string, width: number): string {
-  return truncate(value, width).padEnd(width);
+/**
+ * The unowned-round row's cells, laid out on the exact same column grid
+ * `entryCells` uses: same widths, same gap, same two-character marker slot.
+ * A round with agent turns but no owning hypothesis is the common landing
+ * state (a task profiles before proposing its first hypothesis), not an edge
+ * case, so it has to read as a row under the same headers, not as one string
+ * spanning all of them. The round number and "recorded agent turns" are real;
+ * everything the round genuinely does not have yet (hypothesis, measurement,
+ * outcome, kept) renders as `PLACEHOLDER`, not an invented value.
+ */
+export function unownedRoundCells(
+  roundNumber: number,
+  columns: Columns,
+  isSelected = false,
+): EntryCells {
+  // No active-hypothesis glyph applies to a round with no hypothesis, but the
+  // marker still reserves the same two columns `entryLeadingMarker` does, so
+  // the identity text starts at the same offset as a hypothesis row's.
+  const marker = `${selectionCaret(isSelected)} `;
+  const leading = [
+    fitColumn(`${marker}${truncate(NO_HYPOTHESIS_LABEL, ID_WIDTH - marker.length)}`, ID_WIDTH),
+    fitColumn(String(roundNumber), ROUNDS_WIDTH, 'right'),
+  ];
+  if (columns.claim) leading.push(fitColumn(RECORDED_TURNS_LABEL, columns.claimWidth));
+  if (columns.measured) leading.push(fitColumn(PLACEHOLDER, MEASURED_WIDTH, 'right'));
+  return {
+    leading: leading.join(COLUMN_GAP),
+    outcome: `${COLUMN_GAP}${fitColumn(PLACEHOLDER, OUTCOME_WIDTH)}`,
+    trailing: columns.kept ? `${COLUMN_GAP}${fitColumn(PLACEHOLDER, KEPT_WIDTH, 'right')}` : '',
+  };
+}
+
+export function unownedRoundRow(roundNumber: number, columns: Columns, isSelected = false): string {
+  const cells = unownedRoundCells(roundNumber, columns, isSelected);
+  return `${cells.leading}${cells.outcome}${cells.trailing}`;
+}
+
+const NO_HYPOTHESIS_LABEL = '(no hypothesis)';
+const RECORDED_TURNS_LABEL = 'recorded agent turns';
+
+/**
+ * Pads (or right-pads) `value` to `width` after truncating it, so every
+ * caller shares one place that decides how a column fits. `align: 'right'`
+ * is the smallest addition this needed: same truncation, same width budget,
+ * `padStart` instead of `padEnd`. Left is the default so the many existing
+ * left-aligned calls are unchanged.
+ */
+function fitColumn(value: string, width: number, align: 'left' | 'right' = 'left'): string {
+  const fitted = truncate(value, width);
+  return align === 'right' ? fitted.padStart(width) : fitted.padEnd(width);
 }
 
 export function entryRow(entry: HypothesisEntry, columns: Columns, isSelected = false): string {
@@ -708,7 +804,7 @@ export function outcomeLabel(entry: HypothesisEntry): string {
   if (entry.active === true) return 'Active';
   if (entry.resolved_outcome === 'proven') return 'Accepted';
   if (entry.resolved_outcome === 'disproven') return 'Rejected';
-  return sentenceCase(entry.resolved_outcome ?? '—');
+  return sentenceCase(entry.resolved_outcome ?? PLACEHOLDER);
 }
 
 /** Capitalises a wire value for display without touching the rest of it. */
@@ -740,7 +836,7 @@ export function formatMeasured(entry: HypothesisEntry): string {
     const marker = entry.perf_delta_reason === 'baseline_unresolved' ? '? ' : '';
     return `${marker}${trimNumber(entry.perf_metric)}${entry.perf_unit ? ` ${entry.perf_unit}` : ''}`;
   }
-  return '—';
+  return PLACEHOLDER;
 }
 
 function formatDelta(delta: number): string {


### PR DESCRIPTION
## Problem

The Experiments pane draws the hypothesis table header (Hypothesis / Rounds /
Implementation Details / Measured / Outcome) over a row with no columns:
`#roundRow` concatenated one string for an unowned round instead of calling
`entryCells`, and `#renderTable` drew the header unconditionally. An unowned
round (agent turns outside every hypothesis's range) is the default landing
state, since a task profiles before proposing hypothesis 1.

Closes #712

## Solution

Route the round row through the same column grid `entryCells` uses
(`unownedRoundCells`/`unownedRoundRow`), so it lands under the real headers
with a genuine round number and the honest "recorded agent turns" label;
other fields render the existing `—` placeholder. Add a permanent
fixed-height rule under the header. Right-align the numeric columns (Rounds,
Measured, Kept) via a new `align` parameter on the existing `fitColumn`
helper: open PR #706 (different author) reroutes that same helper for CJK
display width, so both fixes converge on one primitive rather than two.

### Architecture

`clients/tui/src/ui/experiment-log.ts` (`ExperimentLogView`) owns the
Experiments pane's table layout and column widths.

## Verification

| Before (`main`) | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr715-experiments-table-before.png) | ![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr715-experiments-table-after.png) |

Default landing state (an unowned round), 140x36, dark theme, cropped to the Experiments pane.


Formatter tests assert `unownedRoundCells` matches `entryCells`'s column
widths at every panel width; renderer tests confirm on-screen alignment.

### Correctness properties

- An unowned-round row shares column widths with a hypothesis row.
- Absent values always render the existing `—` placeholder, never empty.
- `fitColumn` defaults to left alignment; existing columns are unchanged.
- The header rule is fixed height, independent of row count.

### Testing

- `pnpm --filter @vibesys/tui test`: 834 pass, 0 fail (30 files)
- `pnpm check:clients`: clean

