### PR TITLE
fix(tui): move input-scope errors onto the command input's hint row

### DIFF
--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -34,9 +34,14 @@ describe('session controller', () => {
 
     expect(transport.requests).toEqual([]);
     expect(controller.state.chatConversation).toEqual([]);
-    expect(controller.state.errorBanner?.message).toContain('Commands start with /');
+    // Ordinary text is a routing mistake, not a malformed command: it lands on
+    // the command input's own hint row rather than raising the shared banner
+    // (#564/#635's reasoning, applied to a wrong command instead of an empty
+    // one).
+    expect(controller.state.inputError).toContain('Commands start with /');
+    expect(controller.state.errorBanner).toBeNull();
 
-    controller.dismissErrorBanner();
+    controller.clearInputError();
     await controller.submitChat('what is happening?');
 
     expect(transport.requests).toEqual([{type: 'query.chat', text: 'what is happening?'}]);
@@ -668,20 +673,20 @@ describe('session controller', () => {
     const controller = new SocketSessionController(transport);
 
     await controller.submitCommand('/history');
-    expect(controller.state.errorBanner?.scope).toBe('input');
-    expect(controller.state.errorBanner?.message).toContain('Unknown command: /history');
+    expect(controller.state.errorBanner).toBeNull();
+    expect(controller.state.inputError).toContain('Unknown command: /history');
 
     await controller.submitCommand('/history rounds');
-    expect(controller.state.errorBanner?.message).toContain('Unknown command: /history rounds');
+    expect(controller.state.inputError).toContain('Unknown command: /history rounds');
 
     await controller.submitCommand('/experiments');
-    expect(controller.state.errorBanner?.message).toContain('Unknown command: /experiments');
+    expect(controller.state.inputError).toContain('Unknown command: /experiments');
 
-    controller.dismissErrorBanner();
-    expect(controller.state.errorBanner).toBeNull();
+    controller.clearInputError();
+    expect(controller.state.inputError).toBeNull();
 
     await controller.submitCommand('/history');
-    expect(controller.state.errorBanner?.message).toContain('Unknown command: /history');
+    expect(controller.state.inputError).toContain('Unknown command: /history');
 
     expect(transport.requests).toEqual([]);
   });
@@ -1550,7 +1555,10 @@ describe('session controller', () => {
     const before = transport.requests.length;
     await controller.submitChat('/clear definitely-not');
 
-    expect(controller.state.errorBanner?.message).toBe('Usage: /clear');
+    // A usage error is `scope: 'input'` regardless of which surface typed it,
+    // so it lands on the command input's hint rather than the banner.
+    expect(controller.state.inputError).toBe('Usage: /clear');
+    expect(controller.state.errorBanner).toBeNull();
     // The phrase started no thread and sent no request.
     expect(transport.requests.length).toBe(before);
     expect(controller.state.chatMenu).toBeNull();
@@ -1562,7 +1570,8 @@ describe('session controller', () => {
 
     await controller.submitCommand('/pause typo');
 
-    expect(controller.state.errorBanner).toMatchObject({scope: 'input', message: 'Usage: /pause'});
+    expect(controller.state.inputError).toBe('Usage: /pause');
+    expect(controller.state.errorBanner).toBeNull();
     expect(transport.requests).toEqual([]);
   });
 
@@ -1572,8 +1581,8 @@ describe('session controller', () => {
 
     await controller.submitCommand('/theme monokai');
 
-    expect(controller.state.errorBanner).toMatchObject({scope: 'input'});
-    expect(controller.state.errorBanner?.message).toContain('Unknown theme: monokai');
+    expect(controller.state.errorBanner).toBeNull();
+    expect(controller.state.inputError).toContain('Unknown theme: monokai');
     expect(controller.state.themeName).toBe('dark');
     expect(transport.requests).toEqual([]);
   });

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -26,6 +26,7 @@ import {
   chatPaneVisible,
   clearAgentSelection,
   clearEntrySelection,
+  clearInputError,
   closeChatMenu,
   closeOverlays,
   closePane,
@@ -136,6 +137,7 @@ export interface SessionController {
   closePane(): void;
   closeOverlays(): void;
   dismissErrorBanner(): void;
+  clearInputError(): void;
   cyclePaneFocus(): void;
   focusPane(focus: PaneFocus): void;
   togglePaneZoom(): void;
@@ -598,6 +600,10 @@ export class SocketSessionController implements SessionController {
 
   dismissErrorBanner(): void {
     this.#setState(dismissErrorBanner(this.#state));
+  }
+
+  clearInputError(): void {
+    this.#setState(clearInputError(this.#state));
   }
 
   cyclePaneFocus(): void {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -8,6 +8,7 @@ import {
   applyEventBatch,
   chatDocked,
   chatPaneVisible,
+  clearInputError,
   closePane,
   closeThemePicker,
   cyclePaneFocus,
@@ -52,9 +53,49 @@ import {
 } from './session-model.js';
 import {runStateText, usageText} from './ui/header.js';
 
+describe('input errors', () => {
+  it('routes a scope: input report to the hint row, never the banner', () => {
+    const state = reportError(initialSessionState(), 'Enter a slash command. Use /help.', {
+      scope: 'input',
+    });
+
+    expect(state.inputError).toBe('Enter a slash command. Use /help.');
+    expect(state.errorBanner).toBeNull();
+  });
+
+  it('leaves inputError alone for a real backend scope, and vice versa', () => {
+    const withBanner = reportError(initialSessionState(), 'The request failed.', {
+      scope: 'request',
+    });
+    expect(withBanner.errorBanner).toMatchObject({message: 'The request failed.'});
+    expect(withBanner.inputError).toBeNull();
+
+    const withInput = reportError(withBanner, 'Unknown command: /nope. Use /help.', {
+      scope: 'input',
+    });
+    // Routing input off the banner does not disturb a standing banner from a
+    // real scope, and the reverse: a later banner does not clear the hint.
+    expect(withInput.errorBanner).toEqual(withBanner.errorBanner);
+    expect(withInput.inputError).toBe('Unknown command: /nope. Use /help.');
+  });
+
+  it('clears on request, once, and leaves everything else untouched', () => {
+    const state = reportError({...initialSessionState(), selectedRound: 2}, 'Usage: /pause', {
+      scope: 'input',
+    });
+    const cleared = clearInputError(state);
+
+    expect(cleared.inputError).toBeNull();
+    expect(cleared.selectedRound).toBe(2);
+    expect(clearInputError(cleared)).toBe(cleared);
+  });
+});
+
 describe('event batch projection', () => {
   it('keeps the existing banner while resumed history ends in a running session', () => {
-    const before = reportError(initialSessionState(), 'Local input problem', {scope: 'input'});
+    const before = reportError(initialSessionState(), 'Local protocol problem', {
+      scope: 'protocol',
+    });
 
     const state = applyEventBatch(before, [
       {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -89,6 +89,13 @@ export interface SessionState {
   themePicker: ThemePicker | null;
   /** Root-level error state, independent of the active transcript or log view. */
   errorBanner: ErrorBannerState | null;
+  /**
+   * A `scope: 'input'` message, shown on the command input's hint row rather
+   * than the banner. Unlike `errorBanner`, this never carries a backend
+   * `detail`/`hint`: it names a typo in what the operator just typed, so it is
+   * a short client-side string rather than a diagnostic.
+   */
+  inputError: string | null;
 }
 
 export type ErrorSeverity = 'recoverable' | 'fatal';
@@ -323,6 +330,7 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     chatDockFits: true,
     themePicker: null,
     errorBanner: null,
+    inputError: null,
   };
 }
 
@@ -1746,15 +1754,34 @@ export function dismissErrorBanner(state: SessionState): SessionState {
 }
 
 /**
+ * Clears a standing input-validation message. Called on the next keystroke
+ * and on Esc (#564/#635's reasoning applied to a wrong command rather than an
+ * empty one): the message names a typo in text the operator is already
+ * retyping, so it is stale the moment they start fixing it.
+ */
+export function clearInputError(state: SessionState): SessionState {
+  if (state.inputError === null) return state;
+  return {...state, inputError: null};
+}
+
+/**
  * Records an error independently of any particular view. A terminal event
  * commonly repeats an invocation failure, so equivalent reports promote the
  * current banner instead of burying its cause beneath a duplicate.
+ *
+ * `scope: 'input'` is routed off the banner entirely: it is client-side
+ * validation of what the operator just typed, never a backend diagnostic with
+ * `detail`/`hint`, so it belongs on the command input's own hint row instead
+ * of the shared error surface (see `command-input.ts`).
  */
 export function reportError(
   state: SessionState,
   message: string,
   report: ErrorReport,
 ): SessionState {
+  if (report.scope === 'input') {
+    return {...state, inputError: message};
+  }
   const diagnostic = report.diagnostic ?? null;
   const scope = diagnostic?.scope ?? report.scope;
   const severity = diagnosticSeverity(diagnostic?.severity) ?? report.severity ?? 'recoverable';

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -8,6 +8,7 @@ import {
   rgbToHex,
   ScrollBoxRenderable,
   TextareaRenderable,
+  TextRenderable,
 } from '@opentui/core';
 import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
 import type {ChatOptions, HypothesisEntry} from '@vibesys/backend-client';
@@ -20,6 +21,7 @@ import {
   chatMenuCustomModel,
   clearAgentSelection,
   clearEntrySelection,
+  clearInputError,
   closeChatMenu,
   closeOverlays,
   closePane,
@@ -529,9 +531,13 @@ describe('OpenTUI presentation', () => {
     expect(viewportBottomBorder).toBeGreaterThan(commandTop);
     expect(viewportBottomBorder).toBeLessThan(helpLine);
     const transcriptColumn = Math.max(0, (activityLine?.indexOf('Implementer') ?? 2) - 2);
+    // The command input's reserved hint row sits directly above the box's own
+    // top border, one row of furniture the same way the box itself is, so the
+    // blank-fill check stops above it rather than above the box.
+    const commandChromeTop = commandTop - 1;
     expect(
       lines
-        .slice(activityLineIndex + 1, commandTop)
+        .slice(activityLineIndex + 1, commandChromeTop)
         .every(line => line.slice(transcriptColumn).replaceAll(FRAME_VERTICALS, '').trim() === ''),
     ).toBe(true);
 
@@ -1709,10 +1715,46 @@ describe('OpenTUI presentation', () => {
 
     await testRenderer.mockInput.typeText('what is running?');
     testRenderer.mockInput.pressEnter();
-    const frame = await testRenderer.waitForFrame(value => value.includes('Commands start with /'));
-    expect(frame).toContain('Use Experiment chat for questions.');
+    // Wait on the real state, not frame text: the hint row is half the
+    // screen's width, so this message is truncated on screen and never
+    // appears there verbatim.
+    await testRenderer.waitForFrame(() => controller.state.inputError !== null);
+    // The message lands on the command input's own hint row, not the
+    // full-width banner: #564/#635's reasoning ("reporting a no-op as an error
+    // trains the operator to ignore the banner") applies just as well to a
+    // wrong command as to an empty box.
+    expect(commandHintText(testRenderer)).toBe(
+      '✗ Commands start with /. Use Experiment chat for questions.',
+    );
+    expect(testRenderer.renderer.root.findDescendantById('error-banner')?.visible).toBe(false);
     expect(controller.submissions).toEqual([]);
     expect(controller.chatSubmissions).toEqual([]);
+  });
+
+  it('clears the input error on the next keystroke, and reverts the box border', async () => {
+    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    const controller = new FakeController(initialSessionState());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    const box = (): BoxRenderable => {
+      const node = testRenderer.renderer.root.findDescendantById('command-input-box');
+      if (!(node instanceof BoxRenderable)) throw new Error('command box was missing');
+      return node;
+    };
+    const restingColor = rgbToHex(box().borderColor).toLowerCase();
+
+    await testRenderer.mockInput.typeText('what is running?');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.state.inputError !== null);
+    expect(controller.state.inputError).not.toBeNull();
+    expect(rgbToHex(box().borderColor).toLowerCase()).not.toBe(restingColor);
+
+    // The message named a typo in what was just typed, so it is stale the
+    // moment the operator starts fixing it: the next keystroke clears it.
+    await testRenderer.mockInput.typeText('/');
+    await frameAfter(testRenderer);
+    expect(controller.state.inputError).toBeNull();
+    expect(rgbToHex(box().borderColor).toLowerCase()).toBe(restingColor);
   });
 
   it('suggests and completes slash commands with Tab', async () => {
@@ -3683,7 +3725,11 @@ describe('theming', () => {
     // the boxes share a row because they are siblings rather than because a
     // row was budgeted for it. That budget is what #556 measured, and it is
     // gone: nothing is bought, so a short terminal has nothing to give up.
-    const testRenderer = await createTestRenderer({width: 100, height: 16});
+    //
+    // The command input's own reserved hint row (#input-error-inline) costs
+    // every view one more row than #556 measured, so the heights that used to
+    // mark this boundary are each one row taller now.
+    const testRenderer = await createTestRenderer({width: 100, height: 17});
     const controller = kickoffController();
     const app = createOpenTuiApp(testRenderer.renderer, controller);
     registerCleanup(testRenderer.renderer, app);
@@ -3709,7 +3755,7 @@ describe('theming', () => {
     expect(bottomRows().command).toBe(bottomRows().message);
 
     // And at the height that could afford it before, copy still whole.
-    testRenderer.renderer.resize(100, 17);
+    testRenderer.renderer.resize(100, 18);
     const taller = await frameAfter(testRenderer);
     expect(taller).toContain('This activity becomes');
     expect(bottomRows().command).toBe(bottomRows().message);
@@ -3767,11 +3813,19 @@ describe('theming', () => {
 
     await testRenderer.mockInput.typeText('this belongs in chat');
     testRenderer.mockInput.pressEnter();
-    await testRenderer.waitForFrame(value => value.includes('Commands start with /'));
+    // Wait on the real state, not frame text: the hint row is half the
+    // screen's width, so this message is truncated on screen and never
+    // appears there verbatim.
+    await testRenderer.waitForFrame(() => controller.state.inputError !== null);
+    expect(commandHintText(testRenderer)).toBe(
+      '✗ Commands start with /. Use Experiment chat for questions.',
+    );
     expect(controller.submissions).toEqual([]);
     expect(controller.chatSubmissions).toEqual([]);
     testRenderer.mockInput.pressKey('ESCAPE');
     await frameAfterEscape(testRenderer);
+    // Esc clears the input error the same way it dismisses the banner.
+    expect(controller.state.inputError).toBeNull();
 
     testRenderer.mockInput.pressKey('w', {ctrl: true});
     await frameAfter(testRenderer);
@@ -5219,7 +5273,11 @@ describe('theming', () => {
   });
 
   it('uses the empty hypotheses screen as a truthful planning kickoff', async () => {
-    const testRenderer = await createTestRenderer({width: 100, height: 16});
+    // The command input's own reserved hint row (#input-error-inline) costs
+    // every view one more row than this screen used to need, so the kickoff
+    // copy needs one extra row of height to stay on screen (see the sibling
+    // boundary test above, which hit the same shift).
+    const testRenderer = await createTestRenderer({width: 100, height: 17});
     const controller = kickoffController();
     const app = createOpenTuiApp(testRenderer.renderer, controller);
     registerCleanup(testRenderer.renderer, app);
@@ -6163,6 +6221,18 @@ function boxOf(testRenderer: TestRendererSetup, id: string): Renderable {
   return found;
 }
 
+/**
+ * The command input hint row's rendered text, flattened from its `StyledText`
+ * content (`.content` is not a plain string, so it cannot be compared with
+ * `toBe`/`toMatchObject` directly). Throws if the row is missing, so a typo'd
+ * id fails loudly instead of the assertion passing vacuously.
+ */
+function commandHintText(testRenderer: TestRendererSetup): string {
+  const hint = testRenderer.renderer.root.findDescendantById('command-input-hint');
+  if (!(hint instanceof TextRenderable)) throw new Error('command-input-hint was missing');
+  return hint.content.chunks.map(chunk => chunk.text).join('');
+}
+
 /** The colors of the span carrying `needle`, which the caller expects on screen. */
 function requireSpanColors(
   testRenderer: TestRendererSetup,
@@ -6493,6 +6563,9 @@ class FakeController implements SessionController {
   }
   dismissErrorBanner(): void {
     this.publish(dismissErrorBanner(this.state));
+  }
+  clearInputError(): void {
+    this.publish(clearInputError(this.state));
   }
   cyclePaneFocus(): void {
     this.publish(cyclePaneFocus(this.state));

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -276,6 +276,7 @@ export function createOpenTuiApp(
     value => void controller.submitCommand(value),
     theme,
     () => controller.focusPane('left'),
+    () => controller.clearInputError(),
   );
   /**
    * Moves the command box, and the list that completes it, into one pane.
@@ -287,7 +288,7 @@ export function createOpenTuiApp(
    */
   const hostCommandSurface = (pane: BoxRenderable): void => {
     pane.add(commandInput.suggestions);
-    pane.add(commandInput.box);
+    pane.add(commandInput.output);
   };
 
   // A slash command and a key toggle the same prompt: the controller routes the
@@ -507,7 +508,7 @@ export function createOpenTuiApp(
     // down rather than following the zoom into a pane that does not want it.
     // The key-help line goes with it, the way it did when the two shared a row.
     const showCommand = zoomedPane !== 'chat';
-    commandInput.box.visible = showCommand;
+    commandInput.output.visible = showCommand;
     if (!showCommand) commandInput.suggestions.visible = false;
     help.visible = showCommand;
     // Which pane the command box writes to, and therefore which one it is drawn
@@ -527,13 +528,14 @@ export function createOpenTuiApp(
             : transcriptFrame;
     if (nextHost !== commandHost) {
       commandHost.remove(commandInput.suggestions);
-      commandHost.remove(commandInput.box);
+      commandHost.remove(commandInput.output);
       hostCommandSurface(nextHost);
       commandHost = nextHost;
     }
     // The command list completes the box it belongs to, and on this view that
     // box cannot open a chat that is already beside it.
     commandInput.setCommandContext({chatDocked: showChatPane});
+    commandInput.render(state);
     experimentLog.setAvailableWidth(showSplit || showChatPane ? leftWidth - chatWidth : null);
     experimentLog.render(state);
     experimentLog.output.visible = showExperimentLog;

--- a/clients/tui/src/ui/command-input.test.ts
+++ b/clients/tui/src/ui/command-input.test.ts
@@ -1,0 +1,128 @@
+import {describe, expect, it} from 'bun:test';
+import {BoxRenderable, InputRenderable, rgbToHex, TextRenderable} from '@opentui/core';
+import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
+import {initialSessionState} from '../session-model.js';
+import {createCommandInputPanel} from './command-input.js';
+import {paneBorderColor} from './focus.js';
+import {resolveTheme, type Theme} from './theme.js';
+
+interface Mounted {
+  testRenderer: TestRendererSetup;
+  hint: () => TextRenderable;
+  box: () => BoxRenderable;
+  input: () => InputRenderable;
+  render: (inputError: string | null) => void;
+  destroy: () => void;
+}
+
+/** `.content` is `StyledText`, not a plain string; flatten it for assertions. */
+function text(node: TextRenderable): string {
+  return node.content.chunks.map(chunk => chunk.text).join('');
+}
+
+async function mount(theme: Theme, onChange: () => void = () => {}): Promise<Mounted> {
+  const testRenderer = await createTestRenderer({width: 60, height: 10});
+  const panel = createCommandInputPanel(
+    testRenderer.renderer,
+    () => {},
+    theme,
+    () => {},
+    onChange,
+  );
+  testRenderer.renderer.root.add(panel.output);
+  const find = <T>(id: string, ctor: new (...args: never[]) => T): T => {
+    const node = testRenderer.renderer.root.findDescendantById(id);
+    if (!(node instanceof ctor)) throw new Error(`${id} was missing`);
+    return node;
+  };
+  return {
+    testRenderer,
+    hint: () => find('command-input-hint', TextRenderable),
+    box: () => find('command-input-box', BoxRenderable),
+    input: () => find('command-input', InputRenderable),
+    render: inputError => panel.render({...initialSessionState(), inputError}),
+    destroy: () => {
+      panel.destroy();
+      panel.output.destroyRecursively();
+      testRenderer.renderer.destroy();
+    },
+  };
+}
+
+describe('command input hint row', () => {
+  it('is reserved at rest, with useful key hints', async () => {
+    const theme = resolveTheme('dark');
+    const {hint, destroy} = await mount(theme);
+    try {
+      expect(text(hint())).toBe('Enter: run · Tab: complete');
+    } finally {
+      destroy();
+    }
+  });
+
+  it('keeps the same height at rest and while an error stands', async () => {
+    const theme = resolveTheme('dark');
+    const {testRenderer, render, destroy} = await mount(theme);
+    try {
+      const panelHeight = (): number | undefined =>
+        testRenderer.renderer.root.findDescendantById('command-input-panel')?.height;
+
+      const restingHeight = panelHeight();
+      render('Unknown command: /nope. Use /help.');
+      expect(panelHeight()).toBe(restingHeight);
+      render(null);
+      expect(panelHeight()).toBe(restingHeight);
+    } finally {
+      destroy();
+    }
+  });
+
+  it('shows the message with a non-colour glyph and the box border turns theme.error', async () => {
+    const theme = resolveTheme('dark');
+    const {hint, box, render, destroy} = await mount(theme);
+    try {
+      const restingColor = paneBorderColor(theme, false).toLowerCase();
+      expect(rgbToHex(box().borderColor).toLowerCase()).toBe(restingColor);
+
+      render('Commands start with /. Use Experiment chat for questions.');
+      expect(text(hint())).toBe('✗ Commands start with /. Use Experiment chat for questions.');
+      expect(rgbToHex(hint().fg).toLowerCase()).toBe(theme.error.toLowerCase());
+      expect(rgbToHex(box().borderColor).toLowerCase()).toBe(theme.error.toLowerCase());
+
+      render(null);
+      expect(text(hint())).toBe('Enter: run · Tab: complete');
+      expect(rgbToHex(box().borderColor).toLowerCase()).toBe(restingColor);
+    } finally {
+      destroy();
+    }
+  });
+
+  it('renders the glyph and the error colour under a high-contrast theme', async () => {
+    const theme = resolveTheme('high-contrast-dark');
+    const {hint, box, render, destroy} = await mount(theme);
+    try {
+      render('Usage: /pause');
+      expect(text(hint())).toContain('✗');
+      expect(rgbToHex(hint().fg).toLowerCase()).toBe(theme.error.toLowerCase());
+      expect(rgbToHex(box().borderColor).toLowerCase()).toBe(theme.error.toLowerCase());
+    } finally {
+      destroy();
+    }
+  });
+
+  it('notifies on every keystroke, so a stale error can be cleared by the caller', async () => {
+    let changes = 0;
+    const theme = resolveTheme('dark');
+    const {input, destroy} = await mount(theme, () => {
+      changes += 1;
+    });
+    try {
+      input().insertText('/');
+      expect(changes).toBe(1);
+      input().insertText('h');
+      expect(changes).toBe(2);
+    } finally {
+      destroy();
+    }
+  });
+});

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -7,12 +7,14 @@ import {
   TextRenderable,
 } from '@opentui/core';
 import {type CommandContext, slashCommandRange, suggestSlashCommands} from '../commands.js';
+import type {SessionState} from '../session-model.js';
 import {paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {SuggestionMenu} from './suggestion-menu.js';
 import type {Theme} from './theme.js';
 
 export interface CommandInputPanel {
-  box: BoxRenderable;
+  /** The hint row and the bordered box together: the unit a host pane mounts. */
+  output: BoxRenderable;
   suggestions: BoxRenderable;
   /** Narrows the completions to the commands the current view offers. */
   setCommandContext(context: CommandContext): void;
@@ -21,11 +23,27 @@ export interface CommandInputPanel {
   /** True when nothing is typed, so Enter belongs to whatever pane is behind. */
   isEmpty(): boolean;
   focus(): void;
+  /** Reflects `state.inputError` onto the hint row and the box border. */
+  render(state: SessionState): void;
   applyTheme(theme: Theme): void;
   destroy(): void;
 }
 
 const COMMAND_TITLE = 'Command';
+
+/** Key hints shown on the reserved row above the box while no input error stands. */
+const RESTING_HINT = 'Enter: run · Tab: complete';
+
+/** The bordered box's own rows: top border, the input line, bottom border. */
+const BOX_CHROME = 3;
+
+/**
+ * The box's own rows plus the hint row above it, mirroring `chat-composer.ts`'s
+ * `COMPOSER_CHROME`. The row is reserved rather than inserted on demand: per
+ * `tui-conventions.md`, a row that appears and disappears resizes everything
+ * under it, so it is always present and only its content and colour change.
+ */
+const COMMAND_CHROME = BOX_CHROME + 1;
 
 function commandSyntaxStyle(theme: Theme): SyntaxStyle {
   return SyntaxStyle.fromStyles({'slash-command': {fg: theme.accent, bold: true}});
@@ -37,10 +55,36 @@ export function createCommandInputPanel(
   theme: Theme,
   /** Called when the box is clicked, so the pane focus follows the cursor. */
   onFocusRequest: () => void = () => {},
+  /**
+   * Called on every keystroke (typed or deleted). A stale input error names a
+   * typo in text the operator is already retyping, so it clears as soon as
+   * they touch the box again rather than waiting for them to notice and
+   * dismiss it.
+   */
+  onChange: () => void = () => {},
 ): CommandInputPanel {
+  let currentTheme = theme;
+  /** The last message `render` painted, or null at rest. Skips redundant repaints. */
+  let lastMessage: string | null = null;
+  const output = new BoxRenderable(renderer, {
+    id: 'command-input-panel',
+    width: '100%',
+    height: COMMAND_CHROME,
+    flexDirection: 'column',
+    flexShrink: 0,
+  });
+  const hint = new TextRenderable(renderer, {
+    id: 'command-input-hint',
+    width: '100%',
+    height: 1,
+    wrapMode: 'none',
+    truncate: true,
+    fg: theme.textSubtle,
+    content: RESTING_HINT,
+  });
   const box = new BoxRenderable(renderer, {
     id: 'command-input-box',
-    height: 3,
+    height: BOX_CHROME,
     width: '100%',
     border: true,
     // The focus treatment names the one pane the navigation keys are on. This
@@ -50,6 +94,10 @@ export function createCommandInputPanel(
     // ambiguous, which is the whole complaint behind #433. It still takes the
     // title from `focus.ts` so its label sits at the same column as the pane
     // holding it, and as the chat's `Message` box across the landing view.
+    // An input error is reinforcement, not the focus treatment: it turns this
+    // border `theme.error` (see `render` below), a colour distinct from
+    // `borderFocus`, while the border stays unfocused and the marker gutter
+    // stays blank.
     borderStyle: paneBorderStyle(false),
     borderColor: paneBorderColor(theme, false),
     title: paneTitle(COMMAND_TITLE, false),
@@ -71,7 +119,12 @@ export function createCommandInputPanel(
   const suggestions = new BoxRenderable(renderer, {
     id: 'command-input-suggestions',
     position: 'absolute',
-    bottom: 3,
+    // Flush on the box, not the whole panel: like the chat composer's own
+    // menu, a popup cleared of the hint row above would leave that row
+    // floating in the gap while the list is open, so it sits on the box and
+    // covers the hint instead (see chat-composer.ts's `menu` for the same
+    // reasoning on the other side of the landing view).
+    bottom: BOX_CHROME,
     left: 0,
     width: '100%',
     height: 3,
@@ -114,6 +167,10 @@ export function createCommandInputPanel(
     suggestionList.height = Math.max(1, menu.matches.length);
     suggestionList.content = menu.renderLines(value).join('\n');
   };
+  const handleInput = (value: string): void => {
+    updateDecorations(value);
+    onChange();
+  };
   const submit = (value: string): void => {
     input.value = '';
     // Enter on an empty (or whitespace-only) box belongs to whatever pane is
@@ -121,11 +178,16 @@ export function createCommandInputPanel(
     if (value.trim() === '') return;
     onSubmit(value);
   };
-  input.on(InputRenderableEvents.INPUT, updateDecorations);
+  input.on(InputRenderableEvents.INPUT, handleInput);
   input.on(InputRenderableEvents.ENTER, submit);
   box.add(input);
+  // Hint first, then the box, the same order as the chat composer on the
+  // other side of the landing view, so both columns end on a bordered input
+  // and the two boxes share a row (app.test.ts pins this).
+  output.add(hint);
+  output.add(box);
   return {
-    box,
+    output,
     suggestions,
     setCommandContext(next: CommandContext): void {
       if (next.chatDocked === context.chatDocked) return;
@@ -145,8 +207,28 @@ export function createCommandInputPanel(
     },
     isEmpty: () => input.value.trim() === '',
     focus: () => input.focus(),
+    render(state: SessionState): void {
+      const message = state.inputError;
+      if (message === lastMessage) return;
+      lastMessage = message;
+      if (message === null) {
+        hint.content = RESTING_HINT;
+        hint.fg = currentTheme.textSubtle;
+        box.borderColor = paneBorderColor(currentTheme, false);
+        return;
+      }
+      // The glyph is the non-colour channel WCAG 1.4.1 asks for: the two
+      // high-contrast themes have almost no palette, so the error colour on
+      // its own would say nothing in them.
+      hint.content = `✗ ${message}`;
+      hint.fg = currentTheme.error;
+      box.borderColor = currentTheme.error;
+    },
     applyTheme(next: Theme): void {
-      box.borderColor = paneBorderColor(next, false);
+      currentTheme = next;
+      const hasError = lastMessage !== null;
+      box.borderColor = hasError ? next.error : paneBorderColor(next, false);
+      hint.fg = hasError ? next.error : next.textSubtle;
       input.textColor = next.textStrong;
       input.focusedTextColor = next.textStrong;
       suggestions.borderColor = next.border;
@@ -160,7 +242,7 @@ export function createCommandInputPanel(
       updateDecorations(input.value);
     },
     destroy(): void {
-      input.off(InputRenderableEvents.INPUT, updateDecorations);
+      input.off(InputRenderableEvents.INPUT, handleInput);
       input.off(InputRenderableEvents.ENTER, submit);
       if (!input.isDestroyed) input.syntaxStyle = null;
       syntaxStyle.destroy();

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -78,6 +78,14 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
+    // The command input's own error clears the same way: Esc goes back one
+    // level (tui-conventions.md), and a stale input error is a level to leave
+    // just as much as the banner is.
+    if (controller.state.inputError !== null && key.name === 'escape') {
+      controller.clearInputError();
+      key.preventDefault();
+      return;
+    }
     if (
       key.ctrl &&
       key.name === 'w' &&


### PR DESCRIPTION
## Problem

Any `scope: 'input'` report (empty box, plain text, an unknown or malformed command) raised the same full-width error banner used for real backend failures, mixing operator typos with orchestrator diagnostics on one surface. #564/#635 already made this case for the empty-box instance: "Enter on an empty box is not a malformed command, it is a no-op. Reporting it as an error trains the operator to ignore the error banner, which is the surface that has to stay trustworthy for real failures." `ErrorBannerState` has eight `scope` values; only `'input'` is client-side validation of what was just typed, the other seven carry backend `detail`/`hint` with no length contract.

## Solution

`reportError` now routes `scope: 'input'` to a new `state.inputError: string | null` instead of `errorBanner`; the other seven scopes are unchanged. `command-input.ts` gains a reserved, always-present hint row above the box (mirroring `chat-composer.ts`'s `COMPOSER_CHROME`): at rest it shows key hints (`Enter: run · Tab: complete`), on an input error it shows `✗ <message>` in `theme.error`, and the box border also turns `theme.error` (the glyph is the non-colour channel, WCAG 1.4.1). The row is reserved rather than inserted on demand, since an appearing/disappearing row resizes every pane under it (`tui-conventions.md`); this costs every view one row. The error clears on the next keystroke and on Esc. The suggestions popup now anchors to the box instead of the panel, covering the hint row while open.

### Architecture

`session-model.ts` owns the input/backend routing split and `inputError` state; `command-input.ts` renders the hint row and border from it; `session-controller.ts` and `keybindings.ts` clear it on input and Esc.

## Verification

| Before (`main`) | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr717-input-error-before.png) | ![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr717-input-error-after.png) |

Plain text + Enter in the command box, 120x32, dark theme.

`command-input.test.ts` and `session-model.test.ts` cover the render and routing logic directly; `app.test.ts` exercises the keystroke-to-hint-to-clear path, including Esc and border colour.

### Correctness properties

- `scope: 'input'` never reaches `errorBanner`; the other seven scopes keep the unchanged full-width banner with `detail`/`hint`.
- The hint row's height is constant whether or not an error stands, so no view resizes when one appears or clears.
- The error clears on the next keystroke and on Esc, never lingering on stale input.
- The error colour is paired with a `✗` glyph, not colour alone.

### Testing

- `pnpm --filter @vibesys/tui test`: 833 pass, 0 fail (31 files)
- `pnpm check:clients`: clean

