### PR TITLE
feat(tui): animate round tabs and agent nodes with the shared spinner

### DIFF
--- a/clients/tui/src/ui/agent-map-selection.test.ts
+++ b/clients/tui/src/ui/agent-map-selection.test.ts
@@ -3,6 +3,7 @@ import {createTestRenderer} from '@opentui/core/testing';
 import type {AgentPhase} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import {initialSessionState, type SessionState} from '../session-model.js';
+import {SPINNER_FRAMES} from './activity-bar.js';
 import {AgentMapView, nodeLabel} from './agent-map.js';
 import {resolveTheme} from './theme.js';
 
@@ -21,8 +22,10 @@ describe('nodeLabel', () => {
   }
 
   it('prefixes a caret only when selected, independent of the status marker', () => {
-    expect(nodeLabel(phase('active'), false)).toBe('● implementer');
-    expect(nodeLabel(phase('active'), true)).toBe('› ● implementer');
+    // Active draws the shared spinner's frame 0 rather than a static marker;
+    // see the `nodeLabel spinner frame` suite in agent-map-spinner.test.ts.
+    expect(nodeLabel(phase('active'), false)).toBe(`${SPINNER_FRAMES[0]} implementer`);
+    expect(nodeLabel(phase('active'), true)).toBe(`› ${SPINNER_FRAMES[0]} implementer`);
     expect(nodeLabel(phase('pending'), false)).toBe('○ implementer');
     expect(nodeLabel(phase('pending'), true)).toBe('› ○ implementer');
     expect(nodeLabel(phase('completed'), true)).toBe('› ✓ implementer');
@@ -67,7 +70,7 @@ describe('agent node rendered selection glyph', () => {
     await testRenderer.renderOnce();
     const frame = testRenderer.captureCharFrame();
 
-    expect(frame).toContain('› ● implementer');
+    expect(frame).toContain(`› ${SPINNER_FRAMES[0]} implementer`);
     expect(frame).toContain('○ judge');
     expect(frame).not.toContain('› ○ judge');
   });

--- a/clients/tui/src/ui/agent-map-spinner.test.ts
+++ b/clients/tui/src/ui/agent-map-spinner.test.ts
@@ -1,0 +1,196 @@
+import {afterEach, describe, expect, it, spyOn} from 'bun:test';
+import type {Renderable} from '@opentui/core';
+import {createTestRenderer} from '@opentui/core/testing';
+import type {AgentPhase} from '@vibesys/core-state';
+import type {SessionController} from '../session-controller.js';
+import {initialSessionState, type SessionState} from '../session-model.js';
+import {SPINNER_FRAMES, SPINNER_INTERVAL_MS} from './activity-bar.js';
+import {AgentMapView, nodeLabel} from './agent-map.js';
+import {resolveTheme} from './theme.js';
+
+// Kept apart from agent-map.test.ts and agent-map-selection.test.ts for the
+// same reason those two are split: unrelated changes to either suite should
+// not textually conflict with these spinner-specific tests.
+
+/**
+ * `view.output` itself never changes: it holds one child (`#content`) for the
+ * view's whole life, so checking only the top level would prove nothing about
+ * whether `#clear()` tore down and rebuilt everything underneath it. Walking
+ * every descendant is what actually catches a full rebuild: `#clear()`
+ * destroys and recreates the heading, the canvas, every edge run and every
+ * node box, so any one of those changing identity means a rebuild happened.
+ */
+function descendants(node: Renderable): Renderable[] {
+  return [node, ...node.getChildren().flatMap(descendants)];
+}
+
+/**
+ * Before this, an active node's marker was the static `●`, same as every
+ * other status's marker was its own fixed glyph. `nodeLabel` now draws the
+ * shared `SPINNER_FRAMES` animation in that one cell instead, so "this is
+ * running right now" is visible the way the activity bar and the chat
+ * composer already show it.
+ */
+describe('nodeLabel spinner frame', () => {
+  function phase(status: AgentPhase['status']): AgentPhase {
+    return {kind: 'implementer', status, roundNumber: null, roundLabel: null};
+  }
+
+  it('draws the current spinner frame for an active phase, not a static marker', () => {
+    expect(nodeLabel(phase('active'), false, 0)).toBe(`${SPINNER_FRAMES[0]} implementer`);
+    expect(nodeLabel(phase('active'), false, 1)).toBe(`${SPINNER_FRAMES[1]} implementer`);
+    expect(nodeLabel(phase('active'), false, 0)).not.toBe(nodeLabel(phase('active'), false, 1));
+  });
+
+  it('wraps the frame index the way the activity bar and chat composer do', () => {
+    expect(nodeLabel(phase('active'), false, SPINNER_FRAMES.length)).toBe(
+      nodeLabel(phase('active'), false, 0),
+    );
+  });
+
+  it('leaves every non-active status on its own static glyph, whatever the frame', () => {
+    for (const status of ['pending', 'completed', 'failed', 'cancelled', 'interrupted'] as const) {
+      expect(nodeLabel(phase(status), false, 3)).toBe(nodeLabel(phase(status), false, 0));
+    }
+  });
+
+  it('keeps the marker cell one column wide, static or animated', () => {
+    const width = (label: string): number => [...label].length;
+    const pendingWidth = width(nodeLabel(phase('pending'), false));
+    for (let frame = 0; frame < SPINNER_FRAMES.length; frame += 1) {
+      expect(width(nodeLabel(phase('active'), false, frame))).toBe(pendingWidth);
+    }
+  });
+});
+
+describe('agent node spinner animation', () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const destroy of cleanup.splice(0).reverse()) destroy();
+  });
+
+  /** Never fires in a render-only test; onMouseUp is never simulated. */
+  const controller = {
+    focusRound: () => {},
+    selectAgent: () => {},
+  } as unknown as SessionController;
+
+  function stateWith(phases: AgentPhase[]): SessionState {
+    const base = initialSessionState();
+    return {...base, core: {...base.core, phases}, selectedAgentKind: null};
+  }
+
+  it('animates only the active graph node, in place, without rebuilding the tree', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const view = new AgentMapView(testRenderer.renderer, controller, resolveTheme(null));
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.destroy();
+      view.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    });
+    const phases: AgentPhase[] = [
+      {kind: 'implementer', status: 'active', roundNumber: null, roundLabel: null},
+      {kind: 'judge', status: 'pending', roundNumber: null, roundLabel: null},
+    ];
+    view.render(stateWith(phases), 60);
+    await testRenderer.renderOnce();
+    const before = testRenderer.captureCharFrame();
+    const beforeTree = descendants(view.output);
+
+    // A comfortable margin past one 120ms tick, well short of a full ten-frame
+    // wrap (1200ms), so the frame is guaranteed to differ without pinning
+    // exactly which one it lands on.
+    await new Promise(resolve => setTimeout(resolve, SPINNER_INTERVAL_MS + 130));
+    await testRenderer.renderOnce();
+    const after = testRenderer.captureCharFrame();
+    const afterTree = descendants(view.output);
+
+    const spinnerClass = `[${SPINNER_FRAMES.join('')}]`;
+    expect(before).toMatch(new RegExp(`${spinnerClass} implementer`));
+    expect(after).toMatch(new RegExp(`${spinnerClass} implementer`));
+    expect(before).not.toBe(after);
+    // The static neighbour never moved or changed.
+    expect(after).toContain('○ judge');
+    // Nothing widened: both frames are the same terminal, same row count.
+    expect(after.split('\n').map(row => row.length)).toEqual(
+      before.split('\n').map(row => row.length),
+    );
+    // No full `render()` rebuild happened: every renderable in the tree (the
+    // heading, the canvas, every edge run, every node box and its three text
+    // lines) kept its identity across the tick. `#clear()` destroys and
+    // recreates all of them on a real rebuild, so reference equality here,
+    // node for node, is proof one did not happen.
+    expect(afterTree.length).toBe(beforeTree.length);
+    expect(afterTree.length).toBeGreaterThan(5);
+    for (const [index, node] of beforeTree.entries()) {
+      expect(afterTree[index]).toBe(node);
+    }
+  });
+
+  it('animates the stacked fallback the same way, for a terminal too narrow for the graph', async () => {
+    const testRenderer = await createTestRenderer({width: 50, height: 24});
+    const view = new AgentMapView(testRenderer.renderer, controller, resolveTheme(null));
+    testRenderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.destroy();
+      view.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    });
+    const phases: AgentPhase[] = [
+      {kind: 'implementer', status: 'active', roundNumber: null, roundLabel: null},
+      {kind: 'judge', status: 'pending', roundNumber: null, roundLabel: null},
+    ];
+    view.render(stateWith(phases));
+    await testRenderer.renderOnce();
+    const before = testRenderer.captureCharFrame();
+    // The stacked fallback's own tell: the down arrow between two phases,
+    // which the graph layout never draws.
+    expect(before).toContain('↓');
+
+    await new Promise(resolve => setTimeout(resolve, SPINNER_INTERVAL_MS + 130));
+    await testRenderer.renderOnce();
+    const after = testRenderer.captureCharFrame();
+
+    const spinnerClass = `[${SPINNER_FRAMES.join('')}]`;
+    expect(before).toMatch(new RegExp(`${spinnerClass} implementer`));
+    expect(before).not.toBe(after);
+    expect(after).toContain('○ judge');
+  });
+
+  it('runs no spinner timer while nothing is active, starts one only when a phase is, and clears it', async () => {
+    const setIntervalSpy = spyOn(globalThis, 'setInterval');
+    const clearIntervalSpy = spyOn(globalThis, 'clearInterval');
+    const renderer = await createTestRenderer({width: 100, height: 24});
+    const view = new AgentMapView(renderer.renderer, controller, resolveTheme(null));
+    renderer.renderer.root.add(view.output);
+    cleanup.push(() => {
+      view.output.destroyRecursively();
+      renderer.renderer.destroy();
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    });
+
+    const idle: AgentPhase[] = [
+      {kind: 'implementer', status: 'completed', roundNumber: null, roundLabel: null},
+    ];
+    view.render(stateWith(idle), 60);
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+
+    const active: AgentPhase[] = [
+      {kind: 'implementer', status: 'active', roundNumber: null, roundLabel: null},
+    ];
+    view.render(stateWith(active), 60);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    // A fresh state object forces a real repaint, the way a live update would.
+    view.render(stateWith(idle), 61);
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+    view.render(stateWith(active), 62);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(2);
+    view.destroy();
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/clients/tui/src/ui/agent-map.test.ts
+++ b/clients/tui/src/ui/agent-map.test.ts
@@ -3,8 +3,12 @@ import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing'
 import type {AgentPhase} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import {initialSessionState, type SessionState} from '../session-model.js';
+import {SPINNER_FRAMES} from './activity-bar.js';
 import {AgentMapView, agentPaneWidth, STACKED_WIDTH, TRANSCRIPT_MIN} from './agent-map.js';
 import {resolveTheme} from './theme.js';
+
+/** The active-node marker: `nodeLabel` draws the spinner's frame 0 here first. */
+const activeMarker = SPINNER_FRAMES[0];
 
 /** A round with one agent per kind, in order. */
 function round(...kinds: string[]): AgentPhase[] {
@@ -112,7 +116,8 @@ describe('agent graph row budget', () => {
     await testRenderer.renderOnce();
     const frame = testRenderer.captureCharFrame();
     // Every node draws its kind on its first row, so the markers count nodes.
-    const nodes = (frame.match(/[●!] implementer/g) ?? []).length;
+    // The active attempt draws the spinner's frame 0, not the static `●`.
+    const nodes = (frame.match(new RegExp(`[${activeMarker}!] implementer`, 'g')) ?? []).length;
     return {frame, nodes};
   }
 
@@ -178,7 +183,7 @@ describe('agent graph row budget', () => {
 
     expect(frame).not.toContain('▶');
     expect(frame).toContain('› ✓ orchestrator');
-    expect(frame).toContain('● implementer');
+    expect(frame).toContain(`${activeMarker} implementer`);
     expect(frame).toContain('○ judge');
     expect(frame).not.toContain('…');
   });

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -14,6 +14,7 @@ import {
   visiblePhases,
   visibleRoundNumber,
 } from '../session-model.js';
+import {SPINNER_FRAMES, SPINNER_INTERVAL_MS} from './activity-bar.js';
 import {
   type AgentGraph,
   type EdgeTone,
@@ -63,9 +64,21 @@ function statusColor(theme: Theme, status: AgentPhase['status']): string {
  * only border, background, and text color, invisible on a low-contrast
  * terminal. Follows the '›' precedent in theme-picker.ts and the hypothesis
  * drill-down (`experiment-log.ts#renderDetail`).
+ *
+ * An active phase draws the current spinner frame in the marker's cell
+ * instead of the static `●`, so a phase that is actually running looks like
+ * it: same cell, same width (every `SPINNER_FRAMES` glyph is one column, like
+ * every other `STATUS_MARKER`), one glyph animating in place of another.
+ * `spinnerFrame` defaults to the frame every view starts on.
  */
-export function nodeLabel(phase: AgentPhase, selected: boolean): string {
-  return `${selected ? '› ' : ''}${STATUS_MARKER[phase.status]} ${phase.kind}`;
+export function nodeLabel(phase: AgentPhase, selected: boolean, spinnerFrame = 0): string {
+  const marker =
+    phase.status === 'active'
+      ? (SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length] ??
+        SPINNER_FRAMES[0] ??
+        STATUS_MARKER.active)
+      : STATUS_MARKER[phase.status];
+  return `${selected ? '› ' : ''}${marker} ${phase.kind}`;
 }
 
 function edgeColor(theme: Theme, tone: EdgeTone): string {
@@ -119,6 +132,15 @@ export class AgentMapView {
   #renderedRows = 0;
   #elapsedTimer: ReturnType<typeof setInterval> | null = null;
   #runningRound: {round: RoundSummary; text: TextRenderable} | null = null;
+  #spinnerFrame = 0;
+  #spinnerTimer: ReturnType<typeof setInterval> | null = null;
+  /** Every active node's marker cell, refreshed in place on the spinner tick. */
+  #spinnerNodes: Array<{
+    phase: AgentPhase;
+    selected: boolean;
+    text: TextRenderable;
+    inner: number | null;
+  }> = [];
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -262,10 +284,12 @@ export class AgentMapView {
       );
     }
     this.#syncElapsedTimer();
+    this.#syncSpinnerTimer();
   }
 
   destroy(): void {
     this.#stopElapsedTimer();
+    this.#stopSpinnerTimer();
   }
 
   /**
@@ -371,13 +395,13 @@ export class AgentMapView {
     // painting the ring the edges arrive at (tui-conventions.md).
     if (selected) fillLayer(box, `agent-${phase.kind}-${node.y}-fill`, this.#theme.selectedSurface);
     const inner = node.width - 2;
-    box.add(
-      new TextRenderable(this.renderer, {
-        content: truncate(nodeLabel(phase, selected), inner),
-        fg: selected ? this.#theme.textStrong : color,
-        width: '100%',
-      }),
-    );
+    const label = new TextRenderable(this.renderer, {
+      content: truncate(nodeLabel(phase, selected, this.#spinnerFrame), inner),
+      fg: selected ? this.#theme.textStrong : color,
+      width: '100%',
+    });
+    box.add(label);
+    if (phase.status === 'active') this.#spinnerNodes.push({phase, selected, text: label, inner});
     box.add(
       new TextRenderable(this.renderer, {
         content: truncate(phase.status, inner),
@@ -437,13 +461,14 @@ export class AgentMapView {
     });
     if (selected) fillLayer(row, `agent-${phase.kind}-fill`, this.#theme.selectedSurface);
     const color = statusColor(this.#theme, phase.status);
-    row.add(
-      new TextRenderable(this.renderer, {
-        content: nodeLabel(phase, selected),
-        fg: selected ? this.#theme.textStrong : color,
-        width: '100%',
-      }),
-    );
+    const label = new TextRenderable(this.renderer, {
+      content: nodeLabel(phase, selected, this.#spinnerFrame),
+      fg: selected ? this.#theme.textStrong : color,
+      width: '100%',
+    });
+    row.add(label);
+    if (phase.status === 'active')
+      this.#spinnerNodes.push({phase, selected, text: label, inner: null});
     row.add(
       new TextRenderable(this.renderer, {
         content: phase.status,
@@ -488,9 +513,38 @@ export class AgentMapView {
     this.#elapsedTimer = null;
   }
 
+  /**
+   * Mutates every active node's marker cell in place, the same idiom as
+   * `#syncElapsedTimer`, so a running phase animates without the 120ms tick
+   * ever calling `render()` and rebuilding the graph eight times a second.
+   * Started only while a phase is active, stopped the moment none is.
+   */
+  #syncSpinnerTimer(): void {
+    if (this.#spinnerNodes.length === 0) {
+      this.#stopSpinnerTimer();
+      return;
+    }
+    if (this.#spinnerTimer !== null) return;
+    this.#spinnerTimer = setInterval(() => {
+      this.#spinnerFrame = (this.#spinnerFrame + 1) % SPINNER_FRAMES.length;
+      for (const node of this.#spinnerNodes) {
+        const label = nodeLabel(node.phase, node.selected, this.#spinnerFrame);
+        node.text.content = node.inner === null ? label : truncate(label, node.inner);
+      }
+    }, SPINNER_INTERVAL_MS);
+  }
+
+  #stopSpinnerTimer(): void {
+    if (this.#spinnerTimer === null) return;
+    clearInterval(this.#spinnerTimer);
+    this.#spinnerTimer = null;
+  }
+
   #clear(): void {
     this.#runningRound = null;
     this.#stopElapsedTimer();
+    this.#spinnerNodes = [];
+    this.#stopSpinnerTimer();
     for (const child of [...this.#content.getChildren()]) {
       this.#content.remove(child);
       child.destroyRecursively();

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -65,6 +65,7 @@ import {
   switchChatThread,
   togglePaneZoom,
 } from '../session-model.js';
+import {SPINNER_FRAMES} from './activity-bar.js';
 import {TRANSCRIPT_MIN} from './agent-map.js';
 import {createOpenTuiApp, type OpenTuiApp} from './app.js';
 import {MIN_DOCK_WIDTH} from './chat-pane.js';
@@ -133,7 +134,8 @@ describe('OpenTUI presentation', () => {
     // no rounds yet, so there is no tab row to draw.
     expect(frame).toContain('Run flow');
     expect(tabsVisible(testRenderer)).toBe(false);
-    expect(frame).toContain('● optimizer');
+    // Active draws the shared spinner's frame 0, not a static marker.
+    expect(frame).toContain(`${SPINNER_FRAMES[0]} optimizer`);
     expect(frame).toContain('Result');
     expect(frame).toContain('Command');
     expect(frame).toContain('Type /help for commands');
@@ -253,9 +255,12 @@ describe('OpenTUI presentation', () => {
     expect([agents.y, transcript.y]).toEqual([tabs.y + 1, tabs.y + 1]);
     expect(root.findDescendantById('round-rail')).toBeUndefined();
     // Each tab carries its number and outcome glyph; the running round, open
-    // by default, carries its time measured from its agent start.
-    expect(frameRows(frame)[tabs.y]).toMatch(/r1 ✓.*▎ r2 ⟳ 1m \d+s.*r3 ✗ fail/);
-    // A glyph, never a spinner that reads as motion frozen.
+    // by default, carries its time measured from its agent start, with the
+    // shared braille spinner animating in the glyph cell while it runs.
+    expect(frameRows(frame)[tabs.y]).toMatch(
+      new RegExp(`r1 ✓.*▎ r2 [${SPINNER_FRAMES.join('')}] 1m \\d+s.*r3 ✗ fail`),
+    );
+    // The shared braille spinner, never the quarter-circle glyphs.
     expect(frame).not.toMatch(/[◐◓◑◒]/);
   });
 
@@ -915,7 +920,8 @@ describe('OpenTUI presentation', () => {
     });
     expect(below).not.toContain('▶');
     expect(below).toContain('› ✓ orchestrator');
-    expect(below).toContain('● implementer');
+    // Active draws the shared spinner's frame 0, not a static marker.
+    expect(below).toContain(`${SPINNER_FRAMES[0]} implementer`);
     expect(below).toContain('○ judge');
 
     const at = await agentPaneText(105, threeStageRound());
@@ -1162,7 +1168,8 @@ describe('OpenTUI presentation', () => {
     // Entering the pane selects its active agent. Clicking that inner node
     // keeps Agents focused and clears the filter, preserving node semantics.
     lines = frame.split('\n');
-    row = lines.findIndex(line => line.includes('● judge'));
+    // Active draws the shared spinner's frame 0, not a static marker.
+    row = lines.findIndex(line => line.includes(`${SPINNER_FRAMES[0]} judge`));
     column = (lines[row]?.indexOf('judge') ?? 0) + 2;
     await testRenderer.mockMouse.click(column, row);
     frame = await frameAfter(testRenderer);

--- a/clients/tui/src/ui/round-tabs.test.ts
+++ b/clients/tui/src/ui/round-tabs.test.ts
@@ -1,12 +1,16 @@
-import {describe, expect, test} from 'bun:test';
+import {describe, expect, spyOn, test} from 'bun:test';
 import {BoxRenderable, rgbToHex, TextAttributes} from '@opentui/core';
 import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
 import type {HypothesisRound} from '@vibesys/backend-client';
 import type {RoundState} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import {initialSessionState, type SessionState} from '../session-model.js';
+import {SPINNER_FRAMES, SPINNER_INTERVAL_MS} from './activity-bar.js';
 import {RoundTabsView, roundTab, tabWindow} from './round-tabs.js';
 import {contrastRatio, listThemes, resolveTheme, type Theme} from './theme.js';
+
+/** The live round's marker: `slot` draws the spinner's frame 0 here first. */
+const liveMarker = SPINNER_FRAMES[0] ?? '⠋';
 
 const secondsAgo = (seconds: number): string => new Date(Date.now() - seconds * 1000).toISOString();
 const done = (number: number): RoundState => ({number, status: 'completed'});
@@ -306,7 +310,7 @@ describe('RoundTabsView', () => {
     close(bar);
 
     expect(rowText(cells)).toBe(
-      '   r1 ✓ +12%   ▎ r2 ✓ +1.5%     r3 ✗ fail     r4 ✗ fail     r5 ○ skipped     r6 ⟳ 42s     r7 ·',
+      `   r1 ✓ +12%   ▎ r2 ✓ +1.5%     r3 ✗ fail     r4 ✗ fail     r5 ○ skipped     r6 ${liveMarker} 42s     r7 ·`,
     );
     expect(fgOf(cells, 'r1')).toEqual([theme.textMuted]);
     expect(fgOf(cells, '✓')).toEqual([theme.success]);
@@ -318,7 +322,7 @@ describe('RoundTabsView', () => {
       expect(fgOf(cells, part)).toEqual([theme.textSubtle]);
     }
     expect(fgOf(cells, 'r6')).toEqual([theme.textMuted]);
-    expect(fgOf(cells, '⟳')).toEqual([theme.accent]);
+    expect(fgOf(cells, liveMarker)).toEqual([theme.accent]);
     expect(fgOf(cells, '42s')).toEqual([theme.accent]);
     // Only the selected slot has a fill; everything else is the canvas.
     // From the gap after the selected slot through r4, and the margin before r1.
@@ -350,8 +354,10 @@ describe('RoundTabsView', () => {
 
     // r2 carries the selection, r6 the live state, each unmistakably.
     expect(cellsOf(cells, 'r2')[0]?.bg).toBe(theme.selectedSurface);
-    expect(cellsOf(cells, 'r6 ⟳ 42s').map(cell => cell.bg)).not.toContain(theme.selectedSurface);
-    expect(fgOf(cells, '⟳ 42s')).toEqual([theme.accent]);
+    expect(cellsOf(cells, `r6 ${liveMarker} 42s`).map(cell => cell.bg)).not.toContain(
+      theme.selectedSurface,
+    );
+    expect(fgOf(cells, `${liveMarker} 42s`)).toEqual([theme.accent]);
   });
 
   test('keeps the live colours on a selected live round', async () => {
@@ -359,10 +365,10 @@ describe('RoundTabsView', () => {
     const {cells} = bar;
     close(bar);
 
-    const slot = cellsOf(cells, '▎ r6 ⟳ 42s  ');
+    const slot = cellsOf(cells, `▎ r6 ${liveMarker} 42s  `);
     expect(new Set(slot.map(cell => cell.bg))).toEqual(new Set([theme.selectedSurface]));
     expect(cellsOf(cells, 'r6')[0]).toMatchObject({fg: theme.textStrong, bold: true});
-    expect(cellsOf(cells, '⟳')[0]).toMatchObject({fg: theme.accent, bold: true});
+    expect(cellsOf(cells, liveMarker)[0]).toMatchObject({fg: theme.accent, bold: true});
     expect(fgOf(cells, '42s')).toEqual([theme.accent]);
     // r2 is back to an ordinary done tab.
     expect(fgOf(cells, '+1.5%')).toEqual([theme.textMuted]);
@@ -413,19 +419,19 @@ describe('RoundTabsView', () => {
 
     expect(rows).toEqual([
       // L0: everything fits.
-      [58, ' ▎ r1 ✓ +12%     r2 ✓ +1.5%     r3 ✓ -3.0%     r4 ⟳ 42s'],
+      [58, ` ▎ r1 ✓ +12%     r2 ✓ +1.5%     r3 ✓ -3.0%     r4 ${liveMarker} 42s`],
       // L1: tabs that are neither selected nor live lose their metric.
-      [57, ' ▎ r1 ✓ +12%     r2 ✓     r3 ✓     r4 ⟳ 42s'],
-      [46, ' ▎ r1 ✓ +12%     r2 ✓     r3 ✓     r4 ⟳ 42s'],
+      [57, ` ▎ r1 ✓ +12%     r2 ✓     r3 ✓     r4 ${liveMarker} 42s`],
+      [46, ` ▎ r1 ✓ +12%     r2 ✓     r3 ✓     r4 ${liveMarker} 42s`],
       // L2: padding 2 -> 1.
-      [45, ' ▎r1 ✓ +12%   r2 ✓   r3 ✓   r4 ⟳ 42s'],
-      [38, ' ▎r1 ✓ +12%   r2 ✓   r3 ✓   r4 ⟳ 42s'],
+      [45, ` ▎r1 ✓ +12%   r2 ✓   r3 ✓   r4 ${liveMarker} 42s`],
+      [38, ` ▎r1 ✓ +12%   r2 ✓   r3 ✓   r4 ${liveMarker} 42s`],
       // L3: the selected tab loses its metric; the live one keeps its timer.
-      [37, ' ▎r1 ✓   r2 ✓   r3 ✓   r4 ⟳ 42s'],
-      [33, ' ▎r1 ✓   r2 ✓   r3 ✓   r4 ⟳ 42s'],
+      [37, ` ▎r1 ✓   r2 ✓   r3 ✓   r4 ${liveMarker} 42s`],
+      [33, ` ▎r1 ✓   r2 ✓   r3 ✓   r4 ${liveMarker} 42s`],
       // L4: no inner space.
-      [32, ' ▎r1✓   r2✓   r3✓   r4⟳42s'],
-      [28, ' ▎r1✓   r2✓   r3✓   r4⟳42s'],
+      [32, ` ▎r1✓   r2✓   r3✓   r4${liveMarker}42s`],
+      [28, ` ▎r1✓   r2✓   r3✓   r4${liveMarker}42s`],
       // L4 cannot hold both: the selected round wins and the live one goes.
       [27, ' ▎r1✓   r2✓   r3✓   1 ›'],
       [12, ' ▎r1✓   3 ›'],
@@ -491,7 +497,10 @@ describe('RoundTabsView', () => {
     const state = runState([live(1, 9.0)], {selected: 2, maxRounds: 2});
     const bar = await renderBar(state, 40);
     const before = rowText(bar.cells);
-    // The timer ticks on a real one-second interval; wait past one tick.
+    // The timer ticks on a real one-second interval; wait past one tick. The
+    // 120ms spinner also ticks several times in that window (it is a
+    // different timer than the one this test is about), so its glyph is read
+    // as "some spinner frame" rather than pinned to a specific one.
     await new Promise(resolve => setTimeout(resolve, 1100));
     await bar.setup.renderOnce();
     const after = rowText(rowCells(bar.setup));
@@ -499,8 +508,9 @@ describe('RoundTabsView', () => {
 
     // The label changes, and its slot does not: `9s` is padded to the width of
     // `59s`, so the tab beside it keeps its column.
-    expect(before).toBe('   r1 ⟳ 9s    ▎ r2 ·');
-    expect(after).toBe('   r1 ⟳ 10s   ▎ r2 ·');
+    const spinner = `[${SPINNER_FRAMES.join('')}]`;
+    expect(before).toMatch(new RegExp(`^   r1 ${spinner} 9s    ▎ r2 ·$`));
+    expect(after).toMatch(new RegExp(`^   r1 ${spinner} 10s   ▎ r2 ·$`));
     expect(after.indexOf('▎')).toBe(before.indexOf('▎'));
   });
 
@@ -515,5 +525,79 @@ describe('RoundTabsView', () => {
 
     expect(fgOf(cells, '✓')).toEqual([light.success]);
     expect(cellsOf(cells, 'r2')[0]?.bg).toBe(light.selectedSurface);
+  });
+});
+
+/**
+ * Before this, the live round's glyph was the static `⟳`, same as every other
+ * outcome's fixed glyph. It now draws the shared `SPINNER_FRAMES` animation in
+ * that one cell instead, the same braille spinner the activity bar and the
+ * chat composer already animate.
+ */
+describe('round tab spinner animation', () => {
+  test('advances the live tab through the shared spinner frames on its own 120ms tick', async () => {
+    const state = runState([live(1, 9.0)], {selected: 1});
+    const bar = await renderBar(state, 40);
+    const before = rowText(bar.cells);
+    // A comfortable margin past one tick, well short of a full ten-frame wrap
+    // (1200ms), so the frame is guaranteed to differ without pinning exactly
+    // which one it lands on.
+    await new Promise(resolve => setTimeout(resolve, SPINNER_INTERVAL_MS + 130));
+    await bar.setup.renderOnce();
+    const after = rowText(rowCells(bar.setup));
+    close(bar);
+
+    const glyphIndex = before.indexOf('r1') + 3;
+    const beforeGlyph = before[glyphIndex] ?? '';
+    const afterGlyph = after[glyphIndex] ?? '';
+    expect(SPINNER_FRAMES).toContain(beforeGlyph);
+    expect(SPINNER_FRAMES).toContain(afterGlyph);
+    expect(afterGlyph).not.toBe(beforeGlyph);
+    // Only the glyph cell changed: same width, same everything else in the row.
+    expect(after.length).toBe(before.length);
+    expect(after.slice(0, glyphIndex) + after.slice(glyphIndex + 1)).toBe(
+      before.slice(0, glyphIndex) + before.slice(glyphIndex + 1),
+    );
+  });
+
+  test('mutates the live slot in place on a tick, without rebuilding the tab row', async () => {
+    const state = runState([live(1, 9.0)], {selected: 1});
+    const bar = await renderBar(state, 40);
+    const before = [...bar.view.output.getChildren()];
+    await new Promise(resolve => setTimeout(resolve, SPINNER_INTERVAL_MS + 130));
+    await bar.setup.renderOnce();
+    const after = [...bar.view.output.getChildren()];
+    close(bar);
+
+    // No full `#draw()` rebuild happened: `#draw` destroys and re-adds every
+    // slot, so the same slot renderables surviving the tick, in the same
+    // order, is proof the tick only mutated `.content` in place.
+    expect(after.length).toBe(before.length);
+    for (const [index, child] of before.entries()) {
+      expect(after[index]).toBe(child);
+    }
+  });
+
+  test('runs no spinner timer while no round is live, starts one only while one is, and clears it', async () => {
+    const setIntervalSpy = spyOn(globalThis, 'setInterval');
+    const clearIntervalSpy = spyOn(globalThis, 'clearInterval');
+    const idle = runState([done(1)], {selected: 1, records: [measured(1, 12)]});
+    const bar = await renderBar(idle, 40);
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+
+    await redraw(bar, runState([live(1, 9.0)], {selected: 1}), 41);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    await redraw(bar, runState([done(1)], {selected: 1, records: [measured(1, 12)]}), 42);
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+    await redraw(bar, runState([live(1, 9.0)], {selected: 1}), 43);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(2);
+    bar.view.destroy();
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(2);
+
+    close(bar);
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
   });
 });

--- a/clients/tui/src/ui/round-tabs.ts
+++ b/clients/tui/src/ui/round-tabs.ts
@@ -12,6 +12,7 @@ import {hasActiveAgentTiming, type RoundState, roundAgentElapsedMs} from '@vibes
 import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
 import {hypothesisRoundFor, stripRounds, visibleRoundNumber} from '../session-model.js';
+import {SPINNER_FRAMES, SPINNER_INTERVAL_MS} from './activity-bar.js';
 import {elapsedLabel} from './previews.js';
 import {displayWidth} from './text-width.js';
 import {ensureContrast, type Theme} from './theme.js';
@@ -205,12 +206,30 @@ function tabColors(
   }
 }
 
-/** `  r6 ✓ +1%  `, or `▎ r6 ✓ +1%  ` when selected, trimmed to `level`. */
-function slot(tab: RoundTab, level: Level, selected: boolean, live: boolean, theme: Theme): Slot {
+/**
+ * `  r6 ✓ +1%  `, or `▎ r6 ✓ +1%  ` when selected, trimmed to `level`. A
+ * `live` tab draws the current spinner frame in the glyph cell instead of the
+ * static `⟳`, so `spinnerFrame` only ever matters for that outcome; every
+ * other outcome keeps its glyph exactly as it was.
+ */
+function slot(
+  tab: RoundTab,
+  level: Level,
+  selected: boolean,
+  live: boolean,
+  theme: Theme,
+  spinnerFrame = 0,
+): Slot {
   const pad = level >= 2 ? ' ' : '  ';
   const space = level >= 4 ? '' : ' ';
   const metric = tab.metric !== '' && (live || level < (selected ? 3 : 1));
   const colors = tabColors(tab.outcome, selected, theme);
+  const glyph =
+    tab.outcome === 'live'
+      ? (SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length] ??
+        SPINNER_FRAMES[0] ??
+        OUTCOME_GLYPH.live)
+      : OUTCOME_GLYPH[tab.outcome];
   // The theme holds its colours to the floor against the canvas only, so each
   // one is lifted again to read on the selection fill.
   const ink = (color: string, text: string, strong = false): TextChunk => {
@@ -223,7 +242,7 @@ function slot(tab: RoundTab, level: Level, selected: boolean, live: boolean, the
     colors.number,
     `r${tab.number}`,
     selected,
-  )}${space}${ink(colors.glyph, OUTCOME_GLYPH[tab.outcome], selected)}${
+  )}${space}${ink(colors.glyph, glyph, selected)}${
     metric ? ink(colors.metric, `${space}${tab.metric}`) : ''
   }${pad}`;
   const width = displayWidth(content.chunks.map(chunk => chunk.text).join(''));
@@ -243,6 +262,10 @@ export class RoundTabsView {
   #renderedState: SessionState | null = null;
   #renderedWidth = 0;
   #elapsedTimer: ReturnType<typeof setTimeout> | null = null;
+  #spinnerFrame = 0;
+  #spinnerTimer: ReturnType<typeof setInterval> | null = null;
+  /** The live tab's own text cell, refreshed in place on the spinner tick. */
+  #liveSlot: {tab: RoundTab; level: Level; selected: boolean; text: TextRenderable} | null = null;
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -279,16 +302,21 @@ export class RoundTabsView {
   /** Takes the bar off screen, timer included, until the next `render` draws it afresh. */
   hide(): void {
     this.#stopElapsedTimer();
+    this.#stopSpinnerTimer();
+    this.#liveSlot = null;
     this.#renderedState = null;
     this.output.visible = false;
   }
 
   destroy(): void {
     this.#stopElapsedTimer();
+    this.#stopSpinnerTimer();
   }
 
   #draw(state: SessionState, width: number): void {
     this.#stopElapsedTimer();
+    this.#stopSpinnerTimer();
+    this.#liveSlot = null;
     for (const child of [...this.output.getChildren()]) {
       this.output.remove(child);
       child.destroyRecursively();
@@ -310,9 +338,18 @@ export class RoundTabsView {
 
     let slots: Slot[] = [];
     let view: TabWindow | null = null;
+    let usedLevel: Level = LEVELS[0];
     for (const level of LEVELS) {
+      usedLevel = level;
       slots = tabs.map((tab, index) =>
-        slot(tab, level, tab.number === selectedNumber, index === live, this.#theme),
+        slot(
+          tab,
+          level,
+          tab.number === selectedNumber,
+          index === live,
+          this.#theme,
+          this.#spinnerFrame,
+        ),
       );
       view = tabWindow(
         slots.map(each => each.width),
@@ -336,7 +373,11 @@ export class RoundTabsView {
       this.output.add(this.#marker(beforeMarker(first), {marginRight: MARKER_GAP}));
     }
     slots.slice(first, last + 1).forEach((each, offset) => {
-      this.output.add(this.#slot(each, offset > 0));
+      const text = this.#slot(each, offset > 0);
+      this.output.add(text);
+      if (live !== null && each.tab.number === liveNumber) {
+        this.#liveSlot = {tab: each.tab, level: usedLevel, selected: each.selected, text};
+      }
     });
     if (view !== null && last < tabs.length - 1) {
       this.output.add(this.#marker(afterMarker(tabs.length - 1 - last), {marginLeft: MARKER_GAP}));
@@ -349,6 +390,7 @@ export class RoundTabsView {
       // than rewriting one label.
       this.#elapsedTimer = setTimeout(() => this.#draw(state, width), 1000);
     }
+    this.#syncSpinnerTimer();
   }
 
   #slot({tab, selected, content, width}: Slot, afterAnother: boolean): TextRenderable {
@@ -378,5 +420,32 @@ export class RoundTabsView {
     if (this.#elapsedTimer === null) return;
     clearTimeout(this.#elapsedTimer);
     this.#elapsedTimer = null;
+  }
+
+  /**
+   * Rewrites the live tab's own cell in place on each 120ms tick, the same
+   * idiom `agent-map.ts` uses for its elapsed label, so the spinner never
+   * re-lays out the whole row. Started only while a live tab is on screen,
+   * stopped the moment it scrolls out of the window or the round is no
+   * longer live.
+   */
+  #syncSpinnerTimer(): void {
+    if (this.#liveSlot === null) {
+      this.#stopSpinnerTimer();
+      return;
+    }
+    if (this.#spinnerTimer !== null) return;
+    this.#spinnerTimer = setInterval(() => {
+      this.#spinnerFrame = (this.#spinnerFrame + 1) % SPINNER_FRAMES.length;
+      if (this.#liveSlot === null) return;
+      const {tab, level, selected, text} = this.#liveSlot;
+      text.content = slot(tab, level, selected, true, this.#theme, this.#spinnerFrame).content;
+    }, SPINNER_INTERVAL_MS);
+  }
+
+  #stopSpinnerTimer(): void {
+    if (this.#spinnerTimer === null) return;
+    clearInterval(this.#spinnerTimer);
+    this.#spinnerTimer = null;
   }
 }


### PR DESCRIPTION
## Problem

The running round and the running agent-graph node draw a static glyph (`⟳`, `●`) with nothing distinguishing "running right now" from any other moment in that status, unlike the activity bar and chat composer, which already animate exactly this state.

## Solution

Both views draw the existing shared spinner (`SPINNER_FRAMES`, `SPINNER_INTERVAL_MS` in `activity-bar.ts`) instead of a second animation. The spinner replaces the status glyph in its existing cell: same width, no layout change. Each view rewrites the glyph's `TextRenderable.content` in place on a 120ms `setInterval`, so a tick never calls `render()`/`#clear()` and never rebuilds the tree. Timers run only while a round or phase is live and stop on idle and `destroy()`. Other statuses keep their static glyphs.

Round display is the vertical rail (maintainer decision on #696). This PR originally animated the horizontal round tabs; the maintainer took it over and ported that half to `round-rail.ts`:

- The live rail row shows the spinner frame in place of `⟳`, in both the full (`▸r2 ⠹ run 1m 12s`) and compact (`▸r2⠹`) rail. The rail's existing timer, previously 1s for the elapsed label, now ticks at the spinner rate and rewrites the row's own cell; the elapsed text changes only when a whole second does.
- The frame counter lives on the view, so the animation does not restart on redraw.
- The agent-node spinner (`agent-map.ts`) is unchanged from the original PR, merged with the label-sized graph and width controls now on main.
- The tab bar changes are dropped with `round-tabs.ts`.

Limitation: the rail, graph-node, and activity-bar spinners keep independent frame counters, so they are not phase-locked.

## Verification

Live rail row, before and after (a still frame of each; the spinner glyph changes every 120ms):

```
before  ▸r2 ⟳ run 1m 12s
after   ▸r2 ⠹ run 1m 12s
```

### Correctness properties

- The rail spinner replaces only the live row's glyph; width is unchanged across frames (asserted).
- Timers stop on `destroy()` (asserted: the row content freezes).
- Non-live outcomes keep their static glyphs.

### Testing

- `pnpm check`, `biome check src`: clean
- `bun test src/ui`: 755 pass, 0 fail (new rail tests: frame advance without width change, compact glyph, stop on destroy)
