### PR TITLE
feat(tui): resize the docked chat pane by columns with < > and =

### DIFF
--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -77,6 +77,7 @@ import {
   setChatMenuCustomModel,
   setChatModelMenuOptions,
   setChatThreadPending,
+  setChatWidthOverride,
   setDesignLog,
   setExperiments,
   setGraphWidthOverride,
@@ -129,6 +130,8 @@ export interface SessionController {
   toggleTodos(): void;
   /** `<`/`>`: the Agents pane's explicit column width, already clamped; `=`: null. */
   setGraphWidthOverride(width: number | null): void;
+  /** `<`/`>`: the docked chat pane's explicit column width, already clamped; `=`: null. */
+  setChatWidthOverride(width: number | null): void;
   /** Expands the latest prompt in view; the view owns what "latest" means. */
   togglePrompt(): void;
   onTogglePrompt(handler: () => void): void;
@@ -435,6 +438,10 @@ export class SocketSessionController implements SessionController {
 
   setGraphWidthOverride(width: number | null): void {
     this.#setState(setGraphWidthOverride(this.#state, width));
+  }
+
+  setChatWidthOverride(width: number | null): void {
+    this.#setState(setChatWidthOverride(this.#state, width));
   }
 
   setTheme(themeName: ThemeName): void {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -77,6 +77,16 @@ export interface SessionState {
    * it carries no `agent.toml` key and does not persist past this process.
    */
   graphWidthOverride: number | null;
+  /**
+   * Explicit column width for the docked chat pane on the home page, set and
+   * stepped by `<`/`>` and cleared by `=`. `null` means automatic:
+   * `chat-pane.ts#chatPaneWidth` decides, exactly as it always has. Mirrors
+   * `graphWidthOverride` above in shape and in the reason it exists: an
+   * explicit width is sticky, and `=` is what keeps that from being a trap.
+   * Session-only view state: it carries no `agent.toml` key and does not
+   * persist past this process.
+   */
+  chatWidthOverride: number | null;
   themeName: ThemeName;
   experimentLog: ExperimentLogState | null;
   /**
@@ -322,6 +332,7 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     chatMenu: null,
     todosExpanded: false,
     graphWidthOverride: null,
+    chatWidthOverride: null,
     themeName,
     // The experiment log is the landing view: a run's history reads as a short
     // list of claims before it reads as a long list of rounds.
@@ -1953,6 +1964,16 @@ export function toggleTodos(state: SessionState): SessionState {
  */
 export function setGraphWidthOverride(state: SessionState, width: number | null): SessionState {
   return state.graphWidthOverride === width ? state : {...state, graphWidthOverride: width};
+}
+
+/**
+ * `<`/`>`: sets the docked chat pane's explicit column width. `=`: clears it
+ * back to automatic (`null`). The value handed in is already clamped by the
+ * caller (`chat-pane.ts#clampChatWidthOverride`), which needs the terminal
+ * width and the right pane's width to do that; this reducer only applies it.
+ */
+export function setChatWidthOverride(state: SessionState, width: number | null): SessionState {
+  return state.chatWidthOverride === width ? state : {...state, chatWidthOverride: width};
 }
 
 /**

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -49,16 +49,6 @@ const HEADING_ROWS = 1;
 export const TRANSCRIPT_MIN = 42;
 /** Share of the terminal the graph takes when there is room for it. */
 const GRAPH_SHARE = 0.4;
-/**
- * Columns `<`/`>` move the Agents pane by on each press. 2 rather than 1: a
- * node's width ranges from the 14-column floor to roughly 90 for a wide
- * multi-stage round, and at 1 column a press would rarely change which
- * characters of a name are visible, only pad or shave whitespace no label
- * uses. 2 halves the number of presses to cross that range while still
- * landing on most of the widths where a label's next character appears or
- * disappears.
- */
-export const GRAPH_WIDTH_STEP = 2;
 
 function statusColor(theme: Theme, status: AgentPhase['status']): string {
   if (status === 'active') return theme.success;

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1246,6 +1246,180 @@ describe('OpenTUI presentation', () => {
     expect(controller.state.graphWidthOverride).toBeNull();
   });
 
+  /**
+   * `<`/`>`/`=` resize the docked chat pane on the home page, mirroring the
+   * Agents pane's own mechanism above. The experiment log is never given a
+   * width of its own (`width: '100%', flexGrow: 1`), so whatever the chat
+   * pane does not take is exactly what the log gets.
+   */
+  it('changes the chat pane by exactly one step per press, seeded from the current width', async () => {
+    const width = 140; // automatic sizing renders 45 here.
+    const testRenderer = await createTestRenderer({width, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    const chatPane = () => testRenderer.renderer.root.findDescendantById('chat-pane');
+
+    const before = await frameAfter(testRenderer);
+    expect(before).toContain('Experiment chat');
+    expect(controller.state.chatWidthOverride).toBeNull();
+    expect(chatPane()?.width).toBe(45);
+
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(chatPane()?.width).toBe(43); // seeded from 45, one step down.
+    expect(controller.state.chatWidthOverride).toBe(43);
+
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(chatPane()?.width).toBe(41);
+
+    testRenderer.mockInput.pressKey('>');
+    testRenderer.mockInput.pressKey('>');
+    await frameAfter(testRenderer);
+    expect(chatPane()?.width).toBe(45); // back to where it started.
+  });
+
+  it('= hands the chat pane back to automatic sizing after a resize', async () => {
+    const width = 140;
+    const testRenderer = await createTestRenderer({width, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+    const chatPane = () => testRenderer.renderer.root.findDescendantById('chat-pane');
+
+    // 45 down to 25 (CHAT_PANE_MIN) in 10 steps of 2.
+    for (let step = 0; step < 10; step += 1) testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(chatPane()?.width).toBe(25);
+    expect(controller.state.chatWidthOverride).toBe(25);
+
+    testRenderer.mockInput.pressKey('=');
+    await frameAfter(testRenderer);
+
+    expect(controller.state.chatWidthOverride).toBeNull();
+    expect(chatPane()?.width).toBe(45); // automatic sizing at 140, as before any press.
+  });
+
+  it('a < press at CHAT_PANE_MIN stores nothing once the floor is reached', async () => {
+    const width = 140;
+    const testRenderer = await createTestRenderer({width, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+    const chatPane = () => testRenderer.renderer.root.findDescendantById('chat-pane');
+
+    for (let step = 0; step < 15; step += 1) testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(chatPane()?.width).toBe(25);
+    expect(controller.state.chatWidthOverride).toBe(25);
+
+    // Five presses past the floor changed nothing further: the override
+    // itself stayed 25 rather than drifting under CHAT_PANE_MIN.
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(chatPane()?.width).toBe(25);
+    expect(controller.state.chatWidthOverride).toBe(25);
+  });
+
+  it('the override may exceed CHAT_PANE_MAX, but keeps the log at LOG_COMPACT_PANEL_WIDTH, and a further > stores nothing', async () => {
+    // room = 233 once LOG_COMPACT_PANEL_WIDTH (67) is set aside, far past
+    // CHAT_PANE_MAX (52): automatic sizing never asks for more than 52, but an
+    // explicit override is allowed to.
+    const width = 300;
+    const testRenderer = await createTestRenderer({width, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+    const chatPane = () => testRenderer.renderer.root.findDescendantById('chat-pane');
+    const table = () => testRenderer.renderer.root.findDescendantById('experiment-log');
+
+    expect(chatPane()?.width).toBe(52); // automatic sizing already at its own ceiling.
+
+    for (let step = 0; step < 120; step += 1) testRenderer.mockInput.pressKey('>');
+    await frameAfter(testRenderer);
+
+    expect(chatPane()?.width).toBe(233);
+    expect(chatPane()?.width as number).toBeGreaterThan(52);
+    expect(table()?.width).toBe(width - 233); // 67, LOG_COMPACT_PANEL_WIDTH.
+    expect(controller.state.chatWidthOverride).toBe(233);
+
+    // One more press past the ceiling stores nothing further.
+    testRenderer.mockInput.pressKey('>');
+    await frameAfter(testRenderer);
+    expect(chatPane()?.width).toBe(233);
+    expect(controller.state.chatWidthOverride).toBe(233);
+  });
+
+  it('no-ops the chat resize keys on the round view, where experimentLogVisible is false', async () => {
+    const testRenderer = await createTestRenderer({width: 160, height: 30});
+    const controller = new FakeController(threeStageRound());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+
+    testRenderer.mockInput.pressKey('=');
+    testRenderer.mockInput.pressKey('>');
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(controller.state.chatWidthOverride).toBeNull();
+  });
+
+  it("no-ops the Agents pane's resize keys on the home page, where agentsPaneVisible is false", async () => {
+    // The mirror of the case above: `agentsPaneVisible` returns false wherever
+    // `experimentLogVisible` is true, so the two resize blocks in
+    // `keybindings.ts` never both claim the same press.
+    const testRenderer = await createTestRenderer({width: 160, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+
+    testRenderer.mockInput.pressKey('=');
+    testRenderer.mockInput.pressKey('>');
+    testRenderer.mockInput.pressKey('<');
+    await frameAfter(testRenderer);
+    expect(controller.state.graphWidthOverride).toBeNull();
+  });
+
+  it('stores nothing on a terminal too narrow for the chat to dock at all', async () => {
+    // 90 columns is under MIN_DOCK_WIDTH (92): chatDockFits is false, so
+    // chatPaneVisible is false and the keys are never claimed.
+    const width = 90;
+    const testRenderer = await createTestRenderer({width, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+    expect(controller.state.chatDockFits).toBe(false);
+
+    testRenderer.mockInput.pressKey('>');
+    testRenderer.mockInput.pressKey('<');
+    testRenderer.mockInput.pressKey('=');
+    await frameAfter(testRenderer);
+    expect(controller.state.chatWidthOverride).toBeNull();
+  });
+
+  it('never advertises the resize keys on LOG_KEY_HELP, where chatPaneVisible is false', async () => {
+    // The resize keys are guarded by `chatPaneVisible(state)`, which is false
+    // in every state that shows `LOG_KEY_HELP` (the chat is either not docked,
+    // as here, or covered by a modal or a different zoom). A binding advertised
+    // on a line where it can never fire is worse than not advertising it at
+    // all, so `<>=: width` belongs only on `LOG_CHAT_KEY_HELP`.
+    const width = 90; // under MIN_DOCK_WIDTH: the chat cannot dock here.
+    const testRenderer = await createTestRenderer({width, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    const frame = await frameAfter(testRenderer);
+
+    expect(controller.state.chatDockFits).toBe(false);
+    expect(frame).not.toContain('<>=: width');
+  });
+
   it("reads the tabs' measured delta from the experiment log, not the design log", async () => {
     // Per-round stage facts, the measured delta included, cross the protocol on
     // `HypothesisRound`; the design log carries only each round's file list. The
@@ -6789,6 +6963,13 @@ class FakeController implements SessionController {
     // over by a double that always publishes.
     if (this.state.graphWidthOverride === width) return;
     this.publish({...this.state, graphWidthOverride: width});
+  }
+
+  setChatWidthOverride(width: number | null): void {
+    // The same dedup the real reducer does
+    // (`session-model.ts#setChatWidthOverride`).
+    if (this.state.chatWidthOverride === width) return;
+    this.publish({...this.state, chatWidthOverride: width});
   }
 
   /** Rows the fake server returns for query.experiments. */

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -19,7 +19,7 @@ import {AgentMapView, agentsPaneVisible} from './agent-map.js';
 import {fillLayer} from './box-fill.js';
 import {createChatDraft} from './chat-composer.js';
 import {ChatOverlayView} from './chat-overlay.js';
-import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
+import {ChatPaneView, chatDockFits, chatPaneWidthWithOverride} from './chat-pane.js';
 import {RendererSelectionClipboard, type SelectionClipboard} from './clipboard.js';
 import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
@@ -57,7 +57,21 @@ type FocusTarget = 'command' | 'chat' | 'modal';
 const KEY_HELP = `←→: agents/transcript · ↑↓: within · [/]: round · <>=: width · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Ctrl+L: live`;
 const SCOPED_KEY_HELP = `←→: agents/transcript · ↑↓: within · [/]: round · <>=: width · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Esc: back`;
 const LOG_KEY_HELP = `↑↓ or scroll: select · Enter/click: open hypothesis · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
-const LOG_CHAT_KEY_HELP = `↑↓: select · Enter/click: hypothesis · Ctrl+W: chat · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
+// The resize keys are guarded by `chatPaneVisible(state)` (`keybindings.ts`),
+// which is false in every state `LOG_KEY_HELP` covers, so `<>=: width` goes
+// only on this line, the one state where the keys can actually fire.
+// Advertising a binding that cannot fire is worse than not advertising it at
+// all: tui-conventions.md's "Bindings are visible" is about a person not
+// having to already know a binding, and a dead one on the help line breaks
+// that trust the same way a false error would break the banner's (#635).
+//
+// This line is one row and clips rather than wraps (see `KEY_HELP` above), so
+// the new token still costs a token: `/open-round --N` (93 characters with it
+// restored, one over the 92-column budget at the narrowest terminal the chat
+// can dock in) rather than `Ctrl+W: chat`, which has no other affordance
+// advertising it.
+const LOG_CHAT_KEY_HELP =
+  '↑↓: select · Enter/click: hypothesis · <>=: width · Ctrl+W: chat · F4: zoom';
 const HYPOTHESIS_KEY_HELP =
   '↑↓: select round · Enter/click: trajectory · PgUp/PgDn: scroll · Esc: hypotheses';
 /** Bezel, one content row, bezel. See the header frame below. */
@@ -408,7 +422,7 @@ export function createOpenTuiApp(
     const chatWidth = showChatPane
       ? zoomedPane === 'chat'
         ? renderer.terminalWidth
-        : chatPaneWidth(renderer.terminalWidth, rightWidth)
+        : chatPaneWidthWithOverride(renderer.terminalWidth, rightWidth, state.chatWidthOverride)
       : 0;
     const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
     paintHeader(renderHeader(state, showLog, renderer.terminalWidth - HEADER_CHROME));
@@ -591,6 +605,7 @@ export function createOpenTuiApp(
     selectPreviousRound: () => controller.selectPreviousRound(),
     toggleTodos: () => controller.toggleTodos(),
     setGraphWidthOverride: width => controller.setGraphWidthOverride(width),
+    setChatWidthOverride: width => controller.setChatWidthOverride(width),
     scrollRightPane: delta => rightPane.scrollBy(delta),
     scrollChatPane: delta => chatPane.scrollBy(delta),
     scrollExperimentDetail: delta => experimentLog.scrollBy(delta),

--- a/clients/tui/src/ui/chat-pane.test.ts
+++ b/clients/tui/src/ui/chat-pane.test.ts
@@ -1,5 +1,12 @@
 import {describe, expect, it} from 'bun:test';
-import {chatDockFits, chatPaneWidth, MIN_DOCK_WIDTH} from './chat-pane.js';
+import {
+  CHAT_PANE_MAX,
+  chatDockFits,
+  chatPaneWidth,
+  chatPaneWidthWithOverride,
+  clampChatWidthOverride,
+  MIN_DOCK_WIDTH,
+} from './chat-pane.js';
 import {LOG_CLAIM_PANEL_WIDTH, LOG_COMPACT_PANEL_WIDTH} from './experiment-log.js';
 
 describe('chat dock thresholds', () => {
@@ -50,5 +57,51 @@ describe('chat dock sizing', () => {
 
   it('narrows itself rather than the table when a visualization opens', () => {
     expect(chatPaneWidth(200, 84)).toBeLessThan(chatPaneWidth(200));
+  });
+});
+
+/**
+ * The range a `<`/`>` override is clamped to. Deliberately asymmetric with
+ * automatic sizing: the low bound is the same `CHAT_PANE_MIN` automatic sizing
+ * never crosses, but the high bound is whatever the log's own compact floor
+ * leaves over, not `CHAT_PANE_MAX`. Asking for more than automatic sizing
+ * would ever pick is the point of overriding it.
+ */
+describe('clampChatWidthOverride', () => {
+  it('holds the override between CHAT_PANE_MIN and what the log floor leaves over', () => {
+    const width = 300; // room = 233, far past CHAT_PANE_MAX.
+    expect(clampChatWidthOverride(-1000, width, 0)).toBe(25);
+    expect(clampChatWidthOverride(1000, width, 0)).toBe(width - LOG_COMPACT_PANEL_WIDTH);
+    expect(clampChatWidthOverride(60, width, 0)).toBe(60);
+  });
+
+  it('is allowed past CHAT_PANE_MAX, unlike automatic sizing', () => {
+    const width = 300;
+    const overridden = clampChatWidthOverride(1000, width, 0);
+    expect(overridden).toBeGreaterThan(CHAT_PANE_MAX);
+    // The log still keeps its compact floor: the extra columns come out of
+    // the chat's own ceiling, never out of the log's.
+    expect(width - overridden).toBeGreaterThanOrEqual(LOG_COMPACT_PANEL_WIDTH);
+  });
+
+  it('takes the same columns off a visualization split that automatic sizing does', () => {
+    const width = 300;
+    const right = 84;
+    expect(clampChatWidthOverride(1000, width, right)).toBe(
+      width - right - LOG_COMPACT_PANEL_WIDTH,
+    );
+  });
+});
+
+describe('chatPaneWidthWithOverride', () => {
+  it('with no override, matches automatic sizing exactly', () => {
+    for (const width of [92, 100, 140, 160, 300]) {
+      expect(chatPaneWidthWithOverride(width, 0, null)).toBe(chatPaneWidth(width, 0));
+    }
+  });
+
+  it('with an override, matches the clamp exactly', () => {
+    expect(chatPaneWidthWithOverride(300, 0, 1000)).toBe(clampChatWidthOverride(1000, 300, 0));
+    expect(chatPaneWidthWithOverride(300, 0, -1000)).toBe(clampChatWidthOverride(-1000, 300, 0));
   });
 });

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -22,8 +22,13 @@ import type {Theme} from './theme.js';
  * Columns the chat needs before a question and its answer read as prose rather
  * than as a column of fragments.
  */
-const CHAT_PANE_MIN = 25;
-const CHAT_PANE_MAX = 52;
+export const CHAT_PANE_MIN = 25;
+/**
+ * Ceiling for automatic sizing. An explicit `<`/`>` override is allowed past
+ * it (`clampChatWidthOverride`): asking for a specific width past what
+ * automatic sizing would ever choose on its own is the point of overriding.
+ */
+export const CHAT_PANE_MAX = 52;
 
 /** Stands in until the first render names the active thread. */
 const CHAT_PANE_TITLE = 'Experiment chat';
@@ -52,6 +57,41 @@ export function chatPaneWidth(terminalWidth: number, rightPaneWidth = 0): number
   const surplus = available - LOG_CLAIM_PANEL_WIDTH;
   const wanted = Math.max(CHAT_PANE_MIN, Math.min(CHAT_PANE_MAX, surplus));
   return Math.min(wanted, available - LOG_COMPACT_PANEL_WIDTH);
+}
+
+/**
+ * Clamps a requested `<`/`>` override to what the terminal can actually draw:
+ * never narrower than `CHAT_PANE_MIN`, and never so wide the table drops under
+ * `LOG_COMPACT_PANEL_WIDTH`.
+ *
+ * Deliberately asymmetric with automatic sizing, the mirror of how
+ * `agent-map.ts#clampGraphWidthOverride` lets an override go below
+ * `agentPaneFloor`: automatic sizing (`chatPaneWidth`) caps at `CHAT_PANE_MAX`
+ * because that is already comfortable for a question and its answer, but an
+ * explicit ask is allowed past it, since asking for more than automatic
+ * sizing would ever choose is the point of overriding.
+ */
+export function clampChatWidthOverride(
+  requested: number,
+  terminalWidth: number,
+  rightPaneWidth: number,
+): number {
+  const low = CHAT_PANE_MIN;
+  const high = Math.max(low, terminalWidth - rightPaneWidth - LOG_COMPACT_PANEL_WIDTH);
+  return Math.min(high, Math.max(low, requested));
+}
+
+/**
+ * The docked chat's width honoring an explicit `<`/`>` override, or automatic
+ * sizing (`chatPaneWidth`) when there is none.
+ */
+export function chatPaneWidthWithOverride(
+  terminalWidth: number,
+  rightPaneWidth: number,
+  override: number | null,
+): number {
+  if (override === null) return chatPaneWidth(terminalWidth, rightPaneWidth);
+  return clampChatWidthOverride(override, terminalWidth, rightPaneWidth);
 }
 
 /**

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -12,11 +12,13 @@ import {
   agentPaneWidthWithOverride,
   agentsPaneVisible,
   clampGraphWidthOverride,
-  GRAPH_WIDTH_STEP,
   graphFits,
   STACKED_WIDTH,
 } from './agent-map.js';
+import {chatPaneWidthWithOverride, clampChatWidthOverride} from './chat-pane.js';
 import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
+import {PANE_WIDTH_STEP} from './pane-resize.js';
+import {rightPaneWidth, splitFits} from './right-pane.js';
 
 export interface KeybindingActions {
   completeInput(): boolean;
@@ -40,6 +42,8 @@ export interface KeybindingActions {
   toggleTodos(): void;
   /** `<`/`>`: the Agents pane's explicit column width, already clamped; `=`: null. */
   setGraphWidthOverride(width: number | null): void;
+  /** `<`/`>`: the docked chat pane's explicit column width, already clamped; `=`: null. */
+  setChatWidthOverride(width: number | null): void;
   scrollRightPane(delta: number): void;
   scrollChatPane(delta: number): void;
   scrollExperimentDetail(delta: number): void;
@@ -215,6 +219,63 @@ export function bindKeybindings(
         if (actions.completeChatInput()) key.preventDefault();
         return;
       }
+      // Falls through to the composer's own editor uncaught, on purpose: a
+      // person typing a question must be able to type `<`, `>`, or `=`
+      // literally, so the resize block below never runs while this pane holds
+      // the cursor.
+      return;
+    }
+    // Resizes the docked chat pane by columns, the same mechanism the Agents
+    // pane uses below: `<` shrinks and `>` grows by `PANE_WIDTH_STEP`, and `=`
+    // drops the override back to automatic sizing (`chatPaneWidth`). The
+    // experiment log is `chatPaneWidthWithOverride`'s complement: it is never
+    // given a width of its own, so whatever the chat does not take is exactly
+    // what the log gets, and a resize moves the one column between them
+    // rather than a share of the terminal a floor could round away.
+    //
+    // The pane-visible predicate is `experimentLogVisible(state) &&
+    // chatPaneVisible(state)`, which never overlaps the Agents pane's own
+    // guard below: `agentsPaneVisible` returns false wherever
+    // `experimentLogVisible` is true, so at most one of the two blocks ever
+    // claims a given press. This has to run before `experimentLogVisible`'s
+    // own navigation below, whose final `else return` does not call
+    // `key.preventDefault()`: reaching it with `<`/`>`/`=` unclaimed would
+    // leave the raw key to be typed into the command input instead of
+    // resizing anything.
+    if (
+      (key.name === '>' || key.name === '<' || key.name === '=') &&
+      actions.inputIsEmpty() &&
+      controller.state.layout.zoomedPane === null &&
+      experimentLogVisible(controller.state) &&
+      chatPaneVisible(controller.state)
+    ) {
+      const terminalWidth = renderer.terminalWidth;
+      // A split beside the log takes the same columns off the chat that it
+      // takes off the table (`app.ts` computes `chatWidth` from this same
+      // `rightWidth`), so the override has to clamp against what's actually
+      // left rather than the whole terminal.
+      const rightWidth =
+        controller.state.layout.right !== null && splitFits(terminalWidth)
+          ? rightPaneWidth(terminalWidth)
+          : 0;
+      if (key.name === '=') {
+        actions.setChatWidthOverride(null);
+      } else {
+        const current = chatPaneWidthWithOverride(
+          terminalWidth,
+          rightWidth,
+          controller.state.chatWidthOverride,
+        );
+        const step = key.name === '>' ? PANE_WIDTH_STEP : -PANE_WIDTH_STEP;
+        const next = clampChatWidthOverride(current + step, terminalWidth, rightWidth);
+        // A press that moves nothing stores nothing, the same rule the Agents
+        // pane keeps below: trying the keys can never arm an override the
+        // operator cannot see. It covers a terminal at the low or high clamp
+        // bound already, and a chat pane too narrow to have room to shrink or
+        // grow beside a split.
+        if (next !== current) actions.setChatWidthOverride(next);
+      }
+      key.preventDefault();
       return;
     }
     // The experiment surface owns navigation while it is on screen. The index
@@ -342,7 +403,7 @@ export function bindKeybindings(
       return;
     }
     // Resizes the Agents pane by columns, the way a vim/LazyVim window resize
-    // does: `<` shrinks and `>` grows by `GRAPH_WIDTH_STEP` each press, and `=`
+    // does: `<` shrinks and `>` grows by `PANE_WIDTH_STEP` each press, and `=`
     // drops the override so the pane follows the terminal again, which is
     // vim's `<C-w>=`. An override is otherwise sticky for the life of the
     // process, so without `=` a single press would cost the pane its automatic
@@ -379,7 +440,7 @@ export function bindKeybindings(
         // and the narrowest it goes. The gap up to a graph is 26 columns at
         // three stages, 7 at two, and none at one, so it is never a step.
         const width = current ?? STACKED_WIDTH;
-        const step = key.name === '>' ? GRAPH_WIDTH_STEP : -GRAPH_WIDTH_STEP;
+        const step = key.name === '>' ? PANE_WIDTH_STEP : -PANE_WIDTH_STEP;
         // From the stacked list, `>` is the operator asking for the graph that
         // automatic sizing declined to draw, at the only width it has.
         const next =

--- a/clients/tui/src/ui/pane-resize.ts
+++ b/clients/tui/src/ui/pane-resize.ts
@@ -1,0 +1,9 @@
+/**
+ * Columns `<`/`>` step a resizable pane's width by on each press. The Agents
+ * pane (`agent-map.ts`) and the docked chat pane (`chat-pane.ts`) share one
+ * constant so the two keymaps read as the same convention rather than two
+ * coincidentally equal numbers. 2 rather than 1: at 1 column a press would
+ * often move only padding, not which characters of a label or a line are
+ * visible.
+ */
+export const PANE_WIDTH_STEP = 2;

--- a/docs/contributing/tui-conventions.md
+++ b/docs/contributing/tui-conventions.md
@@ -100,21 +100,26 @@ the one movement rule the current bindings already keep.
 
 ### A resize moves columns, and only columns
 
-`<` and `>` change the Agents pane's width by whole columns
-(`GRAPH_WIDTH_STEP`), the way a window resize does in vim and LazyVim. Not a
-ratio: a share of the terminal that a floor then rounds away is a key press
-that did nothing, and the width the operator sees is what they are aiming at.
+`<` and `>` change a pane's width by whole columns (`PANE_WIDTH_STEP`), the way
+a window resize does in vim and LazyVim. Two panes share the mechanism: the
+round view's Agents pane, and the home page's docked chat pane, which the
+experiment log absorbs the remainder from rather than holding a width of its
+own. Not a ratio: a share of the terminal that a floor then rounds away is a
+key press that did nothing, and the width the operator sees is what they are
+aiming at.
 
 An explicit width is sticky, so `=` gives it back, the way `<C-w>=` does in vim.
 Without it one press would cost the pane its automatic sizing for the life of
-the process: it would stop following the terminal, stop widening as agent names
-get longer, and keep cutting names automatic sizing promises never to cut. A
-resize pair with no way home is a trap, not a feature. `=` shares the guards
-that decide whether the keys belong to the Agents pane at all (an empty command
-input, no zoom, the pane on screen), but alone among the three it is not also
-gated on the pane being resizable: it is the way out, and a terminal or a round
-where `<` and `>` do nothing is exactly where an override left over from a wider
-terminal has to be clearable.
+the process: the Agents pane would stop following the terminal, stop widening
+as agent names get longer, and keep cutting names automatic sizing promises
+never to cut; the chat pane would stop following the terminal and the log
+beside it would stop reclaiming the columns automatic sizing would have given
+it back. A resize pair with no way home is a trap, not a feature. `=` shares
+the guards that decide whether the keys belong to a pane at all (an empty
+command input, no zoom, the pane on screen), but alone among the three it is
+not also gated on the pane being resizable: it is the way out, and a terminal
+or a round where `<` and `>` do nothing is exactly where an override left over
+from a wider terminal has to be clearable.
 
 A resize key also never swaps a pane's contents for a different presentation.
 The Agents pane's stacked list is an automatic fallback for a terminal too
@@ -123,7 +128,9 @@ cannot draw a node with in-degree above one, so reaching it by pressing `<`
 would lose edges the operator was resizing in order to see. `<` stops at
 `agentGraphMinWidth`, the narrowest pane an override may ask for, and `>` stops
 at `agentPaneCeiling`, past which the extra columns are padding rather than
-name.
+name. The chat pane has no fallback presentation to protect: `chatPaneVisible`
+already decides whether it is docked at all, so wherever `<`/`>`/`=` apply to
+it, it is already the chat pane and never becomes something else.
 
 The stacked list is therefore a floor `<` cannot cross in either direction. From
 it `>` opens the narrowest graph, because asking for the graph is the only thing
@@ -131,28 +138,42 @@ it `>` opens the narrowest graph, because asking for the graph is the only thing
 goes, and the gap up to `agentGraphMinWidth` is not a step a shrink key may take
 (26 columns at three stages, 7 at two, none at all at one).
 
-That last case generalizes, and the general rule is the one the code keeps: a
-press that would not change the rendered width stores nothing. A round with no
-phases yet, a round of one short-named stage, and a terminal wide enough that
-automatic sizing already sits at the ceiling each leave `<` or `>` with nowhere
-to go, and a press that stored an override anyway would arm one the operator
-cannot see and pin every later round in the session to it. A terminal too narrow
-for any graph is the same rule reached through the terminal instead of the
-round.
+That last case generalizes, and the general rule is the one the code keeps for
+every resizable pane: a press that would not change the rendered width stores
+nothing. A round with no phases yet, a round of one short-named stage, and a
+terminal wide enough that automatic sizing already sits at the ceiling each
+leave the Agents pane's `<` or `>` with nowhere to go, and a press that stored
+an override anyway would arm one the operator cannot see and pin every later
+round in the session to it. A terminal too narrow for any graph is the same
+rule reached through the terminal instead of the round, and a terminal too
+narrow for the chat to dock at all (`chatDockFits` false) is the same rule
+again: `chatPaneVisible` is already false there, so the keys are not claimed in
+the first place, and nothing is stored either way.
 
 Storing nothing means storing nothing, not storing the bound the press ran into,
 so an explicit width outlives a narrowing. A pane set to 64 columns on a wide
 terminal renders at whatever a narrower one allows, and a dead press there
 leaves the stored 64 alone, so widening back restores 64 rather than the
-narrowed width. That also keeps a dead press on one round from overwriting the
-width the operator chose on a round of a different shape.
+narrowed width. That also keeps a dead press on one round, or on one terminal
+size, from overwriting a width chosen under a different shape.
 
-Automatic sizing keeps its own rule, that no agent name is ever cut. Truncation
-is what an explicit override buys, and it buys only that: `agentGraphMinWidth`
-keeps the same `STACKED_WIDTH` floor `agentPaneFloor` does, so an override
-narrows the agent names and never the round heading or the empty-round
-placeholder. An operator who asks for a narrower pane than the names need has
-said which of the two they want.
+Automatic sizing keeps its own rule for the Agents pane, that no agent name is
+ever cut. Truncation is what an explicit override buys, and it buys only that:
+`agentGraphMinWidth` keeps the same `STACKED_WIDTH` floor `agentPaneFloor`
+does, so an override narrows the agent names and never the round heading or the
+empty-round placeholder. An operator who asks for a narrower pane than the
+names need has said which of the two they want.
+
+The chat pane's override keeps the mirror image of that promise instead.
+Automatic sizing (`chatPaneWidth`) never grows past `CHAT_PANE_MAX`, wide enough
+for a question and its answer to read as prose; an explicit override
+(`clampChatWidthOverride`) is allowed past it, the same way an Agents override
+is allowed under `agentPaneFloor` into truncation automatic sizing would never
+choose on its own. Asking for a width automatic sizing would never pick is the
+point of overriding it. The floor either way is `CHAT_PANE_MIN`, and the
+override still keeps the experiment log at `LOG_COMPACT_PANEL_WIDTH`: the extra
+columns a wide override asks for come out of the chat's own ceiling, never out
+of the log's floor.
 
 ### Nothing moves that does not have to
 


### PR DESCRIPTION
## Problem

The home page's docked chat pane is sized only by automatic sizing: an
operator who wants a wider pane for a long answer, or a narrower one to give
the experiment log more room, cannot ask for it. #691 gave the round view's
Agents pane exactly this escape hatch; this PR generalizes it to the home
page. It stacks on #691 (base `adi/graph-share`) and stays separate because
it is a second, independent surface adopting the same convention.

## Solution

`<`/`>` step the chat pane's width by `PANE_WIDTH_STEP` (#691's constant,
relocated from `agent-map.ts` to shared `pane-resize.ts`) and store the
result in `chatWidthOverride`, mirroring `graphWidthOverride`. `=` clears it
back to automatic sizing. The experiment log holds no width of its own
(`flexGrow: 1`), absorbing whatever the chat pane leaves, so it needs no
resize key.

`clampChatWidthOverride` lets an override exceed `CHAT_PANE_MAX`, keeping
only the log's `LOG_COMPACT_PANEL_WIDTH` floor: automatic sizing caps there
because that width is already comfortable, but an explicit ask may go past
it, mirroring how #691 lets a graph override go below `agentPaneFloor`.

### Architecture

State in `session-model.ts`/`session-controller.ts`; sizing/clamping in
`chat-pane.ts`; keys in `keybindings.ts`, mutually exclusive with #691's
Agents-pane block; shared step constant in `pane-resize.ts`.

## Verification

| Before (#691) | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr719-home-resize-before.png) | ![after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/pr719-home-resize-after.png) |

Home page after pressing `>` four times (then Backspace four times, which clears the `>>>>` the base branch types into the Command box), 140x36, dark theme.


`app.test.ts`: stepping, clamping at both bounds, `=` reset, no-op presses on
the round view and on a terminal too narrow to dock the chat.

### Correctness properties

- `=` restores automatic sizing exactly.
- Clamps at `CHAT_PANE_MIN`; the high end may exceed `CHAT_PANE_MAX` but
  never narrows the log below `LOG_COMPACT_PANEL_WIDTH`.
- Resize keys advertise only on `LOG_CHAT_KEY_HELP`, never `LOG_KEY_HELP`.
- A press that would not change the rendered width stores nothing.

### Testing

- `pnpm --filter @vibesys/tui test`: 869 pass, 0 fail (30 files)
- `pnpm check:clients`: clean

Stacked PR: CI only runs for `main`-based PRs, so these local runs are the signal.

